### PR TITLE
Export LoadingError from entry module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ extern crate shared_library;
 extern crate lazy_static;
 pub use instance::Instance;
 pub use device::Device;
-pub use entry::Entry;
+pub use entry::{Entry, LoadingError};
 
 mod instance;
 mod device;


### PR DESCRIPTION
Required for `corell` PR: https://github.com/gfx-rs/gfx/pull/1125/files#diff-54114f75674de7fb48ec86d044cbc150R40
