### PR TITLE
Fix typo in util::Align documentation

### DIFF
--- a/ash/src/util.rs
+++ b/ash/src/util.rs
@@ -7,7 +7,7 @@ use vk;
 /// the alignment might be different. For example a 4x4 f32 matrix has a size of 64 bytes
 /// but the min alignment for a dynamic uniform buffer might be 256 bytes. A slice of `&[Mat4x4<f32>]`
 /// has a memory layout of `[[64 bytes], [64 bytes], [64 bytes]]`, but it might need to have a memory
-/// layout of `[[256 bytes], [256 bytes], [256 bytes]].
+/// layout of `[[256 bytes], [256 bytes], [256 bytes]]`.
 /// `Align::copy_from_slice` will copy a slice of `&[T]` directly into the host memory without
 /// an additional allocation and with the correct alignment.
 #[derive(Debug, Clone)]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/45)
<!-- Reviewable:end -->
