### PR TITLE
Fix build on ARM

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1335,7 +1335,7 @@ pub fn derive_debug(_struct: &vkxml::Struct, union_types: &HashSet<&str>) -> Opt
         let debug_value = if is_static_array(field) && field.basetype == "char" {
             quote! {
                 &unsafe {
-                    ::std::ffi::CStr::from_ptr(self.#param_ident.as_ptr() as *const i8)
+                    ::std::ffi::CStr::from_ptr(self.#param_ident.as_ptr() as *const c_char)
                 }
             }
         } else if param_ident.as_ref().contains("pfn") {


### PR DESCRIPTION
`CStr::from_ptr` takes a `*const c_char`, which is not synonymous with `*const i8`. On ARM in particular, `c_char` is unsigned.