### PR TITLE
Update `lazy_static` version to match `shared_library`'s

### DIFF
--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/ash"
 
 [dependencies]
 shared_library = "0.1.9"
-lazy_static = "0.2.1"
+lazy_static = "1"
 
 [features]
 default = []


### PR DESCRIPTION
`shared_library` uses a flexible "`1`" for its `lazy_static` lib. By following suit, `ash` can avoid duplicate versions of `lazy_static` in transient dependencies builds.

I tested this by building `ash`: everything built fine.
