### PR TITLE
Fix Windows surface creation in the example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,4 +9,4 @@ image = "0.10.4"
 ash = { path = "../ash" }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.4", features = ["windef", "winuser"] }
+winapi = { version = "0.3.4", features = ["windef", "libloaderapi"] }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -118,11 +118,11 @@ unsafe fn create_surface<E: EntryV1_0, I: InstanceV1_0>(
     window: &winit::Window,
 ) -> Result<vk::SurfaceKHR, vk::Result> {
     use winapi::shared::windef::HWND;
-    use winapi::um::winuser::GetWindow;
+    use winapi::um::libloaderapi::GetModuleHandleW;
     use winit::os::windows::WindowExt;
 
     let hwnd = window.get_hwnd() as HWND;
-    let hinstance = GetWindow(hwnd, 0) as *const c_void;
+    let hinstance = GetModuleHandleW(ptr::null()) as *const c_void;
     let win32_create_info = vk::Win32SurfaceCreateInfoKHR {
         s_type: vk::StructureType::WIN32_SURFACE_CREATE_INFO_KHR,
         p_next: ptr::null(),


### PR DESCRIPTION
The surface creation code expects `hinstance` to be the handle of the process with created the window. For some reason, in the example we were passing in a handle to the top level window.

The `HINSTANCE` parameter isn't really used for anything on modern Windows, and even the validation layers will gladly accept invalid values, but the example should be technically correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/118)
<!-- Reviewable:end -->
