### PR TITLE
Export Vulkan 1.1 traits

### DIFF
--- a/ash/src/version.rs
+++ b/ash/src/version.rs
@@ -1,6 +1,6 @@
-pub use device::DeviceV1_0;
+pub use device::{DeviceV1_0, DeviceV1_1};
 pub use entry::EntryV1_0;
-pub use instance::InstanceV1_0;
+pub use instance::{InstanceV1_0, InstanceV1_1};
 use std::mem;
 use vk;
 pub trait FunctionPointers {


### PR DESCRIPTION
While the traits for Instance / Device 1_1 were added, they were not visible outside of the crate (they are public in the modules `instance` and `device`, but those modules themselves are private).

This pull request re-exports them in the `version` module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/107)
<!-- Reviewable:end -->
