### PR TITLE
Add first_scissor to cmd_set_scissor

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -685,10 +685,15 @@ pub trait DeviceV1_0 {
             .cmd_bind_pipeline(command_buffer, pipeline_bind_point, pipeline);
     }
 
-    unsafe fn cmd_set_scissor(&self, command_buffer: vk::CommandBuffer, scissors: &[vk::Rect2D]) {
+    unsafe fn cmd_set_scissor(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        first_scissor: vk::uint32_t,
+        scissors: &[vk::Rect2D],
+    ) {
         self.fp_v1_0().cmd_set_scissor(
             command_buffer,
-            0,
+            first_scissor,
             scissors.len() as vk::uint32_t,
             scissors.as_ptr(),
         );

--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -910,7 +910,7 @@ fn main() {
                                          vk::PipelineBindPoint::Graphics,
                                          graphic_pipeline);
                 device.cmd_set_viewport(draw_command_buffer, 0, &viewports);
-                device.cmd_set_scissor(draw_command_buffer, &scissors);
+                device.cmd_set_scissor(draw_command_buffer, 0, &scissors);
                 device
                     .cmd_bind_vertex_buffers(draw_command_buffer, 0, &[vertex_input_buffer], &[0]);
                 device.cmd_bind_index_buffer(draw_command_buffer,

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -510,7 +510,7 @@ fn main() {
                         graphic_pipeline,
                     );
                     device.cmd_set_viewport(draw_command_buffer, 0, &viewports);
-                    device.cmd_set_scissor(draw_command_buffer, &scissors);
+                    device.cmd_set_scissor(draw_command_buffer, 0, &scissors);
                     device.cmd_bind_vertex_buffers(
                         draw_command_buffer,
                         0,


### PR DESCRIPTION
(Sorry for opening the previous issue, didn't realize it would be this simple to fix)

Adds the `first_scissor` parameter that was previously missing from `DeviceV1_0` and update the examples to reflect that. Next version bump should be 0.19.0 since this is breaking, naturally.

Resolves #57

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/58)
<!-- Reviewable:end -->
