### PR TITLE
Update examples to winapi 0.3 and winit 0.11; clean up dead code

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 authors = ["maik klein <maikklein@googlemail.com>"]
 
 [dependencies]
-winit = "0.9.0"
+winit = "0.11.1"
 image = "0.10.4"
 ash = { path = "../ash" }
 
 [target.'cfg(windows)'.dependencies]
-user32-sys = "0.2.0"
-winapi = "0.2.8"
+winapi = { version = "0.3.4", features = ["windef", "winuser"] }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -164,7 +164,6 @@ unsafe extern "system" fn vulkan_debug_callback(
     1
 }
 
-
 pub fn find_memorytype_index(
     memory_req: &vk::MemoryRequirements,
     memory_prop: &vk::PhysicalDeviceMemoryProperties,
@@ -259,6 +258,7 @@ impl ExampleBase {
             }
         });
     }
+
     pub fn new(window_width: u32, window_height: u32) -> Self {
         unsafe {
             let events_loop = winit::EventsLoop::new();

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 #[macro_use]
 extern crate ash;
 #[cfg(windows)]
@@ -120,7 +119,7 @@ unsafe fn create_surface<E: EntryV1_0, I: InstanceV1_0>(
 ) -> Result<vk::SurfaceKHR, vk::Result> {
     use winit::os::windows::WindowExt;
     let hwnd = window.get_hwnd() as *mut winapi::windef::HWND__;
-    let hinstance = unsafe { user32::GetWindow(hwnd, 0) as *const vk::c_void };
+    let hinstance = user32::GetWindow(hwnd, 0) as *const vk::c_void;
     let win32_create_info = vk::Win32SurfaceCreateInfoKHR {
         s_type: vk::StructureType::Win32SurfaceCreateInfoKhr,
         p_next: ptr::null(),
@@ -203,10 +202,6 @@ pub fn find_memorytype_index_f<F: Fn(vk::MemoryPropertyFlags, vk::MemoryProperty
     None
 }
 
-fn resize_callback(width: u32, height: u32) {
-    println!("Window resized to {}x{}", width, height);
-}
-
 pub struct ExampleBase {
     pub entry: Entry<V1_0>,
     pub instance: Instance<V1_0>,
@@ -270,7 +265,6 @@ impl ExampleBase {
             let window = winit::WindowBuilder::new()
                 .with_title("Ash - Example")
                 .with_dimensions(window_width, window_height)
-                //.with_window_resize_callback(resize_callback)
                 .build(&events_loop)
                 .unwrap();
             let entry = Entry::new().unwrap();

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate ash;
 #[cfg(windows)]
-extern crate user32;
-#[cfg(windows)]
 extern crate winapi;
 extern crate winit;
 
@@ -117,9 +115,12 @@ unsafe fn create_surface<E: EntryV1_0, I: InstanceV1_0>(
     instance: &I,
     window: &winit::Window,
 ) -> Result<vk::SurfaceKHR, vk::Result> {
+    use winapi::shared::windef::HWND;
+    use winapi::um::winuser::GetWindow;
     use winit::os::windows::WindowExt;
-    let hwnd = window.get_hwnd() as *mut winapi::windef::HWND__;
-    let hinstance = user32::GetWindow(hwnd, 0) as *const vk::c_void;
+
+    let hwnd = window.get_hwnd() as HWND;
+    let hinstance = GetWindow(hwnd, 0) as *const vk::c_void;
     let win32_create_info = vk::Win32SurfaceCreateInfoKHR {
         s_type: vk::StructureType::Win32SurfaceCreateInfoKhr,
         p_next: ptr::null(),


### PR DESCRIPTION
The upgrade to winapi 0.3.x turned out to be super easy, and changing to winit 0.11 didn't appear to break anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/49)
<!-- Reviewable:end -->
