### PR TITLE
Fix Vulkan 1.1 getters

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -35,7 +35,7 @@ pub trait DeviceV1_1: DeviceV1_0 {
         }
     }
 
-	unsafe fn get_device_group_peer_memory_features(
+    unsafe fn get_device_group_peer_memory_features(
         &self,
         heap_index: u32,
         local_device_index: u32,
@@ -85,33 +85,31 @@ pub trait DeviceV1_1: DeviceV1_0 {
     unsafe fn get_image_memory_requirements2(
         &self,
         info: &vk::ImageMemoryRequirementsInfo2,
-    ) -> vk::MemoryRequirements2 {
-        let mut image_memory_requirements = mem::uninitialized();
+        out: &mut vk::MemoryRequirements2,
+    ) {
         self.fp_v1_1().get_image_memory_requirements2(
             self.handle(),
             info,
-            &mut image_memory_requirements,
+            out,
         );
-        image_memory_requirements
     }
 
     unsafe fn get_buffer_memory_requirements2(
         &self,
         info: &vk::BufferMemoryRequirementsInfo2,
-    ) -> vk::MemoryRequirements2 {
-        let mut image_memory_requirements = mem::uninitialized();
+        out: &mut vk::MemoryRequirements2,
+    ) {
         self.fp_v1_1().get_buffer_memory_requirements2(
             self.handle(),
             info,
-            &mut image_memory_requirements,
+            out,
         );
-        image_memory_requirements
     }
 
-    unsafe fn get_image_sparse_memory_requirements2(
+    unsafe fn get_image_sparse_memory_requirements2_len(
         &self,
         info: &vk::ImageSparseMemoryRequirementsInfo2,
-    ) -> Vec<vk::SparseImageMemoryRequirements2> {
+    ) -> usize {
         let mut count = mem::uninitialized();
         self.fp_v1_1().get_image_sparse_memory_requirements2(
             self.handle(),
@@ -119,15 +117,21 @@ pub trait DeviceV1_1: DeviceV1_0 {
             &mut count,
             ptr::null_mut(),
         );
-        let mut requirements = Vec::with_capacity(count as usize);
+        count as usize
+    }
+
+    unsafe fn get_image_sparse_memory_requirements2(
+        &self,
+        info: &vk::ImageSparseMemoryRequirementsInfo2,
+        out: &mut [vk::SparseImageMemoryRequirements2],
+    ) {
+        let mut count = out.len() as u32;
         self.fp_v1_1().get_image_sparse_memory_requirements2(
             self.handle(),
             info,
             &mut count,
-            requirements.as_mut_ptr(),
+            out.as_mut_ptr(),
         );
-        requirements.set_len(count as usize);
-        requirements
     }
 
     unsafe fn trim_command_pool(
@@ -216,14 +220,13 @@ pub trait DeviceV1_1: DeviceV1_0 {
     unsafe fn get_descriptor_set_layout_support(
         &self,
         create_info: &vk::DescriptorSetLayoutCreateInfo,
-    ) -> vk::DescriptorSetLayoutSupport {
-        let mut descriptor_set_layout_support = mem::uninitialized();
+        out: &mut vk::DescriptorSetLayoutSupport,
+    ) {
         self.fp_v1_1().get_descriptor_set_layout_support(
             self.handle(),
             create_info,
-            &mut descriptor_set_layout_support,
+            out,
         );
-        descriptor_set_layout_support
     }
 }
 

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -87,25 +87,30 @@ impl<V: FunctionPointers> Instance<V> {
 pub trait InstanceV1_1: InstanceV1_0 {
     fn fp_v1_1(&self) -> &vk::InstanceFnV1_1;
 
-    fn enumerate_physical_device_groups(&self) -> VkResult<Vec<vk::PhysicalDeviceGroupProperties>> {
+    unsafe fn enumerate_physical_device_groups_len(&self) -> usize {
+        let mut group_count = mem::uninitialized();
+        self.fp_v1_1().enumerate_physical_device_groups(
+            self.handle(),
+            &mut group_count,
+            ptr::null_mut(),
+        );
+        group_count as usize
+    }
+
+    fn enumerate_physical_device_groups(
+        &self,
+        out: &mut [vk::PhysicalDeviceGroupProperties]
+    ) -> VkResult<()> {
         unsafe {
-            let mut group_count = mem::uninitialized();
-            self.fp_v1_1().enumerate_physical_device_groups(
-                self.handle(),
-                &mut group_count,
-                ptr::null_mut(),
-            );
-            let mut physical_device_groups = Vec::with_capacity(group_count as usize);
+            let mut group_count = out.len() as u32;
             let err_code = self.fp_v1_1().enumerate_physical_device_groups(
                 self.handle(),
                 &mut group_count,
-                physical_device_groups.as_mut_ptr(),
+                out.as_mut_ptr(),
             );
-            physical_device_groups.set_len(group_count as usize);
-            match err_code {
-                vk::Result::SUCCESS => Ok(physical_device_groups),
-                _ => Err(err_code),
-            }
+            if err_code == vk::Result::SUCCESS {
+                Ok(())
+            } else { Err(err_code) }
         }
     }
 
@@ -122,15 +127,14 @@ pub trait InstanceV1_1: InstanceV1_0 {
         &self,
         physical_device: vk::PhysicalDevice,
         format: vk::Format,
-    ) -> vk::FormatProperties2 {
+        out: &mut vk::FormatProperties2,
+    ) {
         unsafe {
-            let mut format_prop = mem::uninitialized();
             self.fp_v1_1().get_physical_device_format_properties2(
                 physical_device,
                 format,
-                &mut format_prop,
+                out,
             );
-            format_prop
         }
     }
 
@@ -183,20 +187,19 @@ pub trait InstanceV1_1: InstanceV1_0 {
     fn get_physical_device_memory_properties2(
         &self,
         physical_device: vk::PhysicalDevice,
-    ) -> vk::PhysicalDeviceMemoryProperties2 {
+        out: &mut vk::PhysicalDeviceMemoryProperties2,
+    ) {
         unsafe {
-            let mut memory_prop = mem::uninitialized();
             self.fp_v1_1()
-                .get_physical_device_memory_properties2(physical_device, &mut memory_prop);
-            memory_prop
+                .get_physical_device_memory_properties2(physical_device, out);
         }
     }
 
-    unsafe fn get_physical_device_sparse_image_format_properties2(
+    unsafe fn get_physical_device_sparse_image_format_properties2_len(
         &self,
         physical_device: vk::PhysicalDevice,
         format_info: &vk::PhysicalDeviceSparseImageFormatInfo2,
-    ) -> Vec<vk::SparseImageFormatProperties2> {
+    ) -> usize {
         let mut format_count = 0;
         self.fp_v1_1()
             .get_physical_device_sparse_image_format_properties2(
@@ -205,61 +208,65 @@ pub trait InstanceV1_1: InstanceV1_0 {
                 &mut format_count,
                 ptr::null_mut(),
             );
-        let mut format_prop = Vec::with_capacity(format_count as usize);
+        format_count as usize
+    }
+
+    unsafe fn get_physical_device_sparse_image_format_properties2(
+        &self,
+        physical_device: vk::PhysicalDevice,
+        format_info: &vk::PhysicalDeviceSparseImageFormatInfo2,
+        out: &mut [vk::SparseImageFormatProperties2],
+    ) {
+        let mut format_count = out.len() as u32;
         self.fp_v1_1()
             .get_physical_device_sparse_image_format_properties2(
                 physical_device,
                 format_info,
                 &mut format_count,
-                format_prop.as_mut_ptr(),
+                out.as_mut_ptr(),
             );
-        format_prop.set_len(format_count as usize);
-        format_prop
     }
 
     unsafe fn get_physical_device_external_buffer_properties(
         &self,
         physical_device: vk::PhysicalDevice,
         external_buffer_info: &vk::PhysicalDeviceExternalBufferInfo,
-    ) -> vk::ExternalBufferProperties {
-        let mut image_format_prop = mem::uninitialized();
+        out: &mut vk::ExternalBufferProperties,
+    ) {
         self.fp_v1_1()
             .get_physical_device_external_buffer_properties(
                 physical_device,
                 external_buffer_info,
-                &mut image_format_prop,
+                out,
             );
-        image_format_prop
     }
 
     unsafe fn get_physical_device_external_fence_properties(
         &self,
         physical_device: vk::PhysicalDevice,
         external_fence_info: &vk::PhysicalDeviceExternalFenceInfo,
-    ) -> vk::ExternalFenceProperties {
-        let mut fence_prop = mem::uninitialized();
+        out: &mut vk::ExternalFenceProperties,
+    ) {
         self.fp_v1_1()
             .get_physical_device_external_fence_properties(
                 physical_device,
                 external_fence_info,
-                &mut fence_prop,
+                out,
             );
-        fence_prop
     }
 
     unsafe fn get_physical_device_external_semaphore_properties(
         &self,
         physical_device: vk::PhysicalDevice,
         external_semaphore_info: &vk::PhysicalDeviceExternalSemaphoreInfo,
-    ) -> vk::ExternalSemaphoreProperties {
-        let mut semaphore_prop = mem::uninitialized();
+        out: &mut vk::ExternalSemaphoreProperties,
+    ) {
         self.fp_v1_1()
             .get_physical_device_external_semaphore_properties(
                 physical_device,
                 external_semaphore_info,
-                &mut semaphore_prop,
+                out,
             );
-        semaphore_prop
     }
 }
 


### PR DESCRIPTION
Fixes #109

I checked every vk.xml struct marked `returnedonly`, and made a pass to sanity-check wrapped 1.1 getters in general. Might've missed some, but probably not many.