### PR TITLE
Default trait: set pointers to std::ptr::null()/null_mut()

### DIFF
--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -4945,7 +4945,7 @@ impl ::std::default::Default for BaseOutStructure {
     fn default() -> BaseOutStructure {
         BaseOutStructure {
             s_type: unsafe { ::std::mem::zeroed() },
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
         }
     }
 }
@@ -4959,7 +4959,7 @@ impl ::std::default::Default for BaseInStructure {
     fn default() -> BaseInStructure {
         BaseInStructure {
             s_type: unsafe { ::std::mem::zeroed() },
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
         }
     }
 }
@@ -5138,10 +5138,10 @@ impl ::std::default::Default for ApplicationInfo {
     fn default() -> ApplicationInfo {
         ApplicationInfo {
             s_type: StructureType::APPLICATION_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
-            p_application_name: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
+            p_application_name: ::std::ptr::null(),
             application_version: uint32_t::default(),
-            p_engine_name: unsafe { ::std::mem::zeroed() },
+            p_engine_name: ::std::ptr::null(),
             engine_version: uint32_t::default(),
             api_version: uint32_t::default(),
         }
@@ -5175,7 +5175,7 @@ impl ::std::fmt::Debug for AllocationCallbacks {
 impl ::std::default::Default for AllocationCallbacks {
     fn default() -> AllocationCallbacks {
         AllocationCallbacks {
-            p_user_data: unsafe { ::std::mem::zeroed() },
+            p_user_data: ::std::ptr::null_mut(),
             pfn_allocation: unsafe { ::std::mem::zeroed() },
             pfn_reallocation: unsafe { ::std::mem::zeroed() },
             pfn_free: unsafe { ::std::mem::zeroed() },
@@ -5198,11 +5198,11 @@ impl ::std::default::Default for DeviceQueueCreateInfo {
     fn default() -> DeviceQueueCreateInfo {
         DeviceQueueCreateInfo {
             s_type: StructureType::DEVICE_QUEUE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DeviceQueueCreateFlags::default(),
             queue_family_index: uint32_t::default(),
             queue_count: uint32_t::default(),
-            p_queue_priorities: unsafe { ::std::mem::zeroed() },
+            p_queue_priorities: ::std::ptr::null(),
         }
     }
 }
@@ -5224,15 +5224,15 @@ impl ::std::default::Default for DeviceCreateInfo {
     fn default() -> DeviceCreateInfo {
         DeviceCreateInfo {
             s_type: StructureType::DEVICE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DeviceCreateFlags::default(),
             queue_create_info_count: uint32_t::default(),
-            p_queue_create_infos: unsafe { ::std::mem::zeroed() },
+            p_queue_create_infos: ::std::ptr::null(),
             enabled_layer_count: uint32_t::default(),
-            pp_enabled_layer_names: unsafe { ::std::mem::zeroed() },
+            pp_enabled_layer_names: ::std::ptr::null(),
             enabled_extension_count: uint32_t::default(),
-            pp_enabled_extension_names: unsafe { ::std::mem::zeroed() },
-            p_enabled_features: unsafe { ::std::mem::zeroed() },
+            pp_enabled_extension_names: ::std::ptr::null(),
+            p_enabled_features: ::std::ptr::null(),
         }
     }
 }
@@ -5252,13 +5252,13 @@ impl ::std::default::Default for InstanceCreateInfo {
     fn default() -> InstanceCreateInfo {
         InstanceCreateInfo {
             s_type: StructureType::INSTANCE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: InstanceCreateFlags::default(),
-            p_application_info: unsafe { ::std::mem::zeroed() },
+            p_application_info: ::std::ptr::null(),
             enabled_layer_count: uint32_t::default(),
-            pp_enabled_layer_names: unsafe { ::std::mem::zeroed() },
+            pp_enabled_layer_names: ::std::ptr::null(),
             enabled_extension_count: uint32_t::default(),
-            pp_enabled_extension_names: unsafe { ::std::mem::zeroed() },
+            pp_enabled_extension_names: ::std::ptr::null(),
         }
     }
 }
@@ -5314,7 +5314,7 @@ impl ::std::default::Default for MemoryAllocateInfo {
     fn default() -> MemoryAllocateInfo {
         MemoryAllocateInfo {
             s_type: StructureType::MEMORY_ALLOCATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             allocation_size: DeviceSize::default(),
             memory_type_index: uint32_t::default(),
         }
@@ -5368,7 +5368,7 @@ impl ::std::default::Default for MappedMemoryRange {
     fn default() -> MappedMemoryRange {
         MappedMemoryRange {
             s_type: StructureType::MAPPED_MEMORY_RANGE,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             memory: DeviceMemory::default(),
             offset: DeviceSize::default(),
             size: DeviceSize::default(),
@@ -5423,15 +5423,15 @@ impl ::std::default::Default for WriteDescriptorSet {
     fn default() -> WriteDescriptorSet {
         WriteDescriptorSet {
             s_type: StructureType::WRITE_DESCRIPTOR_SET,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             dst_set: DescriptorSet::default(),
             dst_binding: uint32_t::default(),
             dst_array_element: uint32_t::default(),
             descriptor_count: uint32_t::default(),
             descriptor_type: DescriptorType::default(),
-            p_image_info: unsafe { ::std::mem::zeroed() },
-            p_buffer_info: unsafe { ::std::mem::zeroed() },
-            p_texel_buffer_view: unsafe { ::std::mem::zeroed() },
+            p_image_info: ::std::ptr::null(),
+            p_buffer_info: ::std::ptr::null(),
+            p_texel_buffer_view: ::std::ptr::null(),
         }
     }
 }
@@ -5452,7 +5452,7 @@ impl ::std::default::Default for CopyDescriptorSet {
     fn default() -> CopyDescriptorSet {
         CopyDescriptorSet {
             s_type: StructureType::COPY_DESCRIPTOR_SET,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             src_set: DescriptorSet::default(),
             src_binding: uint32_t::default(),
             src_array_element: uint32_t::default(),
@@ -5479,13 +5479,13 @@ impl ::std::default::Default for BufferCreateInfo {
     fn default() -> BufferCreateInfo {
         BufferCreateInfo {
             s_type: StructureType::BUFFER_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: BufferCreateFlags::default(),
             size: DeviceSize::default(),
             usage: BufferUsageFlags::default(),
             sharing_mode: SharingMode::default(),
             queue_family_index_count: uint32_t::default(),
-            p_queue_family_indices: unsafe { ::std::mem::zeroed() },
+            p_queue_family_indices: ::std::ptr::null(),
         }
     }
 }
@@ -5504,7 +5504,7 @@ impl ::std::default::Default for BufferViewCreateInfo {
     fn default() -> BufferViewCreateInfo {
         BufferViewCreateInfo {
             s_type: StructureType::BUFFER_VIEW_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: BufferViewCreateFlags::default(),
             buffer: Buffer::default(),
             format: Format::default(),
@@ -5549,7 +5549,7 @@ impl ::std::default::Default for MemoryBarrier {
     fn default() -> MemoryBarrier {
         MemoryBarrier {
             s_type: StructureType::MEMORY_BARRIER,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             src_access_mask: AccessFlags::default(),
             dst_access_mask: AccessFlags::default(),
         }
@@ -5572,7 +5572,7 @@ impl ::std::default::Default for BufferMemoryBarrier {
     fn default() -> BufferMemoryBarrier {
         BufferMemoryBarrier {
             s_type: StructureType::BUFFER_MEMORY_BARRIER,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             src_access_mask: AccessFlags::default(),
             dst_access_mask: AccessFlags::default(),
             src_queue_family_index: uint32_t::default(),
@@ -5601,7 +5601,7 @@ impl ::std::default::Default for ImageMemoryBarrier {
     fn default() -> ImageMemoryBarrier {
         ImageMemoryBarrier {
             s_type: StructureType::IMAGE_MEMORY_BARRIER,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             src_access_mask: AccessFlags::default(),
             dst_access_mask: AccessFlags::default(),
             old_layout: ImageLayout::default(),
@@ -5636,7 +5636,7 @@ impl ::std::default::Default for ImageCreateInfo {
     fn default() -> ImageCreateInfo {
         ImageCreateInfo {
             s_type: StructureType::IMAGE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: ImageCreateFlags::default(),
             image_type: ImageType::default(),
             format: Format::default(),
@@ -5648,7 +5648,7 @@ impl ::std::default::Default for ImageCreateInfo {
             usage: ImageUsageFlags::default(),
             sharing_mode: SharingMode::default(),
             queue_family_index_count: uint32_t::default(),
-            p_queue_family_indices: unsafe { ::std::mem::zeroed() },
+            p_queue_family_indices: ::std::ptr::null(),
             initial_layout: ImageLayout::default(),
         }
     }
@@ -5678,7 +5678,7 @@ impl ::std::default::Default for ImageViewCreateInfo {
     fn default() -> ImageViewCreateInfo {
         ImageViewCreateInfo {
             s_type: StructureType::IMAGE_VIEW_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: ImageViewCreateFlags::default(),
             image: Image::default(),
             view_type: ImageViewType::default(),
@@ -5726,7 +5726,7 @@ impl ::std::default::Default for SparseBufferMemoryBindInfo {
         SparseBufferMemoryBindInfo {
             buffer: Buffer::default(),
             bind_count: uint32_t::default(),
-            p_binds: unsafe { ::std::mem::zeroed() },
+            p_binds: ::std::ptr::null(),
         }
     }
 }
@@ -5742,7 +5742,7 @@ impl ::std::default::Default for SparseImageOpaqueMemoryBindInfo {
         SparseImageOpaqueMemoryBindInfo {
             image: Image::default(),
             bind_count: uint32_t::default(),
-            p_binds: unsafe { ::std::mem::zeroed() },
+            p_binds: ::std::ptr::null(),
         }
     }
 }
@@ -5758,7 +5758,7 @@ impl ::std::default::Default for SparseImageMemoryBindInfo {
         SparseImageMemoryBindInfo {
             image: Image::default(),
             bind_count: uint32_t::default(),
-            p_binds: unsafe { ::std::mem::zeroed() },
+            p_binds: ::std::ptr::null(),
         }
     }
 }
@@ -5782,17 +5782,17 @@ impl ::std::default::Default for BindSparseInfo {
     fn default() -> BindSparseInfo {
         BindSparseInfo {
             s_type: StructureType::BIND_SPARSE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             wait_semaphore_count: uint32_t::default(),
-            p_wait_semaphores: unsafe { ::std::mem::zeroed() },
+            p_wait_semaphores: ::std::ptr::null(),
             buffer_bind_count: uint32_t::default(),
-            p_buffer_binds: unsafe { ::std::mem::zeroed() },
+            p_buffer_binds: ::std::ptr::null(),
             image_opaque_bind_count: uint32_t::default(),
-            p_image_opaque_binds: unsafe { ::std::mem::zeroed() },
+            p_image_opaque_binds: ::std::ptr::null(),
             image_bind_count: uint32_t::default(),
-            p_image_binds: unsafe { ::std::mem::zeroed() },
+            p_image_binds: ::std::ptr::null(),
             signal_semaphore_count: uint32_t::default(),
-            p_signal_semaphores: unsafe { ::std::mem::zeroed() },
+            p_signal_semaphores: ::std::ptr::null(),
         }
     }
 }
@@ -5869,10 +5869,10 @@ impl ::std::default::Default for ShaderModuleCreateInfo {
     fn default() -> ShaderModuleCreateInfo {
         ShaderModuleCreateInfo {
             s_type: StructureType::SHADER_MODULE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: ShaderModuleCreateFlags::default(),
             code_size: size_t::default(),
-            p_code: unsafe { ::std::mem::zeroed() },
+            p_code: ::std::ptr::null(),
         }
     }
 }
@@ -5892,7 +5892,7 @@ impl ::std::default::Default for DescriptorSetLayoutBinding {
             descriptor_type: DescriptorType::default(),
             descriptor_count: uint32_t::default(),
             stage_flags: ShaderStageFlags::default(),
-            p_immutable_samplers: unsafe { ::std::mem::zeroed() },
+            p_immutable_samplers: ::std::ptr::null(),
         }
     }
 }
@@ -5909,10 +5909,10 @@ impl ::std::default::Default for DescriptorSetLayoutCreateInfo {
     fn default() -> DescriptorSetLayoutCreateInfo {
         DescriptorSetLayoutCreateInfo {
             s_type: StructureType::DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DescriptorSetLayoutCreateFlags::default(),
             binding_count: uint32_t::default(),
-            p_bindings: unsafe { ::std::mem::zeroed() },
+            p_bindings: ::std::ptr::null(),
         }
     }
 }
@@ -5936,11 +5936,11 @@ impl ::std::default::Default for DescriptorPoolCreateInfo {
     fn default() -> DescriptorPoolCreateInfo {
         DescriptorPoolCreateInfo {
             s_type: StructureType::DESCRIPTOR_POOL_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DescriptorPoolCreateFlags::default(),
             max_sets: uint32_t::default(),
             pool_size_count: uint32_t::default(),
-            p_pool_sizes: unsafe { ::std::mem::zeroed() },
+            p_pool_sizes: ::std::ptr::null(),
         }
     }
 }
@@ -5957,10 +5957,10 @@ impl ::std::default::Default for DescriptorSetAllocateInfo {
     fn default() -> DescriptorSetAllocateInfo {
         DescriptorSetAllocateInfo {
             s_type: StructureType::DESCRIPTOR_SET_ALLOCATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             descriptor_pool: DescriptorPool::default(),
             descriptor_set_count: uint32_t::default(),
-            p_set_layouts: unsafe { ::std::mem::zeroed() },
+            p_set_layouts: ::std::ptr::null(),
         }
     }
 }
@@ -5983,9 +5983,9 @@ impl ::std::default::Default for SpecializationInfo {
     fn default() -> SpecializationInfo {
         SpecializationInfo {
             map_entry_count: uint32_t::default(),
-            p_map_entries: unsafe { ::std::mem::zeroed() },
+            p_map_entries: ::std::ptr::null(),
             data_size: size_t::default(),
-            p_data: unsafe { ::std::mem::zeroed() },
+            p_data: ::std::ptr::null(),
         }
     }
 }
@@ -6004,12 +6004,12 @@ impl ::std::default::Default for PipelineShaderStageCreateInfo {
     fn default() -> PipelineShaderStageCreateInfo {
         PipelineShaderStageCreateInfo {
             s_type: StructureType::PIPELINE_SHADER_STAGE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineShaderStageCreateFlags::default(),
             stage: ShaderStageFlags::default(),
             module: ShaderModule::default(),
-            p_name: unsafe { ::std::mem::zeroed() },
-            p_specialization_info: unsafe { ::std::mem::zeroed() },
+            p_name: ::std::ptr::null(),
+            p_specialization_info: ::std::ptr::null(),
         }
     }
 }
@@ -6028,7 +6028,7 @@ impl ::std::default::Default for ComputePipelineCreateInfo {
     fn default() -> ComputePipelineCreateInfo {
         ComputePipelineCreateInfo {
             s_type: StructureType::COMPUTE_PIPELINE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineCreateFlags::default(),
             stage: PipelineShaderStageCreateInfo::default(),
             layout: PipelineLayout::default(),
@@ -6067,12 +6067,12 @@ impl ::std::default::Default for PipelineVertexInputStateCreateInfo {
     fn default() -> PipelineVertexInputStateCreateInfo {
         PipelineVertexInputStateCreateInfo {
             s_type: StructureType::PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineVertexInputStateCreateFlags::default(),
             vertex_binding_description_count: uint32_t::default(),
-            p_vertex_binding_descriptions: unsafe { ::std::mem::zeroed() },
+            p_vertex_binding_descriptions: ::std::ptr::null(),
             vertex_attribute_description_count: uint32_t::default(),
-            p_vertex_attribute_descriptions: unsafe { ::std::mem::zeroed() },
+            p_vertex_attribute_descriptions: ::std::ptr::null(),
         }
     }
 }
@@ -6089,7 +6089,7 @@ impl ::std::default::Default for PipelineInputAssemblyStateCreateInfo {
     fn default() -> PipelineInputAssemblyStateCreateInfo {
         PipelineInputAssemblyStateCreateInfo {
             s_type: StructureType::PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineInputAssemblyStateCreateFlags::default(),
             topology: PrimitiveTopology::default(),
             primitive_restart_enable: Bool32::default(),
@@ -6108,7 +6108,7 @@ impl ::std::default::Default for PipelineTessellationStateCreateInfo {
     fn default() -> PipelineTessellationStateCreateInfo {
         PipelineTessellationStateCreateInfo {
             s_type: StructureType::PIPELINE_TESSELLATION_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineTessellationStateCreateFlags::default(),
             patch_control_points: uint32_t::default(),
         }
@@ -6129,12 +6129,12 @@ impl ::std::default::Default for PipelineViewportStateCreateInfo {
     fn default() -> PipelineViewportStateCreateInfo {
         PipelineViewportStateCreateInfo {
             s_type: StructureType::PIPELINE_VIEWPORT_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineViewportStateCreateFlags::default(),
             viewport_count: uint32_t::default(),
-            p_viewports: unsafe { ::std::mem::zeroed() },
+            p_viewports: ::std::ptr::null(),
             scissor_count: uint32_t::default(),
-            p_scissors: unsafe { ::std::mem::zeroed() },
+            p_scissors: ::std::ptr::null(),
         }
     }
 }
@@ -6159,7 +6159,7 @@ impl ::std::default::Default for PipelineRasterizationStateCreateInfo {
     fn default() -> PipelineRasterizationStateCreateInfo {
         PipelineRasterizationStateCreateInfo {
             s_type: StructureType::PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineRasterizationStateCreateFlags::default(),
             depth_clamp_enable: Bool32::default(),
             rasterizer_discard_enable: Bool32::default(),
@@ -6191,12 +6191,12 @@ impl ::std::default::Default for PipelineMultisampleStateCreateInfo {
     fn default() -> PipelineMultisampleStateCreateInfo {
         PipelineMultisampleStateCreateInfo {
             s_type: StructureType::PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineMultisampleStateCreateFlags::default(),
             rasterization_samples: SampleCountFlags::default(),
             sample_shading_enable: Bool32::default(),
             min_sample_shading: c_float::default(),
-            p_sample_mask: unsafe { ::std::mem::zeroed() },
+            p_sample_mask: ::std::ptr::null(),
             alpha_to_coverage_enable: Bool32::default(),
             alpha_to_one_enable: Bool32::default(),
         }
@@ -6246,12 +6246,12 @@ impl ::std::default::Default for PipelineColorBlendStateCreateInfo {
     fn default() -> PipelineColorBlendStateCreateInfo {
         PipelineColorBlendStateCreateInfo {
             s_type: StructureType::PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineColorBlendStateCreateFlags::default(),
             logic_op_enable: Bool32::default(),
             logic_op: LogicOp::default(),
             attachment_count: uint32_t::default(),
-            p_attachments: unsafe { ::std::mem::zeroed() },
+            p_attachments: ::std::ptr::null(),
             blend_constants: unsafe { ::std::mem::zeroed() },
         }
     }
@@ -6269,10 +6269,10 @@ impl ::std::default::Default for PipelineDynamicStateCreateInfo {
     fn default() -> PipelineDynamicStateCreateInfo {
         PipelineDynamicStateCreateInfo {
             s_type: StructureType::PIPELINE_DYNAMIC_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineDynamicStateCreateFlags::default(),
             dynamic_state_count: uint32_t::default(),
-            p_dynamic_states: unsafe { ::std::mem::zeroed() },
+            p_dynamic_states: ::std::ptr::null(),
         }
     }
 }
@@ -6307,7 +6307,7 @@ impl ::std::default::Default for PipelineDepthStencilStateCreateInfo {
     fn default() -> PipelineDepthStencilStateCreateInfo {
         PipelineDepthStencilStateCreateInfo {
             s_type: StructureType::PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineDepthStencilStateCreateFlags::default(),
             depth_test_enable: Bool32::default(),
             depth_write_enable: Bool32::default(),
@@ -6348,19 +6348,19 @@ impl ::std::default::Default for GraphicsPipelineCreateInfo {
     fn default() -> GraphicsPipelineCreateInfo {
         GraphicsPipelineCreateInfo {
             s_type: StructureType::GRAPHICS_PIPELINE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineCreateFlags::default(),
             stage_count: uint32_t::default(),
-            p_stages: unsafe { ::std::mem::zeroed() },
-            p_vertex_input_state: unsafe { ::std::mem::zeroed() },
-            p_input_assembly_state: unsafe { ::std::mem::zeroed() },
-            p_tessellation_state: unsafe { ::std::mem::zeroed() },
-            p_viewport_state: unsafe { ::std::mem::zeroed() },
-            p_rasterization_state: unsafe { ::std::mem::zeroed() },
-            p_multisample_state: unsafe { ::std::mem::zeroed() },
-            p_depth_stencil_state: unsafe { ::std::mem::zeroed() },
-            p_color_blend_state: unsafe { ::std::mem::zeroed() },
-            p_dynamic_state: unsafe { ::std::mem::zeroed() },
+            p_stages: ::std::ptr::null(),
+            p_vertex_input_state: ::std::ptr::null(),
+            p_input_assembly_state: ::std::ptr::null(),
+            p_tessellation_state: ::std::ptr::null(),
+            p_viewport_state: ::std::ptr::null(),
+            p_rasterization_state: ::std::ptr::null(),
+            p_multisample_state: ::std::ptr::null(),
+            p_depth_stencil_state: ::std::ptr::null(),
+            p_color_blend_state: ::std::ptr::null(),
+            p_dynamic_state: ::std::ptr::null(),
             layout: PipelineLayout::default(),
             render_pass: RenderPass::default(),
             subpass: uint32_t::default(),
@@ -6382,10 +6382,10 @@ impl ::std::default::Default for PipelineCacheCreateInfo {
     fn default() -> PipelineCacheCreateInfo {
         PipelineCacheCreateInfo {
             s_type: StructureType::PIPELINE_CACHE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineCacheCreateFlags::default(),
             initial_data_size: size_t::default(),
-            p_initial_data: unsafe { ::std::mem::zeroed() },
+            p_initial_data: ::std::ptr::null(),
         }
     }
 }
@@ -6411,12 +6411,12 @@ impl ::std::default::Default for PipelineLayoutCreateInfo {
     fn default() -> PipelineLayoutCreateInfo {
         PipelineLayoutCreateInfo {
             s_type: StructureType::PIPELINE_LAYOUT_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineLayoutCreateFlags::default(),
             set_layout_count: uint32_t::default(),
-            p_set_layouts: unsafe { ::std::mem::zeroed() },
+            p_set_layouts: ::std::ptr::null(),
             push_constant_range_count: uint32_t::default(),
-            p_push_constant_ranges: unsafe { ::std::mem::zeroed() },
+            p_push_constant_ranges: ::std::ptr::null(),
         }
     }
 }
@@ -6446,7 +6446,7 @@ impl ::std::default::Default for SamplerCreateInfo {
     fn default() -> SamplerCreateInfo {
         SamplerCreateInfo {
             s_type: StructureType::SAMPLER_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: SamplerCreateFlags::default(),
             mag_filter: Filter::default(),
             min_filter: Filter::default(),
@@ -6478,7 +6478,7 @@ impl ::std::default::Default for CommandPoolCreateInfo {
     fn default() -> CommandPoolCreateInfo {
         CommandPoolCreateInfo {
             s_type: StructureType::COMMAND_POOL_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: CommandPoolCreateFlags::default(),
             queue_family_index: uint32_t::default(),
         }
@@ -6497,7 +6497,7 @@ impl ::std::default::Default for CommandBufferAllocateInfo {
     fn default() -> CommandBufferAllocateInfo {
         CommandBufferAllocateInfo {
             s_type: StructureType::COMMAND_BUFFER_ALLOCATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             command_pool: CommandPool::default(),
             level: CommandBufferLevel::default(),
             command_buffer_count: uint32_t::default(),
@@ -6520,7 +6520,7 @@ impl ::std::default::Default for CommandBufferInheritanceInfo {
     fn default() -> CommandBufferInheritanceInfo {
         CommandBufferInheritanceInfo {
             s_type: StructureType::COMMAND_BUFFER_INHERITANCE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             render_pass: RenderPass::default(),
             subpass: uint32_t::default(),
             framebuffer: Framebuffer::default(),
@@ -6542,9 +6542,9 @@ impl ::std::default::Default for CommandBufferBeginInfo {
     fn default() -> CommandBufferBeginInfo {
         CommandBufferBeginInfo {
             s_type: StructureType::COMMAND_BUFFER_BEGIN_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: CommandBufferUsageFlags::default(),
-            p_inheritance_info: unsafe { ::std::mem::zeroed() },
+            p_inheritance_info: ::std::ptr::null(),
         }
     }
 }
@@ -6576,12 +6576,12 @@ impl ::std::default::Default for RenderPassBeginInfo {
     fn default() -> RenderPassBeginInfo {
         RenderPassBeginInfo {
             s_type: StructureType::RENDER_PASS_BEGIN_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             render_pass: RenderPass::default(),
             framebuffer: Framebuffer::default(),
             render_area: Rect2D::default(),
             clear_value_count: uint32_t::default(),
-            p_clear_values: unsafe { ::std::mem::zeroed() },
+            p_clear_values: ::std::ptr::null(),
         }
     }
 }
@@ -6669,13 +6669,13 @@ impl ::std::default::Default for SubpassDescription {
             flags: SubpassDescriptionFlags::default(),
             pipeline_bind_point: PipelineBindPoint::default(),
             input_attachment_count: uint32_t::default(),
-            p_input_attachments: unsafe { ::std::mem::zeroed() },
+            p_input_attachments: ::std::ptr::null(),
             color_attachment_count: uint32_t::default(),
-            p_color_attachments: unsafe { ::std::mem::zeroed() },
-            p_resolve_attachments: unsafe { ::std::mem::zeroed() },
-            p_depth_stencil_attachment: unsafe { ::std::mem::zeroed() },
+            p_color_attachments: ::std::ptr::null(),
+            p_resolve_attachments: ::std::ptr::null(),
+            p_depth_stencil_attachment: ::std::ptr::null(),
             preserve_attachment_count: uint32_t::default(),
-            p_preserve_attachments: unsafe { ::std::mem::zeroed() },
+            p_preserve_attachments: ::std::ptr::null(),
         }
     }
 }
@@ -6707,14 +6707,14 @@ impl ::std::default::Default for RenderPassCreateInfo {
     fn default() -> RenderPassCreateInfo {
         RenderPassCreateInfo {
             s_type: StructureType::RENDER_PASS_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: RenderPassCreateFlags::default(),
             attachment_count: uint32_t::default(),
-            p_attachments: unsafe { ::std::mem::zeroed() },
+            p_attachments: ::std::ptr::null(),
             subpass_count: uint32_t::default(),
-            p_subpasses: unsafe { ::std::mem::zeroed() },
+            p_subpasses: ::std::ptr::null(),
             dependency_count: uint32_t::default(),
-            p_dependencies: unsafe { ::std::mem::zeroed() },
+            p_dependencies: ::std::ptr::null(),
         }
     }
 }
@@ -6729,7 +6729,7 @@ impl ::std::default::Default for EventCreateInfo {
     fn default() -> EventCreateInfo {
         EventCreateInfo {
             s_type: StructureType::EVENT_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: EventCreateFlags::default(),
         }
     }
@@ -6745,7 +6745,7 @@ impl ::std::default::Default for FenceCreateInfo {
     fn default() -> FenceCreateInfo {
         FenceCreateInfo {
             s_type: StructureType::FENCE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: FenceCreateFlags::default(),
         }
     }
@@ -7346,7 +7346,7 @@ impl ::std::default::Default for SemaphoreCreateInfo {
     fn default() -> SemaphoreCreateInfo {
         SemaphoreCreateInfo {
             s_type: StructureType::SEMAPHORE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: SemaphoreCreateFlags::default(),
         }
     }
@@ -7365,7 +7365,7 @@ impl ::std::default::Default for QueryPoolCreateInfo {
     fn default() -> QueryPoolCreateInfo {
         QueryPoolCreateInfo {
             s_type: StructureType::QUERY_POOL_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: QueryPoolCreateFlags::default(),
             query_type: QueryType::default(),
             query_count: uint32_t::default(),
@@ -7390,11 +7390,11 @@ impl ::std::default::Default for FramebufferCreateInfo {
     fn default() -> FramebufferCreateInfo {
         FramebufferCreateInfo {
             s_type: StructureType::FRAMEBUFFER_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: FramebufferCreateFlags::default(),
             render_pass: RenderPass::default(),
             attachment_count: uint32_t::default(),
-            p_attachments: unsafe { ::std::mem::zeroed() },
+            p_attachments: ::std::ptr::null(),
             width: uint32_t::default(),
             height: uint32_t::default(),
             layers: uint32_t::default(),
@@ -7442,14 +7442,14 @@ impl ::std::default::Default for SubmitInfo {
     fn default() -> SubmitInfo {
         SubmitInfo {
             s_type: StructureType::SUBMIT_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             wait_semaphore_count: uint32_t::default(),
-            p_wait_semaphores: unsafe { ::std::mem::zeroed() },
-            p_wait_dst_stage_mask: unsafe { ::std::mem::zeroed() },
+            p_wait_semaphores: ::std::ptr::null(),
+            p_wait_dst_stage_mask: ::std::ptr::null(),
             command_buffer_count: uint32_t::default(),
-            p_command_buffers: unsafe { ::std::mem::zeroed() },
+            p_command_buffers: ::std::ptr::null(),
             signal_semaphore_count: uint32_t::default(),
-            p_signal_semaphores: unsafe { ::std::mem::zeroed() },
+            p_signal_semaphores: ::std::ptr::null(),
         }
     }
 }
@@ -7468,7 +7468,7 @@ impl ::std::default::Default for DisplayPropertiesKHR {
     fn default() -> DisplayPropertiesKHR {
         DisplayPropertiesKHR {
             display: DisplayKHR::default(),
-            display_name: unsafe { ::std::mem::zeroed() },
+            display_name: ::std::ptr::null(),
             physical_dimensions: Extent2D::default(),
             physical_resolution: Extent2D::default(),
             supported_transforms: SurfaceTransformFlagsKHR::default(),
@@ -7507,7 +7507,7 @@ impl ::std::default::Default for DisplayModeCreateInfoKHR {
     fn default() -> DisplayModeCreateInfoKHR {
         DisplayModeCreateInfoKHR {
             s_type: StructureType::DISPLAY_MODE_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DisplayModeCreateFlagsKHR::default(),
             parameters: DisplayModeParametersKHR::default(),
         }
@@ -7544,7 +7544,7 @@ impl ::std::default::Default for DisplaySurfaceCreateInfoKHR {
     fn default() -> DisplaySurfaceCreateInfoKHR {
         DisplaySurfaceCreateInfoKHR {
             s_type: StructureType::DISPLAY_SURFACE_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DisplaySurfaceCreateFlagsKHR::default(),
             display_mode: DisplayModeKHR::default(),
             plane_index: uint32_t::default(),
@@ -7569,7 +7569,7 @@ impl ::std::default::Default for DisplayPresentInfoKHR {
     fn default() -> DisplayPresentInfoKHR {
         DisplayPresentInfoKHR {
             s_type: StructureType::DISPLAY_PRESENT_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             src_rect: Rect2D::default(),
             dst_rect: Rect2D::default(),
             persistent: Bool32::default(),
@@ -7602,9 +7602,9 @@ impl ::std::default::Default for AndroidSurfaceCreateInfoKHR {
     fn default() -> AndroidSurfaceCreateInfoKHR {
         AndroidSurfaceCreateInfoKHR {
             s_type: StructureType::ANDROID_SURFACE_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: AndroidSurfaceCreateFlagsKHR::default(),
-            window: unsafe { ::std::mem::zeroed() },
+            window: ::std::ptr::null_mut(),
         }
     }
 }
@@ -7621,10 +7621,10 @@ impl ::std::default::Default for MirSurfaceCreateInfoKHR {
     fn default() -> MirSurfaceCreateInfoKHR {
         MirSurfaceCreateInfoKHR {
             s_type: StructureType::MIR_SURFACE_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: MirSurfaceCreateFlagsKHR::default(),
-            connection: unsafe { ::std::mem::zeroed() },
-            mir_surface: unsafe { ::std::mem::zeroed() },
+            connection: ::std::ptr::null_mut(),
+            mir_surface: ::std::ptr::null_mut(),
         }
     }
 }
@@ -7640,9 +7640,9 @@ impl ::std::default::Default for ViSurfaceCreateInfoNN {
     fn default() -> ViSurfaceCreateInfoNN {
         ViSurfaceCreateInfoNN {
             s_type: StructureType::VI_SURFACE_CREATE_INFO_NN,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: ViSurfaceCreateFlagsNN::default(),
-            window: unsafe { ::std::mem::zeroed() },
+            window: ::std::ptr::null_mut(),
         }
     }
 }
@@ -7659,10 +7659,10 @@ impl ::std::default::Default for WaylandSurfaceCreateInfoKHR {
     fn default() -> WaylandSurfaceCreateInfoKHR {
         WaylandSurfaceCreateInfoKHR {
             s_type: StructureType::WAYLAND_SURFACE_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: WaylandSurfaceCreateFlagsKHR::default(),
-            display: unsafe { ::std::mem::zeroed() },
-            surface: unsafe { ::std::mem::zeroed() },
+            display: ::std::ptr::null_mut(),
+            surface: ::std::ptr::null_mut(),
         }
     }
 }
@@ -7679,7 +7679,7 @@ impl ::std::default::Default for Win32SurfaceCreateInfoKHR {
     fn default() -> Win32SurfaceCreateInfoKHR {
         Win32SurfaceCreateInfoKHR {
             s_type: StructureType::WIN32_SURFACE_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: Win32SurfaceCreateFlagsKHR::default(),
             hinstance: unsafe { ::std::mem::zeroed() },
             hwnd: unsafe { ::std::mem::zeroed() },
@@ -7699,9 +7699,9 @@ impl ::std::default::Default for XlibSurfaceCreateInfoKHR {
     fn default() -> XlibSurfaceCreateInfoKHR {
         XlibSurfaceCreateInfoKHR {
             s_type: StructureType::XLIB_SURFACE_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: XlibSurfaceCreateFlagsKHR::default(),
-            dpy: unsafe { ::std::mem::zeroed() },
+            dpy: ::std::ptr::null_mut(),
             window: Window::default(),
         }
     }
@@ -7719,9 +7719,9 @@ impl ::std::default::Default for XcbSurfaceCreateInfoKHR {
     fn default() -> XcbSurfaceCreateInfoKHR {
         XcbSurfaceCreateInfoKHR {
             s_type: StructureType::XCB_SURFACE_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: XcbSurfaceCreateFlagsKHR::default(),
-            connection: unsafe { ::std::mem::zeroed() },
+            connection: ::std::ptr::null_mut(),
             window: xcb_window_t::default(),
         }
     }
@@ -7758,7 +7758,7 @@ impl ::std::default::Default for SwapchainCreateInfoKHR {
     fn default() -> SwapchainCreateInfoKHR {
         SwapchainCreateInfoKHR {
             s_type: StructureType::SWAPCHAIN_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: SwapchainCreateFlagsKHR::default(),
             surface: SurfaceKHR::default(),
             min_image_count: uint32_t::default(),
@@ -7769,7 +7769,7 @@ impl ::std::default::Default for SwapchainCreateInfoKHR {
             image_usage: ImageUsageFlags::default(),
             image_sharing_mode: SharingMode::default(),
             queue_family_index_count: uint32_t::default(),
-            p_queue_family_indices: unsafe { ::std::mem::zeroed() },
+            p_queue_family_indices: ::std::ptr::null(),
             pre_transform: SurfaceTransformFlagsKHR::default(),
             composite_alpha: CompositeAlphaFlagsKHR::default(),
             present_mode: PresentModeKHR::default(),
@@ -7794,13 +7794,13 @@ impl ::std::default::Default for PresentInfoKHR {
     fn default() -> PresentInfoKHR {
         PresentInfoKHR {
             s_type: StructureType::PRESENT_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             wait_semaphore_count: uint32_t::default(),
-            p_wait_semaphores: unsafe { ::std::mem::zeroed() },
+            p_wait_semaphores: ::std::ptr::null(),
             swapchain_count: uint32_t::default(),
-            p_swapchains: unsafe { ::std::mem::zeroed() },
-            p_image_indices: unsafe { ::std::mem::zeroed() },
-            p_results: unsafe { ::std::mem::zeroed() },
+            p_swapchains: ::std::ptr::null(),
+            p_image_indices: ::std::ptr::null(),
+            p_results: ::std::ptr::null_mut(),
         }
     }
 }
@@ -7828,10 +7828,10 @@ impl ::std::default::Default for DebugReportCallbackCreateInfoEXT {
     fn default() -> DebugReportCallbackCreateInfoEXT {
         DebugReportCallbackCreateInfoEXT {
             s_type: StructureType::DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DebugReportFlagsEXT::default(),
             pfn_callback: unsafe { ::std::mem::zeroed() },
-            p_user_data: unsafe { ::std::mem::zeroed() },
+            p_user_data: ::std::ptr::null_mut(),
         }
     }
 }
@@ -7847,9 +7847,9 @@ impl ::std::default::Default for ValidationFlagsEXT {
     fn default() -> ValidationFlagsEXT {
         ValidationFlagsEXT {
             s_type: StructureType::VALIDATION_FLAGS_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             disabled_validation_check_count: uint32_t::default(),
-            p_disabled_validation_checks: unsafe { ::std::mem::zeroed() },
+            p_disabled_validation_checks: ::std::ptr::null_mut(),
         }
     }
 }
@@ -7864,7 +7864,7 @@ impl ::std::default::Default for PipelineRasterizationStateRasterizationOrderAMD
     fn default() -> PipelineRasterizationStateRasterizationOrderAMD {
         PipelineRasterizationStateRasterizationOrderAMD {
             s_type: StructureType::PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             rasterization_order: RasterizationOrderAMD::default(),
         }
     }
@@ -7882,10 +7882,10 @@ impl ::std::default::Default for DebugMarkerObjectNameInfoEXT {
     fn default() -> DebugMarkerObjectNameInfoEXT {
         DebugMarkerObjectNameInfoEXT {
             s_type: StructureType::DEBUG_MARKER_OBJECT_NAME_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             object_type: DebugReportObjectTypeEXT::default(),
             object: uint64_t::default(),
-            p_object_name: unsafe { ::std::mem::zeroed() },
+            p_object_name: ::std::ptr::null(),
         }
     }
 }
@@ -7904,12 +7904,12 @@ impl ::std::default::Default for DebugMarkerObjectTagInfoEXT {
     fn default() -> DebugMarkerObjectTagInfoEXT {
         DebugMarkerObjectTagInfoEXT {
             s_type: StructureType::DEBUG_MARKER_OBJECT_TAG_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             object_type: DebugReportObjectTypeEXT::default(),
             object: uint64_t::default(),
             tag_name: uint64_t::default(),
             tag_size: size_t::default(),
-            p_tag: unsafe { ::std::mem::zeroed() },
+            p_tag: ::std::ptr::null(),
         }
     }
 }
@@ -7937,8 +7937,8 @@ impl ::std::default::Default for DebugMarkerMarkerInfoEXT {
     fn default() -> DebugMarkerMarkerInfoEXT {
         DebugMarkerMarkerInfoEXT {
             s_type: StructureType::DEBUG_MARKER_MARKER_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
-            p_marker_name: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
+            p_marker_name: ::std::ptr::null(),
             color: unsafe { ::std::mem::zeroed() },
         }
     }
@@ -7954,7 +7954,7 @@ impl ::std::default::Default for DedicatedAllocationImageCreateInfoNV {
     fn default() -> DedicatedAllocationImageCreateInfoNV {
         DedicatedAllocationImageCreateInfoNV {
             s_type: StructureType::DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             dedicated_allocation: Bool32::default(),
         }
     }
@@ -7970,7 +7970,7 @@ impl ::std::default::Default for DedicatedAllocationBufferCreateInfoNV {
     fn default() -> DedicatedAllocationBufferCreateInfoNV {
         DedicatedAllocationBufferCreateInfoNV {
             s_type: StructureType::DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             dedicated_allocation: Bool32::default(),
         }
     }
@@ -7987,7 +7987,7 @@ impl ::std::default::Default for DedicatedAllocationMemoryAllocateInfoNV {
     fn default() -> DedicatedAllocationMemoryAllocateInfoNV {
         DedicatedAllocationMemoryAllocateInfoNV {
             s_type: StructureType::DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             image: Image::default(),
             buffer: Buffer::default(),
         }
@@ -8012,7 +8012,7 @@ impl ::std::default::Default for ExternalMemoryImageCreateInfoNV {
     fn default() -> ExternalMemoryImageCreateInfoNV {
         ExternalMemoryImageCreateInfoNV {
             s_type: StructureType::EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_types: ExternalMemoryHandleTypeFlagsNV::default(),
         }
     }
@@ -8028,7 +8028,7 @@ impl ::std::default::Default for ExportMemoryAllocateInfoNV {
     fn default() -> ExportMemoryAllocateInfoNV {
         ExportMemoryAllocateInfoNV {
             s_type: StructureType::EXPORT_MEMORY_ALLOCATE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_types: ExternalMemoryHandleTypeFlagsNV::default(),
         }
     }
@@ -8045,7 +8045,7 @@ impl ::std::default::Default for ImportMemoryWin32HandleInfoNV {
     fn default() -> ImportMemoryWin32HandleInfoNV {
         ImportMemoryWin32HandleInfoNV {
             s_type: StructureType::IMPORT_MEMORY_WIN32_HANDLE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_type: ExternalMemoryHandleTypeFlagsNV::default(),
             handle: unsafe { ::std::mem::zeroed() },
         }
@@ -8063,8 +8063,8 @@ impl ::std::default::Default for ExportMemoryWin32HandleInfoNV {
     fn default() -> ExportMemoryWin32HandleInfoNV {
         ExportMemoryWin32HandleInfoNV {
             s_type: StructureType::EXPORT_MEMORY_WIN32_HANDLE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
-            p_attributes: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
+            p_attributes: ::std::ptr::null(),
             dw_access: DWORD::default(),
         }
     }
@@ -8086,14 +8086,14 @@ impl ::std::default::Default for Win32KeyedMutexAcquireReleaseInfoNV {
     fn default() -> Win32KeyedMutexAcquireReleaseInfoNV {
         Win32KeyedMutexAcquireReleaseInfoNV {
             s_type: StructureType::WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             acquire_count: uint32_t::default(),
-            p_acquire_syncs: unsafe { ::std::mem::zeroed() },
-            p_acquire_keys: unsafe { ::std::mem::zeroed() },
-            p_acquire_timeout_milliseconds: unsafe { ::std::mem::zeroed() },
+            p_acquire_syncs: ::std::ptr::null(),
+            p_acquire_keys: ::std::ptr::null(),
+            p_acquire_timeout_milliseconds: ::std::ptr::null(),
             release_count: uint32_t::default(),
-            p_release_syncs: unsafe { ::std::mem::zeroed() },
-            p_release_keys: unsafe { ::std::mem::zeroed() },
+            p_release_syncs: ::std::ptr::null(),
+            p_release_keys: ::std::ptr::null(),
         }
     }
 }
@@ -8108,7 +8108,7 @@ impl ::std::default::Default for DeviceGeneratedCommandsFeaturesNVX {
     fn default() -> DeviceGeneratedCommandsFeaturesNVX {
         DeviceGeneratedCommandsFeaturesNVX {
             s_type: StructureType::DEVICE_GENERATED_COMMANDS_FEATURES_NVX,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             compute_binding_point_support: Bool32::default(),
         }
     }
@@ -8128,7 +8128,7 @@ impl ::std::default::Default for DeviceGeneratedCommandsLimitsNVX {
     fn default() -> DeviceGeneratedCommandsLimitsNVX {
         DeviceGeneratedCommandsLimitsNVX {
             s_type: StructureType::DEVICE_GENERATED_COMMANDS_LIMITS_NVX,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             max_indirect_commands_layout_token_count: uint32_t::default(),
             max_object_entry_counts: uint32_t::default(),
             min_sequence_count_buffer_offset_alignment: uint32_t::default(),
@@ -8166,11 +8166,11 @@ impl ::std::default::Default for IndirectCommandsLayoutCreateInfoNVX {
     fn default() -> IndirectCommandsLayoutCreateInfoNVX {
         IndirectCommandsLayoutCreateInfoNVX {
             s_type: StructureType::INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             pipeline_bind_point: PipelineBindPoint::default(),
             flags: IndirectCommandsLayoutUsageFlagsNVX::default(),
             token_count: uint32_t::default(),
-            p_tokens: unsafe { ::std::mem::zeroed() },
+            p_tokens: ::std::ptr::null(),
         }
     }
 }
@@ -8194,11 +8194,11 @@ impl ::std::default::Default for CmdProcessCommandsInfoNVX {
     fn default() -> CmdProcessCommandsInfoNVX {
         CmdProcessCommandsInfoNVX {
             s_type: StructureType::CMD_PROCESS_COMMANDS_INFO_NVX,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             object_table: ObjectTableNVX::default(),
             indirect_commands_layout: IndirectCommandsLayoutNVX::default(),
             indirect_commands_token_count: uint32_t::default(),
-            p_indirect_commands_tokens: unsafe { ::std::mem::zeroed() },
+            p_indirect_commands_tokens: ::std::ptr::null(),
             max_sequences_count: uint32_t::default(),
             target_command_buffer: CommandBuffer::default(),
             sequences_count_buffer: Buffer::default(),
@@ -8221,7 +8221,7 @@ impl ::std::default::Default for CmdReserveSpaceForCommandsInfoNVX {
     fn default() -> CmdReserveSpaceForCommandsInfoNVX {
         CmdReserveSpaceForCommandsInfoNVX {
             s_type: StructureType::CMD_RESERVE_SPACE_FOR_COMMANDS_INFO_NVX,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             object_table: ObjectTableNVX::default(),
             indirect_commands_layout: IndirectCommandsLayoutNVX::default(),
             max_sequences_count: uint32_t::default(),
@@ -8247,11 +8247,11 @@ impl ::std::default::Default for ObjectTableCreateInfoNVX {
     fn default() -> ObjectTableCreateInfoNVX {
         ObjectTableCreateInfoNVX {
             s_type: StructureType::OBJECT_TABLE_CREATE_INFO_NVX,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             object_count: uint32_t::default(),
-            p_object_entry_types: unsafe { ::std::mem::zeroed() },
-            p_object_entry_counts: unsafe { ::std::mem::zeroed() },
-            p_object_entry_usage_flags: unsafe { ::std::mem::zeroed() },
+            p_object_entry_types: ::std::ptr::null(),
+            p_object_entry_counts: ::std::ptr::null(),
+            p_object_entry_usage_flags: ::std::ptr::null(),
             max_uniform_buffers_per_descriptor: uint32_t::default(),
             max_storage_buffers_per_descriptor: uint32_t::default(),
             max_storage_images_per_descriptor: uint32_t::default(),
@@ -8315,7 +8315,7 @@ impl ::std::default::Default for PhysicalDeviceFeatures2 {
     fn default() -> PhysicalDeviceFeatures2 {
         PhysicalDeviceFeatures2 {
             s_type: StructureType::PHYSICAL_DEVICE_FEATURES_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             features: PhysicalDeviceFeatures::default(),
         }
     }
@@ -8331,7 +8331,7 @@ impl ::std::default::Default for PhysicalDeviceProperties2 {
     fn default() -> PhysicalDeviceProperties2 {
         PhysicalDeviceProperties2 {
             s_type: StructureType::PHYSICAL_DEVICE_PROPERTIES_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             properties: PhysicalDeviceProperties::default(),
         }
     }
@@ -8347,7 +8347,7 @@ impl ::std::default::Default for FormatProperties2 {
     fn default() -> FormatProperties2 {
         FormatProperties2 {
             s_type: StructureType::FORMAT_PROPERTIES_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             format_properties: FormatProperties::default(),
         }
     }
@@ -8363,7 +8363,7 @@ impl ::std::default::Default for ImageFormatProperties2 {
     fn default() -> ImageFormatProperties2 {
         ImageFormatProperties2 {
             s_type: StructureType::IMAGE_FORMAT_PROPERTIES_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             image_format_properties: ImageFormatProperties::default(),
         }
     }
@@ -8383,7 +8383,7 @@ impl ::std::default::Default for PhysicalDeviceImageFormatInfo2 {
     fn default() -> PhysicalDeviceImageFormatInfo2 {
         PhysicalDeviceImageFormatInfo2 {
             s_type: StructureType::PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             format: Format::default(),
             ty: ImageType::default(),
             tiling: ImageTiling::default(),
@@ -8403,7 +8403,7 @@ impl ::std::default::Default for QueueFamilyProperties2 {
     fn default() -> QueueFamilyProperties2 {
         QueueFamilyProperties2 {
             s_type: StructureType::QUEUE_FAMILY_PROPERTIES_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             queue_family_properties: QueueFamilyProperties::default(),
         }
     }
@@ -8419,7 +8419,7 @@ impl ::std::default::Default for PhysicalDeviceMemoryProperties2 {
     fn default() -> PhysicalDeviceMemoryProperties2 {
         PhysicalDeviceMemoryProperties2 {
             s_type: StructureType::PHYSICAL_DEVICE_MEMORY_PROPERTIES_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             memory_properties: PhysicalDeviceMemoryProperties::default(),
         }
     }
@@ -8435,7 +8435,7 @@ impl ::std::default::Default for SparseImageFormatProperties2 {
     fn default() -> SparseImageFormatProperties2 {
         SparseImageFormatProperties2 {
             s_type: StructureType::SPARSE_IMAGE_FORMAT_PROPERTIES_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             properties: SparseImageFormatProperties::default(),
         }
     }
@@ -8455,7 +8455,7 @@ impl ::std::default::Default for PhysicalDeviceSparseImageFormatInfo2 {
     fn default() -> PhysicalDeviceSparseImageFormatInfo2 {
         PhysicalDeviceSparseImageFormatInfo2 {
             s_type: StructureType::PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             format: Format::default(),
             ty: ImageType::default(),
             samples: SampleCountFlags::default(),
@@ -8475,7 +8475,7 @@ impl ::std::default::Default for PhysicalDevicePushDescriptorPropertiesKHR {
     fn default() -> PhysicalDevicePushDescriptorPropertiesKHR {
         PhysicalDevicePushDescriptorPropertiesKHR {
             s_type: StructureType::PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             max_push_descriptors: uint32_t::default(),
         }
     }
@@ -8492,9 +8492,9 @@ impl ::std::default::Default for PresentRegionsKHR {
     fn default() -> PresentRegionsKHR {
         PresentRegionsKHR {
             s_type: StructureType::PRESENT_REGIONS_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             swapchain_count: uint32_t::default(),
-            p_regions: unsafe { ::std::mem::zeroed() },
+            p_regions: ::std::ptr::null(),
         }
     }
 }
@@ -8508,7 +8508,7 @@ impl ::std::default::Default for PresentRegionKHR {
     fn default() -> PresentRegionKHR {
         PresentRegionKHR {
             rectangle_count: uint32_t::default(),
-            p_rectangles: unsafe { ::std::mem::zeroed() },
+            p_rectangles: ::std::ptr::null(),
         }
     }
 }
@@ -8531,7 +8531,7 @@ impl ::std::default::Default for PhysicalDeviceVariablePointerFeatures {
     fn default() -> PhysicalDeviceVariablePointerFeatures {
         PhysicalDeviceVariablePointerFeatures {
             s_type: StructureType::PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             variable_pointers_storage_buffer: Bool32::default(),
             variable_pointers: Bool32::default(),
         }
@@ -8555,7 +8555,7 @@ impl ::std::default::Default for PhysicalDeviceExternalImageFormatInfo {
     fn default() -> PhysicalDeviceExternalImageFormatInfo {
         PhysicalDeviceExternalImageFormatInfo {
             s_type: StructureType::PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_type: ExternalMemoryHandleTypeFlags::default(),
         }
     }
@@ -8571,7 +8571,7 @@ impl ::std::default::Default for ExternalImageFormatProperties {
     fn default() -> ExternalImageFormatProperties {
         ExternalImageFormatProperties {
             s_type: StructureType::EXTERNAL_IMAGE_FORMAT_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             external_memory_properties: ExternalMemoryProperties::default(),
         }
     }
@@ -8589,7 +8589,7 @@ impl ::std::default::Default for PhysicalDeviceExternalBufferInfo {
     fn default() -> PhysicalDeviceExternalBufferInfo {
         PhysicalDeviceExternalBufferInfo {
             s_type: StructureType::PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: BufferCreateFlags::default(),
             usage: BufferUsageFlags::default(),
             handle_type: ExternalMemoryHandleTypeFlags::default(),
@@ -8607,7 +8607,7 @@ impl ::std::default::Default for ExternalBufferProperties {
     fn default() -> ExternalBufferProperties {
         ExternalBufferProperties {
             s_type: StructureType::EXTERNAL_BUFFER_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             external_memory_properties: ExternalMemoryProperties::default(),
         }
     }
@@ -8646,7 +8646,7 @@ impl ::std::default::Default for PhysicalDeviceIDProperties {
     fn default() -> PhysicalDeviceIDProperties {
         PhysicalDeviceIDProperties {
             s_type: StructureType::PHYSICAL_DEVICE_ID_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             device_uuid: unsafe { ::std::mem::zeroed() },
             driver_uuid: unsafe { ::std::mem::zeroed() },
             device_luid: unsafe { ::std::mem::zeroed() },
@@ -8666,7 +8666,7 @@ impl ::std::default::Default for ExternalMemoryImageCreateInfo {
     fn default() -> ExternalMemoryImageCreateInfo {
         ExternalMemoryImageCreateInfo {
             s_type: StructureType::EXTERNAL_MEMORY_IMAGE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_types: ExternalMemoryHandleTypeFlags::default(),
         }
     }
@@ -8682,7 +8682,7 @@ impl ::std::default::Default for ExternalMemoryBufferCreateInfo {
     fn default() -> ExternalMemoryBufferCreateInfo {
         ExternalMemoryBufferCreateInfo {
             s_type: StructureType::EXTERNAL_MEMORY_BUFFER_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_types: ExternalMemoryHandleTypeFlags::default(),
         }
     }
@@ -8698,7 +8698,7 @@ impl ::std::default::Default for ExportMemoryAllocateInfo {
     fn default() -> ExportMemoryAllocateInfo {
         ExportMemoryAllocateInfo {
             s_type: StructureType::EXPORT_MEMORY_ALLOCATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_types: ExternalMemoryHandleTypeFlags::default(),
         }
     }
@@ -8716,7 +8716,7 @@ impl ::std::default::Default for ImportMemoryWin32HandleInfoKHR {
     fn default() -> ImportMemoryWin32HandleInfoKHR {
         ImportMemoryWin32HandleInfoKHR {
             s_type: StructureType::IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_type: ExternalMemoryHandleTypeFlags::default(),
             handle: unsafe { ::std::mem::zeroed() },
             name: unsafe { ::std::mem::zeroed() },
@@ -8736,8 +8736,8 @@ impl ::std::default::Default for ExportMemoryWin32HandleInfoKHR {
     fn default() -> ExportMemoryWin32HandleInfoKHR {
         ExportMemoryWin32HandleInfoKHR {
             s_type: StructureType::EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
-            p_attributes: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
+            p_attributes: ::std::ptr::null(),
             dw_access: DWORD::default(),
             name: unsafe { ::std::mem::zeroed() },
         }
@@ -8754,7 +8754,7 @@ impl ::std::default::Default for MemoryWin32HandlePropertiesKHR {
     fn default() -> MemoryWin32HandlePropertiesKHR {
         MemoryWin32HandlePropertiesKHR {
             s_type: StructureType::MEMORY_WIN32_HANDLE_PROPERTIES_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             memory_type_bits: uint32_t::default(),
         }
     }
@@ -8771,7 +8771,7 @@ impl ::std::default::Default for MemoryGetWin32HandleInfoKHR {
     fn default() -> MemoryGetWin32HandleInfoKHR {
         MemoryGetWin32HandleInfoKHR {
             s_type: StructureType::MEMORY_GET_WIN32_HANDLE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             memory: DeviceMemory::default(),
             handle_type: ExternalMemoryHandleTypeFlags::default(),
         }
@@ -8789,7 +8789,7 @@ impl ::std::default::Default for ImportMemoryFdInfoKHR {
     fn default() -> ImportMemoryFdInfoKHR {
         ImportMemoryFdInfoKHR {
             s_type: StructureType::IMPORT_MEMORY_FD_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_type: ExternalMemoryHandleTypeFlags::default(),
             fd: c_int::default(),
         }
@@ -8806,7 +8806,7 @@ impl ::std::default::Default for MemoryFdPropertiesKHR {
     fn default() -> MemoryFdPropertiesKHR {
         MemoryFdPropertiesKHR {
             s_type: StructureType::MEMORY_FD_PROPERTIES_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             memory_type_bits: uint32_t::default(),
         }
     }
@@ -8823,7 +8823,7 @@ impl ::std::default::Default for MemoryGetFdInfoKHR {
     fn default() -> MemoryGetFdInfoKHR {
         MemoryGetFdInfoKHR {
             s_type: StructureType::MEMORY_GET_FD_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             memory: DeviceMemory::default(),
             handle_type: ExternalMemoryHandleTypeFlags::default(),
         }
@@ -8846,14 +8846,14 @@ impl ::std::default::Default for Win32KeyedMutexAcquireReleaseInfoKHR {
     fn default() -> Win32KeyedMutexAcquireReleaseInfoKHR {
         Win32KeyedMutexAcquireReleaseInfoKHR {
             s_type: StructureType::WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             acquire_count: uint32_t::default(),
-            p_acquire_syncs: unsafe { ::std::mem::zeroed() },
-            p_acquire_keys: unsafe { ::std::mem::zeroed() },
-            p_acquire_timeouts: unsafe { ::std::mem::zeroed() },
+            p_acquire_syncs: ::std::ptr::null(),
+            p_acquire_keys: ::std::ptr::null(),
+            p_acquire_timeouts: ::std::ptr::null(),
             release_count: uint32_t::default(),
-            p_release_syncs: unsafe { ::std::mem::zeroed() },
-            p_release_keys: unsafe { ::std::mem::zeroed() },
+            p_release_syncs: ::std::ptr::null(),
+            p_release_keys: ::std::ptr::null(),
         }
     }
 }
@@ -8868,7 +8868,7 @@ impl ::std::default::Default for PhysicalDeviceExternalSemaphoreInfo {
     fn default() -> PhysicalDeviceExternalSemaphoreInfo {
         PhysicalDeviceExternalSemaphoreInfo {
             s_type: StructureType::PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_type: ExternalSemaphoreHandleTypeFlags::default(),
         }
     }
@@ -8886,7 +8886,7 @@ impl ::std::default::Default for ExternalSemaphoreProperties {
     fn default() -> ExternalSemaphoreProperties {
         ExternalSemaphoreProperties {
             s_type: StructureType::EXTERNAL_SEMAPHORE_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             export_from_imported_handle_types: ExternalSemaphoreHandleTypeFlags::default(),
             compatible_handle_types: ExternalSemaphoreHandleTypeFlags::default(),
             external_semaphore_features: ExternalSemaphoreFeatureFlags::default(),
@@ -8904,7 +8904,7 @@ impl ::std::default::Default for ExportSemaphoreCreateInfo {
     fn default() -> ExportSemaphoreCreateInfo {
         ExportSemaphoreCreateInfo {
             s_type: StructureType::EXPORT_SEMAPHORE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_types: ExternalSemaphoreHandleTypeFlags::default(),
         }
     }
@@ -8924,7 +8924,7 @@ impl ::std::default::Default for ImportSemaphoreWin32HandleInfoKHR {
     fn default() -> ImportSemaphoreWin32HandleInfoKHR {
         ImportSemaphoreWin32HandleInfoKHR {
             s_type: StructureType::IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             semaphore: Semaphore::default(),
             flags: SemaphoreImportFlags::default(),
             handle_type: ExternalSemaphoreHandleTypeFlags::default(),
@@ -8946,8 +8946,8 @@ impl ::std::default::Default for ExportSemaphoreWin32HandleInfoKHR {
     fn default() -> ExportSemaphoreWin32HandleInfoKHR {
         ExportSemaphoreWin32HandleInfoKHR {
             s_type: StructureType::EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
-            p_attributes: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
+            p_attributes: ::std::ptr::null(),
             dw_access: DWORD::default(),
             name: unsafe { ::std::mem::zeroed() },
         }
@@ -8967,11 +8967,11 @@ impl ::std::default::Default for D3D12FenceSubmitInfoKHR {
     fn default() -> D3D12FenceSubmitInfoKHR {
         D3D12FenceSubmitInfoKHR {
             s_type: StructureType::D3D12_FENCE_SUBMIT_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             wait_semaphore_values_count: uint32_t::default(),
-            p_wait_semaphore_values: unsafe { ::std::mem::zeroed() },
+            p_wait_semaphore_values: ::std::ptr::null(),
             signal_semaphore_values_count: uint32_t::default(),
-            p_signal_semaphore_values: unsafe { ::std::mem::zeroed() },
+            p_signal_semaphore_values: ::std::ptr::null(),
         }
     }
 }
@@ -8987,7 +8987,7 @@ impl ::std::default::Default for SemaphoreGetWin32HandleInfoKHR {
     fn default() -> SemaphoreGetWin32HandleInfoKHR {
         SemaphoreGetWin32HandleInfoKHR {
             s_type: StructureType::SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             semaphore: Semaphore::default(),
             handle_type: ExternalSemaphoreHandleTypeFlags::default(),
         }
@@ -9007,7 +9007,7 @@ impl ::std::default::Default for ImportSemaphoreFdInfoKHR {
     fn default() -> ImportSemaphoreFdInfoKHR {
         ImportSemaphoreFdInfoKHR {
             s_type: StructureType::IMPORT_SEMAPHORE_FD_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             semaphore: Semaphore::default(),
             flags: SemaphoreImportFlags::default(),
             handle_type: ExternalSemaphoreHandleTypeFlags::default(),
@@ -9027,7 +9027,7 @@ impl ::std::default::Default for SemaphoreGetFdInfoKHR {
     fn default() -> SemaphoreGetFdInfoKHR {
         SemaphoreGetFdInfoKHR {
             s_type: StructureType::SEMAPHORE_GET_FD_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             semaphore: Semaphore::default(),
             handle_type: ExternalSemaphoreHandleTypeFlags::default(),
         }
@@ -9044,7 +9044,7 @@ impl ::std::default::Default for PhysicalDeviceExternalFenceInfo {
     fn default() -> PhysicalDeviceExternalFenceInfo {
         PhysicalDeviceExternalFenceInfo {
             s_type: StructureType::PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_type: ExternalFenceHandleTypeFlags::default(),
         }
     }
@@ -9062,7 +9062,7 @@ impl ::std::default::Default for ExternalFenceProperties {
     fn default() -> ExternalFenceProperties {
         ExternalFenceProperties {
             s_type: StructureType::EXTERNAL_FENCE_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             export_from_imported_handle_types: ExternalFenceHandleTypeFlags::default(),
             compatible_handle_types: ExternalFenceHandleTypeFlags::default(),
             external_fence_features: ExternalFenceFeatureFlags::default(),
@@ -9080,7 +9080,7 @@ impl ::std::default::Default for ExportFenceCreateInfo {
     fn default() -> ExportFenceCreateInfo {
         ExportFenceCreateInfo {
             s_type: StructureType::EXPORT_FENCE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_types: ExternalFenceHandleTypeFlags::default(),
         }
     }
@@ -9100,7 +9100,7 @@ impl ::std::default::Default for ImportFenceWin32HandleInfoKHR {
     fn default() -> ImportFenceWin32HandleInfoKHR {
         ImportFenceWin32HandleInfoKHR {
             s_type: StructureType::IMPORT_FENCE_WIN32_HANDLE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             fence: Fence::default(),
             flags: FenceImportFlags::default(),
             handle_type: ExternalFenceHandleTypeFlags::default(),
@@ -9122,8 +9122,8 @@ impl ::std::default::Default for ExportFenceWin32HandleInfoKHR {
     fn default() -> ExportFenceWin32HandleInfoKHR {
         ExportFenceWin32HandleInfoKHR {
             s_type: StructureType::EXPORT_FENCE_WIN32_HANDLE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
-            p_attributes: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
+            p_attributes: ::std::ptr::null(),
             dw_access: DWORD::default(),
             name: unsafe { ::std::mem::zeroed() },
         }
@@ -9141,7 +9141,7 @@ impl ::std::default::Default for FenceGetWin32HandleInfoKHR {
     fn default() -> FenceGetWin32HandleInfoKHR {
         FenceGetWin32HandleInfoKHR {
             s_type: StructureType::FENCE_GET_WIN32_HANDLE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             fence: Fence::default(),
             handle_type: ExternalFenceHandleTypeFlags::default(),
         }
@@ -9161,7 +9161,7 @@ impl ::std::default::Default for ImportFenceFdInfoKHR {
     fn default() -> ImportFenceFdInfoKHR {
         ImportFenceFdInfoKHR {
             s_type: StructureType::IMPORT_FENCE_FD_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             fence: Fence::default(),
             flags: FenceImportFlags::default(),
             handle_type: ExternalFenceHandleTypeFlags::default(),
@@ -9181,7 +9181,7 @@ impl ::std::default::Default for FenceGetFdInfoKHR {
     fn default() -> FenceGetFdInfoKHR {
         FenceGetFdInfoKHR {
             s_type: StructureType::FENCE_GET_FD_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             fence: Fence::default(),
             handle_type: ExternalFenceHandleTypeFlags::default(),
         }
@@ -9200,7 +9200,7 @@ impl ::std::default::Default for PhysicalDeviceMultiviewFeatures {
     fn default() -> PhysicalDeviceMultiviewFeatures {
         PhysicalDeviceMultiviewFeatures {
             s_type: StructureType::PHYSICAL_DEVICE_MULTIVIEW_FEATURES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             multiview: Bool32::default(),
             multiview_geometry_shader: Bool32::default(),
             multiview_tessellation_shader: Bool32::default(),
@@ -9219,7 +9219,7 @@ impl ::std::default::Default for PhysicalDeviceMultiviewProperties {
     fn default() -> PhysicalDeviceMultiviewProperties {
         PhysicalDeviceMultiviewProperties {
             s_type: StructureType::PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             max_multiview_view_count: uint32_t::default(),
             max_multiview_instance_index: uint32_t::default(),
         }
@@ -9241,13 +9241,13 @@ impl ::std::default::Default for RenderPassMultiviewCreateInfo {
     fn default() -> RenderPassMultiviewCreateInfo {
         RenderPassMultiviewCreateInfo {
             s_type: StructureType::RENDER_PASS_MULTIVIEW_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             subpass_count: uint32_t::default(),
-            p_view_masks: unsafe { ::std::mem::zeroed() },
+            p_view_masks: ::std::ptr::null(),
             dependency_count: uint32_t::default(),
-            p_view_offsets: unsafe { ::std::mem::zeroed() },
+            p_view_offsets: ::std::ptr::null(),
             correlation_mask_count: uint32_t::default(),
-            p_correlation_masks: unsafe { ::std::mem::zeroed() },
+            p_correlation_masks: ::std::ptr::null(),
         }
     }
 }
@@ -9272,7 +9272,7 @@ impl ::std::default::Default for SurfaceCapabilities2EXT {
     fn default() -> SurfaceCapabilities2EXT {
         SurfaceCapabilities2EXT {
             s_type: StructureType::SURFACE_CAPABILITIES_2_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             min_image_count: uint32_t::default(),
             max_image_count: uint32_t::default(),
             current_extent: Extent2D::default(),
@@ -9298,7 +9298,7 @@ impl ::std::default::Default for DisplayPowerInfoEXT {
     fn default() -> DisplayPowerInfoEXT {
         DisplayPowerInfoEXT {
             s_type: StructureType::DISPLAY_POWER_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             power_state: DisplayPowerStateEXT::default(),
         }
     }
@@ -9314,7 +9314,7 @@ impl ::std::default::Default for DeviceEventInfoEXT {
     fn default() -> DeviceEventInfoEXT {
         DeviceEventInfoEXT {
             s_type: StructureType::DEVICE_EVENT_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             device_event: DeviceEventTypeEXT::default(),
         }
     }
@@ -9330,7 +9330,7 @@ impl ::std::default::Default for DisplayEventInfoEXT {
     fn default() -> DisplayEventInfoEXT {
         DisplayEventInfoEXT {
             s_type: StructureType::DISPLAY_EVENT_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             display_event: DisplayEventTypeEXT::default(),
         }
     }
@@ -9346,7 +9346,7 @@ impl ::std::default::Default for SwapchainCounterCreateInfoEXT {
     fn default() -> SwapchainCounterCreateInfoEXT {
         SwapchainCounterCreateInfoEXT {
             s_type: StructureType::SWAPCHAIN_COUNTER_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             surface_counters: SurfaceCounterFlagsEXT::default(),
         }
     }
@@ -9377,7 +9377,7 @@ impl ::std::default::Default for PhysicalDeviceGroupProperties {
     fn default() -> PhysicalDeviceGroupProperties {
         PhysicalDeviceGroupProperties {
             s_type: StructureType::PHYSICAL_DEVICE_GROUP_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             physical_device_count: uint32_t::default(),
             physical_devices: unsafe { ::std::mem::zeroed() },
             subset_allocation: Bool32::default(),
@@ -9396,7 +9396,7 @@ impl ::std::default::Default for MemoryAllocateFlagsInfo {
     fn default() -> MemoryAllocateFlagsInfo {
         MemoryAllocateFlagsInfo {
             s_type: StructureType::MEMORY_ALLOCATE_FLAGS_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: MemoryAllocateFlags::default(),
             device_mask: uint32_t::default(),
         }
@@ -9415,7 +9415,7 @@ impl ::std::default::Default for BindBufferMemoryInfo {
     fn default() -> BindBufferMemoryInfo {
         BindBufferMemoryInfo {
             s_type: StructureType::BIND_BUFFER_MEMORY_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             buffer: Buffer::default(),
             memory: DeviceMemory::default(),
             memory_offset: DeviceSize::default(),
@@ -9434,9 +9434,9 @@ impl ::std::default::Default for BindBufferMemoryDeviceGroupInfo {
     fn default() -> BindBufferMemoryDeviceGroupInfo {
         BindBufferMemoryDeviceGroupInfo {
             s_type: StructureType::BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             device_index_count: uint32_t::default(),
-            p_device_indices: unsafe { ::std::mem::zeroed() },
+            p_device_indices: ::std::ptr::null(),
         }
     }
 }
@@ -9453,7 +9453,7 @@ impl ::std::default::Default for BindImageMemoryInfo {
     fn default() -> BindImageMemoryInfo {
         BindImageMemoryInfo {
             s_type: StructureType::BIND_IMAGE_MEMORY_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             image: Image::default(),
             memory: DeviceMemory::default(),
             memory_offset: DeviceSize::default(),
@@ -9474,11 +9474,11 @@ impl ::std::default::Default for BindImageMemoryDeviceGroupInfo {
     fn default() -> BindImageMemoryDeviceGroupInfo {
         BindImageMemoryDeviceGroupInfo {
             s_type: StructureType::BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             device_index_count: uint32_t::default(),
-            p_device_indices: unsafe { ::std::mem::zeroed() },
+            p_device_indices: ::std::ptr::null(),
             split_instance_bind_region_count: uint32_t::default(),
-            p_split_instance_bind_regions: unsafe { ::std::mem::zeroed() },
+            p_split_instance_bind_regions: ::std::ptr::null(),
         }
     }
 }
@@ -9495,10 +9495,10 @@ impl ::std::default::Default for DeviceGroupRenderPassBeginInfo {
     fn default() -> DeviceGroupRenderPassBeginInfo {
         DeviceGroupRenderPassBeginInfo {
             s_type: StructureType::DEVICE_GROUP_RENDER_PASS_BEGIN_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             device_mask: uint32_t::default(),
             device_render_area_count: uint32_t::default(),
-            p_device_render_areas: unsafe { ::std::mem::zeroed() },
+            p_device_render_areas: ::std::ptr::null(),
         }
     }
 }
@@ -9513,7 +9513,7 @@ impl ::std::default::Default for DeviceGroupCommandBufferBeginInfo {
     fn default() -> DeviceGroupCommandBufferBeginInfo {
         DeviceGroupCommandBufferBeginInfo {
             s_type: StructureType::DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             device_mask: uint32_t::default(),
         }
     }
@@ -9534,13 +9534,13 @@ impl ::std::default::Default for DeviceGroupSubmitInfo {
     fn default() -> DeviceGroupSubmitInfo {
         DeviceGroupSubmitInfo {
             s_type: StructureType::DEVICE_GROUP_SUBMIT_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             wait_semaphore_count: uint32_t::default(),
-            p_wait_semaphore_device_indices: unsafe { ::std::mem::zeroed() },
+            p_wait_semaphore_device_indices: ::std::ptr::null(),
             command_buffer_count: uint32_t::default(),
-            p_command_buffer_device_masks: unsafe { ::std::mem::zeroed() },
+            p_command_buffer_device_masks: ::std::ptr::null(),
             signal_semaphore_count: uint32_t::default(),
-            p_signal_semaphore_device_indices: unsafe { ::std::mem::zeroed() },
+            p_signal_semaphore_device_indices: ::std::ptr::null(),
         }
     }
 }
@@ -9556,7 +9556,7 @@ impl ::std::default::Default for DeviceGroupBindSparseInfo {
     fn default() -> DeviceGroupBindSparseInfo {
         DeviceGroupBindSparseInfo {
             s_type: StructureType::DEVICE_GROUP_BIND_SPARSE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             resource_device_index: uint32_t::default(),
             memory_device_index: uint32_t::default(),
         }
@@ -9586,7 +9586,7 @@ impl ::std::default::Default for DeviceGroupPresentCapabilitiesKHR {
     fn default() -> DeviceGroupPresentCapabilitiesKHR {
         DeviceGroupPresentCapabilitiesKHR {
             s_type: StructureType::DEVICE_GROUP_PRESENT_CAPABILITIES_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             present_mask: unsafe { ::std::mem::zeroed() },
             modes: DeviceGroupPresentModeFlagsKHR::default(),
         }
@@ -9603,7 +9603,7 @@ impl ::std::default::Default for ImageSwapchainCreateInfoKHR {
     fn default() -> ImageSwapchainCreateInfoKHR {
         ImageSwapchainCreateInfoKHR {
             s_type: StructureType::IMAGE_SWAPCHAIN_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             swapchain: SwapchainKHR::default(),
         }
     }
@@ -9620,7 +9620,7 @@ impl ::std::default::Default for BindImageMemorySwapchainInfoKHR {
     fn default() -> BindImageMemorySwapchainInfoKHR {
         BindImageMemorySwapchainInfoKHR {
             s_type: StructureType::BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             swapchain: SwapchainKHR::default(),
             image_index: uint32_t::default(),
         }
@@ -9641,7 +9641,7 @@ impl ::std::default::Default for AcquireNextImageInfoKHR {
     fn default() -> AcquireNextImageInfoKHR {
         AcquireNextImageInfoKHR {
             s_type: StructureType::ACQUIRE_NEXT_IMAGE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             swapchain: SwapchainKHR::default(),
             timeout: uint64_t::default(),
             semaphore: Semaphore::default(),
@@ -9663,9 +9663,9 @@ impl ::std::default::Default for DeviceGroupPresentInfoKHR {
     fn default() -> DeviceGroupPresentInfoKHR {
         DeviceGroupPresentInfoKHR {
             s_type: StructureType::DEVICE_GROUP_PRESENT_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             swapchain_count: uint32_t::default(),
-            p_device_masks: unsafe { ::std::mem::zeroed() },
+            p_device_masks: ::std::ptr::null(),
             mode: DeviceGroupPresentModeFlagsKHR::default(),
         }
     }
@@ -9682,9 +9682,9 @@ impl ::std::default::Default for DeviceGroupDeviceCreateInfo {
     fn default() -> DeviceGroupDeviceCreateInfo {
         DeviceGroupDeviceCreateInfo {
             s_type: StructureType::DEVICE_GROUP_DEVICE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             physical_device_count: uint32_t::default(),
-            p_physical_devices: unsafe { ::std::mem::zeroed() },
+            p_physical_devices: ::std::ptr::null(),
         }
     }
 }
@@ -9699,7 +9699,7 @@ impl ::std::default::Default for DeviceGroupSwapchainCreateInfoKHR {
     fn default() -> DeviceGroupSwapchainCreateInfoKHR {
         DeviceGroupSwapchainCreateInfoKHR {
             s_type: StructureType::DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             modes: DeviceGroupPresentModeFlagsKHR::default(),
         }
     }
@@ -9732,10 +9732,10 @@ impl ::std::default::Default for DescriptorUpdateTemplateCreateInfo {
     fn default() -> DescriptorUpdateTemplateCreateInfo {
         DescriptorUpdateTemplateCreateInfo {
             s_type: StructureType::DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             flags: DescriptorUpdateTemplateCreateFlags::default(),
             descriptor_update_entry_count: uint32_t::default(),
-            p_descriptor_update_entries: unsafe { ::std::mem::zeroed() },
+            p_descriptor_update_entries: ::std::ptr::null(),
             template_type: DescriptorUpdateTemplateType::default(),
             descriptor_set_layout: DescriptorSetLayout::default(),
             pipeline_bind_point: PipelineBindPoint::default(),
@@ -9768,7 +9768,7 @@ impl ::std::default::Default for HdrMetadataEXT {
     fn default() -> HdrMetadataEXT {
         HdrMetadataEXT {
             s_type: StructureType::HDR_METADATA_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             display_primary_red: XYColorEXT::default(),
             display_primary_green: XYColorEXT::default(),
             display_primary_blue: XYColorEXT::default(),
@@ -9806,9 +9806,9 @@ impl ::std::default::Default for PresentTimesInfoGOOGLE {
     fn default() -> PresentTimesInfoGOOGLE {
         PresentTimesInfoGOOGLE {
             s_type: StructureType::PRESENT_TIMES_INFO_GOOGLE,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             swapchain_count: uint32_t::default(),
-            p_times: unsafe { ::std::mem::zeroed() },
+            p_times: ::std::ptr::null(),
         }
     }
 }
@@ -9830,9 +9830,9 @@ impl ::std::default::Default for IOSSurfaceCreateInfoMVK {
     fn default() -> IOSSurfaceCreateInfoMVK {
         IOSSurfaceCreateInfoMVK {
             s_type: StructureType::IOS_SURFACE_CREATE_INFO_M,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: IOSSurfaceCreateFlagsMVK::default(),
-            p_view: unsafe { ::std::mem::zeroed() },
+            p_view: ::std::ptr::null(),
         }
     }
 }
@@ -9848,9 +9848,9 @@ impl ::std::default::Default for MacOSSurfaceCreateInfoMVK {
     fn default() -> MacOSSurfaceCreateInfoMVK {
         MacOSSurfaceCreateInfoMVK {
             s_type: StructureType::MACOS_SURFACE_CREATE_INFO_M,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: MacOSSurfaceCreateFlagsMVK::default(),
-            p_view: unsafe { ::std::mem::zeroed() },
+            p_view: ::std::ptr::null(),
         }
     }
 }
@@ -9873,10 +9873,10 @@ impl ::std::default::Default for PipelineViewportWScalingStateCreateInfoNV {
     fn default() -> PipelineViewportWScalingStateCreateInfoNV {
         PipelineViewportWScalingStateCreateInfoNV {
             s_type: StructureType::PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             viewport_w_scaling_enable: Bool32::default(),
             viewport_count: uint32_t::default(),
-            p_viewport_w_scalings: unsafe { ::std::mem::zeroed() },
+            p_viewport_w_scalings: ::std::ptr::null(),
         }
     }
 }
@@ -9901,10 +9901,10 @@ impl ::std::default::Default for PipelineViewportSwizzleStateCreateInfoNV {
     fn default() -> PipelineViewportSwizzleStateCreateInfoNV {
         PipelineViewportSwizzleStateCreateInfoNV {
             s_type: StructureType::PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineViewportSwizzleStateCreateFlagsNV::default(),
             viewport_count: uint32_t::default(),
-            p_viewport_swizzles: unsafe { ::std::mem::zeroed() },
+            p_viewport_swizzles: ::std::ptr::null(),
         }
     }
 }
@@ -9919,7 +9919,7 @@ impl ::std::default::Default for PhysicalDeviceDiscardRectanglePropertiesEXT {
     fn default() -> PhysicalDeviceDiscardRectanglePropertiesEXT {
         PhysicalDeviceDiscardRectanglePropertiesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             max_discard_rectangles: uint32_t::default(),
         }
     }
@@ -9938,11 +9938,11 @@ impl ::std::default::Default for PipelineDiscardRectangleStateCreateInfoEXT {
     fn default() -> PipelineDiscardRectangleStateCreateInfoEXT {
         PipelineDiscardRectangleStateCreateInfoEXT {
             s_type: StructureType::PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineDiscardRectangleStateCreateFlagsEXT::default(),
             discard_rectangle_mode: DiscardRectangleModeEXT::default(),
             discard_rectangle_count: uint32_t::default(),
-            p_discard_rectangles: unsafe { ::std::mem::zeroed() },
+            p_discard_rectangles: ::std::ptr::null(),
         }
     }
 }
@@ -9957,7 +9957,7 @@ impl ::std::default::Default for PhysicalDeviceMultiviewPerViewAttributesPropert
     fn default() -> PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX {
         PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX {
             s_type: StructureType::PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             per_view_position_all_components: Bool32::default(),
         }
     }
@@ -9981,9 +9981,9 @@ impl ::std::default::Default for RenderPassInputAttachmentAspectCreateInfo {
     fn default() -> RenderPassInputAttachmentAspectCreateInfo {
         RenderPassInputAttachmentAspectCreateInfo {
             s_type: StructureType::RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             aspect_reference_count: uint32_t::default(),
-            p_aspect_references: unsafe { ::std::mem::zeroed() },
+            p_aspect_references: ::std::ptr::null(),
         }
     }
 }
@@ -9998,7 +9998,7 @@ impl ::std::default::Default for PhysicalDeviceSurfaceInfo2KHR {
     fn default() -> PhysicalDeviceSurfaceInfo2KHR {
         PhysicalDeviceSurfaceInfo2KHR {
             s_type: StructureType::PHYSICAL_DEVICE_SURFACE_INFO_2_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             surface: SurfaceKHR::default(),
         }
     }
@@ -10014,7 +10014,7 @@ impl ::std::default::Default for SurfaceCapabilities2KHR {
     fn default() -> SurfaceCapabilities2KHR {
         SurfaceCapabilities2KHR {
             s_type: StructureType::SURFACE_CAPABILITIES_2_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             surface_capabilities: SurfaceCapabilitiesKHR::default(),
         }
     }
@@ -10030,7 +10030,7 @@ impl ::std::default::Default for SurfaceFormat2KHR {
     fn default() -> SurfaceFormat2KHR {
         SurfaceFormat2KHR {
             s_type: StructureType::SURFACE_FORMAT_2_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             surface_format: SurfaceFormatKHR::default(),
         }
     }
@@ -10046,7 +10046,7 @@ impl ::std::default::Default for DisplayProperties2KHR {
     fn default() -> DisplayProperties2KHR {
         DisplayProperties2KHR {
             s_type: StructureType::DISPLAY_PROPERTIES_2_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             display_properties: DisplayPropertiesKHR::default(),
         }
     }
@@ -10062,7 +10062,7 @@ impl ::std::default::Default for DisplayPlaneProperties2KHR {
     fn default() -> DisplayPlaneProperties2KHR {
         DisplayPlaneProperties2KHR {
             s_type: StructureType::DISPLAY_PLANE_PROPERTIES_2_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             display_plane_properties: DisplayPlanePropertiesKHR::default(),
         }
     }
@@ -10078,7 +10078,7 @@ impl ::std::default::Default for DisplayModeProperties2KHR {
     fn default() -> DisplayModeProperties2KHR {
         DisplayModeProperties2KHR {
             s_type: StructureType::DISPLAY_MODE_PROPERTIES_2_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             display_mode_properties: DisplayModePropertiesKHR::default(),
         }
     }
@@ -10095,7 +10095,7 @@ impl ::std::default::Default for DisplayPlaneInfo2KHR {
     fn default() -> DisplayPlaneInfo2KHR {
         DisplayPlaneInfo2KHR {
             s_type: StructureType::DISPLAY_PLANE_INFO_2_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             mode: DisplayModeKHR::default(),
             plane_index: uint32_t::default(),
         }
@@ -10112,7 +10112,7 @@ impl ::std::default::Default for DisplayPlaneCapabilities2KHR {
     fn default() -> DisplayPlaneCapabilities2KHR {
         DisplayPlaneCapabilities2KHR {
             s_type: StructureType::DISPLAY_PLANE_CAPABILITIES_2_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             capabilities: DisplayPlaneCapabilitiesKHR::default(),
         }
     }
@@ -10128,7 +10128,7 @@ impl ::std::default::Default for SharedPresentSurfaceCapabilitiesKHR {
     fn default() -> SharedPresentSurfaceCapabilitiesKHR {
         SharedPresentSurfaceCapabilitiesKHR {
             s_type: StructureType::SHARED_PRESENT_SURFACE_CAPABILITIES_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             shared_present_supported_usage_flags: ImageUsageFlags::default(),
         }
     }
@@ -10147,7 +10147,7 @@ impl ::std::default::Default for PhysicalDevice16BitStorageFeatures {
     fn default() -> PhysicalDevice16BitStorageFeatures {
         PhysicalDevice16BitStorageFeatures {
             s_type: StructureType::PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             storage_buffer16_bit_access: Bool32::default(),
             uniform_and_storage_buffer16_bit_access: Bool32::default(),
             storage_push_constant16: Bool32::default(),
@@ -10169,7 +10169,7 @@ impl ::std::default::Default for PhysicalDeviceSubgroupProperties {
     fn default() -> PhysicalDeviceSubgroupProperties {
         PhysicalDeviceSubgroupProperties {
             s_type: StructureType::PHYSICAL_DEVICE_SUBGROUP_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             subgroup_size: uint32_t::default(),
             supported_stages: ShaderStageFlags::default(),
             supported_operations: SubgroupFeatureFlags::default(),
@@ -10188,7 +10188,7 @@ impl ::std::default::Default for BufferMemoryRequirementsInfo2 {
     fn default() -> BufferMemoryRequirementsInfo2 {
         BufferMemoryRequirementsInfo2 {
             s_type: StructureType::BUFFER_MEMORY_REQUIREMENTS_INFO_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             buffer: Buffer::default(),
         }
     }
@@ -10204,7 +10204,7 @@ impl ::std::default::Default for ImageMemoryRequirementsInfo2 {
     fn default() -> ImageMemoryRequirementsInfo2 {
         ImageMemoryRequirementsInfo2 {
             s_type: StructureType::IMAGE_MEMORY_REQUIREMENTS_INFO_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             image: Image::default(),
         }
     }
@@ -10220,7 +10220,7 @@ impl ::std::default::Default for ImageSparseMemoryRequirementsInfo2 {
     fn default() -> ImageSparseMemoryRequirementsInfo2 {
         ImageSparseMemoryRequirementsInfo2 {
             s_type: StructureType::IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             image: Image::default(),
         }
     }
@@ -10236,7 +10236,7 @@ impl ::std::default::Default for MemoryRequirements2 {
     fn default() -> MemoryRequirements2 {
         MemoryRequirements2 {
             s_type: StructureType::MEMORY_REQUIREMENTS_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             memory_requirements: MemoryRequirements::default(),
         }
     }
@@ -10252,7 +10252,7 @@ impl ::std::default::Default for SparseImageMemoryRequirements2 {
     fn default() -> SparseImageMemoryRequirements2 {
         SparseImageMemoryRequirements2 {
             s_type: StructureType::SPARSE_IMAGE_MEMORY_REQUIREMENTS_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             memory_requirements: SparseImageMemoryRequirements::default(),
         }
     }
@@ -10268,7 +10268,7 @@ impl ::std::default::Default for PhysicalDevicePointClippingProperties {
     fn default() -> PhysicalDevicePointClippingProperties {
         PhysicalDevicePointClippingProperties {
             s_type: StructureType::PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             point_clipping_behavior: PointClippingBehavior::default(),
         }
     }
@@ -10285,7 +10285,7 @@ impl ::std::default::Default for MemoryDedicatedRequirements {
     fn default() -> MemoryDedicatedRequirements {
         MemoryDedicatedRequirements {
             s_type: StructureType::MEMORY_DEDICATED_REQUIREMENTS,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             prefers_dedicated_allocation: Bool32::default(),
             requires_dedicated_allocation: Bool32::default(),
         }
@@ -10303,7 +10303,7 @@ impl ::std::default::Default for MemoryDedicatedAllocateInfo {
     fn default() -> MemoryDedicatedAllocateInfo {
         MemoryDedicatedAllocateInfo {
             s_type: StructureType::MEMORY_DEDICATED_ALLOCATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             image: Image::default(),
             buffer: Buffer::default(),
         }
@@ -10320,7 +10320,7 @@ impl ::std::default::Default for ImageViewUsageCreateInfo {
     fn default() -> ImageViewUsageCreateInfo {
         ImageViewUsageCreateInfo {
             s_type: StructureType::IMAGE_VIEW_USAGE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             usage: ImageUsageFlags::default(),
         }
     }
@@ -10336,7 +10336,7 @@ impl ::std::default::Default for PipelineTessellationDomainOriginStateCreateInfo
     fn default() -> PipelineTessellationDomainOriginStateCreateInfo {
         PipelineTessellationDomainOriginStateCreateInfo {
             s_type: StructureType::PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             domain_origin: TessellationDomainOrigin::default(),
         }
     }
@@ -10352,7 +10352,7 @@ impl ::std::default::Default for SamplerYcbcrConversionInfo {
     fn default() -> SamplerYcbcrConversionInfo {
         SamplerYcbcrConversionInfo {
             s_type: StructureType::SAMPLER_YCBCR_CONVERSION_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             conversion: SamplerYcbcrConversion::default(),
         }
     }
@@ -10375,7 +10375,7 @@ impl ::std::default::Default for SamplerYcbcrConversionCreateInfo {
     fn default() -> SamplerYcbcrConversionCreateInfo {
         SamplerYcbcrConversionCreateInfo {
             s_type: StructureType::SAMPLER_YCBCR_CONVERSION_CREATE_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             format: Format::default(),
             ycbcr_model: SamplerYcbcrModelConversion::default(),
             ycbcr_range: SamplerYcbcrRange::default(),
@@ -10398,7 +10398,7 @@ impl ::std::default::Default for BindImagePlaneMemoryInfo {
     fn default() -> BindImagePlaneMemoryInfo {
         BindImagePlaneMemoryInfo {
             s_type: StructureType::BIND_IMAGE_PLANE_MEMORY_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             plane_aspect: ImageAspectFlags::default(),
         }
     }
@@ -10414,7 +10414,7 @@ impl ::std::default::Default for ImagePlaneMemoryRequirementsInfo {
     fn default() -> ImagePlaneMemoryRequirementsInfo {
         ImagePlaneMemoryRequirementsInfo {
             s_type: StructureType::IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             plane_aspect: ImageAspectFlags::default(),
         }
     }
@@ -10430,7 +10430,7 @@ impl ::std::default::Default for PhysicalDeviceSamplerYcbcrConversionFeatures {
     fn default() -> PhysicalDeviceSamplerYcbcrConversionFeatures {
         PhysicalDeviceSamplerYcbcrConversionFeatures {
             s_type: StructureType::PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             sampler_ycbcr_conversion: Bool32::default(),
         }
     }
@@ -10446,7 +10446,7 @@ impl ::std::default::Default for SamplerYcbcrConversionImageFormatProperties {
     fn default() -> SamplerYcbcrConversionImageFormatProperties {
         SamplerYcbcrConversionImageFormatProperties {
             s_type: StructureType::SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             combined_image_sampler_descriptor_count: uint32_t::default(),
         }
     }
@@ -10462,7 +10462,7 @@ impl ::std::default::Default for TextureLODGatherFormatPropertiesAMD {
     fn default() -> TextureLODGatherFormatPropertiesAMD {
         TextureLODGatherFormatPropertiesAMD {
             s_type: StructureType::TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             supports_texture_gather_lod_bias_amd: Bool32::default(),
         }
     }
@@ -10478,7 +10478,7 @@ impl ::std::default::Default for ProtectedSubmitInfo {
     fn default() -> ProtectedSubmitInfo {
         ProtectedSubmitInfo {
             s_type: StructureType::PROTECTED_SUBMIT_INFO,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             protected_submit: Bool32::default(),
         }
     }
@@ -10494,7 +10494,7 @@ impl ::std::default::Default for PhysicalDeviceProtectedMemoryFeatures {
     fn default() -> PhysicalDeviceProtectedMemoryFeatures {
         PhysicalDeviceProtectedMemoryFeatures {
             s_type: StructureType::PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             protected_memory: Bool32::default(),
         }
     }
@@ -10510,7 +10510,7 @@ impl ::std::default::Default for PhysicalDeviceProtectedMemoryProperties {
     fn default() -> PhysicalDeviceProtectedMemoryProperties {
         PhysicalDeviceProtectedMemoryProperties {
             s_type: StructureType::PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             protected_no_fault: Bool32::default(),
         }
     }
@@ -10528,7 +10528,7 @@ impl ::std::default::Default for DeviceQueueInfo2 {
     fn default() -> DeviceQueueInfo2 {
         DeviceQueueInfo2 {
             s_type: StructureType::DEVICE_QUEUE_INFO_2,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DeviceQueueCreateFlags::default(),
             queue_family_index: uint32_t::default(),
             queue_index: uint32_t::default(),
@@ -10548,7 +10548,7 @@ impl ::std::default::Default for PipelineCoverageToColorStateCreateInfoNV {
     fn default() -> PipelineCoverageToColorStateCreateInfoNV {
         PipelineCoverageToColorStateCreateInfoNV {
             s_type: StructureType::PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineCoverageToColorStateCreateFlagsNV::default(),
             coverage_to_color_enable: Bool32::default(),
             coverage_to_color_location: uint32_t::default(),
@@ -10567,7 +10567,7 @@ impl ::std::default::Default for PhysicalDeviceSamplerFilterMinmaxPropertiesEXT 
     fn default() -> PhysicalDeviceSamplerFilterMinmaxPropertiesEXT {
         PhysicalDeviceSamplerFilterMinmaxPropertiesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             filter_minmax_single_component_formats: Bool32::default(),
             filter_minmax_image_component_mapping: Bool32::default(),
         }
@@ -10593,11 +10593,11 @@ impl ::std::default::Default for SampleLocationsInfoEXT {
     fn default() -> SampleLocationsInfoEXT {
         SampleLocationsInfoEXT {
             s_type: StructureType::SAMPLE_LOCATIONS_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             sample_locations_per_pixel: SampleCountFlags::default(),
             sample_location_grid_size: Extent2D::default(),
             sample_locations_count: uint32_t::default(),
-            p_sample_locations: unsafe { ::std::mem::zeroed() },
+            p_sample_locations: ::std::ptr::null(),
         }
     }
 }
@@ -10627,11 +10627,11 @@ impl ::std::default::Default for RenderPassSampleLocationsBeginInfoEXT {
     fn default() -> RenderPassSampleLocationsBeginInfoEXT {
         RenderPassSampleLocationsBeginInfoEXT {
             s_type: StructureType::RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             attachment_initial_sample_locations_count: uint32_t::default(),
-            p_attachment_initial_sample_locations: unsafe { ::std::mem::zeroed() },
+            p_attachment_initial_sample_locations: ::std::ptr::null(),
             post_subpass_sample_locations_count: uint32_t::default(),
-            p_post_subpass_sample_locations: unsafe { ::std::mem::zeroed() },
+            p_post_subpass_sample_locations: ::std::ptr::null(),
         }
     }
 }
@@ -10647,7 +10647,7 @@ impl ::std::default::Default for PipelineSampleLocationsStateCreateInfoEXT {
     fn default() -> PipelineSampleLocationsStateCreateInfoEXT {
         PipelineSampleLocationsStateCreateInfoEXT {
             s_type: StructureType::PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             sample_locations_enable: Bool32::default(),
             sample_locations_info: SampleLocationsInfoEXT::default(),
         }
@@ -10694,7 +10694,7 @@ impl ::std::default::Default for PhysicalDeviceSampleLocationsPropertiesEXT {
     fn default() -> PhysicalDeviceSampleLocationsPropertiesEXT {
         PhysicalDeviceSampleLocationsPropertiesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             sample_location_sample_counts: SampleCountFlags::default(),
             max_sample_location_grid_size: Extent2D::default(),
             sample_location_coordinate_range: unsafe { ::std::mem::zeroed() },
@@ -10714,7 +10714,7 @@ impl ::std::default::Default for MultisamplePropertiesEXT {
     fn default() -> MultisamplePropertiesEXT {
         MultisamplePropertiesEXT {
             s_type: StructureType::MULTISAMPLE_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             max_sample_location_grid_size: Extent2D::default(),
         }
     }
@@ -10730,7 +10730,7 @@ impl ::std::default::Default for SamplerReductionModeCreateInfoEXT {
     fn default() -> SamplerReductionModeCreateInfoEXT {
         SamplerReductionModeCreateInfoEXT {
             s_type: StructureType::SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             reduction_mode: SamplerReductionModeEXT::default(),
         }
     }
@@ -10746,7 +10746,7 @@ impl ::std::default::Default for PhysicalDeviceBlendOperationAdvancedFeaturesEXT
     fn default() -> PhysicalDeviceBlendOperationAdvancedFeaturesEXT {
         PhysicalDeviceBlendOperationAdvancedFeaturesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             advanced_blend_coherent_operations: Bool32::default(),
         }
     }
@@ -10767,7 +10767,7 @@ impl ::std::default::Default for PhysicalDeviceBlendOperationAdvancedPropertiesE
     fn default() -> PhysicalDeviceBlendOperationAdvancedPropertiesEXT {
         PhysicalDeviceBlendOperationAdvancedPropertiesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             advanced_blend_max_color_attachments: uint32_t::default(),
             advanced_blend_independent_blend: Bool32::default(),
             advanced_blend_non_premultiplied_src_color: Bool32::default(),
@@ -10790,7 +10790,7 @@ impl ::std::default::Default for PipelineColorBlendAdvancedStateCreateInfoEXT {
     fn default() -> PipelineColorBlendAdvancedStateCreateInfoEXT {
         PipelineColorBlendAdvancedStateCreateInfoEXT {
             s_type: StructureType::PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             src_premultiplied: Bool32::default(),
             dst_premultiplied: Bool32::default(),
             blend_overlap: BlendOverlapEXT::default(),
@@ -10812,12 +10812,12 @@ impl ::std::default::Default for PipelineCoverageModulationStateCreateInfoNV {
     fn default() -> PipelineCoverageModulationStateCreateInfoNV {
         PipelineCoverageModulationStateCreateInfoNV {
             s_type: StructureType::PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineCoverageModulationStateCreateFlagsNV::default(),
             coverage_modulation_mode: CoverageModulationModeNV::default(),
             coverage_modulation_table_enable: Bool32::default(),
             coverage_modulation_table_count: uint32_t::default(),
-            p_coverage_modulation_table: unsafe { ::std::mem::zeroed() },
+            p_coverage_modulation_table: ::std::ptr::null(),
         }
     }
 }
@@ -10833,9 +10833,9 @@ impl ::std::default::Default for ImageFormatListCreateInfoKHR {
     fn default() -> ImageFormatListCreateInfoKHR {
         ImageFormatListCreateInfoKHR {
             s_type: StructureType::IMAGE_FORMAT_LIST_CREATE_INFO_KHR,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             view_format_count: uint32_t::default(),
-            p_view_formats: unsafe { ::std::mem::zeroed() },
+            p_view_formats: ::std::ptr::null(),
         }
     }
 }
@@ -10852,10 +10852,10 @@ impl ::std::default::Default for ValidationCacheCreateInfoEXT {
     fn default() -> ValidationCacheCreateInfoEXT {
         ValidationCacheCreateInfoEXT {
             s_type: StructureType::VALIDATION_CACHE_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: ValidationCacheCreateFlagsEXT::default(),
             initial_data_size: size_t::default(),
-            p_initial_data: unsafe { ::std::mem::zeroed() },
+            p_initial_data: ::std::ptr::null(),
         }
     }
 }
@@ -10870,7 +10870,7 @@ impl ::std::default::Default for ShaderModuleValidationCacheCreateInfoEXT {
     fn default() -> ShaderModuleValidationCacheCreateInfoEXT {
         ShaderModuleValidationCacheCreateInfoEXT {
             s_type: StructureType::SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             validation_cache: ValidationCacheEXT::default(),
         }
     }
@@ -10887,7 +10887,7 @@ impl ::std::default::Default for PhysicalDeviceMaintenance3Properties {
     fn default() -> PhysicalDeviceMaintenance3Properties {
         PhysicalDeviceMaintenance3Properties {
             s_type: StructureType::PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             max_per_set_descriptors: uint32_t::default(),
             max_memory_allocation_size: DeviceSize::default(),
         }
@@ -10904,7 +10904,7 @@ impl ::std::default::Default for DescriptorSetLayoutSupport {
     fn default() -> DescriptorSetLayoutSupport {
         DescriptorSetLayoutSupport {
             s_type: StructureType::DESCRIPTOR_SET_LAYOUT_SUPPORT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             supported: Bool32::default(),
         }
     }
@@ -10920,7 +10920,7 @@ impl ::std::default::Default for PhysicalDeviceShaderDrawParameterFeatures {
     fn default() -> PhysicalDeviceShaderDrawParameterFeatures {
         PhysicalDeviceShaderDrawParameterFeatures {
             s_type: StructureType::PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             shader_draw_parameters: Bool32::default(),
         }
     }
@@ -10939,8 +10939,8 @@ impl ::std::default::Default for NativeBufferANDROID {
     fn default() -> NativeBufferANDROID {
         NativeBufferANDROID {
             s_type: StructureType::NATIVE_BUFFER_ANDROID,
-            p_next: unsafe { ::std::mem::zeroed() },
-            handle: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
+            handle: ::std::ptr::null(),
             stride: c_int::default(),
             format: c_int::default(),
             usage: c_int::default(),
@@ -11006,7 +11006,7 @@ impl ::std::default::Default for DeviceQueueGlobalPriorityCreateInfoEXT {
     fn default() -> DeviceQueueGlobalPriorityCreateInfoEXT {
         DeviceQueueGlobalPriorityCreateInfoEXT {
             s_type: StructureType::DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             global_priority: QueueGlobalPriorityEXT::default(),
         }
     }
@@ -11024,10 +11024,10 @@ impl ::std::default::Default for DebugUtilsObjectNameInfoEXT {
     fn default() -> DebugUtilsObjectNameInfoEXT {
         DebugUtilsObjectNameInfoEXT {
             s_type: StructureType::DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             object_type: ObjectType::default(),
             object_handle: uint64_t::default(),
-            p_object_name: unsafe { ::std::mem::zeroed() },
+            p_object_name: ::std::ptr::null(),
         }
     }
 }
@@ -11046,12 +11046,12 @@ impl ::std::default::Default for DebugUtilsObjectTagInfoEXT {
     fn default() -> DebugUtilsObjectTagInfoEXT {
         DebugUtilsObjectTagInfoEXT {
             s_type: StructureType::DEBUG_UTILS_OBJECT_TAG_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             object_type: ObjectType::default(),
             object_handle: uint64_t::default(),
             tag_name: uint64_t::default(),
             tag_size: size_t::default(),
-            p_tag: unsafe { ::std::mem::zeroed() },
+            p_tag: ::std::ptr::null(),
         }
     }
 }
@@ -11079,8 +11079,8 @@ impl ::std::default::Default for DebugUtilsLabelEXT {
     fn default() -> DebugUtilsLabelEXT {
         DebugUtilsLabelEXT {
             s_type: StructureType::DEBUG_UTILS_LABEL_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
-            p_label_name: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
+            p_label_name: ::std::ptr::null(),
             color: unsafe { ::std::mem::zeroed() },
         }
     }
@@ -11113,12 +11113,12 @@ impl ::std::default::Default for DebugUtilsMessengerCreateInfoEXT {
     fn default() -> DebugUtilsMessengerCreateInfoEXT {
         DebugUtilsMessengerCreateInfoEXT {
             s_type: StructureType::DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DebugUtilsMessengerCreateFlagsEXT::default(),
             message_severity: DebugUtilsMessageSeverityFlagsEXT::default(),
             message_type: DebugUtilsMessageTypeFlagsEXT::default(),
             pfn_user_callback: unsafe { ::std::mem::zeroed() },
-            p_user_data: unsafe { ::std::mem::zeroed() },
+            p_user_data: ::std::ptr::null_mut(),
         }
     }
 }
@@ -11142,17 +11142,17 @@ impl ::std::default::Default for DebugUtilsMessengerCallbackDataEXT {
     fn default() -> DebugUtilsMessengerCallbackDataEXT {
         DebugUtilsMessengerCallbackDataEXT {
             s_type: StructureType::DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: DebugUtilsMessengerCallbackDataFlagsEXT::default(),
-            p_message_id_name: unsafe { ::std::mem::zeroed() },
+            p_message_id_name: ::std::ptr::null(),
             message_id_number: int32_t::default(),
-            p_message: unsafe { ::std::mem::zeroed() },
+            p_message: ::std::ptr::null(),
             queue_label_count: uint32_t::default(),
-            p_queue_labels: unsafe { ::std::mem::zeroed() },
+            p_queue_labels: ::std::ptr::null_mut(),
             cmd_buf_label_count: uint32_t::default(),
-            p_cmd_buf_labels: unsafe { ::std::mem::zeroed() },
+            p_cmd_buf_labels: ::std::ptr::null_mut(),
             object_count: uint32_t::default(),
-            p_objects: unsafe { ::std::mem::zeroed() },
+            p_objects: ::std::ptr::null_mut(),
         }
     }
 }
@@ -11168,9 +11168,9 @@ impl ::std::default::Default for ImportMemoryHostPointerInfoEXT {
     fn default() -> ImportMemoryHostPointerInfoEXT {
         ImportMemoryHostPointerInfoEXT {
             s_type: StructureType::IMPORT_MEMORY_HOST_POINTER_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             handle_type: ExternalMemoryHandleTypeFlags::default(),
-            p_host_pointer: unsafe { ::std::mem::zeroed() },
+            p_host_pointer: ::std::ptr::null_mut(),
         }
     }
 }
@@ -11185,7 +11185,7 @@ impl ::std::default::Default for MemoryHostPointerPropertiesEXT {
     fn default() -> MemoryHostPointerPropertiesEXT {
         MemoryHostPointerPropertiesEXT {
             s_type: StructureType::MEMORY_HOST_POINTER_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             memory_type_bits: uint32_t::default(),
         }
     }
@@ -11201,7 +11201,7 @@ impl ::std::default::Default for PhysicalDeviceExternalMemoryHostPropertiesEXT {
     fn default() -> PhysicalDeviceExternalMemoryHostPropertiesEXT {
         PhysicalDeviceExternalMemoryHostPropertiesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             min_imported_host_pointer_alignment: DeviceSize::default(),
         }
     }
@@ -11225,7 +11225,7 @@ impl ::std::default::Default for PhysicalDeviceConservativeRasterizationProperti
     fn default() -> PhysicalDeviceConservativeRasterizationPropertiesEXT {
         PhysicalDeviceConservativeRasterizationPropertiesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             primitive_overestimation_size: c_float::default(),
             max_extra_primitive_overestimation_size: c_float::default(),
             extra_primitive_overestimation_size_granularity: c_float::default(),
@@ -11262,7 +11262,7 @@ impl ::std::default::Default for PhysicalDeviceShaderCorePropertiesAMD {
     fn default() -> PhysicalDeviceShaderCorePropertiesAMD {
         PhysicalDeviceShaderCorePropertiesAMD {
             s_type: StructureType::PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             shader_engine_count: uint32_t::default(),
             shader_arrays_per_engine_count: uint32_t::default(),
             compute_units_per_shader_array: uint32_t::default(),
@@ -11293,7 +11293,7 @@ impl ::std::default::Default for PipelineRasterizationConservativeStateCreateInf
     fn default() -> PipelineRasterizationConservativeStateCreateInfoEXT {
         PipelineRasterizationConservativeStateCreateInfoEXT {
             s_type: StructureType::PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             flags: PipelineRasterizationConservativeStateCreateFlagsEXT::default(),
             conservative_rasterization_mode: ConservativeRasterizationModeEXT::default(),
             extra_primitive_overestimation_size: c_float::default(),
@@ -11330,7 +11330,7 @@ impl ::std::default::Default for PhysicalDeviceDescriptorIndexingFeaturesEXT {
     fn default() -> PhysicalDeviceDescriptorIndexingFeaturesEXT {
         PhysicalDeviceDescriptorIndexingFeaturesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             shader_input_attachment_array_dynamic_indexing: Bool32::default(),
             shader_uniform_texel_buffer_array_dynamic_indexing: Bool32::default(),
             shader_storage_texel_buffer_array_dynamic_indexing: Bool32::default(),
@@ -11387,7 +11387,7 @@ impl ::std::default::Default for PhysicalDeviceDescriptorIndexingPropertiesEXT {
     fn default() -> PhysicalDeviceDescriptorIndexingPropertiesEXT {
         PhysicalDeviceDescriptorIndexingPropertiesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             max_update_after_bind_descriptors_in_all_pools: uint32_t::default(),
             shader_uniform_buffer_array_non_uniform_indexing_native: Bool32::default(),
             shader_sampled_image_array_non_uniform_indexing_native: Bool32::default(),
@@ -11426,9 +11426,9 @@ impl ::std::default::Default for DescriptorSetLayoutBindingFlagsCreateInfoEXT {
     fn default() -> DescriptorSetLayoutBindingFlagsCreateInfoEXT {
         DescriptorSetLayoutBindingFlagsCreateInfoEXT {
             s_type: StructureType::DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             binding_count: uint32_t::default(),
-            p_binding_flags: unsafe { ::std::mem::zeroed() },
+            p_binding_flags: ::std::ptr::null(),
         }
     }
 }
@@ -11444,9 +11444,9 @@ impl ::std::default::Default for DescriptorSetVariableDescriptorCountAllocateInf
     fn default() -> DescriptorSetVariableDescriptorCountAllocateInfoEXT {
         DescriptorSetVariableDescriptorCountAllocateInfoEXT {
             s_type: StructureType::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             descriptor_set_count: uint32_t::default(),
-            p_descriptor_counts: unsafe { ::std::mem::zeroed() },
+            p_descriptor_counts: ::std::ptr::null(),
         }
     }
 }
@@ -11461,7 +11461,7 @@ impl ::std::default::Default for DescriptorSetVariableDescriptorCountLayoutSuppo
     fn default() -> DescriptorSetVariableDescriptorCountLayoutSupportEXT {
         DescriptorSetVariableDescriptorCountLayoutSupportEXT {
             s_type: StructureType::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             max_variable_descriptor_count: uint32_t::default(),
         }
     }
@@ -11484,9 +11484,9 @@ impl ::std::default::Default for PipelineVertexInputDivisorStateCreateInfoEXT {
     fn default() -> PipelineVertexInputDivisorStateCreateInfoEXT {
         PipelineVertexInputDivisorStateCreateInfoEXT {
             s_type: StructureType::PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             vertex_binding_divisor_count: uint32_t::default(),
-            p_vertex_binding_divisors: unsafe { ::std::mem::zeroed() },
+            p_vertex_binding_divisors: ::std::ptr::null(),
         }
     }
 }
@@ -11501,7 +11501,7 @@ impl ::std::default::Default for PhysicalDeviceVertexAttributeDivisorPropertiesE
     fn default() -> PhysicalDeviceVertexAttributeDivisorPropertiesEXT {
         PhysicalDeviceVertexAttributeDivisorPropertiesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             max_vertex_attrib_divisor: uint32_t::default(),
         }
     }
@@ -11517,8 +11517,8 @@ impl ::std::default::Default for ImportAndroidHardwareBufferInfoANDROID {
     fn default() -> ImportAndroidHardwareBufferInfoANDROID {
         ImportAndroidHardwareBufferInfoANDROID {
             s_type: StructureType::IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
-            p_next: unsafe { ::std::mem::zeroed() },
-            buffer: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
+            buffer: ::std::ptr::null_mut(),
         }
     }
 }
@@ -11533,7 +11533,7 @@ impl ::std::default::Default for AndroidHardwareBufferUsageANDROID {
     fn default() -> AndroidHardwareBufferUsageANDROID {
         AndroidHardwareBufferUsageANDROID {
             s_type: StructureType::ANDROID_HARDWARE_BUFFER_USAGE_ANDROID,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             android_hardware_buffer_usage: uint64_t::default(),
         }
     }
@@ -11550,7 +11550,7 @@ impl ::std::default::Default for AndroidHardwareBufferPropertiesANDROID {
     fn default() -> AndroidHardwareBufferPropertiesANDROID {
         AndroidHardwareBufferPropertiesANDROID {
             s_type: StructureType::ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             allocation_size: DeviceSize::default(),
             memory_type_bits: uint32_t::default(),
         }
@@ -11567,7 +11567,7 @@ impl ::std::default::Default for MemoryGetAndroidHardwareBufferInfoANDROID {
     fn default() -> MemoryGetAndroidHardwareBufferInfoANDROID {
         MemoryGetAndroidHardwareBufferInfoANDROID {
             s_type: StructureType::MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null(),
             memory: DeviceMemory::default(),
         }
     }
@@ -11590,7 +11590,7 @@ impl ::std::default::Default for AndroidHardwareBufferFormatPropertiesANDROID {
     fn default() -> AndroidHardwareBufferFormatPropertiesANDROID {
         AndroidHardwareBufferFormatPropertiesANDROID {
             s_type: StructureType::ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             format: Format::default(),
             external_format: uint64_t::default(),
             format_features: FormatFeatureFlags::default(),
@@ -11613,7 +11613,7 @@ impl ::std::default::Default for ExternalFormatANDROID {
     fn default() -> ExternalFormatANDROID {
         ExternalFormatANDROID {
             s_type: StructureType::EXTERNAL_FORMAT_ANDROID,
-            p_next: unsafe { ::std::mem::zeroed() },
+            p_next: ::std::ptr::null_mut(),
             external_format: uint64_t::default(),
         }
     }


### PR DESCRIPTION
Set pointers in Default implementation fo structs to std::ptr::null()/null_mut() instead of zeroed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/110)
<!-- Reviewable:end -->
