### PR TITLE
Pass constant size arrays by reference

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -1132,7 +1132,7 @@ pub trait DeviceV1_0 {
     unsafe fn cmd_set_blend_constants(
         &self,
         command_buffer: vk::CommandBuffer,
-        blend_constants: [f32; 4],
+        blend_constants: &[f32; 4],
     ) {
         self.fp_v1_0()
             .cmd_set_blend_constants(command_buffer, blend_constants);

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -2190,7 +2190,7 @@ pub struct DeviceFnV1_0 {
         depth_bias_slope_factor: f32,
     ) -> c_void,
     pub cmd_set_blend_constants:
-        extern "system" fn(command_buffer: CommandBuffer, blend_constants: [f32; 4]) -> c_void,
+        extern "system" fn(command_buffer: CommandBuffer, blend_constants: &[f32; 4]) -> c_void,
     pub cmd_set_depth_bounds: extern "system" fn(
         command_buffer: CommandBuffer,
         min_depth_bounds: f32,
@@ -4058,7 +4058,7 @@ impl DeviceFnV1_0 {
             cmd_set_blend_constants: unsafe {
                 extern "system" fn cmd_set_blend_constants(
                     _command_buffer: CommandBuffer,
-                    _blend_constants: [f32; 4],
+                    _blend_constants: &[f32; 4],
                 ) -> c_void {
                     panic!(concat!(
                         "Unable to load ",
@@ -5545,7 +5545,7 @@ impl DeviceFnV1_0 {
     pub unsafe fn cmd_set_blend_constants(
         &self,
         command_buffer: CommandBuffer,
-        blend_constants: [f32; 4],
+        blend_constants: &[f32; 4],
     ) -> c_void {
         (self.cmd_set_blend_constants)(command_buffer, blend_constants)
     }

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -663,7 +663,7 @@ impl FieldExt for vkxml::Field {
                 let size = constant_name(size);
                 let size = Term::intern(&size);
                 Some(quote! {
-                    [#ty; #size]
+                    &[#ty; #size]
                 })
             }
             _ => None,


### PR DESCRIPTION
Note: this is a breaking change!
Some related reading: https://lkml.org/lkml/2015/9/3/428
This has been plaguing WebRender on gfx-rs port running Windows/Vulkan.