### PR TITLE
Add methods to create instance & device from raw handles

### DIFF
--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -83,6 +83,11 @@ pub trait EntryV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> Result<Self::Instance, InstanceError>;
 
+    unsafe fn create_instance_from_raw_handle(
+        &self,
+        raw_instance_handle: u64,
+    ) -> Result<Self::Instance, InstanceError>;
+
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumerateInstanceLayerProperties.html>"]
     fn enumerate_instance_layer_properties(&self) -> VkResult<Vec<vk::LayerProperties>> {
         unsafe {
@@ -154,6 +159,16 @@ impl<L> EntryV1_0 for EntryCustom<L> {
         }
         Ok(Instance::load(&self.static_fn, instance))
     }
+
+    unsafe fn create_instance_from_raw_handle(
+        &self,
+        raw_instance_handle: u64,
+    ) -> Result<Self::Instance, InstanceError> {
+        use vk::Handle;
+        let instance = vk::Instance::from_raw(raw_instance_handle);
+        Ok(Instance::load(&self.static_fn, instance))
+    }
+
     fn fp_v1_0(&self) -> &vk::EntryFnV1_0 {
         &self.entry_fn_1_0
     }

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -52,6 +52,16 @@ impl InstanceV1_0 for Instance {
         }
         Ok(Device::load(&self.instance_fn_1_0, device))
     }
+
+    unsafe fn create_device_from_raw_handle(
+        &self,
+        raw_device_handle: u64,
+    ) -> Result<Self::Device, vk::Result> {
+        use vk::Handle;
+        let device = vk::Device::from_raw(raw_device_handle);
+        Ok(Device::load(&self.instance_fn_1_0, device))
+    }
+
     fn handle(&self) -> vk::Instance {
         self.handle
     }
@@ -268,6 +278,11 @@ pub trait InstanceV1_0 {
         physical_device: vk::PhysicalDevice,
         create_info: &vk::DeviceCreateInfo,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
+    ) -> Result<Self::Device, vk::Result>;
+
+    unsafe fn create_device_from_raw_handle(
+        &self,
+        raw_device_handle: u64,
     ) -> Result<Self::Device, vk::Result>;
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceProcAddr.html>"]


### PR DESCRIPTION
This would allow downstream vulkan library creators to share VkInstance and VkDevice handles with an application while still relying on `ash` to do the function pointer loading.

This way there would have to be no `ash` related types on the API boundries and thus libraries can stick to their own version of `ash` without having to upgrade every time a new `ash` version gets pushed.

@MaikKlein I'm not entirely sure if these are the only methods that would need a `create_x_from_raw_handle` function so if there are any more please comment & let me know.

Example usage:

```rust
use ash::{vk, Entry, Instance, Device};
use ash::version::{EntryV1_0, InstanceV1_0, DeviceV1_0};
use ash::vk_make_version;
use std::ffi::CString;
use ash::vk::Handle;

fn app_init(entry: &ash::Entry) -> (Instance, Device) {
    let app_name = CString::new("Test").unwrap();

    let appinfo = vk::ApplicationInfo::builder()
        .application_name(&app_name)
        .application_version(0)
        .engine_name(&app_name)
        .engine_version(0)
        .api_version(vk_make_version!(1, 1, 0));


    let create_info = vk::InstanceCreateInfo::builder()
        .application_info(&appinfo)
        .enabled_layer_names(&[])
        .enabled_extension_names(&[]);

    let app_instance: Instance = unsafe {
        entry
            .create_instance(&create_info, None)
            .expect("Instance creation error")
    };
    
    let pdevices = unsafe {
        app_instance
            .enumerate_physical_devices()
            .expect("Physical device error")
    };

    let priorities = [1.0];
    let queue_family_index = 0;

    let queue_info = [vk::DeviceQueueCreateInfo::builder()
        .queue_family_index(queue_family_index)
        .queue_priorities(&priorities)
        .build()];

    let device_create_info = vk::DeviceCreateInfo {
        p_queue_create_infos: queue_info.as_ptr(),
        queue_create_info_count: queue_info.len() as u32,
        ..Default::default()
    };

    let app_device = unsafe {
        app_instance.create_device(pdevices[0], &device_create_info, None).unwrap()
    };

    (app_instance, app_device)
}

fn lib_init_2(raw_instance: u64, raw_device: u64) {
    let entry = Entry::new().unwrap();
    let lib_instance = unsafe {
        entry.create_instance_from_raw_handle(raw_instance).unwrap()
    };

    let lib_device = unsafe {
        lib_instance.create_device_from_raw_handle(raw_device).unwrap()
    };

    let create_info = vk::CommandPoolCreateInfo::builder().queue_family_index(0).build();

    let pool = unsafe {
        lib_device.create_command_pool(
            &create_info,
            None
        ).unwrap()
    };

    dbg!(pool);

    let cmd_create_info = vk::CommandBufferAllocateInfo::builder()
        .level(vk::CommandBufferLevel::PRIMARY)
        .command_pool(pool)
        .command_buffer_count(1)
        .build();

    let cmd = unsafe {
        lib_device.allocate_command_buffers(&cmd_create_info)
    };

    dbg!(lib_device.handle());
    dbg!(cmd);
}

fn main() {
    let entry = Entry::new().unwrap();
    let (app_instance, app_device) = app_init(&entry);

    lib_init_2(app_instance.handle().as_raw(), app_device.handle().as_raw());
}
```