### PR TITLE
Replaces Vec in return types with generic FromIterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ let instance = entry.create_instance(&create_info, None)
 ### `Vec<T>` instead of mutable slices
 
 ```Rust
-pub fn get_swapchain_images(&self,
-                            swapchain: vk::SwapchainKHR)
-                            -> VkResult<Vec<vk::Image>>;
-let present_images = swapchain_loader.get_swapchain_images_khr(swapchain).unwrap();
+pub fn get_swapchain_images<
+    T: FromIterator<vk::Image> + DerefMut<Target = [vk::Image]>,
+>(
+    &self,
+    swapchain: vk::SwapchainKHR,
+) -> VkResult<T>;
+let present_images: Vec<T> = swapchain_loader.get_swapchain_images_khr(swapchain).unwrap();
 ```
-*Note*: Functions don't return `Vec<T>` if this would limit the functionality. See `p_next`.
+*Note*: Functions don't return `FromIterator<T> + DerefMut<[T]>` if this would limit the functionality. See `p_next`.
 
 ### Slices
 ```Rust

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -2,7 +2,9 @@
 use crate::prelude::*;
 use crate::vk;
 use crate::RawPtr;
+use std::iter::{self, FromIterator};
 use std::mem;
+use std::ops::DerefMut;
 use std::os::raw::c_void;
 use std::ptr;
 
@@ -756,18 +758,20 @@ pub trait DeviceV1_0 {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAllocateDescriptorSets.html>"]
-    unsafe fn allocate_descriptor_sets(
+    unsafe fn allocate_descriptor_sets<
+        T: FromIterator<vk::DescriptorSet> + DerefMut<Target = [vk::DescriptorSet]>,
+    >(
         &self,
         create_info: &vk::DescriptorSetAllocateInfo,
-    ) -> VkResult<Vec<vk::DescriptorSet>> {
-        let mut desc_set = Vec::with_capacity(create_info.descriptor_set_count as usize);
+    ) -> VkResult<T> {
+        let mut desc_set: T = iter::repeat(mem::zeroed())
+            .take(create_info.descriptor_set_count as usize)
+            .collect();
         let err_code = self.fp_v1_0().allocate_descriptor_sets(
             self.handle(),
             create_info,
             desc_set.as_mut_ptr(),
         );
-
-        desc_set.set_len(create_info.descriptor_set_count as usize);
         match err_code {
             vk::Result::SUCCESS => Ok(desc_set),
             _ => Err(err_code),
@@ -1370,13 +1374,17 @@ pub trait DeviceV1_0 {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateGraphicsPipelines.html>"]
-    unsafe fn create_graphics_pipelines(
+    unsafe fn create_graphics_pipelines<
+        T: FromIterator<vk::Pipeline> + DerefMut<Target = [vk::Pipeline]>,
+    >(
         &self,
         pipeline_cache: vk::PipelineCache,
         create_infos: &[vk::GraphicsPipelineCreateInfo],
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
-    ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
-        let mut pipelines = Vec::with_capacity(create_infos.len());
+    ) -> Result<T, (T, vk::Result)> {
+        let mut pipelines: T = iter::repeat(mem::zeroed())
+            .take(create_infos.len())
+            .collect();
         let err_code = self.fp_v1_0().create_graphics_pipelines(
             self.handle(),
             pipeline_cache,
@@ -1385,7 +1393,6 @@ pub trait DeviceV1_0 {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         );
-        pipelines.set_len(create_infos.len());
         match err_code {
             vk::Result::SUCCESS => Ok(pipelines),
             _ => Err((pipelines, err_code)),
@@ -1393,13 +1400,17 @@ pub trait DeviceV1_0 {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateComputePipelines.html>"]
-    unsafe fn create_compute_pipelines(
+    unsafe fn create_compute_pipelines<
+        T: FromIterator<vk::Pipeline> + DerefMut<Target = [vk::Pipeline]>,
+    >(
         &self,
         pipeline_cache: vk::PipelineCache,
         create_infos: &[vk::ComputePipelineCreateInfo],
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
-    ) -> Result<Vec<vk::Pipeline>, (Vec<vk::Pipeline>, vk::Result)> {
-        let mut pipelines = Vec::with_capacity(create_infos.len());
+    ) -> Result<T, (T, vk::Result)> {
+        let mut pipelines: T = iter::repeat(mem::zeroed())
+            .take(create_infos.len())
+            .collect();
         let err_code = self.fp_v1_0().create_compute_pipelines(
             self.handle(),
             pipeline_cache,
@@ -1408,7 +1419,6 @@ pub trait DeviceV1_0 {
             allocation_callbacks.as_raw_ptr(),
             pipelines.as_mut_ptr(),
         );
-        pipelines.set_len(create_infos.len());
         match err_code {
             vk::Result::SUCCESS => Ok(pipelines),
             _ => Err((pipelines, err_code)),
@@ -1474,10 +1484,12 @@ pub trait DeviceV1_0 {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPipelineCacheData.html>"]
-    unsafe fn get_pipeline_cache_data(
+    unsafe fn get_pipeline_cache_data<
+        T: FromIterator<u8> + DerefMut<Target = [u8]>,
+    >(
         &self,
         pipeline_cache: vk::PipelineCache,
-    ) -> VkResult<Vec<u8>> {
+    ) -> VkResult<T> {
         let mut data_size: usize = 0;
         let err_code = self.fp_v1_0().get_pipeline_cache_data(
             self.handle(),
@@ -1488,14 +1500,13 @@ pub trait DeviceV1_0 {
         if err_code != vk::Result::SUCCESS {
             return Err(err_code);
         };
-        let mut data: Vec<u8> = Vec::with_capacity(data_size);
+        let mut data: T = iter::repeat(0).take(data_size).collect();
         let err_code = self.fp_v1_0().get_pipeline_cache_data(
             self.handle(),
             pipeline_cache,
             &mut data_size,
             data.as_mut_ptr() as _,
         );
-        data.set_len(data_size);
         match err_code {
             vk::Result::SUCCESS => Ok(data),
             _ => Err(err_code),
@@ -1755,17 +1766,20 @@ pub trait DeviceV1_0 {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAllocateCommandBuffers.html>"]
-    unsafe fn allocate_command_buffers(
+    unsafe fn allocate_command_buffers<
+        T: FromIterator<vk::CommandBuffer> + DerefMut<Target = [vk::CommandBuffer]>,
+    >(
         &self,
         create_info: &vk::CommandBufferAllocateInfo,
-    ) -> VkResult<Vec<vk::CommandBuffer>> {
-        let mut buffers = Vec::with_capacity(create_info.command_buffer_count as usize);
+    ) -> VkResult<T> {
+        let mut buffers: T = iter::repeat(mem::zeroed())
+            .take(create_info.command_buffer_count as usize)
+            .collect();
         let err_code = self.fp_v1_0().allocate_command_buffers(
             self.handle(),
             create_info,
             buffers.as_mut_ptr(),
         );
-        buffers.set_len(create_info.command_buffer_count as usize);
         match err_code {
             vk::Result::SUCCESS => Ok(buffers),
             _ => Err(err_code),

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -4,7 +4,9 @@ use crate::version::{DeviceV1_0, InstanceV1_0};
 use crate::vk;
 use crate::RawPtr;
 use std::ffi::CStr;
+use std::iter::{self, FromIterator};
 use std::mem;
+use std::ops::DerefMut;
 
 #[derive(Clone)]
 pub struct DisplaySwapchain {
@@ -28,12 +30,16 @@ impl DisplaySwapchain {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateSharedSwapchainsKHR.html>"]
-    pub unsafe fn create_shared_swapchains(
+    pub unsafe fn create_shared_swapchains<
+        T: FromIterator<vk::SwapchainKHR> + DerefMut<Target = [vk::SwapchainKHR]>,
+    >(
         &self,
         create_infos: &[vk::SwapchainCreateInfoKHR],
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
-    ) -> VkResult<Vec<vk::SwapchainKHR>> {
-        let mut swapchains = Vec::with_capacity(create_infos.len());
+    ) -> VkResult<T> {
+        let mut swapchains: T = iter::repeat(mem::zeroed())
+            .take(create_infos.len())
+            .collect();
         let err_code = self.swapchain_fn.create_shared_swapchains_khr(
             self.handle,
             create_infos.len() as u32,
@@ -41,7 +47,6 @@ impl DisplaySwapchain {
             allocation_callbacks.as_raw_ptr(),
             swapchains.as_mut_ptr(),
         );
-        swapchains.set_len(create_infos.len());
         match err_code {
             vk::Result::SUCCESS => Ok(swapchains),
             _ => Err(err_code),

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -4,7 +4,9 @@ use crate::version::{EntryV1_0, InstanceV1_0};
 use crate::vk;
 use crate::RawPtr;
 use std::ffi::CStr;
+use std::iter::{self, FromIterator};
 use std::mem;
+use std::ops::DerefMut;
 use std::ptr;
 
 #[derive(Clone)]
@@ -50,11 +52,13 @@ impl Surface {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModesKHR.html>"]
-    pub unsafe fn get_physical_device_surface_present_modes(
+    pub unsafe fn get_physical_device_surface_present_modes<
+        T: FromIterator<vk::PresentModeKHR> + DerefMut<Target = [vk::PresentModeKHR]>,
+    >(
         &self,
         physical_device: vk::PhysicalDevice,
         surface: vk::SurfaceKHR,
-    ) -> VkResult<Vec<vk::PresentModeKHR>> {
+    ) -> VkResult<T> {
         let mut count = 0;
         self.surface_fn
             .get_physical_device_surface_present_modes_khr(
@@ -63,7 +67,9 @@ impl Surface {
                 &mut count,
                 ptr::null_mut(),
             );
-        let mut v = Vec::with_capacity(count as usize);
+        let mut v: T = iter::repeat(mem::zeroed())
+            .take(count as usize)
+            .collect();
         let err_code = self
             .surface_fn
             .get_physical_device_surface_present_modes_khr(
@@ -72,7 +78,6 @@ impl Surface {
                 &mut count,
                 v.as_mut_ptr(),
             );
-        v.set_len(count as usize);
         match err_code {
             vk::Result::SUCCESS => Ok(v),
             _ => Err(err_code),
@@ -100,11 +105,13 @@ impl Surface {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html>"]
-    pub unsafe fn get_physical_device_surface_formats(
+    pub unsafe fn get_physical_device_surface_formats<
+        T: FromIterator<vk::SurfaceFormatKHR> + DerefMut<Target = [vk::SurfaceFormatKHR]>,
+    >(
         &self,
         physical_device: vk::PhysicalDevice,
         surface: vk::SurfaceKHR,
-    ) -> VkResult<Vec<vk::SurfaceFormatKHR>> {
+    ) -> VkResult<T> {
         let mut count = 0;
         self.surface_fn.get_physical_device_surface_formats_khr(
             physical_device,
@@ -112,14 +119,15 @@ impl Surface {
             &mut count,
             ptr::null_mut(),
         );
-        let mut v = Vec::with_capacity(count as usize);
+        let mut v: T = iter::repeat(mem::zeroed())
+            .take(count as usize)
+            .collect();
         let err_code = self.surface_fn.get_physical_device_surface_formats_khr(
             physical_device,
             surface,
             &mut count,
             v.as_mut_ptr(),
         );
-        v.set_len(count as usize);
         match err_code {
             vk::Result::SUCCESS => Ok(v),
             _ => Err(err_code),

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -4,7 +4,9 @@ use crate::version::{DeviceV1_0, InstanceV1_0, InstanceV1_1};
 use crate::vk;
 use crate::RawPtr;
 use std::ffi::CStr;
+use std::iter::{self, FromIterator};
 use std::mem;
+use std::ops::DerefMut;
 
 #[derive(Clone)]
 pub struct RayTracing {
@@ -175,13 +177,17 @@ impl RayTracing {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateRayTracingPipelinesNV.html>"]
-    pub unsafe fn create_ray_tracing_pipelines(
+    pub unsafe fn create_ray_tracing_pipelines<
+        T: FromIterator<vk::Pipeline> + DerefMut<Target = [vk::Pipeline]>,
+    >(
         &self,
         pipeline_cache: vk::PipelineCache,
         create_info: &[vk::RayTracingPipelineCreateInfoNV],
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
-    ) -> VkResult<Vec<vk::Pipeline>> {
-        let mut pipelines = vec![mem::zeroed(); create_info.len()];
+    ) -> VkResult<T> {
+        let mut pipelines: T = iter::repeat(mem::zeroed())
+            .take(create_info.len())
+            .collect();
         let err_code = self.ray_tracing_fn.create_ray_tracing_pipelines_nv(
             self.handle,
             pipeline_cache,

--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -508,7 +508,7 @@ fn main() {
         let desc_alloc_info = vk::DescriptorSetAllocateInfo::builder()
             .descriptor_pool(descriptor_pool)
             .set_layouts(&desc_set_layouts);
-        let descriptor_sets = base
+        let descriptor_sets: Vec<_> = base
             .device
             .allocate_descriptor_sets(&desc_alloc_info)
             .unwrap();
@@ -547,11 +547,11 @@ fn main() {
         let mut vertex_spv_file = Cursor::new(&include_bytes!("../../shader/texture/vert.spv")[..]);
         let mut frag_spv_file = Cursor::new(&include_bytes!("../../shader/texture/frag.spv")[..]);
 
-        let vertex_code =
+        let vertex_code: Vec<_> =
             read_spv(&mut vertex_spv_file).expect("Failed to read vertex shader spv file");
         let vertex_shader_info = vk::ShaderModuleCreateInfo::builder().code(&vertex_code);
 
-        let frag_code =
+        let frag_code: Vec<_> =
             read_spv(&mut frag_spv_file).expect("Failed to read fragment shader spv file");
         let frag_shader_info = vk::ShaderModuleCreateInfo::builder().code(&frag_code);
 
@@ -689,7 +689,7 @@ fn main() {
             .layout(pipeline_layout)
             .render_pass(renderpass);
 
-        let graphics_pipelines = base
+        let graphics_pipelines: Vec<_> = base
             .device
             .create_graphics_pipelines(
                 vk::PipelineCache::null(),

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -202,11 +202,11 @@ fn main() {
             Cursor::new(&include_bytes!("../../shader/triangle/vert.spv")[..]);
         let mut frag_spv_file = Cursor::new(&include_bytes!("../../shader/triangle/frag.spv")[..]);
 
-        let vertex_code =
+        let vertex_code: Vec<_> =
             read_spv(&mut vertex_spv_file).expect("Failed to read vertex shader spv file");
         let vertex_shader_info = vk::ShaderModuleCreateInfo::builder().code(&vertex_code);
 
-        let frag_code =
+        let frag_code: Vec<_> =
             read_spv(&mut frag_spv_file).expect("Failed to read fragment shader spv file");
         let frag_shader_info = vk::ShaderModuleCreateInfo::builder().code(&frag_code);
 
@@ -347,7 +347,7 @@ fn main() {
             .layout(pipeline_layout)
             .render_pass(renderpass);
 
-        let graphics_pipelines = base
+        let graphics_pipelines: Vec<_> = base
             .device
             .create_graphics_pipelines(
                 vk::PipelineCache::null(),

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -364,7 +364,7 @@ impl ExampleBase {
                 .create_debug_report_callback(&debug_info, None)
                 .unwrap();
             let surface = create_surface(&entry, &instance, &window).unwrap();
-            let pdevices = instance
+            let pdevices: Vec<_> = instance
                 .enumerate_physical_devices()
                 .expect("Physical device error");
             let surface_loader = Surface::new(&entry, &instance);
@@ -372,7 +372,7 @@ impl ExampleBase {
                 .iter()
                 .map(|pdevice| {
                     instance
-                        .get_physical_device_queue_family_properties(*pdevice)
+                        .get_physical_device_queue_family_properties::<Vec<_>>(*pdevice)
                         .iter()
                         .enumerate()
                         .filter_map(|(index, ref info)| {
@@ -419,7 +419,7 @@ impl ExampleBase {
 
             let present_queue = device.get_device_queue(queue_family_index as u32, 0);
 
-            let surface_formats = surface_loader
+            let surface_formats: Vec<_> = surface_loader
                 .get_physical_device_surface_formats(pdevice, surface)
                 .unwrap();
             let surface_format = surface_formats
@@ -457,7 +457,7 @@ impl ExampleBase {
             } else {
                 surface_capabilities.current_transform
             };
-            let present_modes = surface_loader
+            let present_modes: Vec<_> = surface_loader
                 .get_physical_device_surface_present_modes(pdevice, surface)
                 .unwrap();
             let present_mode = present_modes
@@ -496,13 +496,13 @@ impl ExampleBase {
                 .command_pool(pool)
                 .level(vk::CommandBufferLevel::PRIMARY);
 
-            let command_buffers = device
+            let command_buffers: Vec<_> = device
                 .allocate_command_buffers(&command_buffer_allocate_info)
                 .unwrap();
             let setup_command_buffer = command_buffers[0];
             let draw_command_buffer = command_buffers[1];
 
-            let present_images = swapchain_loader.get_swapchain_images(swapchain).unwrap();
+            let present_images: Vec<_> = swapchain_loader.get_swapchain_images(swapchain).unwrap();
             let present_image_views: Vec<vk::ImageView> = present_images
                 .iter()
                 .map(|&image| {


### PR DESCRIPTION
**This is a breaking change.**

This replaces every occurence of `Vec<T>` in a return type with a generic `FromIterator<T> + DerefMut<Target = [T]>`.
That way, the library is way more flexible, while still not needing mutable slice parameters. If one knows the size of the collection at compile time, for example, `ArrayVec` may be used. If one haves a guess, `SmallVec` may be used, and so on.
The behaviour should be unchanged if one chooses to use `Vec`.

With this change, the only structs that implicitly allocate are `Entry` and `InstanceError`.
