### PR TITLE
Expose raw function pointers in extensions

### DIFF
--- a/ash/src/extensions/ext/debug_marker.rs
+++ b/ash/src/extensions/ext/debug_marker.rs
@@ -64,4 +64,8 @@ impl DebugMarker {
         self.debug_marker_fn
             .cmd_debug_marker_insert_ext(command_buffer, marker_info);
     }
+
+    pub fn fp(&self) -> &vk::ExtDebugMarkerFn {
+        &self.debug_marker_fn
+    }
 }

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -58,4 +58,12 @@ impl DebugReport {
             _ => Err(err_code),
         }
     }
+
+    pub fn fp(&self) -> &vk::ExtDebugReportFn {
+        &self.debug_report_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -154,4 +154,12 @@ impl DebugUtils {
             callback_data,
         );
     }
+
+    pub fn fp(&self) -> &vk::ExtDebugUtilsFn {
+        &self.debug_utils_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -45,4 +45,12 @@ impl AndroidSurface {
             _ => Err(err_code),
         }
     }
+
+    pub fn fp(&self) -> &vk::KhrAndroidSurfaceFn {
+        &self.android_surface_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -47,4 +47,12 @@ impl DisplaySwapchain {
             _ => Err(err_code),
         }
     }
+
+    pub fn fp(&self) -> &vk::KhrDisplaySwapchainFn {
+        &self.swapchain_fn
+    }
+
+    pub fn device(&self) -> vk::Device {
+        self.handle
+    }
 }

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -138,4 +138,12 @@ impl Surface {
             allocation_callbacks.as_raw_ptr(),
         );
     }
+
+    pub fn raw_fp(&self) -> &vk::KhrSurfaceFn {
+        &self.surface_fn
+    }
+
+    pub fn instance_handle(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -139,11 +139,11 @@ impl Surface {
         );
     }
 
-    pub fn raw_fp(&self) -> &vk::KhrSurfaceFn {
+    pub fn fp(&self) -> &vk::KhrSurfaceFn {
         &self.surface_fn
     }
 
-    pub fn instance_handle(&self) -> vk::Instance {
+    pub fn instance(&self) -> vk::Instance {
         self.handle
     }
 }

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -126,4 +126,12 @@ impl Swapchain {
             _ => Err(err_code),
         }
     }
+
+    pub fn raw_fp(&self) -> &vk::KhrSwapchainFn {
+        &self.swapchain_fn
+    }
+
+    pub fn device_handle(&self) -> vk::Device {
+        self.handle
+    }
 }

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -127,11 +127,11 @@ impl Swapchain {
         }
     }
 
-    pub fn raw_fp(&self) -> &vk::KhrSwapchainFn {
+    pub fn fp(&self) -> &vk::KhrSwapchainFn {
         &self.swapchain_fn
     }
 
-    pub fn device_handle(&self) -> vk::Device {
+    pub fn device(&self) -> vk::Device {
         self.handle
     }
 }

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -63,4 +63,12 @@ impl WaylandSurface {
 
         b > 0
     }
+
+    pub fn fp(&self) -> &vk::KhrWaylandSurfaceFn {
+        &self.wayland_surface_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -61,4 +61,12 @@ impl Win32Surface {
 
         b > 0
     }
+
+    pub fn fp(&self) -> &vk::KhrWin32SurfaceFn {
+        &self.win32_surface_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -65,4 +65,12 @@ impl XcbSurface {
 
         b > 0
     }
+
+    pub fn fp(&self) -> &vk::KhrXcbSurfaceFn {
+        &self.xcb_surface_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/khr/xlib_surface.rs
+++ b/ash/src/extensions/khr/xlib_surface.rs
@@ -65,4 +65,12 @@ impl XlibSurface {
 
         b > 0
     }
+
+    pub fn fp(&self) -> &vk::KhrXlibSurfaceFn {
+        &self.xlib_surface_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -45,4 +45,12 @@ impl IOSSurface {
             _ => Err(err_code),
         }
     }
+
+    pub fn fp(&self) -> &vk::MvkIosSurfaceFn {
+        &self.ios_surface_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -45,4 +45,12 @@ impl MacOSSurface {
             _ => Err(err_code),
         }
     }
+
+    pub fn fp(&self) -> &vk::MvkMacosSurfaceFn {
+        &self.macos_surface_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
 }

--- a/ash/src/extensions/nv/mesh_shader.rs
+++ b/ash/src/extensions/nv/mesh_shader.rs
@@ -67,4 +67,8 @@ impl MeshShader {
     pub fn name() -> &'static CStr {
         vk::NvMeshShaderFn::name()
     }
+
+    pub fn fp(&self) -> &vk::NvMeshShaderFn {
+        &self.mesh_shader_fn
+    }
 }

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -271,4 +271,12 @@ impl RayTracing {
     pub fn name() -> &'static CStr {
         vk::NvRayTracingFn::name()
     }
+
+    pub fn fp(&self) -> &vk::NvRayTracingFn {
+        &self.ray_tracing_fn
+    }
+
+    pub fn device(&self) -> vk::Device {
+        self.handle
+    }
 }


### PR DESCRIPTION
Disclaimer: This pull request is not ready to be merged into master. This is a proposal for an interface addition

So in order to remedy issue #226, I've made this pull request. I've implemented an interface proposal for `ash::extensions::khr::Surface` and `ash::extensions::khr::Swapchain` as example code that needs to be reviewed.

The idea is to add a `raw_fp()` function to every extension struct (i.e Surface) that returns a non-mutable reference to the inner structure that holds the function pointer(s). In the case of Surface, this is the `ash::vk::KhrSurfaceFn` struct.

Additonally, we could also add `instance_handle()` and `device_handle()` functions where applicable, since the structures that hold these handles, have grabbed the function pointers specifically for those handles.

Example usage:
```rust
let mut swapchain_image_count: u32 = 0;

unsafe {
    let result = swapchain_loader.raw_fp().get_swapchain_images_khr(
        swapchain_loader.device_handle(), 
        swapchain, 
        &mut swapchain_image_count, 
        std::ptr::null_mut::<vk::Image>());
    assert_eq!(result, vk::Result::SUCCESS);
}

let mut images = // Allocate custom buffer based on swapchain_image_count

unsafe {
    let result = swapchain_loader.raw_fp().get_swapchain_images_khr(
        swapchain_loader.device_handle(), 
        swapchain, &mut swapchain_image_count, 
        images.as_mut_ptr());
    assert_eq!(result, vk::Result::SUCCESS);
}
```

If the interface seems fine, I'll go ahead and implement it for all the extension structs except `experimental`