### PR TITLE
Make examples work on macOS using LunarG SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ Displays a triangle with vertex colors.
 cd examples
 cargo run --bin triangle
 ```
+#### macOS
+Install the [LunarG Vulkan SDK](https://lunarg.com/vulkan-sdk/). This basically entails extracting the downloaded tarball to any location you choose and then setting a few environment variables. Specifically, if `SDK_PATH` is set to the root extracted SDK directory,
+
+* `DYLD_LIBRARY_PATH = $SDK_PATH/macOS/lib`
+* `VK_ICD_FILENAMES = $SDK_PATH/macOS/etc/vulkan/icd.d/MoltenVK_icd.json`
+* `VK_LAYER_PATH = $SDK_PATH/macOS/etc/vulkan/explicit_layer.d`
 
 ![screenshot](http://i.imgur.com/PQZcL6w.jpg)
 

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -19,8 +19,11 @@ const LIB_PATH: &'static str = "libvulkan.so.1";
 #[cfg(target_os = "android")]
 const LIB_PATH: &'static str = "libvulkan.so";
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_os = "macos")]
 const LIB_PATH: &'static str = "libvulkan.1.dylib";
+
+#[cfg(target_os = "ios")]
+const LIB_PATH: &'static str = "libMoltenVK.dylib";
 
 lazy_static!{
     static ref VK_LIB: Result<DynamicLibrary, String> = DynamicLibrary::open(Some(&Path::new(LIB_PATH)));

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -20,7 +20,7 @@ const LIB_PATH: &'static str = "libvulkan.so.1";
 const LIB_PATH: &'static str = "libvulkan.so";
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-const LIB_PATH: &'static str = "libMoltenVK.dylib";
+const LIB_PATH: &'static str = "libvulkan.1.dylib";
 
 lazy_static!{
     static ref VK_LIB: Result<DynamicLibrary, String> = DynamicLibrary::open(Some(&Path::new(LIB_PATH)));

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,3 +10,8 @@ ash = { path = "../ash" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.4", features = ["windef", "winuser"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+metal-rs = "0.6"
+cocoa = "0.13"
+objc = "0.2.2"

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -338,16 +338,11 @@ impl ExampleBase {
             let app_name = CString::new("VulkanTriangle").unwrap();
             let raw_name = app_name.as_ptr();
 
-            // MoltenVK does not support LunarG validation layer
-            // #[cfg(not(target_os = "macos"))]
             let layer_names = [CString::new("VK_LAYER_LUNARG_standard_validation").unwrap()];
-            // #[cfg(not(target_os = "macos"))]
             let layers_names_raw: Vec<*const i8> = layer_names
                 .iter()
                 .map(|raw_name| raw_name.as_ptr())
                 .collect();
-            // #[cfg(target_os = "macos")]
-            // let layers_names_raw: Vec<*const i8> = Vec::new();
 
             let extension_names_raw = extension_names();
             let appinfo = vk::ApplicationInfo {


### PR DESCRIPTION
Basically, fixes #51 and brings in some of the kind of the macOS specific doohickeys needed to get a surface to draw on when using MoltenVK. The examples now work on macOS out of the box (after installing the LunarG SDK) 🎉

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/69)
<!-- Reviewable:end -->
