### PR TITLE
Fix closing the examples through the close button

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -253,7 +253,7 @@ impl ExampleBase {
                             ControlFlow::Continue
                         }
                     }
-                    WindowEvent::Destroyed => winit::ControlFlow::Break,
+                    WindowEvent::CloseRequested => winit::ControlFlow::Break,
                     _ => ControlFlow::Continue,
                 },
                 _ => ControlFlow::Continue,


### PR DESCRIPTION
I ran the examples and was surprised the close (X) button didn't work.

Due to changes in `winit`, the  `CloseRequested` event does what the `Destroyed` event used to do.