### PR TITLE
Make `enumerate_instance_version` an `Entry` function

### DIFF
--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -170,3 +170,17 @@ impl<V: FunctionPointers> Entry<V> {
         })
     }
 }
+
+#[allow(non_camel_case_types)]
+pub trait EntryV1_1: EntryV1_0 {
+    fn fp_v1_1(&self) -> &vk::EntryFnV1_1;
+
+    unsafe fn enumerate_instance_version(&self) -> VkResult<vk::uint32_t> {
+        let mut api_version = mem::uninitialized();
+        let err_code = self.fp_v1_1().enumerate_instance_version(&mut api_version);
+        match err_code {
+            vk::Result::SUCCESS => Ok(api_version),
+            _ => Err(err_code),
+        }
+    }
+}

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::mem;
 use std::path::Path;
 use std::ptr;
-use version::{EntryLoader, FunctionPointers, InstanceLoader, V1_0};
+use version::{EntryLoader, FunctionPointers, InstanceLoader, V1_0, V1_1};
 use vk;
 use RawPtr;
 
@@ -147,6 +147,22 @@ impl EntryV1_0 for Entry<V1_0> {
     }
     fn static_fn(&self) -> &vk::StaticFn {
         &self.static_fn
+    }
+}
+
+impl EntryV1_0 for Entry<V1_1> {
+    type Fp = V1_1;
+    fn fp_v1_0(&self) -> &vk::EntryFnV1_0 {
+        self.entry_fn.fp_v1_0()
+    }
+    fn static_fn(&self) -> &vk::StaticFn {
+        &self.static_fn
+    }
+}
+
+impl EntryV1_1 for Entry<V1_1> {
+    fn fp_v1_1(&self) -> &vk::EntryFnV1_1 {
+        &self.entry_fn.entry_fn_1_1
     }
 }
 

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -191,12 +191,14 @@ impl<V: FunctionPointers> Entry<V> {
 pub trait EntryV1_1: EntryV1_0 {
     fn fp_v1_1(&self) -> &vk::EntryFnV1_1;
 
-    unsafe fn enumerate_instance_version(&self) -> VkResult<vk::uint32_t> {
-        let mut api_version = mem::uninitialized();
-        let err_code = self.fp_v1_1().enumerate_instance_version(&mut api_version);
-        match err_code {
-            vk::Result::SUCCESS => Ok(api_version),
-            _ => Err(err_code),
+    fn enumerate_instance_version(&self) -> VkResult<vk::uint32_t> {
+        unsafe {
+            let mut api_version = 0;
+            let err_code = self.fp_v1_1().enumerate_instance_version(&mut api_version);
+            match err_code {
+                vk::Result::SUCCESS => Ok(api_version),
+                _ => Err(err_code),
+            }
         }
     }
 }

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -86,15 +86,6 @@ impl<V: FunctionPointers> Instance<V> {
 pub trait InstanceV1_1: InstanceV1_0 {
     fn fp_v1_1(&self) -> &vk::InstanceFnV1_1;
 
-    unsafe fn enumerate_instance_version(&self) -> VkResult<vk::uint32_t> {
-        let mut api_version = mem::uninitialized();
-        let err_code = self.fp_v1_1().enumerate_instance_version(&mut api_version);
-        match err_code {
-            vk::Result::SUCCESS => Ok(api_version),
-            _ => Err(err_code),
-        }
-    }
-
     fn enumerate_physical_device_groups(&self) -> VkResult<Vec<vk::PhysicalDeviceGroupProperties>> {
         unsafe {
             let mut group_count = mem::uninitialized();

--- a/ash/src/version.rs
+++ b/ash/src/version.rs
@@ -15,7 +15,7 @@ pub struct V1_1;
 impl FunctionPointers for V1_1 {
     type InstanceFp = InstanceFpV1_1;
     type DeviceFp = DeviceFpV1_1;
-    type EntryFp = EntryFpV1_0;
+    type EntryFp = EntryFpV1_1;
 }
 
 #[allow(non_camel_case_types)]
@@ -48,6 +48,32 @@ impl EntryLoader for EntryFpV1_0 {
 pub trait EntryLoader: Sized {
     fn fp_v1_0(&self) -> &vk::EntryFnV1_0;
     unsafe fn load(static_fn: &vk::StaticFn) -> Result<Self, Vec<&'static str>>;
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Clone)]
+pub struct EntryFpV1_1 {
+    pub entry_fn_1_0: vk::EntryFnV1_0,
+    pub entry_fn_1_1: vk::EntryFnV1_1,
+}
+
+impl EntryLoader for EntryFpV1_1 {
+    fn fp_v1_0(&self) -> &vk::EntryFnV1_0 {
+        &self.entry_fn_1_0
+    }
+    unsafe fn load(static_fn: &vk::StaticFn) -> Result<Self, Vec<&'static str>> {
+        let entry_fn_1_0 = vk::EntryFnV1_0::load(|name| {
+            mem::transmute(static_fn.get_instance_proc_addr(vk::Instance::null(), name.as_ptr()))
+        })?;
+        let entry_fn_1_1 = vk::EntryFnV1_1::load(|name| {
+            mem::transmute(static_fn.get_instance_proc_addr(vk::Instance::null(), name.as_ptr()))
+        })?;
+
+        Ok(EntryFpV1_1 {
+            entry_fn_1_0,
+            entry_fn_1_1,
+        })
+    }
 }
 
 pub trait InstanceLoader: Sized {

--- a/ash/src/version.rs
+++ b/ash/src/version.rs
@@ -1,5 +1,5 @@
 pub use device::{DeviceV1_0, DeviceV1_1};
-pub use entry::EntryV1_0;
+pub use entry::{EntryV1_0, EntryV1_1};
 pub use instance::{InstanceV1_0, InstanceV1_1};
 use std::mem;
 use vk;

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -3844,12 +3844,16 @@ impl DeviceFnV1_0 {
         (self.cmd_execute_commands)(command_buffer, command_buffer_count, p_command_buffers)
     }
 }
-pub struct EntryFnV1_1 {}
+pub struct EntryFnV1_1 {
+    enumerate_instance_version: extern "system" fn(p_api_version: *mut uint32_t) -> Result,
+}
 unsafe impl Send for EntryFnV1_1 {}
 unsafe impl Sync for EntryFnV1_1 {}
 impl ::std::clone::Clone for EntryFnV1_1 {
     fn clone(&self) -> Self {
-        EntryFnV1_1 {}
+        EntryFnV1_1 {
+            enumerate_instance_version: self.enumerate_instance_version,
+        }
     }
 }
 impl EntryFnV1_1 {
@@ -3858,16 +3862,28 @@ impl EntryFnV1_1 {
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
         let mut _err_str = Vec::new();
-        let s = EntryFnV1_1 {};
+        let s = EntryFnV1_1 {
+            enumerate_instance_version: unsafe {
+                let raw_name = stringify!(vkEnumerateInstanceVersion);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    _err_str.push(raw_name);
+                }
+                ::std::mem::transmute(val)
+            },
+        };
         if _err_str.is_empty() {
             Ok(s)
         } else {
             Err(_err_str)
         }
     }
+    pub unsafe fn enumerate_instance_version(&self, p_api_version: *mut uint32_t) -> Result {
+        (self.enumerate_instance_version)(p_api_version)
+    }
 }
 pub struct InstanceFnV1_1 {
-    enumerate_instance_version: extern "system" fn(p_api_version: *mut uint32_t) -> Result,
     enumerate_physical_device_groups:
         extern "system" fn(
             instance: Instance,
@@ -3937,7 +3953,6 @@ unsafe impl Sync for InstanceFnV1_1 {}
 impl ::std::clone::Clone for InstanceFnV1_1 {
     fn clone(&self) -> Self {
         InstanceFnV1_1 {
-            enumerate_instance_version: self.enumerate_instance_version,
             enumerate_physical_device_groups: self.enumerate_physical_device_groups,
             get_physical_device_features2: self.get_physical_device_features2,
             get_physical_device_properties2: self.get_physical_device_properties2,
@@ -3965,15 +3980,6 @@ impl InstanceFnV1_1 {
     {
         let mut _err_str = Vec::new();
         let s = InstanceFnV1_1 {
-            enumerate_instance_version: unsafe {
-                let raw_name = stringify!(vkEnumerateInstanceVersion);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
-                if val.is_null() {
-                    _err_str.push(raw_name);
-                }
-                ::std::mem::transmute(val)
-            },
             enumerate_physical_device_groups: unsafe {
                 let raw_name = stringify!(vkEnumeratePhysicalDeviceGroups);
                 let cname = ::std::ffi::CString::new(raw_name).unwrap();
@@ -4079,9 +4085,6 @@ impl InstanceFnV1_1 {
         } else {
             Err(_err_str)
         }
-    }
-    pub unsafe fn enumerate_instance_version(&self, p_api_version: *mut uint32_t) -> Result {
-        (self.enumerate_instance_version)(p_api_version)
     }
     pub unsafe fn enumerate_physical_device_groups(
         &self,

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -540,7 +540,8 @@ impl CommandExt for vkxml::Command {
             "vkGetInstanceProcAddr" => FunctionType::Static,
             "vkCreateInstance"
             | "vkEnumerateInstanceLayerProperties"
-            | "vkEnumerateInstanceExtensionProperties" => FunctionType::Entry,
+            | "vkEnumerateInstanceExtensionProperties"
+            | "vkEnumerateInstanceVersion" => FunctionType::Entry,
             // This is actually not a device level function
             "vkGetDeviceProcAddr" => FunctionType::Instance,
             _ => {


### PR DESCRIPTION
`enumerate_instance_version` is a function meant to be called before instance creation. This pull request moves its function pointer to `Entry`.

~~Also adds the `EntryV1_1` trait. I have not added any other functions to the trait yet, so as per [this comment](https://github.com/MaikKlein/ash/issues/52#issuecomment-412281719) it is not currently possible to create a 1.1 instance safely.~~
Nevermind, I tested this and it works. The issue mentioned in the comment is fixed now. Ash now basically has Vulkan 1.1 support, although there still are some issues remaining.

**Note**: ~~do we want this function to be marked as `unsafe`? It seems pretty safe to me.~~
It's been made safe.

Fixes #103.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/108)
<!-- Reviewable:end -->
