### PR TITLE
Fix: Device::get_fence_status

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -1119,10 +1119,11 @@ pub trait DeviceV1_0 {
         }
     }
 
-    unsafe fn get_fence_status(&self, fence: vk::Fence) -> VkResult<()> {
+    unsafe fn get_fence_status(&self, fence: vk::Fence) -> VkResult<bool> {
         let err_code = self.fp_v1_0().get_fence_status(self.handle(), fence);
         match err_code {
-            vk::Result::Success => Ok(()),
+            vk::Result::Success => Ok(true),
+            vk::Result::NotReady => Ok(false),
             _ => Err(err_code),
         }
     }


### PR DESCRIPTION
1. Device::get_fence_status should return the boolean value whether the fence is signaled.
2. The original code misinterprets vk::Result::NotReady as error instead of UNSIGNALED status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/38)
<!-- Reviewable:end -->
