### PR TITLE
Refresh dependencies

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["maik klein <maikklein@googlemail.com>"]
 edition = "2018"
 
 [dependencies]
-winit = "0.16"
+winit = "0.19"
 image = "0.10.4"
 ash = { path = "../ash" }
 
@@ -13,6 +13,6 @@ ash = { path = "../ash" }
 winapi = { version = "0.3.4", features = ["windef", "winuser"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-metal-rs = "0.6"
-cocoa = "0.13"
+metal = "0.17"
+cocoa = "0.20"
 objc = "0.2.2"

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -5,7 +5,7 @@ extern crate winapi;
 #[cfg(target_os = "macos")]
 extern crate cocoa;
 #[cfg(target_os = "macos")]
-extern crate metal_rs as metal;
+extern crate metal;
 #[cfg(target_os = "macos")]
 extern crate objc;
 extern crate winit;


### PR DESCRIPTION
Build wasn't working on macOS due to cocoa 0.13 and 0.15 being used by some dependencies. I've bumped everything and it builds successfully on macOS 10.14 with rustc 1.40.0-nightly (c23a7aa77 2019-10-19)