### PR TITLE
Add Device cmd_push_constants()

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -316,6 +316,21 @@ pub trait DeviceV1_0 {
                                         first_instance);
     }
 
+    unsafe fn cmd_push_constants<T>(&self,
+                                    command_buffer: vk::CommandBuffer,
+                                    layout: vk::PipelineLayout,
+                                    stage_flags: vk::ShaderStageFlags,
+                                    offset: vk::uint32_t,
+                                    size: vk::uint32_t,
+                                    p_values: &T) {
+        self.fp_v1_0().cmd_push_constants(command_buffer,
+                                          layout,
+                                          stage_flags,
+                                          offset,
+                                          size,
+                                          p_values as *const T as *const ())
+    }
+
     unsafe fn cmd_bind_descriptor_sets(&self,
                                        command_buffer: vk::CommandBuffer,
                                        pipeline_bind_point: vk::PipelineBindPoint,

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -355,6 +355,12 @@ pub trait DeviceV1_0 {
         self.fp_v1_0().cmd_begin_render_pass(command_buffer, create_info, contents);
     }
 
+    unsafe fn cmd_next_subpass(&self,
+                               command_buffer: vk::CommandBuffer,
+                               contents: vk::SubpassContents) {
+        self.fp_v1_0().cmd_next_subpass(command_buffer, contents);
+    }
+
     unsafe fn cmd_bind_pipeline(&self,
                                 command_buffer: vk::CommandBuffer,
                                 pipeline_bind_point: vk::PipelineBindPoint,


### PR DESCRIPTION
Double check if the casting is how you want it.  Push constants are untyped (`*const c_void`) so I thought a &T where T is anything made sense.  Since `size` isn't really the size of T (but just the size of the range in T starting at offset) I don't think we can hide those details.