### PR TITLE
Expose InstanceError

### DIFF
--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -3,7 +3,7 @@ extern crate shared_library;
 extern crate lazy_static;
 pub use instance::{Instance, DeviceError};
 pub use device::Device;
-pub use entry::{Entry, LoadingError};
+pub use entry::{Entry, InstanceError, LoadingError};
 
 mod instance;
 mod device;


### PR DESCRIPTION
Shouldn't this be exposed publicly, since it's used in the public `Entry::create_instance`?