### PR TITLE
Fix example debug callback return value

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -162,7 +162,7 @@ unsafe extern "system" fn vulkan_debug_callback(
     _: *mut vk::c_void,
 ) -> u32 {
     println!("{:?}", CStr::from_ptr(p_message));
-    1
+    vk::VK_FALSE
 }
 
 pub fn find_memorytype_index(


### PR DESCRIPTION
Vulkan 1.1 §33.3:
> The application should always return VK_FALSE. The VK_TRUE value is reserved for
use in layer development.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/66)
<!-- Reviewable:end -->
