### PR TITLE
Compile fixes for macOS

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -153,15 +153,15 @@ unsafe fn create_surface<E: EntryV1_0, I: InstanceV1_0>(
     view.setWantsLayer(YES);
 
     let create_info = vk::MacOSSurfaceCreateInfoMVK {
-        s_type: vk::StructureType::MacOSSurfaceCreateInfoMvk,
+        s_type: vk::StructureType::MACOS_SURFACE_CREATE_INFO_M,
         p_next: ptr::null(),
         flags: Default::default(),
-        p_view: window.get_nsview() as *const vk::types::c_void
+        p_view: window.get_nsview() as *const c_void
     };
 
     let macos_surface_loader =
-        MacOSSurface::new(entry, instance).expect("Unable to load macOS surface");
-    macos_surface_loader.create_macos_surface_mvk(&create_info, None)
+        MacOSSurface::new(entry, instance);
+    macos_surface_loader.create_mac_os_surface_mvk(&create_info, None)
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
The changes for Ash 0.25 resulted in the macOS demo to fail compilation. There is a new runtime loader issue that still remains, which I will open a new issue for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maikklein/ash/147)
<!-- Reviewable:end -->
