### PR TITLE
fix build errors for examples on osx

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["maik klein <maikklein@googlemail.com>"]
 edition = "2018"
 
 [dependencies]
-winit = "0.16"
+winit = "0.19.5"
 image = "0.10.4"
 ash = { path = "../ash" }
 
@@ -13,6 +13,6 @@ ash = { path = "../ash" }
 winapi = { version = "0.3.4", features = ["windef", "winuser"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-metal-rs = "0.6"
-cocoa = "0.13"
-objc = "0.2.2"
+metal = "0.17.1"
+cocoa = "0.20.0"
+objc = "0.2.7"

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -5,7 +5,7 @@ extern crate winapi;
 #[cfg(target_os = "macos")]
 extern crate cocoa;
 #[cfg(target_os = "macos")]
-extern crate metal_rs as metal;
+extern crate metal;
 #[cfg(target_os = "macos")]
 extern crate objc;
 extern crate winit;


### PR DESCRIPTION
While trying to build the examples on osx I would get the following error:
```
error[E0282]: type annotations needed
    --> /Users/plot/.cargo/registry/src/github.com-1ecc6299db9ec823/cocoa-0.13.0/src/appkit.rs:3418:9
     |
3418 |         msg_send![self, setStringValue:label];
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider giving `result` a type
     |
     = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```
After making the changes in this PR I was able to build the examples on osx and run the bin.