### PR TITLE
Fix shader and texture data loading in examples

### DIFF
--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -1,9 +1,8 @@
 use std::default::Default;
 use std::ffi::CString;
-use std::fs::File;
+use std::io::Cursor;
 use std::mem::{self, align_of};
 use std::os::raw::c_void;
-use std::path::Path;
 
 use ash::util::*;
 use ash::vk;
@@ -263,7 +262,9 @@ fn main() {
             .bind_buffer_memory(uniform_color_buffer, uniform_color_buffer_memory, 0)
             .unwrap();
 
-        let image = image::open("assets/rust.png").unwrap().to_rgba();
+        let image = image::load_from_memory(include_bytes!("../../assets/rust.png"))
+            .unwrap()
+            .to_rgba();
         let image_dimensions = image.dimensions();
         let image_data = image.into_raw();
         let image_buffer_info = vk::BufferCreateInfo {
@@ -544,9 +545,9 @@ fn main() {
         base.device.update_descriptor_sets(&write_desc_sets, &[]);
 
         let mut vertex_spv_file =
-            File::open(Path::new("shader/texture/vert.spv")).expect("Could not find vert.spv.");
+            Cursor::new(include_bytes!("../../shader/texture/vert.spv").to_vec());
         let mut frag_spv_file =
-            File::open(Path::new("shader/texture/frag.spv")).expect("Could not find frag.spv.");
+            Cursor::new(include_bytes!("../../shader/texture/frag.spv").to_vec());
 
         let vertex_code =
             read_spv(&mut vertex_spv_file).expect("Failed to read vertex shader spv file");

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -3,10 +3,9 @@ use ash::vk;
 use examples::*;
 use std::default::Default;
 use std::ffi::CString;
-use std::fs::File;
+use std::io::Cursor;
 use std::mem;
 use std::mem::align_of;
-use std::path::Path;
 
 #[derive(Clone, Debug, Copy)]
 struct Vertex {
@@ -200,9 +199,9 @@ fn main() {
             .bind_buffer_memory(vertex_input_buffer, vertex_input_buffer_memory, 0)
             .unwrap();
         let mut vertex_spv_file =
-            File::open(Path::new("shader/triangle/vert.spv")).expect("Could not find vert.spv.");
+            Cursor::new(include_bytes!("../../shader/triangle/vert.spv").to_vec());
         let mut frag_spv_file =
-            File::open(Path::new("shader/triangle/frag.spv")).expect("Could not find frag.spv.");
+            Cursor::new(include_bytes!("../../shader/triangle/frag.spv").to_vec());
 
         let vertex_code =
             read_spv(&mut vertex_spv_file).expect("Failed to read vertex shader spv file");


### PR DESCRIPTION
Load the example shader and texture files with `include_bytes!` so that they can be run from the root project directory. Previously, `cargn run --bin <EXAMPLE>` could only be run from the `examples` directory.