### PR TITLE
Fix instance getters to support extensions

### DIFF
--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -151,10 +151,10 @@ pub trait InstanceV1_1: InstanceV1_0 {
         }
     }
 
-    fn get_physical_device_queue_family_properties2(
+    fn get_physical_device_queue_family_properties2_len(
         &self,
         physical_device: vk::PhysicalDevice,
-    ) -> Vec<vk::QueueFamilyProperties2> {
+    ) -> usize {
         unsafe {
             let mut queue_count = 0;
             self.fp_v1_1().get_physical_device_queue_family_properties2(
@@ -162,15 +162,21 @@ pub trait InstanceV1_1: InstanceV1_0 {
                 &mut queue_count,
                 ptr::null_mut(),
             );
-            let mut queue_families_vec = Vec::with_capacity(queue_count as usize);
-            self.fp_v1_1().get_physical_device_queue_family_properties2(
-                physical_device,
-                &mut queue_count,
-                queue_families_vec.as_mut_ptr(),
-            );
-            queue_families_vec.set_len(queue_count as usize);
-            queue_families_vec
+            queue_count as usize
         }
+    }
+
+    unsafe fn get_physical_device_queue_family_properties2(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        queue_family_props: &mut [vk::QueueFamilyProperties2]
+    ) {
+        let mut queue_count = queue_family_props.len() as u32;
+        self.fp_v1_1().get_physical_device_queue_family_properties2(
+            physical_device,
+            &mut queue_count,
+            queue_family_props.as_mut_ptr(),
+        );
     }
 
     fn get_physical_device_memory_properties2(

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -108,16 +108,13 @@ pub trait InstanceV1_1: InstanceV1_0 {
         }
     }
 
-    fn get_physical_device_properties2(
+    unsafe fn get_physical_device_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-    ) -> vk::PhysicalDeviceProperties2 {
-        unsafe {
-            let mut prop = mem::uninitialized();
-            self.fp_v1_1()
-                .get_physical_device_properties2(physical_device, &mut prop);
-            prop
-        }
+        prop: &mut vk::PhysicalDeviceProperties2,
+    ) {
+        self.fp_v1_1()
+            .get_physical_device_properties2(physical_device, prop);
     }
 
     fn get_physical_device_format_properties2(
@@ -140,15 +137,15 @@ pub trait InstanceV1_1: InstanceV1_0 {
         &self,
         physical_device: vk::PhysicalDevice,
         format_info: &vk::PhysicalDeviceImageFormatInfo2,
-    ) -> VkResult<vk::ImageFormatProperties2> {
-        let mut image_format_prop = mem::uninitialized();
+        image_format_prop: &mut vk::ImageFormatProperties2
+    ) -> VkResult<()> {
         let err_code = self.fp_v1_1().get_physical_device_image_format_properties2(
             physical_device,
             format_info,
-            &mut image_format_prop,
+            image_format_prop,
         );
         if err_code == vk::Result::SUCCESS {
-            Ok(image_format_prop)
+            Ok(())
         } else {
             Err(err_code)
         }


### PR DESCRIPTION
As discussed in #109, the various getter functions for physical device don't work, because the user isn't able to pass in a chain of mutable structures for the Vulkan driver to fill in.

- All getters will probably have to be marked `unsafe`, since we cannot validate the user passed in a structure with a valid `p_next` pointer.

- I have not touched the getters which don't have any extensions yet. For example, I haven't modified `get_physical_device_external_fence_properties` since there are no published extensions which affect it (yet).

- I don't know how to solve the issue with functions which need to work with vectors, specifically `get_physical_device_queue_family_properties2`, which does have an extension structure for it (`QueueFamilyCheckpointPropertiesNV`).
  - We would have to provide a function to get the length of the returned array.
The user would then allocate an array of structures, create an array of extension structures, then properly set the `p_next` pointers, and call the function to fill in the array of structure chains.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/111)
<!-- Reviewable:end -->
