### PR TITLE
Vulkan 1.2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A very lightweight wrapper around Vulkan
 - [x] No validation, everything is **unsafe**
 - [x] Generated from `vk.xml`
 - [x] Support for Vulkan 1.1
+- [x] Support for Vulkan 1.2
 
 ## Features
 ### Explicit returns with `Result`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ A very lightweight wrapper around Vulkan
 - [x] No validation, everything is **unsafe**
 - [x] Generated from `vk.xml`
 - [x] Support for Vulkan 1.1
-- [x] Support for Vulkan 1.2
 
 ## Features
 ### Explicit returns with `Result`

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -47415,7 +47415,7 @@ pub struct PipelineExecutableInternalRepresentationKHR {
     pub description: [c_char; MAX_DESCRIPTION_SIZE],
     pub is_text: Bool32,
     pub data_size: usize,
-    pub p_data: *const c_void,
+    pub p_data: *mut c_void,
 }
 impl fmt::Debug for PipelineExecutableInternalRepresentationKHR {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -47443,7 +47443,7 @@ impl ::std::default::Default for PipelineExecutableInternalRepresentationKHR {
             description: unsafe { ::std::mem::zeroed() },
             is_text: Bool32::default(),
             data_size: usize::default(),
-            p_data: ::std::ptr::null(),
+            p_data: ::std::ptr::null_mut(),
         }
     }
 }
@@ -47496,10 +47496,10 @@ impl<'a> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
     }
     pub fn data(
         mut self,
-        data: &'a [u8],
+        data: &'a mut [u8],
     ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
         self.inner.data_size = data.len() as _;
-        self.inner.p_data = data.as_ptr() as *const c_void;
+        self.inner.p_data = data.as_mut_ptr() as *mut c_void;
         self
     }
     #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -7466,6 +7466,588 @@ impl DeviceFnV1_1 {
         (self.get_descriptor_set_layout_support)(device, p_create_info, p_support)
     }
 }
+pub struct EntryFnV1_2 {}
+unsafe impl Send for EntryFnV1_2 {}
+unsafe impl Sync for EntryFnV1_2 {}
+impl ::std::clone::Clone for EntryFnV1_2 {
+    fn clone(&self) -> Self {
+        EntryFnV1_2 {}
+    }
+}
+impl EntryFnV1_2 {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        EntryFnV1_2 {}
+    }
+}
+pub struct InstanceFnV1_2 {}
+unsafe impl Send for InstanceFnV1_2 {}
+unsafe impl Sync for InstanceFnV1_2 {}
+impl ::std::clone::Clone for InstanceFnV1_2 {
+    fn clone(&self) -> Self {
+        InstanceFnV1_2 {}
+    }
+}
+impl InstanceFnV1_2 {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        InstanceFnV1_2 {}
+    }
+}
+#[allow(non_camel_case_types)]
+pub type PFN_vkCmdDrawIndirectCount = extern "system" fn(
+    command_buffer: CommandBuffer,
+    buffer: Buffer,
+    offset: DeviceSize,
+    count_buffer: Buffer,
+    count_buffer_offset: DeviceSize,
+    max_draw_count: u32,
+    stride: u32,
+) -> c_void;
+#[allow(non_camel_case_types)]
+pub type PFN_vkCmdDrawIndexedIndirectCount = extern "system" fn(
+    command_buffer: CommandBuffer,
+    buffer: Buffer,
+    offset: DeviceSize,
+    count_buffer: Buffer,
+    count_buffer_offset: DeviceSize,
+    max_draw_count: u32,
+    stride: u32,
+) -> c_void;
+#[allow(non_camel_case_types)]
+pub type PFN_vkCreateRenderPass2 = extern "system" fn(
+    device: Device,
+    p_create_info: *const RenderPassCreateInfo2,
+    p_allocator: *const AllocationCallbacks,
+    p_render_pass: *mut RenderPass,
+) -> Result;
+#[allow(non_camel_case_types)]
+pub type PFN_vkCmdBeginRenderPass2 = extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_render_pass_begin: *const RenderPassBeginInfo,
+    p_subpass_begin_info: *const SubpassBeginInfo,
+) -> c_void;
+#[allow(non_camel_case_types)]
+pub type PFN_vkCmdNextSubpass2 = extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_subpass_begin_info: *const SubpassBeginInfo,
+    p_subpass_end_info: *const SubpassEndInfo,
+) -> c_void;
+#[allow(non_camel_case_types)]
+pub type PFN_vkCmdEndRenderPass2 = extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_subpass_end_info: *const SubpassEndInfo,
+) -> c_void;
+#[allow(non_camel_case_types)]
+pub type PFN_vkResetQueryPool = extern "system" fn(
+    device: Device,
+    query_pool: QueryPool,
+    first_query: u32,
+    query_count: u32,
+) -> c_void;
+#[allow(non_camel_case_types)]
+pub type PFN_vkGetSemaphoreCounterValue =
+    extern "system" fn(device: Device, semaphore: Semaphore, p_value: *mut u64) -> Result;
+#[allow(non_camel_case_types)]
+pub type PFN_vkWaitSemaphores = extern "system" fn(
+    device: Device,
+    p_wait_info: *const SemaphoreWaitInfo,
+    timeout: u64,
+) -> Result;
+#[allow(non_camel_case_types)]
+pub type PFN_vkSignalSemaphore =
+    extern "system" fn(device: Device, p_signal_info: *const SemaphoreSignalInfo) -> Result;
+#[allow(non_camel_case_types)]
+pub type PFN_vkGetBufferDeviceAddress =
+    extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> DeviceAddress;
+#[allow(non_camel_case_types)]
+pub type PFN_vkGetBufferOpaqueCaptureAddress =
+    extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> u64;
+#[allow(non_camel_case_types)]
+pub type PFN_vkGetDeviceMemoryOpaqueCaptureAddress =
+    extern "system" fn(device: Device, p_info: *const DeviceMemoryOpaqueCaptureAddressInfo) -> u64;
+pub struct DeviceFnV1_2 {
+    pub cmd_draw_indirect_count: extern "system" fn(
+        command_buffer: CommandBuffer,
+        buffer: Buffer,
+        offset: DeviceSize,
+        count_buffer: Buffer,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> c_void,
+    pub cmd_draw_indexed_indirect_count: extern "system" fn(
+        command_buffer: CommandBuffer,
+        buffer: Buffer,
+        offset: DeviceSize,
+        count_buffer: Buffer,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> c_void,
+    pub create_render_pass2: extern "system" fn(
+        device: Device,
+        p_create_info: *const RenderPassCreateInfo2,
+        p_allocator: *const AllocationCallbacks,
+        p_render_pass: *mut RenderPass,
+    ) -> Result,
+    pub cmd_begin_render_pass2: extern "system" fn(
+        command_buffer: CommandBuffer,
+        p_render_pass_begin: *const RenderPassBeginInfo,
+        p_subpass_begin_info: *const SubpassBeginInfo,
+    ) -> c_void,
+    pub cmd_next_subpass2: extern "system" fn(
+        command_buffer: CommandBuffer,
+        p_subpass_begin_info: *const SubpassBeginInfo,
+        p_subpass_end_info: *const SubpassEndInfo,
+    ) -> c_void,
+    pub cmd_end_render_pass2: extern "system" fn(
+        command_buffer: CommandBuffer,
+        p_subpass_end_info: *const SubpassEndInfo,
+    ) -> c_void,
+    pub reset_query_pool: extern "system" fn(
+        device: Device,
+        query_pool: QueryPool,
+        first_query: u32,
+        query_count: u32,
+    ) -> c_void,
+    pub get_semaphore_counter_value:
+        extern "system" fn(device: Device, semaphore: Semaphore, p_value: *mut u64) -> Result,
+    pub wait_semaphores: extern "system" fn(
+        device: Device,
+        p_wait_info: *const SemaphoreWaitInfo,
+        timeout: u64,
+    ) -> Result,
+    pub signal_semaphore:
+        extern "system" fn(device: Device, p_signal_info: *const SemaphoreSignalInfo) -> Result,
+    pub get_buffer_device_address:
+        extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> DeviceAddress,
+    pub get_buffer_opaque_capture_address:
+        extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> u64,
+    pub get_device_memory_opaque_capture_address: extern "system" fn(
+        device: Device,
+        p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
+    ) -> u64,
+}
+unsafe impl Send for DeviceFnV1_2 {}
+unsafe impl Sync for DeviceFnV1_2 {}
+impl ::std::clone::Clone for DeviceFnV1_2 {
+    fn clone(&self) -> Self {
+        DeviceFnV1_2 {
+            cmd_draw_indirect_count: self.cmd_draw_indirect_count,
+            cmd_draw_indexed_indirect_count: self.cmd_draw_indexed_indirect_count,
+            create_render_pass2: self.create_render_pass2,
+            cmd_begin_render_pass2: self.cmd_begin_render_pass2,
+            cmd_next_subpass2: self.cmd_next_subpass2,
+            cmd_end_render_pass2: self.cmd_end_render_pass2,
+            reset_query_pool: self.reset_query_pool,
+            get_semaphore_counter_value: self.get_semaphore_counter_value,
+            wait_semaphores: self.wait_semaphores,
+            signal_semaphore: self.signal_semaphore,
+            get_buffer_device_address: self.get_buffer_device_address,
+            get_buffer_opaque_capture_address: self.get_buffer_opaque_capture_address,
+            get_device_memory_opaque_capture_address: self.get_device_memory_opaque_capture_address,
+        }
+    }
+}
+impl DeviceFnV1_2 {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        DeviceFnV1_2 {
+            cmd_draw_indirect_count: unsafe {
+                extern "system" fn cmd_draw_indirect_count(
+                    _command_buffer: CommandBuffer,
+                    _buffer: Buffer,
+                    _offset: DeviceSize,
+                    _count_buffer: Buffer,
+                    _count_buffer_offset: DeviceSize,
+                    _max_draw_count: u32,
+                    _stride: u32,
+                ) -> c_void {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_draw_indirect_count)
+                    ))
+                }
+                let raw_name = stringify!(vkCmdDrawIndirectCount);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    cmd_draw_indirect_count
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_draw_indexed_indirect_count: unsafe {
+                extern "system" fn cmd_draw_indexed_indirect_count(
+                    _command_buffer: CommandBuffer,
+                    _buffer: Buffer,
+                    _offset: DeviceSize,
+                    _count_buffer: Buffer,
+                    _count_buffer_offset: DeviceSize,
+                    _max_draw_count: u32,
+                    _stride: u32,
+                ) -> c_void {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_draw_indexed_indirect_count)
+                    ))
+                }
+                let raw_name = stringify!(vkCmdDrawIndexedIndirectCount);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    cmd_draw_indexed_indirect_count
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            create_render_pass2: unsafe {
+                extern "system" fn create_render_pass2(
+                    _device: Device,
+                    _p_create_info: *const RenderPassCreateInfo2,
+                    _p_allocator: *const AllocationCallbacks,
+                    _p_render_pass: *mut RenderPass,
+                ) -> Result {
+                    panic!(concat!("Unable to load ", stringify!(create_render_pass2)))
+                }
+                let raw_name = stringify!(vkCreateRenderPass2);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    create_render_pass2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_begin_render_pass2: unsafe {
+                extern "system" fn cmd_begin_render_pass2(
+                    _command_buffer: CommandBuffer,
+                    _p_render_pass_begin: *const RenderPassBeginInfo,
+                    _p_subpass_begin_info: *const SubpassBeginInfo,
+                ) -> c_void {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_begin_render_pass2)
+                    ))
+                }
+                let raw_name = stringify!(vkCmdBeginRenderPass2);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    cmd_begin_render_pass2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_next_subpass2: unsafe {
+                extern "system" fn cmd_next_subpass2(
+                    _command_buffer: CommandBuffer,
+                    _p_subpass_begin_info: *const SubpassBeginInfo,
+                    _p_subpass_end_info: *const SubpassEndInfo,
+                ) -> c_void {
+                    panic!(concat!("Unable to load ", stringify!(cmd_next_subpass2)))
+                }
+                let raw_name = stringify!(vkCmdNextSubpass2);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    cmd_next_subpass2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_end_render_pass2: unsafe {
+                extern "system" fn cmd_end_render_pass2(
+                    _command_buffer: CommandBuffer,
+                    _p_subpass_end_info: *const SubpassEndInfo,
+                ) -> c_void {
+                    panic!(concat!("Unable to load ", stringify!(cmd_end_render_pass2)))
+                }
+                let raw_name = stringify!(vkCmdEndRenderPass2);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    cmd_end_render_pass2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            reset_query_pool: unsafe {
+                extern "system" fn reset_query_pool(
+                    _device: Device,
+                    _query_pool: QueryPool,
+                    _first_query: u32,
+                    _query_count: u32,
+                ) -> c_void {
+                    panic!(concat!("Unable to load ", stringify!(reset_query_pool)))
+                }
+                let raw_name = stringify!(vkResetQueryPool);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    reset_query_pool
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_semaphore_counter_value: unsafe {
+                extern "system" fn get_semaphore_counter_value(
+                    _device: Device,
+                    _semaphore: Semaphore,
+                    _p_value: *mut u64,
+                ) -> Result {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_semaphore_counter_value)
+                    ))
+                }
+                let raw_name = stringify!(vkGetSemaphoreCounterValue);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    get_semaphore_counter_value
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            wait_semaphores: unsafe {
+                extern "system" fn wait_semaphores(
+                    _device: Device,
+                    _p_wait_info: *const SemaphoreWaitInfo,
+                    _timeout: u64,
+                ) -> Result {
+                    panic!(concat!("Unable to load ", stringify!(wait_semaphores)))
+                }
+                let raw_name = stringify!(vkWaitSemaphores);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    wait_semaphores
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            signal_semaphore: unsafe {
+                extern "system" fn signal_semaphore(
+                    _device: Device,
+                    _p_signal_info: *const SemaphoreSignalInfo,
+                ) -> Result {
+                    panic!(concat!("Unable to load ", stringify!(signal_semaphore)))
+                }
+                let raw_name = stringify!(vkSignalSemaphore);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    signal_semaphore
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_buffer_device_address: unsafe {
+                extern "system" fn get_buffer_device_address(
+                    _device: Device,
+                    _p_info: *const BufferDeviceAddressInfo,
+                ) -> DeviceAddress {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_buffer_device_address)
+                    ))
+                }
+                let raw_name = stringify!(vkGetBufferDeviceAddress);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    get_buffer_device_address
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_buffer_opaque_capture_address: unsafe {
+                extern "system" fn get_buffer_opaque_capture_address(
+                    _device: Device,
+                    _p_info: *const BufferDeviceAddressInfo,
+                ) -> u64 {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_buffer_opaque_capture_address)
+                    ))
+                }
+                let raw_name = stringify!(vkGetBufferOpaqueCaptureAddress);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    get_buffer_opaque_capture_address
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_device_memory_opaque_capture_address: unsafe {
+                extern "system" fn get_device_memory_opaque_capture_address(
+                    _device: Device,
+                    _p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
+                ) -> u64 {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_device_memory_opaque_capture_address)
+                    ))
+                }
+                let raw_name = stringify!(vkGetDeviceMemoryOpaqueCaptureAddress);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    get_device_memory_opaque_capture_address
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+        }
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndirectCount.html>"]
+    pub unsafe fn cmd_draw_indirect_count(
+        &self,
+        command_buffer: CommandBuffer,
+        buffer: Buffer,
+        offset: DeviceSize,
+        count_buffer: Buffer,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> c_void {
+        (self.cmd_draw_indirect_count)(
+            command_buffer,
+            buffer,
+            offset,
+            count_buffer,
+            count_buffer_offset,
+            max_draw_count,
+            stride,
+        )
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndexedIndirectCount.html>"]
+    pub unsafe fn cmd_draw_indexed_indirect_count(
+        &self,
+        command_buffer: CommandBuffer,
+        buffer: Buffer,
+        offset: DeviceSize,
+        count_buffer: Buffer,
+        count_buffer_offset: DeviceSize,
+        max_draw_count: u32,
+        stride: u32,
+    ) -> c_void {
+        (self.cmd_draw_indexed_indirect_count)(
+            command_buffer,
+            buffer,
+            offset,
+            count_buffer,
+            count_buffer_offset,
+            max_draw_count,
+            stride,
+        )
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateRenderPass2.html>"]
+    pub unsafe fn create_render_pass2(
+        &self,
+        device: Device,
+        p_create_info: *const RenderPassCreateInfo2,
+        p_allocator: *const AllocationCallbacks,
+        p_render_pass: *mut RenderPass,
+    ) -> Result {
+        (self.create_render_pass2)(device, p_create_info, p_allocator, p_render_pass)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBeginRenderPass2.html>"]
+    pub unsafe fn cmd_begin_render_pass2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_render_pass_begin: *const RenderPassBeginInfo,
+        p_subpass_begin_info: *const SubpassBeginInfo,
+    ) -> c_void {
+        (self.cmd_begin_render_pass2)(command_buffer, p_render_pass_begin, p_subpass_begin_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdNextSubpass2.html>"]
+    pub unsafe fn cmd_next_subpass2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_subpass_begin_info: *const SubpassBeginInfo,
+        p_subpass_end_info: *const SubpassEndInfo,
+    ) -> c_void {
+        (self.cmd_next_subpass2)(command_buffer, p_subpass_begin_info, p_subpass_end_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdEndRenderPass2.html>"]
+    pub unsafe fn cmd_end_render_pass2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_subpass_end_info: *const SubpassEndInfo,
+    ) -> c_void {
+        (self.cmd_end_render_pass2)(command_buffer, p_subpass_end_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkResetQueryPool.html>"]
+    pub unsafe fn reset_query_pool(
+        &self,
+        device: Device,
+        query_pool: QueryPool,
+        first_query: u32,
+        query_count: u32,
+    ) -> c_void {
+        (self.reset_query_pool)(device, query_pool, first_query, query_count)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetSemaphoreCounterValue.html>"]
+    pub unsafe fn get_semaphore_counter_value(
+        &self,
+        device: Device,
+        semaphore: Semaphore,
+        p_value: *mut u64,
+    ) -> Result {
+        (self.get_semaphore_counter_value)(device, semaphore, p_value)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkWaitSemaphores.html>"]
+    pub unsafe fn wait_semaphores(
+        &self,
+        device: Device,
+        p_wait_info: *const SemaphoreWaitInfo,
+        timeout: u64,
+    ) -> Result {
+        (self.wait_semaphores)(device, p_wait_info, timeout)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkSignalSemaphore.html>"]
+    pub unsafe fn signal_semaphore(
+        &self,
+        device: Device,
+        p_signal_info: *const SemaphoreSignalInfo,
+    ) -> Result {
+        (self.signal_semaphore)(device, p_signal_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetBufferDeviceAddress.html>"]
+    pub unsafe fn get_buffer_device_address(
+        &self,
+        device: Device,
+        p_info: *const BufferDeviceAddressInfo,
+    ) -> DeviceAddress {
+        (self.get_buffer_device_address)(device, p_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetBufferOpaqueCaptureAddress.html>"]
+    pub unsafe fn get_buffer_opaque_capture_address(
+        &self,
+        device: Device,
+        p_info: *const BufferDeviceAddressInfo,
+    ) -> u64 {
+        (self.get_buffer_opaque_capture_address)(device, p_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceMemoryOpaqueCaptureAddress.html>"]
+    pub unsafe fn get_device_memory_opaque_capture_address(
+        &self,
+        device: Device,
+        p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
+    ) -> u64 {
+        (self.get_device_memory_opaque_capture_address)(device, p_info)
+    }
+}
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSampleMask.html>"]
 pub type SampleMask = u32;
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBool32.html>"]
@@ -7551,11 +8133,6 @@ vk_bitflags_wrapped!(InstanceCreateFlags, 0b0, Flags);
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceCreateFlags.html>"]
 pub struct DeviceCreateFlags(Flags);
 vk_bitflags_wrapped!(DeviceCreateFlags, 0b0, Flags);
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreCreateFlags.html>"]
-pub struct SemaphoreCreateFlags(Flags);
-vk_bitflags_wrapped!(SemaphoreCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkEventCreateFlags.html>"]
@@ -22733,75 +23310,75 @@ impl<'a> PhysicalDevicePushDescriptorPropertiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkConformanceVersionKHR.html>"]
-pub struct ConformanceVersionKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkConformanceVersion.html>"]
+pub struct ConformanceVersion {
     pub major: u8,
     pub minor: u8,
     pub subminor: u8,
     pub patch: u8,
 }
-impl ConformanceVersionKHR {
-    pub fn builder<'a>() -> ConformanceVersionKHRBuilder<'a> {
-        ConformanceVersionKHRBuilder {
-            inner: ConformanceVersionKHR::default(),
+impl ConformanceVersion {
+    pub fn builder<'a>() -> ConformanceVersionBuilder<'a> {
+        ConformanceVersionBuilder {
+            inner: ConformanceVersion::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct ConformanceVersionKHRBuilder<'a> {
-    inner: ConformanceVersionKHR,
+pub struct ConformanceVersionBuilder<'a> {
+    inner: ConformanceVersion,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for ConformanceVersionKHRBuilder<'a> {
-    type Target = ConformanceVersionKHR;
+impl<'a> ::std::ops::Deref for ConformanceVersionBuilder<'a> {
+    type Target = ConformanceVersion;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for ConformanceVersionKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for ConformanceVersionBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> ConformanceVersionKHRBuilder<'a> {
-    pub fn major(mut self, major: u8) -> ConformanceVersionKHRBuilder<'a> {
+impl<'a> ConformanceVersionBuilder<'a> {
+    pub fn major(mut self, major: u8) -> ConformanceVersionBuilder<'a> {
         self.inner.major = major;
         self
     }
-    pub fn minor(mut self, minor: u8) -> ConformanceVersionKHRBuilder<'a> {
+    pub fn minor(mut self, minor: u8) -> ConformanceVersionBuilder<'a> {
         self.inner.minor = minor;
         self
     }
-    pub fn subminor(mut self, subminor: u8) -> ConformanceVersionKHRBuilder<'a> {
+    pub fn subminor(mut self, subminor: u8) -> ConformanceVersionBuilder<'a> {
         self.inner.subminor = subminor;
         self
     }
-    pub fn patch(mut self, patch: u8) -> ConformanceVersionKHRBuilder<'a> {
+    pub fn patch(mut self, patch: u8) -> ConformanceVersionBuilder<'a> {
         self.inner.patch = patch;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> ConformanceVersionKHR {
+    pub fn build(self) -> ConformanceVersion {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDriverPropertiesKHR.html>"]
-pub struct PhysicalDeviceDriverPropertiesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDriverProperties.html>"]
+pub struct PhysicalDeviceDriverProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
-    pub driver_id: DriverIdKHR,
-    pub driver_name: [c_char; MAX_DRIVER_NAME_SIZE_KHR],
-    pub driver_info: [c_char; MAX_DRIVER_INFO_SIZE_KHR],
-    pub conformance_version: ConformanceVersionKHR,
+    pub driver_id: DriverId,
+    pub driver_name: [c_char; MAX_DRIVER_NAME_SIZE],
+    pub driver_info: [c_char; MAX_DRIVER_INFO_SIZE],
+    pub conformance_version: ConformanceVersion,
 }
-impl fmt::Debug for PhysicalDeviceDriverPropertiesKHR {
+impl fmt::Debug for PhysicalDeviceDriverProperties {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("PhysicalDeviceDriverPropertiesKHR")
+        fmt.debug_struct("PhysicalDeviceDriverProperties")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
             .field("driver_id", &self.driver_id)
@@ -22815,77 +23392,74 @@ impl fmt::Debug for PhysicalDeviceDriverPropertiesKHR {
             .finish()
     }
 }
-impl ::std::default::Default for PhysicalDeviceDriverPropertiesKHR {
-    fn default() -> PhysicalDeviceDriverPropertiesKHR {
-        PhysicalDeviceDriverPropertiesKHR {
-            s_type: StructureType::PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR,
+impl ::std::default::Default for PhysicalDeviceDriverProperties {
+    fn default() -> PhysicalDeviceDriverProperties {
+        PhysicalDeviceDriverProperties {
+            s_type: StructureType::PHYSICAL_DEVICE_DRIVER_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
-            driver_id: DriverIdKHR::default(),
+            driver_id: DriverId::default(),
             driver_name: unsafe { ::std::mem::zeroed() },
             driver_info: unsafe { ::std::mem::zeroed() },
-            conformance_version: ConformanceVersionKHR::default(),
+            conformance_version: ConformanceVersion::default(),
         }
     }
 }
-impl PhysicalDeviceDriverPropertiesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceDriverPropertiesKHRBuilder<'a> {
-        PhysicalDeviceDriverPropertiesKHRBuilder {
-            inner: PhysicalDeviceDriverPropertiesKHR::default(),
+impl PhysicalDeviceDriverProperties {
+    pub fn builder<'a>() -> PhysicalDeviceDriverPropertiesBuilder<'a> {
+        PhysicalDeviceDriverPropertiesBuilder {
+            inner: PhysicalDeviceDriverProperties::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceDriverPropertiesKHRBuilder<'a> {
-    inner: PhysicalDeviceDriverPropertiesKHR,
+pub struct PhysicalDeviceDriverPropertiesBuilder<'a> {
+    inner: PhysicalDeviceDriverProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceDriverPropertiesKHRBuilder<'_> {}
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceDriverPropertiesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceDriverPropertiesKHRBuilder<'a> {
-    type Target = PhysicalDeviceDriverPropertiesKHR;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceDriverPropertiesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceDriverProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceDriverPropertiesBuilder<'a> {
+    type Target = PhysicalDeviceDriverProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceDriverPropertiesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceDriverPropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceDriverPropertiesKHRBuilder<'a> {
-    pub fn driver_id(
-        mut self,
-        driver_id: DriverIdKHR,
-    ) -> PhysicalDeviceDriverPropertiesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceDriverPropertiesBuilder<'a> {
+    pub fn driver_id(mut self, driver_id: DriverId) -> PhysicalDeviceDriverPropertiesBuilder<'a> {
         self.inner.driver_id = driver_id;
         self
     }
     pub fn driver_name(
         mut self,
-        driver_name: [c_char; MAX_DRIVER_NAME_SIZE_KHR],
-    ) -> PhysicalDeviceDriverPropertiesKHRBuilder<'a> {
+        driver_name: [c_char; MAX_DRIVER_NAME_SIZE],
+    ) -> PhysicalDeviceDriverPropertiesBuilder<'a> {
         self.inner.driver_name = driver_name;
         self
     }
     pub fn driver_info(
         mut self,
-        driver_info: [c_char; MAX_DRIVER_INFO_SIZE_KHR],
-    ) -> PhysicalDeviceDriverPropertiesKHRBuilder<'a> {
+        driver_info: [c_char; MAX_DRIVER_INFO_SIZE],
+    ) -> PhysicalDeviceDriverPropertiesBuilder<'a> {
         self.inner.driver_info = driver_info;
         self
     }
     pub fn conformance_version(
         mut self,
-        conformance_version: ConformanceVersionKHR,
-    ) -> PhysicalDeviceDriverPropertiesKHRBuilder<'a> {
+        conformance_version: ConformanceVersion,
+    ) -> PhysicalDeviceDriverPropertiesBuilder<'a> {
         self.inner.conformance_version = conformance_version;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceDriverPropertiesKHR {
+    pub fn build(self) -> PhysicalDeviceDriverProperties {
         self.inner
     }
 }
@@ -29936,6 +30510,67 @@ impl<'a> PhysicalDeviceSubgroupPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures.html>"]
+pub struct PhysicalDeviceShaderSubgroupExtendedTypesFeatures {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub shader_subgroup_extended_types: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceShaderSubgroupExtendedTypesFeatures {
+    fn default() -> PhysicalDeviceShaderSubgroupExtendedTypesFeatures {
+        PhysicalDeviceShaderSubgroupExtendedTypesFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES,
+            p_next: ::std::ptr::null_mut(),
+            shader_subgroup_extended_types: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceShaderSubgroupExtendedTypesFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'a> {
+        PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder {
+            inner: PhysicalDeviceShaderSubgroupExtendedTypesFeatures::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'a> {
+    inner: PhysicalDeviceShaderSubgroupExtendedTypesFeatures,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo
+    for PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'_>
+{
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderSubgroupExtendedTypesFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceShaderSubgroupExtendedTypesFeatures;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'a> {
+    pub fn shader_subgroup_extended_types(
+        mut self,
+        shader_subgroup_extended_types: bool,
+    ) -> PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'a> {
+        self.inner.shader_subgroup_extended_types = shader_subgroup_extended_types.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceShaderSubgroupExtendedTypesFeatures {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferMemoryRequirementsInfo2.html>"]
 pub struct BufferMemoryRequirementsInfo2 {
     pub s_type: StructureType,
@@ -31513,57 +32148,57 @@ impl<'a> PipelineCoverageToColorStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT.html>"]
-pub struct PhysicalDeviceSamplerFilterMinmaxPropertiesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSamplerFilterMinmaxProperties.html>"]
+pub struct PhysicalDeviceSamplerFilterMinmaxProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub filter_minmax_single_component_formats: Bool32,
     pub filter_minmax_image_component_mapping: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceSamplerFilterMinmaxPropertiesEXT {
-    fn default() -> PhysicalDeviceSamplerFilterMinmaxPropertiesEXT {
-        PhysicalDeviceSamplerFilterMinmaxPropertiesEXT {
-            s_type: StructureType::PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT,
+impl ::std::default::Default for PhysicalDeviceSamplerFilterMinmaxProperties {
+    fn default() -> PhysicalDeviceSamplerFilterMinmaxProperties {
+        PhysicalDeviceSamplerFilterMinmaxProperties {
+            s_type: StructureType::PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
             filter_minmax_single_component_formats: Bool32::default(),
             filter_minmax_image_component_mapping: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceSamplerFilterMinmaxPropertiesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'a> {
-        PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder {
-            inner: PhysicalDeviceSamplerFilterMinmaxPropertiesEXT::default(),
+impl PhysicalDeviceSamplerFilterMinmaxProperties {
+    pub fn builder<'a>() -> PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
+        PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder {
+            inner: PhysicalDeviceSamplerFilterMinmaxProperties::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'a> {
-    inner: PhysicalDeviceSamplerFilterMinmaxPropertiesEXT,
+pub struct PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
+    inner: PhysicalDeviceSamplerFilterMinmaxProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'_>
+    for PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceSamplerFilterMinmaxPropertiesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'a> {
-    type Target = PhysicalDeviceSamplerFilterMinmaxPropertiesEXT;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceSamplerFilterMinmaxProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
+    type Target = PhysicalDeviceSamplerFilterMinmaxProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
     pub fn filter_minmax_single_component_formats(
         mut self,
         filter_minmax_single_component_formats: bool,
-    ) -> PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
         self.inner.filter_minmax_single_component_formats =
             filter_minmax_single_component_formats.into();
         self
@@ -31571,7 +32206,7 @@ impl<'a> PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'a> {
     pub fn filter_minmax_image_component_mapping(
         mut self,
         filter_minmax_image_component_mapping: bool,
-    ) -> PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
         self.inner.filter_minmax_image_component_mapping =
             filter_minmax_image_component_mapping.into();
         self
@@ -31579,7 +32214,7 @@ impl<'a> PhysicalDeviceSamplerFilterMinmaxPropertiesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceSamplerFilterMinmaxPropertiesEXT {
+    pub fn build(self) -> PhysicalDeviceSamplerFilterMinmaxProperties {
         self.inner
     }
 }
@@ -32133,59 +32768,59 @@ impl<'a> MultisamplePropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerReductionModeCreateInfoEXT.html>"]
-pub struct SamplerReductionModeCreateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerReductionModeCreateInfo.html>"]
+pub struct SamplerReductionModeCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub reduction_mode: SamplerReductionModeEXT,
+    pub reduction_mode: SamplerReductionMode,
 }
-impl ::std::default::Default for SamplerReductionModeCreateInfoEXT {
-    fn default() -> SamplerReductionModeCreateInfoEXT {
-        SamplerReductionModeCreateInfoEXT {
-            s_type: StructureType::SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT,
+impl ::std::default::Default for SamplerReductionModeCreateInfo {
+    fn default() -> SamplerReductionModeCreateInfo {
+        SamplerReductionModeCreateInfo {
+            s_type: StructureType::SAMPLER_REDUCTION_MODE_CREATE_INFO,
             p_next: ::std::ptr::null(),
-            reduction_mode: SamplerReductionModeEXT::default(),
+            reduction_mode: SamplerReductionMode::default(),
         }
     }
 }
-impl SamplerReductionModeCreateInfoEXT {
-    pub fn builder<'a>() -> SamplerReductionModeCreateInfoEXTBuilder<'a> {
-        SamplerReductionModeCreateInfoEXTBuilder {
-            inner: SamplerReductionModeCreateInfoEXT::default(),
+impl SamplerReductionModeCreateInfo {
+    pub fn builder<'a>() -> SamplerReductionModeCreateInfoBuilder<'a> {
+        SamplerReductionModeCreateInfoBuilder {
+            inner: SamplerReductionModeCreateInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct SamplerReductionModeCreateInfoEXTBuilder<'a> {
-    inner: SamplerReductionModeCreateInfoEXT,
+pub struct SamplerReductionModeCreateInfoBuilder<'a> {
+    inner: SamplerReductionModeCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsSamplerCreateInfo for SamplerReductionModeCreateInfoEXTBuilder<'_> {}
-unsafe impl ExtendsSamplerCreateInfo for SamplerReductionModeCreateInfoEXT {}
-impl<'a> ::std::ops::Deref for SamplerReductionModeCreateInfoEXTBuilder<'a> {
-    type Target = SamplerReductionModeCreateInfoEXT;
+unsafe impl ExtendsSamplerCreateInfo for SamplerReductionModeCreateInfoBuilder<'_> {}
+unsafe impl ExtendsSamplerCreateInfo for SamplerReductionModeCreateInfo {}
+impl<'a> ::std::ops::Deref for SamplerReductionModeCreateInfoBuilder<'a> {
+    type Target = SamplerReductionModeCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for SamplerReductionModeCreateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for SamplerReductionModeCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> SamplerReductionModeCreateInfoEXTBuilder<'a> {
+impl<'a> SamplerReductionModeCreateInfoBuilder<'a> {
     pub fn reduction_mode(
         mut self,
-        reduction_mode: SamplerReductionModeEXT,
-    ) -> SamplerReductionModeCreateInfoEXTBuilder<'a> {
+        reduction_mode: SamplerReductionMode,
+    ) -> SamplerReductionModeCreateInfoBuilder<'a> {
         self.inner.reduction_mode = reduction_mode;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> SamplerReductionModeCreateInfoEXT {
+    pub fn build(self) -> SamplerReductionModeCreateInfo {
         self.inner
     }
 }
@@ -32824,58 +33459,58 @@ impl<'a> PipelineCoverageModulationStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageFormatListCreateInfoKHR.html>"]
-pub struct ImageFormatListCreateInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageFormatListCreateInfo.html>"]
+pub struct ImageFormatListCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub view_format_count: u32,
     pub p_view_formats: *const Format,
 }
-impl ::std::default::Default for ImageFormatListCreateInfoKHR {
-    fn default() -> ImageFormatListCreateInfoKHR {
-        ImageFormatListCreateInfoKHR {
-            s_type: StructureType::IMAGE_FORMAT_LIST_CREATE_INFO_KHR,
+impl ::std::default::Default for ImageFormatListCreateInfo {
+    fn default() -> ImageFormatListCreateInfo {
+        ImageFormatListCreateInfo {
+            s_type: StructureType::IMAGE_FORMAT_LIST_CREATE_INFO,
             p_next: ::std::ptr::null(),
             view_format_count: u32::default(),
             p_view_formats: ::std::ptr::null(),
         }
     }
 }
-impl ImageFormatListCreateInfoKHR {
-    pub fn builder<'a>() -> ImageFormatListCreateInfoKHRBuilder<'a> {
-        ImageFormatListCreateInfoKHRBuilder {
-            inner: ImageFormatListCreateInfoKHR::default(),
+impl ImageFormatListCreateInfo {
+    pub fn builder<'a>() -> ImageFormatListCreateInfoBuilder<'a> {
+        ImageFormatListCreateInfoBuilder {
+            inner: ImageFormatListCreateInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct ImageFormatListCreateInfoKHRBuilder<'a> {
-    inner: ImageFormatListCreateInfoKHR,
+pub struct ImageFormatListCreateInfoBuilder<'a> {
+    inner: ImageFormatListCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsImageCreateInfo for ImageFormatListCreateInfoKHRBuilder<'_> {}
-unsafe impl ExtendsImageCreateInfo for ImageFormatListCreateInfoKHR {}
-unsafe impl ExtendsSwapchainCreateInfoKHR for ImageFormatListCreateInfoKHRBuilder<'_> {}
-unsafe impl ExtendsSwapchainCreateInfoKHR for ImageFormatListCreateInfoKHR {}
-unsafe impl ExtendsPhysicalDeviceImageFormatInfo2 for ImageFormatListCreateInfoKHRBuilder<'_> {}
-unsafe impl ExtendsPhysicalDeviceImageFormatInfo2 for ImageFormatListCreateInfoKHR {}
-impl<'a> ::std::ops::Deref for ImageFormatListCreateInfoKHRBuilder<'a> {
-    type Target = ImageFormatListCreateInfoKHR;
+unsafe impl ExtendsImageCreateInfo for ImageFormatListCreateInfoBuilder<'_> {}
+unsafe impl ExtendsImageCreateInfo for ImageFormatListCreateInfo {}
+unsafe impl ExtendsSwapchainCreateInfoKHR for ImageFormatListCreateInfoBuilder<'_> {}
+unsafe impl ExtendsSwapchainCreateInfoKHR for ImageFormatListCreateInfo {}
+unsafe impl ExtendsPhysicalDeviceImageFormatInfo2 for ImageFormatListCreateInfoBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceImageFormatInfo2 for ImageFormatListCreateInfo {}
+impl<'a> ::std::ops::Deref for ImageFormatListCreateInfoBuilder<'a> {
+    type Target = ImageFormatListCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for ImageFormatListCreateInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for ImageFormatListCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> ImageFormatListCreateInfoKHRBuilder<'a> {
+impl<'a> ImageFormatListCreateInfoBuilder<'a> {
     pub fn view_formats(
         mut self,
         view_formats: &'a [Format],
-    ) -> ImageFormatListCreateInfoKHRBuilder<'a> {
+    ) -> ImageFormatListCreateInfoBuilder<'a> {
         self.inner.view_format_count = view_formats.len() as _;
         self.inner.p_view_formats = view_formats.as_ptr();
         self
@@ -32883,7 +33518,7 @@ impl<'a> ImageFormatListCreateInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> ImageFormatListCreateInfoKHR {
+    pub fn build(self) -> ImageFormatListCreateInfo {
         self.inner
     }
 }
@@ -33229,79 +33864,79 @@ impl<'a> PhysicalDeviceShaderDrawParametersFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderFloat16Int8FeaturesKHR.html>"]
-pub struct PhysicalDeviceShaderFloat16Int8FeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderFloat16Int8Features.html>"]
+pub struct PhysicalDeviceShaderFloat16Int8Features {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub shader_float16: Bool32,
     pub shader_int8: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceShaderFloat16Int8FeaturesKHR {
-    fn default() -> PhysicalDeviceShaderFloat16Int8FeaturesKHR {
-        PhysicalDeviceShaderFloat16Int8FeaturesKHR {
-            s_type: StructureType::PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR,
+impl ::std::default::Default for PhysicalDeviceShaderFloat16Int8Features {
+    fn default() -> PhysicalDeviceShaderFloat16Int8Features {
+        PhysicalDeviceShaderFloat16Int8Features {
+            s_type: StructureType::PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES,
             p_next: ::std::ptr::null_mut(),
             shader_float16: Bool32::default(),
             shader_int8: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceShaderFloat16Int8FeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceShaderFloat16Int8FeaturesKHRBuilder<'a> {
-        PhysicalDeviceShaderFloat16Int8FeaturesKHRBuilder {
-            inner: PhysicalDeviceShaderFloat16Int8FeaturesKHR::default(),
+impl PhysicalDeviceShaderFloat16Int8Features {
+    pub fn builder<'a>() -> PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
+        PhysicalDeviceShaderFloat16Int8FeaturesBuilder {
+            inner: PhysicalDeviceShaderFloat16Int8Features::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceShaderFloat16Int8FeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceShaderFloat16Int8FeaturesKHR,
+pub struct PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
+    inner: PhysicalDeviceShaderFloat16Int8Features,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderFloat16Int8FeaturesKHRBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderFloat16Int8FeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceShaderFloat16Int8FeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceShaderFloat16Int8FeaturesKHR;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderFloat16Int8Features {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
+    type Target = PhysicalDeviceShaderFloat16Int8Features;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderFloat16Int8FeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceShaderFloat16Int8FeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
     pub fn shader_float16(
         mut self,
         shader_float16: bool,
-    ) -> PhysicalDeviceShaderFloat16Int8FeaturesKHRBuilder<'a> {
+    ) -> PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
         self.inner.shader_float16 = shader_float16.into();
         self
     }
     pub fn shader_int8(
         mut self,
         shader_int8: bool,
-    ) -> PhysicalDeviceShaderFloat16Int8FeaturesKHRBuilder<'a> {
+    ) -> PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
         self.inner.shader_int8 = shader_int8.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceShaderFloat16Int8FeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceShaderFloat16Int8Features {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceFloatControlsPropertiesKHR.html>"]
-pub struct PhysicalDeviceFloatControlsPropertiesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceFloatControlsProperties.html>"]
+pub struct PhysicalDeviceFloatControlsProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
-    pub denorm_behavior_independence: ShaderFloatControlsIndependenceKHR,
-    pub rounding_mode_independence: ShaderFloatControlsIndependenceKHR,
+    pub denorm_behavior_independence: ShaderFloatControlsIndependence,
+    pub rounding_mode_independence: ShaderFloatControlsIndependence,
     pub shader_signed_zero_inf_nan_preserve_float16: Bool32,
     pub shader_signed_zero_inf_nan_preserve_float32: Bool32,
     pub shader_signed_zero_inf_nan_preserve_float64: Bool32,
@@ -33318,13 +33953,13 @@ pub struct PhysicalDeviceFloatControlsPropertiesKHR {
     pub shader_rounding_mode_rtz_float32: Bool32,
     pub shader_rounding_mode_rtz_float64: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceFloatControlsPropertiesKHR {
-    fn default() -> PhysicalDeviceFloatControlsPropertiesKHR {
-        PhysicalDeviceFloatControlsPropertiesKHR {
-            s_type: StructureType::PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR,
+impl ::std::default::Default for PhysicalDeviceFloatControlsProperties {
+    fn default() -> PhysicalDeviceFloatControlsProperties {
+        PhysicalDeviceFloatControlsProperties {
+            s_type: StructureType::PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
-            denorm_behavior_independence: ShaderFloatControlsIndependenceKHR::default(),
-            rounding_mode_independence: ShaderFloatControlsIndependenceKHR::default(),
+            denorm_behavior_independence: ShaderFloatControlsIndependence::default(),
+            rounding_mode_independence: ShaderFloatControlsIndependence::default(),
             shader_signed_zero_inf_nan_preserve_float16: Bool32::default(),
             shader_signed_zero_inf_nan_preserve_float32: Bool32::default(),
             shader_signed_zero_inf_nan_preserve_float64: Bool32::default(),
@@ -33343,54 +33978,51 @@ impl ::std::default::Default for PhysicalDeviceFloatControlsPropertiesKHR {
         }
     }
 }
-impl PhysicalDeviceFloatControlsPropertiesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
-        PhysicalDeviceFloatControlsPropertiesKHRBuilder {
-            inner: PhysicalDeviceFloatControlsPropertiesKHR::default(),
+impl PhysicalDeviceFloatControlsProperties {
+    pub fn builder<'a>() -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+        PhysicalDeviceFloatControlsPropertiesBuilder {
+            inner: PhysicalDeviceFloatControlsProperties::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
-    inner: PhysicalDeviceFloatControlsPropertiesKHR,
+pub struct PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    inner: PhysicalDeviceFloatControlsProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceFloatControlsPropertiesKHRBuilder<'_>
-{
-}
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceFloatControlsPropertiesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
-    type Target = PhysicalDeviceFloatControlsPropertiesKHR;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceFloatControlsPropertiesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceFloatControlsProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    type Target = PhysicalDeviceFloatControlsProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
     pub fn denorm_behavior_independence(
         mut self,
-        denorm_behavior_independence: ShaderFloatControlsIndependenceKHR,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+        denorm_behavior_independence: ShaderFloatControlsIndependence,
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.denorm_behavior_independence = denorm_behavior_independence;
         self
     }
     pub fn rounding_mode_independence(
         mut self,
-        rounding_mode_independence: ShaderFloatControlsIndependenceKHR,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+        rounding_mode_independence: ShaderFloatControlsIndependence,
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.rounding_mode_independence = rounding_mode_independence;
         self
     }
     pub fn shader_signed_zero_inf_nan_preserve_float16(
         mut self,
         shader_signed_zero_inf_nan_preserve_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_signed_zero_inf_nan_preserve_float16 =
             shader_signed_zero_inf_nan_preserve_float16.into();
         self
@@ -33398,7 +34030,7 @@ impl<'a> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
     pub fn shader_signed_zero_inf_nan_preserve_float32(
         mut self,
         shader_signed_zero_inf_nan_preserve_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_signed_zero_inf_nan_preserve_float32 =
             shader_signed_zero_inf_nan_preserve_float32.into();
         self
@@ -33406,7 +34038,7 @@ impl<'a> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
     pub fn shader_signed_zero_inf_nan_preserve_float64(
         mut self,
         shader_signed_zero_inf_nan_preserve_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_signed_zero_inf_nan_preserve_float64 =
             shader_signed_zero_inf_nan_preserve_float64.into();
         self
@@ -33414,149 +34046,149 @@ impl<'a> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
     pub fn shader_denorm_preserve_float16(
         mut self,
         shader_denorm_preserve_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_denorm_preserve_float16 = shader_denorm_preserve_float16.into();
         self
     }
     pub fn shader_denorm_preserve_float32(
         mut self,
         shader_denorm_preserve_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_denorm_preserve_float32 = shader_denorm_preserve_float32.into();
         self
     }
     pub fn shader_denorm_preserve_float64(
         mut self,
         shader_denorm_preserve_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_denorm_preserve_float64 = shader_denorm_preserve_float64.into();
         self
     }
     pub fn shader_denorm_flush_to_zero_float16(
         mut self,
         shader_denorm_flush_to_zero_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_denorm_flush_to_zero_float16 = shader_denorm_flush_to_zero_float16.into();
         self
     }
     pub fn shader_denorm_flush_to_zero_float32(
         mut self,
         shader_denorm_flush_to_zero_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_denorm_flush_to_zero_float32 = shader_denorm_flush_to_zero_float32.into();
         self
     }
     pub fn shader_denorm_flush_to_zero_float64(
         mut self,
         shader_denorm_flush_to_zero_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_denorm_flush_to_zero_float64 = shader_denorm_flush_to_zero_float64.into();
         self
     }
     pub fn shader_rounding_mode_rte_float16(
         mut self,
         shader_rounding_mode_rte_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_rounding_mode_rte_float16 = shader_rounding_mode_rte_float16.into();
         self
     }
     pub fn shader_rounding_mode_rte_float32(
         mut self,
         shader_rounding_mode_rte_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_rounding_mode_rte_float32 = shader_rounding_mode_rte_float32.into();
         self
     }
     pub fn shader_rounding_mode_rte_float64(
         mut self,
         shader_rounding_mode_rte_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_rounding_mode_rte_float64 = shader_rounding_mode_rte_float64.into();
         self
     }
     pub fn shader_rounding_mode_rtz_float16(
         mut self,
         shader_rounding_mode_rtz_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_rounding_mode_rtz_float16 = shader_rounding_mode_rtz_float16.into();
         self
     }
     pub fn shader_rounding_mode_rtz_float32(
         mut self,
         shader_rounding_mode_rtz_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_rounding_mode_rtz_float32 = shader_rounding_mode_rtz_float32.into();
         self
     }
     pub fn shader_rounding_mode_rtz_float64(
         mut self,
         shader_rounding_mode_rtz_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
         self.inner.shader_rounding_mode_rtz_float64 = shader_rounding_mode_rtz_float64.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceFloatControlsPropertiesKHR {
+    pub fn build(self) -> PhysicalDeviceFloatControlsProperties {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceHostQueryResetFeaturesEXT.html>"]
-pub struct PhysicalDeviceHostQueryResetFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceHostQueryResetFeatures.html>"]
+pub struct PhysicalDeviceHostQueryResetFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub host_query_reset: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceHostQueryResetFeaturesEXT {
-    fn default() -> PhysicalDeviceHostQueryResetFeaturesEXT {
-        PhysicalDeviceHostQueryResetFeaturesEXT {
-            s_type: StructureType::PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT,
+impl ::std::default::Default for PhysicalDeviceHostQueryResetFeatures {
+    fn default() -> PhysicalDeviceHostQueryResetFeatures {
+        PhysicalDeviceHostQueryResetFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES,
             p_next: ::std::ptr::null_mut(),
             host_query_reset: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceHostQueryResetFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceHostQueryResetFeaturesEXTBuilder<'a> {
-        PhysicalDeviceHostQueryResetFeaturesEXTBuilder {
-            inner: PhysicalDeviceHostQueryResetFeaturesEXT::default(),
+impl PhysicalDeviceHostQueryResetFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceHostQueryResetFeaturesBuilder<'a> {
+        PhysicalDeviceHostQueryResetFeaturesBuilder {
+            inner: PhysicalDeviceHostQueryResetFeatures::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceHostQueryResetFeaturesEXTBuilder<'a> {
-    inner: PhysicalDeviceHostQueryResetFeaturesEXT,
+pub struct PhysicalDeviceHostQueryResetFeaturesBuilder<'a> {
+    inner: PhysicalDeviceHostQueryResetFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceHostQueryResetFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceHostQueryResetFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceHostQueryResetFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDeviceHostQueryResetFeaturesEXT;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceHostQueryResetFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceHostQueryResetFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceHostQueryResetFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceHostQueryResetFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceHostQueryResetFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceHostQueryResetFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceHostQueryResetFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceHostQueryResetFeaturesBuilder<'a> {
     pub fn host_query_reset(
         mut self,
         host_query_reset: bool,
-    ) -> PhysicalDeviceHostQueryResetFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceHostQueryResetFeaturesBuilder<'a> {
         self.inner.host_query_reset = host_query_reset.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceHostQueryResetFeaturesEXT {
+    pub fn build(self) -> PhysicalDeviceHostQueryResetFeatures {
         self.inner
     }
 }
@@ -35184,6 +35816,73 @@ impl<'a> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderCoreProperties2AMD.html>"]
+pub struct PhysicalDeviceShaderCoreProperties2AMD {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub shader_core_features: ShaderCorePropertiesFlagsAMD,
+    pub active_compute_unit_count: u32,
+}
+impl ::std::default::Default for PhysicalDeviceShaderCoreProperties2AMD {
+    fn default() -> PhysicalDeviceShaderCoreProperties2AMD {
+        PhysicalDeviceShaderCoreProperties2AMD {
+            s_type: StructureType::PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD,
+            p_next: ::std::ptr::null_mut(),
+            shader_core_features: ShaderCorePropertiesFlagsAMD::default(),
+            active_compute_unit_count: u32::default(),
+        }
+    }
+}
+impl PhysicalDeviceShaderCoreProperties2AMD {
+    pub fn builder<'a>() -> PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
+        PhysicalDeviceShaderCoreProperties2AMDBuilder {
+            inner: PhysicalDeviceShaderCoreProperties2AMD::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
+    inner: PhysicalDeviceShaderCoreProperties2AMD,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceShaderCoreProperties2AMDBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceShaderCoreProperties2AMD {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
+    type Target = PhysicalDeviceShaderCoreProperties2AMD;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
+    pub fn shader_core_features(
+        mut self,
+        shader_core_features: ShaderCorePropertiesFlagsAMD,
+    ) -> PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
+        self.inner.shader_core_features = shader_core_features;
+        self
+    }
+    pub fn active_compute_unit_count(
+        mut self,
+        active_compute_unit_count: u32,
+    ) -> PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
+        self.inner.active_compute_unit_count = active_compute_unit_count;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceShaderCoreProperties2AMD {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationConservativeStateCreateInfoEXT.html>"]
 pub struct PipelineRasterizationConservativeStateCreateInfoEXT {
     pub s_type: StructureType,
@@ -35266,8 +35965,8 @@ impl<'a> PipelineRasterizationConservativeStateCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDescriptorIndexingFeaturesEXT.html>"]
-pub struct PhysicalDeviceDescriptorIndexingFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDescriptorIndexingFeatures.html>"]
+pub struct PhysicalDeviceDescriptorIndexingFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub shader_input_attachment_array_dynamic_indexing: Bool32,
@@ -35291,10 +35990,10 @@ pub struct PhysicalDeviceDescriptorIndexingFeaturesEXT {
     pub descriptor_binding_variable_descriptor_count: Bool32,
     pub runtime_descriptor_array: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceDescriptorIndexingFeaturesEXT {
-    fn default() -> PhysicalDeviceDescriptorIndexingFeaturesEXT {
-        PhysicalDeviceDescriptorIndexingFeaturesEXT {
-            s_type: StructureType::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT,
+impl ::std::default::Default for PhysicalDeviceDescriptorIndexingFeatures {
+    fn default() -> PhysicalDeviceDescriptorIndexingFeatures {
+        PhysicalDeviceDescriptorIndexingFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES,
             p_next: ::std::ptr::null_mut(),
             shader_input_attachment_array_dynamic_indexing: Bool32::default(),
             shader_uniform_texel_buffer_array_dynamic_indexing: Bool32::default(),
@@ -35319,37 +36018,37 @@ impl ::std::default::Default for PhysicalDeviceDescriptorIndexingFeaturesEXT {
         }
     }
 }
-impl PhysicalDeviceDescriptorIndexingFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
-        PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder {
-            inner: PhysicalDeviceDescriptorIndexingFeaturesEXT::default(),
+impl PhysicalDeviceDescriptorIndexingFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+        PhysicalDeviceDescriptorIndexingFeaturesBuilder {
+            inner: PhysicalDeviceDescriptorIndexingFeatures::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
-    inner: PhysicalDeviceDescriptorIndexingFeaturesEXT,
+pub struct PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    inner: PhysicalDeviceDescriptorIndexingFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceDescriptorIndexingFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDeviceDescriptorIndexingFeaturesEXT;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceDescriptorIndexingFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceDescriptorIndexingFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceDescriptorIndexingFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_input_attachment_array_dynamic_indexing(
         mut self,
         shader_input_attachment_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner.shader_input_attachment_array_dynamic_indexing =
             shader_input_attachment_array_dynamic_indexing.into();
         self
@@ -35357,7 +36056,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn shader_uniform_texel_buffer_array_dynamic_indexing(
         mut self,
         shader_uniform_texel_buffer_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .shader_uniform_texel_buffer_array_dynamic_indexing =
             shader_uniform_texel_buffer_array_dynamic_indexing.into();
@@ -35366,7 +36065,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn shader_storage_texel_buffer_array_dynamic_indexing(
         mut self,
         shader_storage_texel_buffer_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .shader_storage_texel_buffer_array_dynamic_indexing =
             shader_storage_texel_buffer_array_dynamic_indexing.into();
@@ -35375,7 +36074,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn shader_uniform_buffer_array_non_uniform_indexing(
         mut self,
         shader_uniform_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner.shader_uniform_buffer_array_non_uniform_indexing =
             shader_uniform_buffer_array_non_uniform_indexing.into();
         self
@@ -35383,7 +36082,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn shader_sampled_image_array_non_uniform_indexing(
         mut self,
         shader_sampled_image_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner.shader_sampled_image_array_non_uniform_indexing =
             shader_sampled_image_array_non_uniform_indexing.into();
         self
@@ -35391,7 +36090,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn shader_storage_buffer_array_non_uniform_indexing(
         mut self,
         shader_storage_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner.shader_storage_buffer_array_non_uniform_indexing =
             shader_storage_buffer_array_non_uniform_indexing.into();
         self
@@ -35399,7 +36098,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn shader_storage_image_array_non_uniform_indexing(
         mut self,
         shader_storage_image_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner.shader_storage_image_array_non_uniform_indexing =
             shader_storage_image_array_non_uniform_indexing.into();
         self
@@ -35407,7 +36106,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn shader_input_attachment_array_non_uniform_indexing(
         mut self,
         shader_input_attachment_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .shader_input_attachment_array_non_uniform_indexing =
             shader_input_attachment_array_non_uniform_indexing.into();
@@ -35416,7 +36115,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn shader_uniform_texel_buffer_array_non_uniform_indexing(
         mut self,
         shader_uniform_texel_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .shader_uniform_texel_buffer_array_non_uniform_indexing =
             shader_uniform_texel_buffer_array_non_uniform_indexing.into();
@@ -35425,7 +36124,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn shader_storage_texel_buffer_array_non_uniform_indexing(
         mut self,
         shader_storage_texel_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .shader_storage_texel_buffer_array_non_uniform_indexing =
             shader_storage_texel_buffer_array_non_uniform_indexing.into();
@@ -35434,7 +36133,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn descriptor_binding_uniform_buffer_update_after_bind(
         mut self,
         descriptor_binding_uniform_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .descriptor_binding_uniform_buffer_update_after_bind =
             descriptor_binding_uniform_buffer_update_after_bind.into();
@@ -35443,7 +36142,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn descriptor_binding_sampled_image_update_after_bind(
         mut self,
         descriptor_binding_sampled_image_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .descriptor_binding_sampled_image_update_after_bind =
             descriptor_binding_sampled_image_update_after_bind.into();
@@ -35452,7 +36151,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn descriptor_binding_storage_image_update_after_bind(
         mut self,
         descriptor_binding_storage_image_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .descriptor_binding_storage_image_update_after_bind =
             descriptor_binding_storage_image_update_after_bind.into();
@@ -35461,7 +36160,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn descriptor_binding_storage_buffer_update_after_bind(
         mut self,
         descriptor_binding_storage_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .descriptor_binding_storage_buffer_update_after_bind =
             descriptor_binding_storage_buffer_update_after_bind.into();
@@ -35470,7 +36169,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn descriptor_binding_uniform_texel_buffer_update_after_bind(
         mut self,
         descriptor_binding_uniform_texel_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .descriptor_binding_uniform_texel_buffer_update_after_bind =
             descriptor_binding_uniform_texel_buffer_update_after_bind.into();
@@ -35479,7 +36178,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn descriptor_binding_storage_texel_buffer_update_after_bind(
         mut self,
         descriptor_binding_storage_texel_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner
             .descriptor_binding_storage_texel_buffer_update_after_bind =
             descriptor_binding_storage_texel_buffer_update_after_bind.into();
@@ -35488,7 +36187,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn descriptor_binding_update_unused_while_pending(
         mut self,
         descriptor_binding_update_unused_while_pending: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner.descriptor_binding_update_unused_while_pending =
             descriptor_binding_update_unused_while_pending.into();
         self
@@ -35496,14 +36195,14 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn descriptor_binding_partially_bound(
         mut self,
         descriptor_binding_partially_bound: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner.descriptor_binding_partially_bound = descriptor_binding_partially_bound.into();
         self
     }
     pub fn descriptor_binding_variable_descriptor_count(
         mut self,
         descriptor_binding_variable_descriptor_count: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner.descriptor_binding_variable_descriptor_count =
             descriptor_binding_variable_descriptor_count.into();
         self
@@ -35511,21 +36210,21 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
     pub fn runtime_descriptor_array(
         mut self,
         runtime_descriptor_array: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
         self.inner.runtime_descriptor_array = runtime_descriptor_array.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceDescriptorIndexingFeaturesEXT {
+    pub fn build(self) -> PhysicalDeviceDescriptorIndexingFeatures {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDescriptorIndexingPropertiesEXT.html>"]
-pub struct PhysicalDeviceDescriptorIndexingPropertiesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDescriptorIndexingProperties.html>"]
+pub struct PhysicalDeviceDescriptorIndexingProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub max_update_after_bind_descriptors_in_all_pools: u32,
@@ -35552,10 +36251,10 @@ pub struct PhysicalDeviceDescriptorIndexingPropertiesEXT {
     pub max_descriptor_set_update_after_bind_storage_images: u32,
     pub max_descriptor_set_update_after_bind_input_attachments: u32,
 }
-impl ::std::default::Default for PhysicalDeviceDescriptorIndexingPropertiesEXT {
-    fn default() -> PhysicalDeviceDescriptorIndexingPropertiesEXT {
-        PhysicalDeviceDescriptorIndexingPropertiesEXT {
-            s_type: StructureType::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT,
+impl ::std::default::Default for PhysicalDeviceDescriptorIndexingProperties {
+    fn default() -> PhysicalDeviceDescriptorIndexingProperties {
+        PhysicalDeviceDescriptorIndexingProperties {
+            s_type: StructureType::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
             max_update_after_bind_descriptors_in_all_pools: u32::default(),
             shader_uniform_buffer_array_non_uniform_indexing_native: Bool32::default(),
@@ -35583,40 +36282,40 @@ impl ::std::default::Default for PhysicalDeviceDescriptorIndexingPropertiesEXT {
         }
     }
 }
-impl PhysicalDeviceDescriptorIndexingPropertiesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
-        PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder {
-            inner: PhysicalDeviceDescriptorIndexingPropertiesEXT::default(),
+impl PhysicalDeviceDescriptorIndexingProperties {
+    pub fn builder<'a>() -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+        PhysicalDeviceDescriptorIndexingPropertiesBuilder {
+            inner: PhysicalDeviceDescriptorIndexingProperties::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
-    inner: PhysicalDeviceDescriptorIndexingPropertiesEXT,
+pub struct PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    inner: PhysicalDeviceDescriptorIndexingProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'_>
+    for PhysicalDeviceDescriptorIndexingPropertiesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceDescriptorIndexingPropertiesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
-    type Target = PhysicalDeviceDescriptorIndexingPropertiesEXT;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceDescriptorIndexingProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    type Target = PhysicalDeviceDescriptorIndexingProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_update_after_bind_descriptors_in_all_pools(
         mut self,
         max_update_after_bind_descriptors_in_all_pools: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner.max_update_after_bind_descriptors_in_all_pools =
             max_update_after_bind_descriptors_in_all_pools;
         self
@@ -35624,7 +36323,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn shader_uniform_buffer_array_non_uniform_indexing_native(
         mut self,
         shader_uniform_buffer_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .shader_uniform_buffer_array_non_uniform_indexing_native =
             shader_uniform_buffer_array_non_uniform_indexing_native.into();
@@ -35633,7 +36332,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn shader_sampled_image_array_non_uniform_indexing_native(
         mut self,
         shader_sampled_image_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .shader_sampled_image_array_non_uniform_indexing_native =
             shader_sampled_image_array_non_uniform_indexing_native.into();
@@ -35642,7 +36341,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn shader_storage_buffer_array_non_uniform_indexing_native(
         mut self,
         shader_storage_buffer_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .shader_storage_buffer_array_non_uniform_indexing_native =
             shader_storage_buffer_array_non_uniform_indexing_native.into();
@@ -35651,7 +36350,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn shader_storage_image_array_non_uniform_indexing_native(
         mut self,
         shader_storage_image_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .shader_storage_image_array_non_uniform_indexing_native =
             shader_storage_image_array_non_uniform_indexing_native.into();
@@ -35660,7 +36359,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn shader_input_attachment_array_non_uniform_indexing_native(
         mut self,
         shader_input_attachment_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .shader_input_attachment_array_non_uniform_indexing_native =
             shader_input_attachment_array_non_uniform_indexing_native.into();
@@ -35669,7 +36368,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn robust_buffer_access_update_after_bind(
         mut self,
         robust_buffer_access_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner.robust_buffer_access_update_after_bind =
             robust_buffer_access_update_after_bind.into();
         self
@@ -35677,14 +36376,14 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn quad_divergent_implicit_lod(
         mut self,
         quad_divergent_implicit_lod: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner.quad_divergent_implicit_lod = quad_divergent_implicit_lod.into();
         self
     }
     pub fn max_per_stage_descriptor_update_after_bind_samplers(
         mut self,
         max_per_stage_descriptor_update_after_bind_samplers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_per_stage_descriptor_update_after_bind_samplers =
             max_per_stage_descriptor_update_after_bind_samplers;
@@ -35693,7 +36392,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_uniform_buffers(
         mut self,
         max_per_stage_descriptor_update_after_bind_uniform_buffers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_per_stage_descriptor_update_after_bind_uniform_buffers =
             max_per_stage_descriptor_update_after_bind_uniform_buffers;
@@ -35702,7 +36401,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_storage_buffers(
         mut self,
         max_per_stage_descriptor_update_after_bind_storage_buffers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_per_stage_descriptor_update_after_bind_storage_buffers =
             max_per_stage_descriptor_update_after_bind_storage_buffers;
@@ -35711,7 +36410,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_sampled_images(
         mut self,
         max_per_stage_descriptor_update_after_bind_sampled_images: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_per_stage_descriptor_update_after_bind_sampled_images =
             max_per_stage_descriptor_update_after_bind_sampled_images;
@@ -35720,7 +36419,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_storage_images(
         mut self,
         max_per_stage_descriptor_update_after_bind_storage_images: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_per_stage_descriptor_update_after_bind_storage_images =
             max_per_stage_descriptor_update_after_bind_storage_images;
@@ -35729,7 +36428,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_input_attachments(
         mut self,
         max_per_stage_descriptor_update_after_bind_input_attachments: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_per_stage_descriptor_update_after_bind_input_attachments =
             max_per_stage_descriptor_update_after_bind_input_attachments;
@@ -35738,7 +36437,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_per_stage_update_after_bind_resources(
         mut self,
         max_per_stage_update_after_bind_resources: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner.max_per_stage_update_after_bind_resources =
             max_per_stage_update_after_bind_resources;
         self
@@ -35746,7 +36445,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_samplers(
         mut self,
         max_descriptor_set_update_after_bind_samplers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner.max_descriptor_set_update_after_bind_samplers =
             max_descriptor_set_update_after_bind_samplers;
         self
@@ -35754,7 +36453,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_uniform_buffers(
         mut self,
         max_descriptor_set_update_after_bind_uniform_buffers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_descriptor_set_update_after_bind_uniform_buffers =
             max_descriptor_set_update_after_bind_uniform_buffers;
@@ -35763,7 +36462,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_uniform_buffers_dynamic(
         mut self,
         max_descriptor_set_update_after_bind_uniform_buffers_dynamic: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_descriptor_set_update_after_bind_uniform_buffers_dynamic =
             max_descriptor_set_update_after_bind_uniform_buffers_dynamic;
@@ -35772,7 +36471,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_storage_buffers(
         mut self,
         max_descriptor_set_update_after_bind_storage_buffers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_descriptor_set_update_after_bind_storage_buffers =
             max_descriptor_set_update_after_bind_storage_buffers;
@@ -35781,7 +36480,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_storage_buffers_dynamic(
         mut self,
         max_descriptor_set_update_after_bind_storage_buffers_dynamic: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_descriptor_set_update_after_bind_storage_buffers_dynamic =
             max_descriptor_set_update_after_bind_storage_buffers_dynamic;
@@ -35790,7 +36489,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_sampled_images(
         mut self,
         max_descriptor_set_update_after_bind_sampled_images: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_descriptor_set_update_after_bind_sampled_images =
             max_descriptor_set_update_after_bind_sampled_images;
@@ -35799,7 +36498,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_storage_images(
         mut self,
         max_descriptor_set_update_after_bind_storage_images: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_descriptor_set_update_after_bind_storage_images =
             max_descriptor_set_update_after_bind_storage_images;
@@ -35808,7 +36507,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_input_attachments(
         mut self,
         max_descriptor_set_update_after_bind_input_attachments: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
+    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
         self.inner
             .max_descriptor_set_update_after_bind_input_attachments =
             max_descriptor_set_update_after_bind_input_attachments;
@@ -35817,63 +36516,63 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceDescriptorIndexingPropertiesEXT {
+    pub fn build(self) -> PhysicalDeviceDescriptorIndexingProperties {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetLayoutBindingFlagsCreateInfoEXT.html>"]
-pub struct DescriptorSetLayoutBindingFlagsCreateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetLayoutBindingFlagsCreateInfo.html>"]
+pub struct DescriptorSetLayoutBindingFlagsCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub binding_count: u32,
-    pub p_binding_flags: *const DescriptorBindingFlagsEXT,
+    pub p_binding_flags: *const DescriptorBindingFlags,
 }
-impl ::std::default::Default for DescriptorSetLayoutBindingFlagsCreateInfoEXT {
-    fn default() -> DescriptorSetLayoutBindingFlagsCreateInfoEXT {
-        DescriptorSetLayoutBindingFlagsCreateInfoEXT {
-            s_type: StructureType::DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT,
+impl ::std::default::Default for DescriptorSetLayoutBindingFlagsCreateInfo {
+    fn default() -> DescriptorSetLayoutBindingFlagsCreateInfo {
+        DescriptorSetLayoutBindingFlagsCreateInfo {
+            s_type: StructureType::DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO,
             p_next: ::std::ptr::null(),
             binding_count: u32::default(),
             p_binding_flags: ::std::ptr::null(),
         }
     }
 }
-impl DescriptorSetLayoutBindingFlagsCreateInfoEXT {
-    pub fn builder<'a>() -> DescriptorSetLayoutBindingFlagsCreateInfoEXTBuilder<'a> {
-        DescriptorSetLayoutBindingFlagsCreateInfoEXTBuilder {
-            inner: DescriptorSetLayoutBindingFlagsCreateInfoEXT::default(),
+impl DescriptorSetLayoutBindingFlagsCreateInfo {
+    pub fn builder<'a>() -> DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'a> {
+        DescriptorSetLayoutBindingFlagsCreateInfoBuilder {
+            inner: DescriptorSetLayoutBindingFlagsCreateInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct DescriptorSetLayoutBindingFlagsCreateInfoEXTBuilder<'a> {
-    inner: DescriptorSetLayoutBindingFlagsCreateInfoEXT,
+pub struct DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'a> {
+    inner: DescriptorSetLayoutBindingFlagsCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsDescriptorSetLayoutCreateInfo
-    for DescriptorSetLayoutBindingFlagsCreateInfoEXTBuilder<'_>
+    for DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'_>
 {
 }
-unsafe impl ExtendsDescriptorSetLayoutCreateInfo for DescriptorSetLayoutBindingFlagsCreateInfoEXT {}
-impl<'a> ::std::ops::Deref for DescriptorSetLayoutBindingFlagsCreateInfoEXTBuilder<'a> {
-    type Target = DescriptorSetLayoutBindingFlagsCreateInfoEXT;
+unsafe impl ExtendsDescriptorSetLayoutCreateInfo for DescriptorSetLayoutBindingFlagsCreateInfo {}
+impl<'a> ::std::ops::Deref for DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'a> {
+    type Target = DescriptorSetLayoutBindingFlagsCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for DescriptorSetLayoutBindingFlagsCreateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> DescriptorSetLayoutBindingFlagsCreateInfoEXTBuilder<'a> {
+impl<'a> DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'a> {
     pub fn binding_flags(
         mut self,
-        binding_flags: &'a [DescriptorBindingFlagsEXT],
-    ) -> DescriptorSetLayoutBindingFlagsCreateInfoEXTBuilder<'a> {
+        binding_flags: &'a [DescriptorBindingFlags],
+    ) -> DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'a> {
         self.inner.binding_count = binding_flags.len() as _;
         self.inner.p_binding_flags = binding_flags.as_ptr();
         self
@@ -35881,66 +36580,63 @@ impl<'a> DescriptorSetLayoutBindingFlagsCreateInfoEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> DescriptorSetLayoutBindingFlagsCreateInfoEXT {
+    pub fn build(self) -> DescriptorSetLayoutBindingFlagsCreateInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetVariableDescriptorCountAllocateInfoEXT.html>"]
-pub struct DescriptorSetVariableDescriptorCountAllocateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetVariableDescriptorCountAllocateInfo.html>"]
+pub struct DescriptorSetVariableDescriptorCountAllocateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub descriptor_set_count: u32,
     pub p_descriptor_counts: *const u32,
 }
-impl ::std::default::Default for DescriptorSetVariableDescriptorCountAllocateInfoEXT {
-    fn default() -> DescriptorSetVariableDescriptorCountAllocateInfoEXT {
-        DescriptorSetVariableDescriptorCountAllocateInfoEXT {
-            s_type: StructureType::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT,
+impl ::std::default::Default for DescriptorSetVariableDescriptorCountAllocateInfo {
+    fn default() -> DescriptorSetVariableDescriptorCountAllocateInfo {
+        DescriptorSetVariableDescriptorCountAllocateInfo {
+            s_type: StructureType::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO,
             p_next: ::std::ptr::null(),
             descriptor_set_count: u32::default(),
             p_descriptor_counts: ::std::ptr::null(),
         }
     }
 }
-impl DescriptorSetVariableDescriptorCountAllocateInfoEXT {
-    pub fn builder<'a>() -> DescriptorSetVariableDescriptorCountAllocateInfoEXTBuilder<'a> {
-        DescriptorSetVariableDescriptorCountAllocateInfoEXTBuilder {
-            inner: DescriptorSetVariableDescriptorCountAllocateInfoEXT::default(),
+impl DescriptorSetVariableDescriptorCountAllocateInfo {
+    pub fn builder<'a>() -> DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'a> {
+        DescriptorSetVariableDescriptorCountAllocateInfoBuilder {
+            inner: DescriptorSetVariableDescriptorCountAllocateInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct DescriptorSetVariableDescriptorCountAllocateInfoEXTBuilder<'a> {
-    inner: DescriptorSetVariableDescriptorCountAllocateInfoEXT,
+pub struct DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'a> {
+    inner: DescriptorSetVariableDescriptorCountAllocateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsDescriptorSetAllocateInfo
-    for DescriptorSetVariableDescriptorCountAllocateInfoEXTBuilder<'_>
+    for DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'_>
 {
 }
-unsafe impl ExtendsDescriptorSetAllocateInfo
-    for DescriptorSetVariableDescriptorCountAllocateInfoEXT
-{
-}
-impl<'a> ::std::ops::Deref for DescriptorSetVariableDescriptorCountAllocateInfoEXTBuilder<'a> {
-    type Target = DescriptorSetVariableDescriptorCountAllocateInfoEXT;
+unsafe impl ExtendsDescriptorSetAllocateInfo for DescriptorSetVariableDescriptorCountAllocateInfo {}
+impl<'a> ::std::ops::Deref for DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'a> {
+    type Target = DescriptorSetVariableDescriptorCountAllocateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for DescriptorSetVariableDescriptorCountAllocateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> DescriptorSetVariableDescriptorCountAllocateInfoEXTBuilder<'a> {
+impl<'a> DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'a> {
     pub fn descriptor_counts(
         mut self,
         descriptor_counts: &'a [u32],
-    ) -> DescriptorSetVariableDescriptorCountAllocateInfoEXTBuilder<'a> {
+    ) -> DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'a> {
         self.inner.descriptor_set_count = descriptor_counts.len() as _;
         self.inner.p_descriptor_counts = descriptor_counts.as_ptr();
         self
@@ -35948,78 +36644,78 @@ impl<'a> DescriptorSetVariableDescriptorCountAllocateInfoEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> DescriptorSetVariableDescriptorCountAllocateInfoEXT {
+    pub fn build(self) -> DescriptorSetVariableDescriptorCountAllocateInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetVariableDescriptorCountLayoutSupportEXT.html>"]
-pub struct DescriptorSetVariableDescriptorCountLayoutSupportEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetVariableDescriptorCountLayoutSupport.html>"]
+pub struct DescriptorSetVariableDescriptorCountLayoutSupport {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub max_variable_descriptor_count: u32,
 }
-impl ::std::default::Default for DescriptorSetVariableDescriptorCountLayoutSupportEXT {
-    fn default() -> DescriptorSetVariableDescriptorCountLayoutSupportEXT {
-        DescriptorSetVariableDescriptorCountLayoutSupportEXT {
-            s_type: StructureType::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT_EXT,
+impl ::std::default::Default for DescriptorSetVariableDescriptorCountLayoutSupport {
+    fn default() -> DescriptorSetVariableDescriptorCountLayoutSupport {
+        DescriptorSetVariableDescriptorCountLayoutSupport {
+            s_type: StructureType::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT,
             p_next: ::std::ptr::null_mut(),
             max_variable_descriptor_count: u32::default(),
         }
     }
 }
-impl DescriptorSetVariableDescriptorCountLayoutSupportEXT {
-    pub fn builder<'a>() -> DescriptorSetVariableDescriptorCountLayoutSupportEXTBuilder<'a> {
-        DescriptorSetVariableDescriptorCountLayoutSupportEXTBuilder {
-            inner: DescriptorSetVariableDescriptorCountLayoutSupportEXT::default(),
+impl DescriptorSetVariableDescriptorCountLayoutSupport {
+    pub fn builder<'a>() -> DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'a> {
+        DescriptorSetVariableDescriptorCountLayoutSupportBuilder {
+            inner: DescriptorSetVariableDescriptorCountLayoutSupport::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct DescriptorSetVariableDescriptorCountLayoutSupportEXTBuilder<'a> {
-    inner: DescriptorSetVariableDescriptorCountLayoutSupportEXT,
+pub struct DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'a> {
+    inner: DescriptorSetVariableDescriptorCountLayoutSupport,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsDescriptorSetLayoutSupport
-    for DescriptorSetVariableDescriptorCountLayoutSupportEXTBuilder<'_>
+    for DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'_>
 {
 }
 unsafe impl ExtendsDescriptorSetLayoutSupport
-    for DescriptorSetVariableDescriptorCountLayoutSupportEXT
+    for DescriptorSetVariableDescriptorCountLayoutSupport
 {
 }
-impl<'a> ::std::ops::Deref for DescriptorSetVariableDescriptorCountLayoutSupportEXTBuilder<'a> {
-    type Target = DescriptorSetVariableDescriptorCountLayoutSupportEXT;
+impl<'a> ::std::ops::Deref for DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'a> {
+    type Target = DescriptorSetVariableDescriptorCountLayoutSupport;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for DescriptorSetVariableDescriptorCountLayoutSupportEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> DescriptorSetVariableDescriptorCountLayoutSupportEXTBuilder<'a> {
+impl<'a> DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'a> {
     pub fn max_variable_descriptor_count(
         mut self,
         max_variable_descriptor_count: u32,
-    ) -> DescriptorSetVariableDescriptorCountLayoutSupportEXTBuilder<'a> {
+    ) -> DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'a> {
         self.inner.max_variable_descriptor_count = max_variable_descriptor_count;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> DescriptorSetVariableDescriptorCountLayoutSupportEXT {
+    pub fn build(self) -> DescriptorSetVariableDescriptorCountLayoutSupport {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentDescription2KHR.html>"]
-pub struct AttachmentDescription2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentDescription2.html>"]
+pub struct AttachmentDescription2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub flags: AttachmentDescriptionFlags,
@@ -36032,10 +36728,10 @@ pub struct AttachmentDescription2KHR {
     pub initial_layout: ImageLayout,
     pub final_layout: ImageLayout,
 }
-impl ::std::default::Default for AttachmentDescription2KHR {
-    fn default() -> AttachmentDescription2KHR {
-        AttachmentDescription2KHR {
-            s_type: StructureType::ATTACHMENT_DESCRIPTION_2_KHR,
+impl ::std::default::Default for AttachmentDescription2 {
+    fn default() -> AttachmentDescription2 {
+        AttachmentDescription2 {
+            s_type: StructureType::ATTACHMENT_DESCRIPTION_2,
             p_next: ::std::ptr::null(),
             flags: AttachmentDescriptionFlags::default(),
             format: Format::default(),
@@ -36049,80 +36745,74 @@ impl ::std::default::Default for AttachmentDescription2KHR {
         }
     }
 }
-impl AttachmentDescription2KHR {
-    pub fn builder<'a>() -> AttachmentDescription2KHRBuilder<'a> {
-        AttachmentDescription2KHRBuilder {
-            inner: AttachmentDescription2KHR::default(),
+impl AttachmentDescription2 {
+    pub fn builder<'a>() -> AttachmentDescription2Builder<'a> {
+        AttachmentDescription2Builder {
+            inner: AttachmentDescription2::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct AttachmentDescription2KHRBuilder<'a> {
-    inner: AttachmentDescription2KHR,
+pub struct AttachmentDescription2Builder<'a> {
+    inner: AttachmentDescription2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsAttachmentDescription2KHR {}
-impl<'a> ::std::ops::Deref for AttachmentDescription2KHRBuilder<'a> {
-    type Target = AttachmentDescription2KHR;
+pub unsafe trait ExtendsAttachmentDescription2 {}
+impl<'a> ::std::ops::Deref for AttachmentDescription2Builder<'a> {
+    type Target = AttachmentDescription2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for AttachmentDescription2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for AttachmentDescription2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> AttachmentDescription2KHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: AttachmentDescriptionFlags,
-    ) -> AttachmentDescription2KHRBuilder<'a> {
+impl<'a> AttachmentDescription2Builder<'a> {
+    pub fn flags(mut self, flags: AttachmentDescriptionFlags) -> AttachmentDescription2Builder<'a> {
         self.inner.flags = flags;
         self
     }
-    pub fn format(mut self, format: Format) -> AttachmentDescription2KHRBuilder<'a> {
+    pub fn format(mut self, format: Format) -> AttachmentDescription2Builder<'a> {
         self.inner.format = format;
         self
     }
-    pub fn samples(mut self, samples: SampleCountFlags) -> AttachmentDescription2KHRBuilder<'a> {
+    pub fn samples(mut self, samples: SampleCountFlags) -> AttachmentDescription2Builder<'a> {
         self.inner.samples = samples;
         self
     }
-    pub fn load_op(mut self, load_op: AttachmentLoadOp) -> AttachmentDescription2KHRBuilder<'a> {
+    pub fn load_op(mut self, load_op: AttachmentLoadOp) -> AttachmentDescription2Builder<'a> {
         self.inner.load_op = load_op;
         self
     }
-    pub fn store_op(mut self, store_op: AttachmentStoreOp) -> AttachmentDescription2KHRBuilder<'a> {
+    pub fn store_op(mut self, store_op: AttachmentStoreOp) -> AttachmentDescription2Builder<'a> {
         self.inner.store_op = store_op;
         self
     }
     pub fn stencil_load_op(
         mut self,
         stencil_load_op: AttachmentLoadOp,
-    ) -> AttachmentDescription2KHRBuilder<'a> {
+    ) -> AttachmentDescription2Builder<'a> {
         self.inner.stencil_load_op = stencil_load_op;
         self
     }
     pub fn stencil_store_op(
         mut self,
         stencil_store_op: AttachmentStoreOp,
-    ) -> AttachmentDescription2KHRBuilder<'a> {
+    ) -> AttachmentDescription2Builder<'a> {
         self.inner.stencil_store_op = stencil_store_op;
         self
     }
     pub fn initial_layout(
         mut self,
         initial_layout: ImageLayout,
-    ) -> AttachmentDescription2KHRBuilder<'a> {
+    ) -> AttachmentDescription2Builder<'a> {
         self.inner.initial_layout = initial_layout;
         self
     }
-    pub fn final_layout(
-        mut self,
-        final_layout: ImageLayout,
-    ) -> AttachmentDescription2KHRBuilder<'a> {
+    pub fn final_layout(mut self, final_layout: ImageLayout) -> AttachmentDescription2Builder<'a> {
         self.inner.final_layout = final_layout;
         self
     }
@@ -36131,10 +36821,10 @@ impl<'a> AttachmentDescription2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsAttachmentDescription2KHR>(
+    pub fn push_next<T: ExtendsAttachmentDescription2>(
         mut self,
         next: &'a mut T,
-    ) -> AttachmentDescription2KHRBuilder<'a> {
+    ) -> AttachmentDescription2Builder<'a> {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -36146,24 +36836,24 @@ impl<'a> AttachmentDescription2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> AttachmentDescription2KHR {
+    pub fn build(self) -> AttachmentDescription2 {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentReference2KHR.html>"]
-pub struct AttachmentReference2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentReference2.html>"]
+pub struct AttachmentReference2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub attachment: u32,
     pub layout: ImageLayout,
     pub aspect_mask: ImageAspectFlags,
 }
-impl ::std::default::Default for AttachmentReference2KHR {
-    fn default() -> AttachmentReference2KHR {
-        AttachmentReference2KHR {
-            s_type: StructureType::ATTACHMENT_REFERENCE_2_KHR,
+impl ::std::default::Default for AttachmentReference2 {
+    fn default() -> AttachmentReference2 {
+        AttachmentReference2 {
+            s_type: StructureType::ATTACHMENT_REFERENCE_2,
             p_next: ::std::ptr::null(),
             attachment: u32::default(),
             layout: ImageLayout::default(),
@@ -36171,44 +36861,41 @@ impl ::std::default::Default for AttachmentReference2KHR {
         }
     }
 }
-impl AttachmentReference2KHR {
-    pub fn builder<'a>() -> AttachmentReference2KHRBuilder<'a> {
-        AttachmentReference2KHRBuilder {
-            inner: AttachmentReference2KHR::default(),
+impl AttachmentReference2 {
+    pub fn builder<'a>() -> AttachmentReference2Builder<'a> {
+        AttachmentReference2Builder {
+            inner: AttachmentReference2::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct AttachmentReference2KHRBuilder<'a> {
-    inner: AttachmentReference2KHR,
+pub struct AttachmentReference2Builder<'a> {
+    inner: AttachmentReference2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsAttachmentReference2KHR {}
-impl<'a> ::std::ops::Deref for AttachmentReference2KHRBuilder<'a> {
-    type Target = AttachmentReference2KHR;
+pub unsafe trait ExtendsAttachmentReference2 {}
+impl<'a> ::std::ops::Deref for AttachmentReference2Builder<'a> {
+    type Target = AttachmentReference2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for AttachmentReference2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for AttachmentReference2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> AttachmentReference2KHRBuilder<'a> {
-    pub fn attachment(mut self, attachment: u32) -> AttachmentReference2KHRBuilder<'a> {
+impl<'a> AttachmentReference2Builder<'a> {
+    pub fn attachment(mut self, attachment: u32) -> AttachmentReference2Builder<'a> {
         self.inner.attachment = attachment;
         self
     }
-    pub fn layout(mut self, layout: ImageLayout) -> AttachmentReference2KHRBuilder<'a> {
+    pub fn layout(mut self, layout: ImageLayout) -> AttachmentReference2Builder<'a> {
         self.inner.layout = layout;
         self
     }
-    pub fn aspect_mask(
-        mut self,
-        aspect_mask: ImageAspectFlags,
-    ) -> AttachmentReference2KHRBuilder<'a> {
+    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> AttachmentReference2Builder<'a> {
         self.inner.aspect_mask = aspect_mask;
         self
     }
@@ -36217,10 +36904,10 @@ impl<'a> AttachmentReference2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsAttachmentReference2KHR>(
+    pub fn push_next<T: ExtendsAttachmentReference2>(
         mut self,
         next: &'a mut T,
-    ) -> AttachmentReference2KHRBuilder<'a> {
+    ) -> AttachmentReference2Builder<'a> {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -36232,32 +36919,32 @@ impl<'a> AttachmentReference2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> AttachmentReference2KHR {
+    pub fn build(self) -> AttachmentReference2 {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDescription2KHR.html>"]
-pub struct SubpassDescription2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDescription2.html>"]
+pub struct SubpassDescription2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub flags: SubpassDescriptionFlags,
     pub pipeline_bind_point: PipelineBindPoint,
     pub view_mask: u32,
     pub input_attachment_count: u32,
-    pub p_input_attachments: *const AttachmentReference2KHR,
+    pub p_input_attachments: *const AttachmentReference2,
     pub color_attachment_count: u32,
-    pub p_color_attachments: *const AttachmentReference2KHR,
-    pub p_resolve_attachments: *const AttachmentReference2KHR,
-    pub p_depth_stencil_attachment: *const AttachmentReference2KHR,
+    pub p_color_attachments: *const AttachmentReference2,
+    pub p_resolve_attachments: *const AttachmentReference2,
+    pub p_depth_stencil_attachment: *const AttachmentReference2,
     pub preserve_attachment_count: u32,
     pub p_preserve_attachments: *const u32,
 }
-impl ::std::default::Default for SubpassDescription2KHR {
-    fn default() -> SubpassDescription2KHR {
-        SubpassDescription2KHR {
-            s_type: StructureType::SUBPASS_DESCRIPTION_2_KHR,
+impl ::std::default::Default for SubpassDescription2 {
+    fn default() -> SubpassDescription2 {
+        SubpassDescription2 {
+            s_type: StructureType::SUBPASS_DESCRIPTION_2,
             p_next: ::std::ptr::null(),
             flags: SubpassDescriptionFlags::default(),
             pipeline_bind_point: PipelineBindPoint::default(),
@@ -36273,82 +36960,82 @@ impl ::std::default::Default for SubpassDescription2KHR {
         }
     }
 }
-impl SubpassDescription2KHR {
-    pub fn builder<'a>() -> SubpassDescription2KHRBuilder<'a> {
-        SubpassDescription2KHRBuilder {
-            inner: SubpassDescription2KHR::default(),
+impl SubpassDescription2 {
+    pub fn builder<'a>() -> SubpassDescription2Builder<'a> {
+        SubpassDescription2Builder {
+            inner: SubpassDescription2::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct SubpassDescription2KHRBuilder<'a> {
-    inner: SubpassDescription2KHR,
+pub struct SubpassDescription2Builder<'a> {
+    inner: SubpassDescription2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsSubpassDescription2KHR {}
-impl<'a> ::std::ops::Deref for SubpassDescription2KHRBuilder<'a> {
-    type Target = SubpassDescription2KHR;
+pub unsafe trait ExtendsSubpassDescription2 {}
+impl<'a> ::std::ops::Deref for SubpassDescription2Builder<'a> {
+    type Target = SubpassDescription2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for SubpassDescription2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for SubpassDescription2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> SubpassDescription2KHRBuilder<'a> {
-    pub fn flags(mut self, flags: SubpassDescriptionFlags) -> SubpassDescription2KHRBuilder<'a> {
+impl<'a> SubpassDescription2Builder<'a> {
+    pub fn flags(mut self, flags: SubpassDescriptionFlags) -> SubpassDescription2Builder<'a> {
         self.inner.flags = flags;
         self
     }
     pub fn pipeline_bind_point(
         mut self,
         pipeline_bind_point: PipelineBindPoint,
-    ) -> SubpassDescription2KHRBuilder<'a> {
+    ) -> SubpassDescription2Builder<'a> {
         self.inner.pipeline_bind_point = pipeline_bind_point;
         self
     }
-    pub fn view_mask(mut self, view_mask: u32) -> SubpassDescription2KHRBuilder<'a> {
+    pub fn view_mask(mut self, view_mask: u32) -> SubpassDescription2Builder<'a> {
         self.inner.view_mask = view_mask;
         self
     }
     pub fn input_attachments(
         mut self,
-        input_attachments: &'a [AttachmentReference2KHR],
-    ) -> SubpassDescription2KHRBuilder<'a> {
+        input_attachments: &'a [AttachmentReference2],
+    ) -> SubpassDescription2Builder<'a> {
         self.inner.input_attachment_count = input_attachments.len() as _;
         self.inner.p_input_attachments = input_attachments.as_ptr();
         self
     }
     pub fn color_attachments(
         mut self,
-        color_attachments: &'a [AttachmentReference2KHR],
-    ) -> SubpassDescription2KHRBuilder<'a> {
+        color_attachments: &'a [AttachmentReference2],
+    ) -> SubpassDescription2Builder<'a> {
         self.inner.color_attachment_count = color_attachments.len() as _;
         self.inner.p_color_attachments = color_attachments.as_ptr();
         self
     }
     pub fn resolve_attachments(
         mut self,
-        resolve_attachments: &'a [AttachmentReference2KHR],
-    ) -> SubpassDescription2KHRBuilder<'a> {
+        resolve_attachments: &'a [AttachmentReference2],
+    ) -> SubpassDescription2Builder<'a> {
         self.inner.color_attachment_count = resolve_attachments.len() as _;
         self.inner.p_resolve_attachments = resolve_attachments.as_ptr();
         self
     }
     pub fn depth_stencil_attachment(
         mut self,
-        depth_stencil_attachment: &'a AttachmentReference2KHR,
-    ) -> SubpassDescription2KHRBuilder<'a> {
+        depth_stencil_attachment: &'a AttachmentReference2,
+    ) -> SubpassDescription2Builder<'a> {
         self.inner.p_depth_stencil_attachment = depth_stencil_attachment;
         self
     }
     pub fn preserve_attachments(
         mut self,
         preserve_attachments: &'a [u32],
-    ) -> SubpassDescription2KHRBuilder<'a> {
+    ) -> SubpassDescription2Builder<'a> {
         self.inner.preserve_attachment_count = preserve_attachments.len() as _;
         self.inner.p_preserve_attachments = preserve_attachments.as_ptr();
         self
@@ -36358,10 +37045,10 @@ impl<'a> SubpassDescription2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubpassDescription2KHR>(
+    pub fn push_next<T: ExtendsSubpassDescription2>(
         mut self,
         next: &'a mut T,
-    ) -> SubpassDescription2KHRBuilder<'a> {
+    ) -> SubpassDescription2Builder<'a> {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -36373,14 +37060,14 @@ impl<'a> SubpassDescription2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> SubpassDescription2KHR {
+    pub fn build(self) -> SubpassDescription2 {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDependency2KHR.html>"]
-pub struct SubpassDependency2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDependency2.html>"]
+pub struct SubpassDependency2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_subpass: u32,
@@ -36392,10 +37079,10 @@ pub struct SubpassDependency2KHR {
     pub dependency_flags: DependencyFlags,
     pub view_offset: i32,
 }
-impl ::std::default::Default for SubpassDependency2KHR {
-    fn default() -> SubpassDependency2KHR {
-        SubpassDependency2KHR {
-            s_type: StructureType::SUBPASS_DEPENDENCY_2_KHR,
+impl ::std::default::Default for SubpassDependency2 {
+    fn default() -> SubpassDependency2 {
+        SubpassDependency2 {
+            s_type: StructureType::SUBPASS_DEPENDENCY_2,
             p_next: ::std::ptr::null(),
             src_subpass: u32::default(),
             dst_subpass: u32::default(),
@@ -36408,76 +37095,76 @@ impl ::std::default::Default for SubpassDependency2KHR {
         }
     }
 }
-impl SubpassDependency2KHR {
-    pub fn builder<'a>() -> SubpassDependency2KHRBuilder<'a> {
-        SubpassDependency2KHRBuilder {
-            inner: SubpassDependency2KHR::default(),
+impl SubpassDependency2 {
+    pub fn builder<'a>() -> SubpassDependency2Builder<'a> {
+        SubpassDependency2Builder {
+            inner: SubpassDependency2::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct SubpassDependency2KHRBuilder<'a> {
-    inner: SubpassDependency2KHR,
+pub struct SubpassDependency2Builder<'a> {
+    inner: SubpassDependency2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsSubpassDependency2KHR {}
-impl<'a> ::std::ops::Deref for SubpassDependency2KHRBuilder<'a> {
-    type Target = SubpassDependency2KHR;
+pub unsafe trait ExtendsSubpassDependency2 {}
+impl<'a> ::std::ops::Deref for SubpassDependency2Builder<'a> {
+    type Target = SubpassDependency2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for SubpassDependency2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for SubpassDependency2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> SubpassDependency2KHRBuilder<'a> {
-    pub fn src_subpass(mut self, src_subpass: u32) -> SubpassDependency2KHRBuilder<'a> {
+impl<'a> SubpassDependency2Builder<'a> {
+    pub fn src_subpass(mut self, src_subpass: u32) -> SubpassDependency2Builder<'a> {
         self.inner.src_subpass = src_subpass;
         self
     }
-    pub fn dst_subpass(mut self, dst_subpass: u32) -> SubpassDependency2KHRBuilder<'a> {
+    pub fn dst_subpass(mut self, dst_subpass: u32) -> SubpassDependency2Builder<'a> {
         self.inner.dst_subpass = dst_subpass;
         self
     }
     pub fn src_stage_mask(
         mut self,
         src_stage_mask: PipelineStageFlags,
-    ) -> SubpassDependency2KHRBuilder<'a> {
+    ) -> SubpassDependency2Builder<'a> {
         self.inner.src_stage_mask = src_stage_mask;
         self
     }
     pub fn dst_stage_mask(
         mut self,
         dst_stage_mask: PipelineStageFlags,
-    ) -> SubpassDependency2KHRBuilder<'a> {
+    ) -> SubpassDependency2Builder<'a> {
         self.inner.dst_stage_mask = dst_stage_mask;
         self
     }
     pub fn src_access_mask(
         mut self,
         src_access_mask: AccessFlags,
-    ) -> SubpassDependency2KHRBuilder<'a> {
+    ) -> SubpassDependency2Builder<'a> {
         self.inner.src_access_mask = src_access_mask;
         self
     }
     pub fn dst_access_mask(
         mut self,
         dst_access_mask: AccessFlags,
-    ) -> SubpassDependency2KHRBuilder<'a> {
+    ) -> SubpassDependency2Builder<'a> {
         self.inner.dst_access_mask = dst_access_mask;
         self
     }
     pub fn dependency_flags(
         mut self,
         dependency_flags: DependencyFlags,
-    ) -> SubpassDependency2KHRBuilder<'a> {
+    ) -> SubpassDependency2Builder<'a> {
         self.inner.dependency_flags = dependency_flags;
         self
     }
-    pub fn view_offset(mut self, view_offset: i32) -> SubpassDependency2KHRBuilder<'a> {
+    pub fn view_offset(mut self, view_offset: i32) -> SubpassDependency2Builder<'a> {
         self.inner.view_offset = view_offset;
         self
     }
@@ -36486,10 +37173,10 @@ impl<'a> SubpassDependency2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubpassDependency2KHR>(
+    pub fn push_next<T: ExtendsSubpassDependency2>(
         mut self,
         next: &'a mut T,
-    ) -> SubpassDependency2KHRBuilder<'a> {
+    ) -> SubpassDependency2Builder<'a> {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -36501,30 +37188,30 @@ impl<'a> SubpassDependency2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> SubpassDependency2KHR {
+    pub fn build(self) -> SubpassDependency2 {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassCreateInfo2KHR.html>"]
-pub struct RenderPassCreateInfo2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassCreateInfo2.html>"]
+pub struct RenderPassCreateInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub flags: RenderPassCreateFlags,
     pub attachment_count: u32,
-    pub p_attachments: *const AttachmentDescription2KHR,
+    pub p_attachments: *const AttachmentDescription2,
     pub subpass_count: u32,
-    pub p_subpasses: *const SubpassDescription2KHR,
+    pub p_subpasses: *const SubpassDescription2,
     pub dependency_count: u32,
-    pub p_dependencies: *const SubpassDependency2KHR,
+    pub p_dependencies: *const SubpassDependency2,
     pub correlated_view_mask_count: u32,
     pub p_correlated_view_masks: *const u32,
 }
-impl ::std::default::Default for RenderPassCreateInfo2KHR {
-    fn default() -> RenderPassCreateInfo2KHR {
-        RenderPassCreateInfo2KHR {
-            s_type: StructureType::RENDER_PASS_CREATE_INFO_2_KHR,
+impl ::std::default::Default for RenderPassCreateInfo2 {
+    fn default() -> RenderPassCreateInfo2 {
+        RenderPassCreateInfo2 {
+            s_type: StructureType::RENDER_PASS_CREATE_INFO_2,
             p_next: ::std::ptr::null(),
             flags: RenderPassCreateFlags::default(),
             attachment_count: u32::default(),
@@ -36538,56 +37225,56 @@ impl ::std::default::Default for RenderPassCreateInfo2KHR {
         }
     }
 }
-impl RenderPassCreateInfo2KHR {
-    pub fn builder<'a>() -> RenderPassCreateInfo2KHRBuilder<'a> {
-        RenderPassCreateInfo2KHRBuilder {
-            inner: RenderPassCreateInfo2KHR::default(),
+impl RenderPassCreateInfo2 {
+    pub fn builder<'a>() -> RenderPassCreateInfo2Builder<'a> {
+        RenderPassCreateInfo2Builder {
+            inner: RenderPassCreateInfo2::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct RenderPassCreateInfo2KHRBuilder<'a> {
-    inner: RenderPassCreateInfo2KHR,
+pub struct RenderPassCreateInfo2Builder<'a> {
+    inner: RenderPassCreateInfo2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsRenderPassCreateInfo2KHR {}
-impl<'a> ::std::ops::Deref for RenderPassCreateInfo2KHRBuilder<'a> {
-    type Target = RenderPassCreateInfo2KHR;
+pub unsafe trait ExtendsRenderPassCreateInfo2 {}
+impl<'a> ::std::ops::Deref for RenderPassCreateInfo2Builder<'a> {
+    type Target = RenderPassCreateInfo2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for RenderPassCreateInfo2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for RenderPassCreateInfo2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> RenderPassCreateInfo2KHRBuilder<'a> {
-    pub fn flags(mut self, flags: RenderPassCreateFlags) -> RenderPassCreateInfo2KHRBuilder<'a> {
+impl<'a> RenderPassCreateInfo2Builder<'a> {
+    pub fn flags(mut self, flags: RenderPassCreateFlags) -> RenderPassCreateInfo2Builder<'a> {
         self.inner.flags = flags;
         self
     }
     pub fn attachments(
         mut self,
-        attachments: &'a [AttachmentDescription2KHR],
-    ) -> RenderPassCreateInfo2KHRBuilder<'a> {
+        attachments: &'a [AttachmentDescription2],
+    ) -> RenderPassCreateInfo2Builder<'a> {
         self.inner.attachment_count = attachments.len() as _;
         self.inner.p_attachments = attachments.as_ptr();
         self
     }
     pub fn subpasses(
         mut self,
-        subpasses: &'a [SubpassDescription2KHR],
-    ) -> RenderPassCreateInfo2KHRBuilder<'a> {
+        subpasses: &'a [SubpassDescription2],
+    ) -> RenderPassCreateInfo2Builder<'a> {
         self.inner.subpass_count = subpasses.len() as _;
         self.inner.p_subpasses = subpasses.as_ptr();
         self
     }
     pub fn dependencies(
         mut self,
-        dependencies: &'a [SubpassDependency2KHR],
-    ) -> RenderPassCreateInfo2KHRBuilder<'a> {
+        dependencies: &'a [SubpassDependency2],
+    ) -> RenderPassCreateInfo2Builder<'a> {
         self.inner.dependency_count = dependencies.len() as _;
         self.inner.p_dependencies = dependencies.as_ptr();
         self
@@ -36595,7 +37282,7 @@ impl<'a> RenderPassCreateInfo2KHRBuilder<'a> {
     pub fn correlated_view_masks(
         mut self,
         correlated_view_masks: &'a [u32],
-    ) -> RenderPassCreateInfo2KHRBuilder<'a> {
+    ) -> RenderPassCreateInfo2Builder<'a> {
         self.inner.correlated_view_mask_count = correlated_view_masks.len() as _;
         self.inner.p_correlated_view_masks = correlated_view_masks.as_ptr();
         self
@@ -36605,10 +37292,10 @@ impl<'a> RenderPassCreateInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsRenderPassCreateInfo2KHR>(
+    pub fn push_next<T: ExtendsRenderPassCreateInfo2>(
         mut self,
         next: &'a mut T,
-    ) -> RenderPassCreateInfo2KHRBuilder<'a> {
+    ) -> RenderPassCreateInfo2Builder<'a> {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -36620,54 +37307,54 @@ impl<'a> RenderPassCreateInfo2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> RenderPassCreateInfo2KHR {
+    pub fn build(self) -> RenderPassCreateInfo2 {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassBeginInfoKHR.html>"]
-pub struct SubpassBeginInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassBeginInfo.html>"]
+pub struct SubpassBeginInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub contents: SubpassContents,
 }
-impl ::std::default::Default for SubpassBeginInfoKHR {
-    fn default() -> SubpassBeginInfoKHR {
-        SubpassBeginInfoKHR {
-            s_type: StructureType::SUBPASS_BEGIN_INFO_KHR,
+impl ::std::default::Default for SubpassBeginInfo {
+    fn default() -> SubpassBeginInfo {
+        SubpassBeginInfo {
+            s_type: StructureType::SUBPASS_BEGIN_INFO,
             p_next: ::std::ptr::null(),
             contents: SubpassContents::default(),
         }
     }
 }
-impl SubpassBeginInfoKHR {
-    pub fn builder<'a>() -> SubpassBeginInfoKHRBuilder<'a> {
-        SubpassBeginInfoKHRBuilder {
-            inner: SubpassBeginInfoKHR::default(),
+impl SubpassBeginInfo {
+    pub fn builder<'a>() -> SubpassBeginInfoBuilder<'a> {
+        SubpassBeginInfoBuilder {
+            inner: SubpassBeginInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct SubpassBeginInfoKHRBuilder<'a> {
-    inner: SubpassBeginInfoKHR,
+pub struct SubpassBeginInfoBuilder<'a> {
+    inner: SubpassBeginInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsSubpassBeginInfoKHR {}
-impl<'a> ::std::ops::Deref for SubpassBeginInfoKHRBuilder<'a> {
-    type Target = SubpassBeginInfoKHR;
+pub unsafe trait ExtendsSubpassBeginInfo {}
+impl<'a> ::std::ops::Deref for SubpassBeginInfoBuilder<'a> {
+    type Target = SubpassBeginInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for SubpassBeginInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for SubpassBeginInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> SubpassBeginInfoKHRBuilder<'a> {
-    pub fn contents(mut self, contents: SubpassContents) -> SubpassBeginInfoKHRBuilder<'a> {
+impl<'a> SubpassBeginInfoBuilder<'a> {
+    pub fn contents(mut self, contents: SubpassContents) -> SubpassBeginInfoBuilder<'a> {
         self.inner.contents = contents;
         self
     }
@@ -36676,10 +37363,10 @@ impl<'a> SubpassBeginInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubpassBeginInfoKHR>(
+    pub fn push_next<T: ExtendsSubpassBeginInfo>(
         mut self,
         next: &'a mut T,
-    ) -> SubpassBeginInfoKHRBuilder<'a> {
+    ) -> SubpassBeginInfoBuilder<'a> {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -36691,60 +37378,60 @@ impl<'a> SubpassBeginInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> SubpassBeginInfoKHR {
+    pub fn build(self) -> SubpassBeginInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassEndInfoKHR.html>"]
-pub struct SubpassEndInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassEndInfo.html>"]
+pub struct SubpassEndInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
 }
-impl ::std::default::Default for SubpassEndInfoKHR {
-    fn default() -> SubpassEndInfoKHR {
-        SubpassEndInfoKHR {
-            s_type: StructureType::SUBPASS_END_INFO_KHR,
+impl ::std::default::Default for SubpassEndInfo {
+    fn default() -> SubpassEndInfo {
+        SubpassEndInfo {
+            s_type: StructureType::SUBPASS_END_INFO,
             p_next: ::std::ptr::null(),
         }
     }
 }
-impl SubpassEndInfoKHR {
-    pub fn builder<'a>() -> SubpassEndInfoKHRBuilder<'a> {
-        SubpassEndInfoKHRBuilder {
-            inner: SubpassEndInfoKHR::default(),
+impl SubpassEndInfo {
+    pub fn builder<'a>() -> SubpassEndInfoBuilder<'a> {
+        SubpassEndInfoBuilder {
+            inner: SubpassEndInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct SubpassEndInfoKHRBuilder<'a> {
-    inner: SubpassEndInfoKHR,
+pub struct SubpassEndInfoBuilder<'a> {
+    inner: SubpassEndInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsSubpassEndInfoKHR {}
-impl<'a> ::std::ops::Deref for SubpassEndInfoKHRBuilder<'a> {
-    type Target = SubpassEndInfoKHR;
+pub unsafe trait ExtendsSubpassEndInfo {}
+impl<'a> ::std::ops::Deref for SubpassEndInfoBuilder<'a> {
+    type Target = SubpassEndInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for SubpassEndInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for SubpassEndInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> SubpassEndInfoKHRBuilder<'a> {
+impl<'a> SubpassEndInfoBuilder<'a> {
     #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
     #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubpassEndInfoKHR>(
+    pub fn push_next<T: ExtendsSubpassEndInfo>(
         mut self,
         next: &'a mut T,
-    ) -> SubpassEndInfoKHRBuilder<'a> {
+    ) -> SubpassEndInfoBuilder<'a> {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -36756,7 +37443,432 @@ impl<'a> SubpassEndInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> SubpassEndInfoKHR {
+    pub fn build(self) -> SubpassEndInfo {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTimelineSemaphoreFeatures.html>"]
+pub struct PhysicalDeviceTimelineSemaphoreFeatures {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub timeline_semaphore: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceTimelineSemaphoreFeatures {
+    fn default() -> PhysicalDeviceTimelineSemaphoreFeatures {
+        PhysicalDeviceTimelineSemaphoreFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES,
+            p_next: ::std::ptr::null_mut(),
+            timeline_semaphore: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceTimelineSemaphoreFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'a> {
+        PhysicalDeviceTimelineSemaphoreFeaturesBuilder {
+            inner: PhysicalDeviceTimelineSemaphoreFeatures::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'a> {
+    inner: PhysicalDeviceTimelineSemaphoreFeatures,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceTimelineSemaphoreFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceTimelineSemaphoreFeatures;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'a> {
+    pub fn timeline_semaphore(
+        mut self,
+        timeline_semaphore: bool,
+    ) -> PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'a> {
+        self.inner.timeline_semaphore = timeline_semaphore.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceTimelineSemaphoreFeatures {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTimelineSemaphoreProperties.html>"]
+pub struct PhysicalDeviceTimelineSemaphoreProperties {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub max_timeline_semaphore_value_difference: u64,
+}
+impl ::std::default::Default for PhysicalDeviceTimelineSemaphoreProperties {
+    fn default() -> PhysicalDeviceTimelineSemaphoreProperties {
+        PhysicalDeviceTimelineSemaphoreProperties {
+            s_type: StructureType::PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES,
+            p_next: ::std::ptr::null_mut(),
+            max_timeline_semaphore_value_difference: u64::default(),
+        }
+    }
+}
+impl PhysicalDeviceTimelineSemaphoreProperties {
+    pub fn builder<'a>() -> PhysicalDeviceTimelineSemaphorePropertiesBuilder<'a> {
+        PhysicalDeviceTimelineSemaphorePropertiesBuilder {
+            inner: PhysicalDeviceTimelineSemaphoreProperties::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceTimelineSemaphorePropertiesBuilder<'a> {
+    inner: PhysicalDeviceTimelineSemaphoreProperties,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsPhysicalDeviceProperties2
+    for PhysicalDeviceTimelineSemaphorePropertiesBuilder<'_>
+{
+}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceTimelineSemaphoreProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceTimelineSemaphorePropertiesBuilder<'a> {
+    type Target = PhysicalDeviceTimelineSemaphoreProperties;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceTimelineSemaphorePropertiesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceTimelineSemaphorePropertiesBuilder<'a> {
+    pub fn max_timeline_semaphore_value_difference(
+        mut self,
+        max_timeline_semaphore_value_difference: u64,
+    ) -> PhysicalDeviceTimelineSemaphorePropertiesBuilder<'a> {
+        self.inner.max_timeline_semaphore_value_difference =
+            max_timeline_semaphore_value_difference;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceTimelineSemaphoreProperties {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreTypeCreateInfo.html>"]
+pub struct SemaphoreTypeCreateInfo {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub semaphore_type: SemaphoreType,
+    pub initial_value: u64,
+}
+impl ::std::default::Default for SemaphoreTypeCreateInfo {
+    fn default() -> SemaphoreTypeCreateInfo {
+        SemaphoreTypeCreateInfo {
+            s_type: StructureType::SEMAPHORE_TYPE_CREATE_INFO,
+            p_next: ::std::ptr::null(),
+            semaphore_type: SemaphoreType::default(),
+            initial_value: u64::default(),
+        }
+    }
+}
+impl SemaphoreTypeCreateInfo {
+    pub fn builder<'a>() -> SemaphoreTypeCreateInfoBuilder<'a> {
+        SemaphoreTypeCreateInfoBuilder {
+            inner: SemaphoreTypeCreateInfo::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct SemaphoreTypeCreateInfoBuilder<'a> {
+    inner: SemaphoreTypeCreateInfo,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsSemaphoreCreateInfo for SemaphoreTypeCreateInfoBuilder<'_> {}
+unsafe impl ExtendsSemaphoreCreateInfo for SemaphoreTypeCreateInfo {}
+unsafe impl ExtendsPhysicalDeviceExternalSemaphoreInfo for SemaphoreTypeCreateInfoBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceExternalSemaphoreInfo for SemaphoreTypeCreateInfo {}
+impl<'a> ::std::ops::Deref for SemaphoreTypeCreateInfoBuilder<'a> {
+    type Target = SemaphoreTypeCreateInfo;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for SemaphoreTypeCreateInfoBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> SemaphoreTypeCreateInfoBuilder<'a> {
+    pub fn semaphore_type(
+        mut self,
+        semaphore_type: SemaphoreType,
+    ) -> SemaphoreTypeCreateInfoBuilder<'a> {
+        self.inner.semaphore_type = semaphore_type;
+        self
+    }
+    pub fn initial_value(mut self, initial_value: u64) -> SemaphoreTypeCreateInfoBuilder<'a> {
+        self.inner.initial_value = initial_value;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> SemaphoreTypeCreateInfo {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkTimelineSemaphoreSubmitInfo.html>"]
+pub struct TimelineSemaphoreSubmitInfo {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub wait_semaphore_value_count: u32,
+    pub p_wait_semaphore_values: *const u64,
+    pub signal_semaphore_value_count: u32,
+    pub p_signal_semaphore_values: *const u64,
+}
+impl ::std::default::Default for TimelineSemaphoreSubmitInfo {
+    fn default() -> TimelineSemaphoreSubmitInfo {
+        TimelineSemaphoreSubmitInfo {
+            s_type: StructureType::TIMELINE_SEMAPHORE_SUBMIT_INFO,
+            p_next: ::std::ptr::null(),
+            wait_semaphore_value_count: u32::default(),
+            p_wait_semaphore_values: ::std::ptr::null(),
+            signal_semaphore_value_count: u32::default(),
+            p_signal_semaphore_values: ::std::ptr::null(),
+        }
+    }
+}
+impl TimelineSemaphoreSubmitInfo {
+    pub fn builder<'a>() -> TimelineSemaphoreSubmitInfoBuilder<'a> {
+        TimelineSemaphoreSubmitInfoBuilder {
+            inner: TimelineSemaphoreSubmitInfo::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct TimelineSemaphoreSubmitInfoBuilder<'a> {
+    inner: TimelineSemaphoreSubmitInfo,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsSubmitInfo for TimelineSemaphoreSubmitInfoBuilder<'_> {}
+unsafe impl ExtendsSubmitInfo for TimelineSemaphoreSubmitInfo {}
+unsafe impl ExtendsBindSparseInfo for TimelineSemaphoreSubmitInfoBuilder<'_> {}
+unsafe impl ExtendsBindSparseInfo for TimelineSemaphoreSubmitInfo {}
+impl<'a> ::std::ops::Deref for TimelineSemaphoreSubmitInfoBuilder<'a> {
+    type Target = TimelineSemaphoreSubmitInfo;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for TimelineSemaphoreSubmitInfoBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> TimelineSemaphoreSubmitInfoBuilder<'a> {
+    pub fn wait_semaphore_values(
+        mut self,
+        wait_semaphore_values: &'a [u64],
+    ) -> TimelineSemaphoreSubmitInfoBuilder<'a> {
+        self.inner.wait_semaphore_value_count = wait_semaphore_values.len() as _;
+        self.inner.p_wait_semaphore_values = wait_semaphore_values.as_ptr();
+        self
+    }
+    pub fn signal_semaphore_values(
+        mut self,
+        signal_semaphore_values: &'a [u64],
+    ) -> TimelineSemaphoreSubmitInfoBuilder<'a> {
+        self.inner.signal_semaphore_value_count = signal_semaphore_values.len() as _;
+        self.inner.p_signal_semaphore_values = signal_semaphore_values.as_ptr();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> TimelineSemaphoreSubmitInfo {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreWaitInfo.html>"]
+pub struct SemaphoreWaitInfo {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub flags: SemaphoreWaitFlags,
+    pub semaphore_count: u32,
+    pub p_semaphores: *const Semaphore,
+    pub p_values: *const u64,
+}
+impl ::std::default::Default for SemaphoreWaitInfo {
+    fn default() -> SemaphoreWaitInfo {
+        SemaphoreWaitInfo {
+            s_type: StructureType::SEMAPHORE_WAIT_INFO,
+            p_next: ::std::ptr::null(),
+            flags: SemaphoreWaitFlags::default(),
+            semaphore_count: u32::default(),
+            p_semaphores: ::std::ptr::null(),
+            p_values: ::std::ptr::null(),
+        }
+    }
+}
+impl SemaphoreWaitInfo {
+    pub fn builder<'a>() -> SemaphoreWaitInfoBuilder<'a> {
+        SemaphoreWaitInfoBuilder {
+            inner: SemaphoreWaitInfo::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct SemaphoreWaitInfoBuilder<'a> {
+    inner: SemaphoreWaitInfo,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsSemaphoreWaitInfo {}
+impl<'a> ::std::ops::Deref for SemaphoreWaitInfoBuilder<'a> {
+    type Target = SemaphoreWaitInfo;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for SemaphoreWaitInfoBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> SemaphoreWaitInfoBuilder<'a> {
+    pub fn flags(mut self, flags: SemaphoreWaitFlags) -> SemaphoreWaitInfoBuilder<'a> {
+        self.inner.flags = flags;
+        self
+    }
+    pub fn semaphores(mut self, semaphores: &'a [Semaphore]) -> SemaphoreWaitInfoBuilder<'a> {
+        self.inner.semaphore_count = semaphores.len() as _;
+        self.inner.p_semaphores = semaphores.as_ptr();
+        self
+    }
+    pub fn values(mut self, values: &'a [u64]) -> SemaphoreWaitInfoBuilder<'a> {
+        self.inner.semaphore_count = values.len() as _;
+        self.inner.p_values = values.as_ptr();
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsSemaphoreWaitInfo>(
+        mut self,
+        next: &'a mut T,
+    ) -> SemaphoreWaitInfoBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> SemaphoreWaitInfo {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreSignalInfo.html>"]
+pub struct SemaphoreSignalInfo {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub semaphore: Semaphore,
+    pub value: u64,
+}
+impl ::std::default::Default for SemaphoreSignalInfo {
+    fn default() -> SemaphoreSignalInfo {
+        SemaphoreSignalInfo {
+            s_type: StructureType::SEMAPHORE_SIGNAL_INFO,
+            p_next: ::std::ptr::null(),
+            semaphore: Semaphore::default(),
+            value: u64::default(),
+        }
+    }
+}
+impl SemaphoreSignalInfo {
+    pub fn builder<'a>() -> SemaphoreSignalInfoBuilder<'a> {
+        SemaphoreSignalInfoBuilder {
+            inner: SemaphoreSignalInfo::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct SemaphoreSignalInfoBuilder<'a> {
+    inner: SemaphoreSignalInfo,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsSemaphoreSignalInfo {}
+impl<'a> ::std::ops::Deref for SemaphoreSignalInfoBuilder<'a> {
+    type Target = SemaphoreSignalInfo;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for SemaphoreSignalInfoBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> SemaphoreSignalInfoBuilder<'a> {
+    pub fn semaphore(mut self, semaphore: Semaphore) -> SemaphoreSignalInfoBuilder<'a> {
+        self.inner.semaphore = semaphore;
+        self
+    }
+    pub fn value(mut self, value: u64) -> SemaphoreSignalInfoBuilder<'a> {
+        self.inner.value = value;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsSemaphoreSignalInfo>(
+        mut self,
+        next: &'a mut T,
+    ) -> SemaphoreSignalInfoBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> SemaphoreSignalInfo {
         self.inner
     }
 }
@@ -37540,18 +38652,18 @@ impl<'a> ExternalFormatANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevice8BitStorageFeaturesKHR.html>"]
-pub struct PhysicalDevice8BitStorageFeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevice8BitStorageFeatures.html>"]
+pub struct PhysicalDevice8BitStorageFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub storage_buffer8_bit_access: Bool32,
     pub uniform_and_storage_buffer8_bit_access: Bool32,
     pub storage_push_constant8: Bool32,
 }
-impl ::std::default::Default for PhysicalDevice8BitStorageFeaturesKHR {
-    fn default() -> PhysicalDevice8BitStorageFeaturesKHR {
-        PhysicalDevice8BitStorageFeaturesKHR {
-            s_type: StructureType::PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR,
+impl ::std::default::Default for PhysicalDevice8BitStorageFeatures {
+    fn default() -> PhysicalDevice8BitStorageFeatures {
+        PhysicalDevice8BitStorageFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES,
             p_next: ::std::ptr::null_mut(),
             storage_buffer8_bit_access: Bool32::default(),
             uniform_and_storage_buffer8_bit_access: Bool32::default(),
@@ -37559,44 +38671,44 @@ impl ::std::default::Default for PhysicalDevice8BitStorageFeaturesKHR {
         }
     }
 }
-impl PhysicalDevice8BitStorageFeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDevice8BitStorageFeaturesKHRBuilder<'a> {
-        PhysicalDevice8BitStorageFeaturesKHRBuilder {
-            inner: PhysicalDevice8BitStorageFeaturesKHR::default(),
+impl PhysicalDevice8BitStorageFeatures {
+    pub fn builder<'a>() -> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
+        PhysicalDevice8BitStorageFeaturesBuilder {
+            inner: PhysicalDevice8BitStorageFeatures::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDevice8BitStorageFeaturesKHRBuilder<'a> {
-    inner: PhysicalDevice8BitStorageFeaturesKHR,
+pub struct PhysicalDevice8BitStorageFeaturesBuilder<'a> {
+    inner: PhysicalDevice8BitStorageFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDevice8BitStorageFeaturesKHRBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDevice8BitStorageFeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDevice8BitStorageFeaturesKHRBuilder<'a> {
-    type Target = PhysicalDevice8BitStorageFeaturesKHR;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDevice8BitStorageFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDevice8BitStorageFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDevice8BitStorageFeaturesBuilder<'a> {
+    type Target = PhysicalDevice8BitStorageFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDevice8BitStorageFeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDevice8BitStorageFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDevice8BitStorageFeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
     pub fn storage_buffer8_bit_access(
         mut self,
         storage_buffer8_bit_access: bool,
-    ) -> PhysicalDevice8BitStorageFeaturesKHRBuilder<'a> {
+    ) -> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
         self.inner.storage_buffer8_bit_access = storage_buffer8_bit_access.into();
         self
     }
     pub fn uniform_and_storage_buffer8_bit_access(
         mut self,
         uniform_and_storage_buffer8_bit_access: bool,
-    ) -> PhysicalDevice8BitStorageFeaturesKHRBuilder<'a> {
+    ) -> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
         self.inner.uniform_and_storage_buffer8_bit_access =
             uniform_and_storage_buffer8_bit_access.into();
         self
@@ -37604,14 +38716,14 @@ impl<'a> PhysicalDevice8BitStorageFeaturesKHRBuilder<'a> {
     pub fn storage_push_constant8(
         mut self,
         storage_push_constant8: bool,
-    ) -> PhysicalDevice8BitStorageFeaturesKHRBuilder<'a> {
+    ) -> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
         self.inner.storage_push_constant8 = storage_push_constant8.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDevice8BitStorageFeaturesKHR {
+    pub fn build(self) -> PhysicalDevice8BitStorageFeatures {
         self.inner
     }
 }
@@ -37684,18 +38796,18 @@ impl<'a> PhysicalDeviceConditionalRenderingFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkanMemoryModelFeaturesKHR.html>"]
-pub struct PhysicalDeviceVulkanMemoryModelFeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkanMemoryModelFeatures.html>"]
+pub struct PhysicalDeviceVulkanMemoryModelFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub vulkan_memory_model: Bool32,
     pub vulkan_memory_model_device_scope: Bool32,
     pub vulkan_memory_model_availability_visibility_chains: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceVulkanMemoryModelFeaturesKHR {
-    fn default() -> PhysicalDeviceVulkanMemoryModelFeaturesKHR {
-        PhysicalDeviceVulkanMemoryModelFeaturesKHR {
-            s_type: StructureType::PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR,
+impl ::std::default::Default for PhysicalDeviceVulkanMemoryModelFeatures {
+    fn default() -> PhysicalDeviceVulkanMemoryModelFeatures {
+        PhysicalDeviceVulkanMemoryModelFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES,
             p_next: ::std::ptr::null_mut(),
             vulkan_memory_model: Bool32::default(),
             vulkan_memory_model_device_scope: Bool32::default(),
@@ -37703,51 +38815,51 @@ impl ::std::default::Default for PhysicalDeviceVulkanMemoryModelFeaturesKHR {
         }
     }
 }
-impl PhysicalDeviceVulkanMemoryModelFeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'a> {
-        PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder {
-            inner: PhysicalDeviceVulkanMemoryModelFeaturesKHR::default(),
+impl PhysicalDeviceVulkanMemoryModelFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
+        PhysicalDeviceVulkanMemoryModelFeaturesBuilder {
+            inner: PhysicalDeviceVulkanMemoryModelFeatures::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceVulkanMemoryModelFeaturesKHR,
+pub struct PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
+    inner: PhysicalDeviceVulkanMemoryModelFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkanMemoryModelFeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceVulkanMemoryModelFeaturesKHR;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkanMemoryModelFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceVulkanMemoryModelFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
     pub fn vulkan_memory_model(
         mut self,
         vulkan_memory_model: bool,
-    ) -> PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'a> {
+    ) -> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
         self.inner.vulkan_memory_model = vulkan_memory_model.into();
         self
     }
     pub fn vulkan_memory_model_device_scope(
         mut self,
         vulkan_memory_model_device_scope: bool,
-    ) -> PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'a> {
+    ) -> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
         self.inner.vulkan_memory_model_device_scope = vulkan_memory_model_device_scope.into();
         self
     }
     pub fn vulkan_memory_model_availability_visibility_chains(
         mut self,
         vulkan_memory_model_availability_visibility_chains: bool,
-    ) -> PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'a> {
+    ) -> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
         self.inner
             .vulkan_memory_model_availability_visibility_chains =
             vulkan_memory_model_availability_visibility_chains.into();
@@ -37756,74 +38868,74 @@ impl<'a> PhysicalDeviceVulkanMemoryModelFeaturesKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceVulkanMemoryModelFeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceVulkanMemoryModelFeatures {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderAtomicInt64FeaturesKHR.html>"]
-pub struct PhysicalDeviceShaderAtomicInt64FeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderAtomicInt64Features.html>"]
+pub struct PhysicalDeviceShaderAtomicInt64Features {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub shader_buffer_int64_atomics: Bool32,
     pub shader_shared_int64_atomics: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceShaderAtomicInt64FeaturesKHR {
-    fn default() -> PhysicalDeviceShaderAtomicInt64FeaturesKHR {
-        PhysicalDeviceShaderAtomicInt64FeaturesKHR {
-            s_type: StructureType::PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR,
+impl ::std::default::Default for PhysicalDeviceShaderAtomicInt64Features {
+    fn default() -> PhysicalDeviceShaderAtomicInt64Features {
+        PhysicalDeviceShaderAtomicInt64Features {
+            s_type: StructureType::PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES,
             p_next: ::std::ptr::null_mut(),
             shader_buffer_int64_atomics: Bool32::default(),
             shader_shared_int64_atomics: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceShaderAtomicInt64FeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceShaderAtomicInt64FeaturesKHRBuilder<'a> {
-        PhysicalDeviceShaderAtomicInt64FeaturesKHRBuilder {
-            inner: PhysicalDeviceShaderAtomicInt64FeaturesKHR::default(),
+impl PhysicalDeviceShaderAtomicInt64Features {
+    pub fn builder<'a>() -> PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
+        PhysicalDeviceShaderAtomicInt64FeaturesBuilder {
+            inner: PhysicalDeviceShaderAtomicInt64Features::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceShaderAtomicInt64FeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceShaderAtomicInt64FeaturesKHR,
+pub struct PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
+    inner: PhysicalDeviceShaderAtomicInt64Features,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderAtomicInt64FeaturesKHRBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderAtomicInt64FeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceShaderAtomicInt64FeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceShaderAtomicInt64FeaturesKHR;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderAtomicInt64Features {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
+    type Target = PhysicalDeviceShaderAtomicInt64Features;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderAtomicInt64FeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceShaderAtomicInt64FeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
     pub fn shader_buffer_int64_atomics(
         mut self,
         shader_buffer_int64_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicInt64FeaturesKHRBuilder<'a> {
+    ) -> PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
         self.inner.shader_buffer_int64_atomics = shader_buffer_int64_atomics.into();
         self
     }
     pub fn shader_shared_int64_atomics(
         mut self,
         shader_shared_int64_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicInt64FeaturesKHRBuilder<'a> {
+    ) -> PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
         self.inner.shader_shared_int64_atomics = shader_shared_int64_atomics.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceShaderAtomicInt64FeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceShaderAtomicInt64Features {
         self.inner
     }
 }
@@ -38036,165 +39148,165 @@ impl<'a> CheckpointDataNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDepthStencilResolvePropertiesKHR.html>"]
-pub struct PhysicalDeviceDepthStencilResolvePropertiesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDepthStencilResolveProperties.html>"]
+pub struct PhysicalDeviceDepthStencilResolveProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
-    pub supported_depth_resolve_modes: ResolveModeFlagsKHR,
-    pub supported_stencil_resolve_modes: ResolveModeFlagsKHR,
+    pub supported_depth_resolve_modes: ResolveModeFlags,
+    pub supported_stencil_resolve_modes: ResolveModeFlags,
     pub independent_resolve_none: Bool32,
     pub independent_resolve: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceDepthStencilResolvePropertiesKHR {
-    fn default() -> PhysicalDeviceDepthStencilResolvePropertiesKHR {
-        PhysicalDeviceDepthStencilResolvePropertiesKHR {
-            s_type: StructureType::PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES_KHR,
+impl ::std::default::Default for PhysicalDeviceDepthStencilResolveProperties {
+    fn default() -> PhysicalDeviceDepthStencilResolveProperties {
+        PhysicalDeviceDepthStencilResolveProperties {
+            s_type: StructureType::PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
-            supported_depth_resolve_modes: ResolveModeFlagsKHR::default(),
-            supported_stencil_resolve_modes: ResolveModeFlagsKHR::default(),
+            supported_depth_resolve_modes: ResolveModeFlags::default(),
+            supported_stencil_resolve_modes: ResolveModeFlags::default(),
             independent_resolve_none: Bool32::default(),
             independent_resolve: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceDepthStencilResolvePropertiesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'a> {
-        PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder {
-            inner: PhysicalDeviceDepthStencilResolvePropertiesKHR::default(),
+impl PhysicalDeviceDepthStencilResolveProperties {
+    pub fn builder<'a>() -> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
+        PhysicalDeviceDepthStencilResolvePropertiesBuilder {
+            inner: PhysicalDeviceDepthStencilResolveProperties::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'a> {
-    inner: PhysicalDeviceDepthStencilResolvePropertiesKHR,
+pub struct PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
+    inner: PhysicalDeviceDepthStencilResolveProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'_>
+    for PhysicalDeviceDepthStencilResolvePropertiesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceDepthStencilResolvePropertiesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'a> {
-    type Target = PhysicalDeviceDepthStencilResolvePropertiesKHR;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceDepthStencilResolveProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
+    type Target = PhysicalDeviceDepthStencilResolveProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
     pub fn supported_depth_resolve_modes(
         mut self,
-        supported_depth_resolve_modes: ResolveModeFlagsKHR,
-    ) -> PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'a> {
+        supported_depth_resolve_modes: ResolveModeFlags,
+    ) -> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
         self.inner.supported_depth_resolve_modes = supported_depth_resolve_modes;
         self
     }
     pub fn supported_stencil_resolve_modes(
         mut self,
-        supported_stencil_resolve_modes: ResolveModeFlagsKHR,
-    ) -> PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'a> {
+        supported_stencil_resolve_modes: ResolveModeFlags,
+    ) -> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
         self.inner.supported_stencil_resolve_modes = supported_stencil_resolve_modes;
         self
     }
     pub fn independent_resolve_none(
         mut self,
         independent_resolve_none: bool,
-    ) -> PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
         self.inner.independent_resolve_none = independent_resolve_none.into();
         self
     }
     pub fn independent_resolve(
         mut self,
         independent_resolve: bool,
-    ) -> PhysicalDeviceDepthStencilResolvePropertiesKHRBuilder<'a> {
+    ) -> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
         self.inner.independent_resolve = independent_resolve.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceDepthStencilResolvePropertiesKHR {
+    pub fn build(self) -> PhysicalDeviceDepthStencilResolveProperties {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDescriptionDepthStencilResolveKHR.html>"]
-pub struct SubpassDescriptionDepthStencilResolveKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDescriptionDepthStencilResolve.html>"]
+pub struct SubpassDescriptionDepthStencilResolve {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub depth_resolve_mode: ResolveModeFlagsKHR,
-    pub stencil_resolve_mode: ResolveModeFlagsKHR,
-    pub p_depth_stencil_resolve_attachment: *const AttachmentReference2KHR,
+    pub depth_resolve_mode: ResolveModeFlags,
+    pub stencil_resolve_mode: ResolveModeFlags,
+    pub p_depth_stencil_resolve_attachment: *const AttachmentReference2,
 }
-impl ::std::default::Default for SubpassDescriptionDepthStencilResolveKHR {
-    fn default() -> SubpassDescriptionDepthStencilResolveKHR {
-        SubpassDescriptionDepthStencilResolveKHR {
-            s_type: StructureType::SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE_KHR,
+impl ::std::default::Default for SubpassDescriptionDepthStencilResolve {
+    fn default() -> SubpassDescriptionDepthStencilResolve {
+        SubpassDescriptionDepthStencilResolve {
+            s_type: StructureType::SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE,
             p_next: ::std::ptr::null(),
-            depth_resolve_mode: ResolveModeFlagsKHR::default(),
-            stencil_resolve_mode: ResolveModeFlagsKHR::default(),
+            depth_resolve_mode: ResolveModeFlags::default(),
+            stencil_resolve_mode: ResolveModeFlags::default(),
             p_depth_stencil_resolve_attachment: ::std::ptr::null(),
         }
     }
 }
-impl SubpassDescriptionDepthStencilResolveKHR {
-    pub fn builder<'a>() -> SubpassDescriptionDepthStencilResolveKHRBuilder<'a> {
-        SubpassDescriptionDepthStencilResolveKHRBuilder {
-            inner: SubpassDescriptionDepthStencilResolveKHR::default(),
+impl SubpassDescriptionDepthStencilResolve {
+    pub fn builder<'a>() -> SubpassDescriptionDepthStencilResolveBuilder<'a> {
+        SubpassDescriptionDepthStencilResolveBuilder {
+            inner: SubpassDescriptionDepthStencilResolve::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct SubpassDescriptionDepthStencilResolveKHRBuilder<'a> {
-    inner: SubpassDescriptionDepthStencilResolveKHR,
+pub struct SubpassDescriptionDepthStencilResolveBuilder<'a> {
+    inner: SubpassDescriptionDepthStencilResolve,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsSubpassDescription2KHR for SubpassDescriptionDepthStencilResolveKHRBuilder<'_> {}
-unsafe impl ExtendsSubpassDescription2KHR for SubpassDescriptionDepthStencilResolveKHR {}
-impl<'a> ::std::ops::Deref for SubpassDescriptionDepthStencilResolveKHRBuilder<'a> {
-    type Target = SubpassDescriptionDepthStencilResolveKHR;
+unsafe impl ExtendsSubpassDescription2 for SubpassDescriptionDepthStencilResolveBuilder<'_> {}
+unsafe impl ExtendsSubpassDescription2 for SubpassDescriptionDepthStencilResolve {}
+impl<'a> ::std::ops::Deref for SubpassDescriptionDepthStencilResolveBuilder<'a> {
+    type Target = SubpassDescriptionDepthStencilResolve;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for SubpassDescriptionDepthStencilResolveKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for SubpassDescriptionDepthStencilResolveBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> SubpassDescriptionDepthStencilResolveKHRBuilder<'a> {
+impl<'a> SubpassDescriptionDepthStencilResolveBuilder<'a> {
     pub fn depth_resolve_mode(
         mut self,
-        depth_resolve_mode: ResolveModeFlagsKHR,
-    ) -> SubpassDescriptionDepthStencilResolveKHRBuilder<'a> {
+        depth_resolve_mode: ResolveModeFlags,
+    ) -> SubpassDescriptionDepthStencilResolveBuilder<'a> {
         self.inner.depth_resolve_mode = depth_resolve_mode;
         self
     }
     pub fn stencil_resolve_mode(
         mut self,
-        stencil_resolve_mode: ResolveModeFlagsKHR,
-    ) -> SubpassDescriptionDepthStencilResolveKHRBuilder<'a> {
+        stencil_resolve_mode: ResolveModeFlags,
+    ) -> SubpassDescriptionDepthStencilResolveBuilder<'a> {
         self.inner.stencil_resolve_mode = stencil_resolve_mode;
         self
     }
     pub fn depth_stencil_resolve_attachment(
         mut self,
-        depth_stencil_resolve_attachment: &'a AttachmentReference2KHR,
-    ) -> SubpassDescriptionDepthStencilResolveKHRBuilder<'a> {
+        depth_stencil_resolve_attachment: &'a AttachmentReference2,
+    ) -> SubpassDescriptionDepthStencilResolveBuilder<'a> {
         self.inner.p_depth_stencil_resolve_attachment = depth_stencil_resolve_attachment;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> SubpassDescriptionDepthStencilResolveKHR {
+    pub fn build(self) -> SubpassDescriptionDepthStencilResolve {
         self.inner
     }
 }
@@ -41466,61 +42578,61 @@ impl<'a> ImageDrmFormatModifierPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageStencilUsageCreateInfoEXT.html>"]
-pub struct ImageStencilUsageCreateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageStencilUsageCreateInfo.html>"]
+pub struct ImageStencilUsageCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub stencil_usage: ImageUsageFlags,
 }
-impl ::std::default::Default for ImageStencilUsageCreateInfoEXT {
-    fn default() -> ImageStencilUsageCreateInfoEXT {
-        ImageStencilUsageCreateInfoEXT {
-            s_type: StructureType::IMAGE_STENCIL_USAGE_CREATE_INFO_EXT,
+impl ::std::default::Default for ImageStencilUsageCreateInfo {
+    fn default() -> ImageStencilUsageCreateInfo {
+        ImageStencilUsageCreateInfo {
+            s_type: StructureType::IMAGE_STENCIL_USAGE_CREATE_INFO,
             p_next: ::std::ptr::null(),
             stencil_usage: ImageUsageFlags::default(),
         }
     }
 }
-impl ImageStencilUsageCreateInfoEXT {
-    pub fn builder<'a>() -> ImageStencilUsageCreateInfoEXTBuilder<'a> {
-        ImageStencilUsageCreateInfoEXTBuilder {
-            inner: ImageStencilUsageCreateInfoEXT::default(),
+impl ImageStencilUsageCreateInfo {
+    pub fn builder<'a>() -> ImageStencilUsageCreateInfoBuilder<'a> {
+        ImageStencilUsageCreateInfoBuilder {
+            inner: ImageStencilUsageCreateInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct ImageStencilUsageCreateInfoEXTBuilder<'a> {
-    inner: ImageStencilUsageCreateInfoEXT,
+pub struct ImageStencilUsageCreateInfoBuilder<'a> {
+    inner: ImageStencilUsageCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsImageCreateInfo for ImageStencilUsageCreateInfoEXTBuilder<'_> {}
-unsafe impl ExtendsImageCreateInfo for ImageStencilUsageCreateInfoEXT {}
-unsafe impl ExtendsPhysicalDeviceImageFormatInfo2 for ImageStencilUsageCreateInfoEXTBuilder<'_> {}
-unsafe impl ExtendsPhysicalDeviceImageFormatInfo2 for ImageStencilUsageCreateInfoEXT {}
-impl<'a> ::std::ops::Deref for ImageStencilUsageCreateInfoEXTBuilder<'a> {
-    type Target = ImageStencilUsageCreateInfoEXT;
+unsafe impl ExtendsImageCreateInfo for ImageStencilUsageCreateInfoBuilder<'_> {}
+unsafe impl ExtendsImageCreateInfo for ImageStencilUsageCreateInfo {}
+unsafe impl ExtendsPhysicalDeviceImageFormatInfo2 for ImageStencilUsageCreateInfoBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceImageFormatInfo2 for ImageStencilUsageCreateInfo {}
+impl<'a> ::std::ops::Deref for ImageStencilUsageCreateInfoBuilder<'a> {
+    type Target = ImageStencilUsageCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for ImageStencilUsageCreateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for ImageStencilUsageCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> ImageStencilUsageCreateInfoEXTBuilder<'a> {
+impl<'a> ImageStencilUsageCreateInfoBuilder<'a> {
     pub fn stencil_usage(
         mut self,
         stencil_usage: ImageUsageFlags,
-    ) -> ImageStencilUsageCreateInfoEXTBuilder<'a> {
+    ) -> ImageStencilUsageCreateInfoBuilder<'a> {
         self.inner.stencil_usage = stencil_usage;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> ImageStencilUsageCreateInfoEXT {
+    pub fn build(self) -> ImageStencilUsageCreateInfo {
         self.inner
     }
 }
@@ -41770,6 +42882,8 @@ pub struct RenderPassFragmentDensityMapCreateInfoEXTBuilder<'a> {
 }
 unsafe impl ExtendsRenderPassCreateInfo for RenderPassFragmentDensityMapCreateInfoEXTBuilder<'_> {}
 unsafe impl ExtendsRenderPassCreateInfo for RenderPassFragmentDensityMapCreateInfoEXT {}
+unsafe impl ExtendsRenderPassCreateInfo2 for RenderPassFragmentDensityMapCreateInfoEXTBuilder<'_> {}
+unsafe impl ExtendsRenderPassCreateInfo2 for RenderPassFragmentDensityMapCreateInfoEXT {}
 impl<'a> ::std::ops::Deref for RenderPassFragmentDensityMapCreateInfoEXTBuilder<'a> {
     type Target = RenderPassFragmentDensityMapCreateInfoEXT;
     fn deref(&self) -> &Self::Target {
@@ -41798,59 +42912,59 @@ impl<'a> RenderPassFragmentDensityMapCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceScalarBlockLayoutFeaturesEXT.html>"]
-pub struct PhysicalDeviceScalarBlockLayoutFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceScalarBlockLayoutFeatures.html>"]
+pub struct PhysicalDeviceScalarBlockLayoutFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub scalar_block_layout: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceScalarBlockLayoutFeaturesEXT {
-    fn default() -> PhysicalDeviceScalarBlockLayoutFeaturesEXT {
-        PhysicalDeviceScalarBlockLayoutFeaturesEXT {
-            s_type: StructureType::PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT,
+impl ::std::default::Default for PhysicalDeviceScalarBlockLayoutFeatures {
+    fn default() -> PhysicalDeviceScalarBlockLayoutFeatures {
+        PhysicalDeviceScalarBlockLayoutFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES,
             p_next: ::std::ptr::null_mut(),
             scalar_block_layout: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceScalarBlockLayoutFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceScalarBlockLayoutFeaturesEXTBuilder<'a> {
-        PhysicalDeviceScalarBlockLayoutFeaturesEXTBuilder {
-            inner: PhysicalDeviceScalarBlockLayoutFeaturesEXT::default(),
+impl PhysicalDeviceScalarBlockLayoutFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'a> {
+        PhysicalDeviceScalarBlockLayoutFeaturesBuilder {
+            inner: PhysicalDeviceScalarBlockLayoutFeatures::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceScalarBlockLayoutFeaturesEXTBuilder<'a> {
-    inner: PhysicalDeviceScalarBlockLayoutFeaturesEXT,
+pub struct PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'a> {
+    inner: PhysicalDeviceScalarBlockLayoutFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceScalarBlockLayoutFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceScalarBlockLayoutFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceScalarBlockLayoutFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDeviceScalarBlockLayoutFeaturesEXT;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceScalarBlockLayoutFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceScalarBlockLayoutFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceScalarBlockLayoutFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceScalarBlockLayoutFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'a> {
     pub fn scalar_block_layout(
         mut self,
         scalar_block_layout: bool,
-    ) -> PhysicalDeviceScalarBlockLayoutFeaturesEXTBuilder<'a> {
+    ) -> PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'a> {
         self.inner.scalar_block_layout = scalar_block_layout.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceScalarBlockLayoutFeaturesEXT {
+    pub fn build(self) -> PhysicalDeviceScalarBlockLayoutFeatures {
         self.inner
     }
 }
@@ -41914,62 +43028,62 @@ impl<'a> SurfaceProtectedCapabilitiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR.html>"]
-pub struct PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceUniformBufferStandardLayoutFeatures.html>"]
+pub struct PhysicalDeviceUniformBufferStandardLayoutFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub uniform_buffer_standard_layout: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR {
-    fn default() -> PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR {
-        PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR {
-            s_type: StructureType::PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR,
+impl ::std::default::Default for PhysicalDeviceUniformBufferStandardLayoutFeatures {
+    fn default() -> PhysicalDeviceUniformBufferStandardLayoutFeatures {
+        PhysicalDeviceUniformBufferStandardLayoutFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES,
             p_next: ::std::ptr::null_mut(),
             uniform_buffer_standard_layout: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceUniformBufferStandardLayoutFeaturesKHRBuilder<'a> {
-        PhysicalDeviceUniformBufferStandardLayoutFeaturesKHRBuilder {
-            inner: PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR::default(),
+impl PhysicalDeviceUniformBufferStandardLayoutFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'a> {
+        PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder {
+            inner: PhysicalDeviceUniformBufferStandardLayoutFeatures::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceUniformBufferStandardLayoutFeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR,
+pub struct PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'a> {
+    inner: PhysicalDeviceUniformBufferStandardLayoutFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsDeviceCreateInfo
-    for PhysicalDeviceUniformBufferStandardLayoutFeaturesKHRBuilder<'_>
+    for PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceUniformBufferStandardLayoutFeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceUniformBufferStandardLayoutFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceUniformBufferStandardLayoutFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceUniformBufferStandardLayoutFeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceUniformBufferStandardLayoutFeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'a> {
     pub fn uniform_buffer_standard_layout(
         mut self,
         uniform_buffer_standard_layout: bool,
-    ) -> PhysicalDeviceUniformBufferStandardLayoutFeaturesKHRBuilder<'a> {
+    ) -> PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'a> {
         self.inner.uniform_buffer_standard_layout = uniform_buffer_standard_layout.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceUniformBufferStandardLayoutFeatures {
         self.inner
     }
 }
@@ -42289,6 +43403,83 @@ impl<'a> MemoryPriorityAllocateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceBufferDeviceAddressFeatures.html>"]
+pub struct PhysicalDeviceBufferDeviceAddressFeatures {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub buffer_device_address: Bool32,
+    pub buffer_device_address_capture_replay: Bool32,
+    pub buffer_device_address_multi_device: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceBufferDeviceAddressFeatures {
+    fn default() -> PhysicalDeviceBufferDeviceAddressFeatures {
+        PhysicalDeviceBufferDeviceAddressFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES,
+            p_next: ::std::ptr::null_mut(),
+            buffer_device_address: Bool32::default(),
+            buffer_device_address_capture_replay: Bool32::default(),
+            buffer_device_address_multi_device: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceBufferDeviceAddressFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+        PhysicalDeviceBufferDeviceAddressFeaturesBuilder {
+            inner: PhysicalDeviceBufferDeviceAddressFeatures::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+    inner: PhysicalDeviceBufferDeviceAddressFeatures,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceBufferDeviceAddressFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceBufferDeviceAddressFeatures;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+    pub fn buffer_device_address(
+        mut self,
+        buffer_device_address: bool,
+    ) -> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+        self.inner.buffer_device_address = buffer_device_address.into();
+        self
+    }
+    pub fn buffer_device_address_capture_replay(
+        mut self,
+        buffer_device_address_capture_replay: bool,
+    ) -> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+        self.inner.buffer_device_address_capture_replay =
+            buffer_device_address_capture_replay.into();
+        self
+    }
+    pub fn buffer_device_address_multi_device(
+        mut self,
+        buffer_device_address_multi_device: bool,
+    ) -> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+        self.inner.buffer_device_address_multi_device = buffer_device_address_multi_device.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceBufferDeviceAddressFeatures {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT.html>"]
 pub struct PhysicalDeviceBufferDeviceAddressFeaturesEXT {
     pub s_type: StructureType,
@@ -42366,48 +43557,48 @@ impl<'a> PhysicalDeviceBufferDeviceAddressFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferDeviceAddressInfoEXT.html>"]
-pub struct BufferDeviceAddressInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferDeviceAddressInfo.html>"]
+pub struct BufferDeviceAddressInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub buffer: Buffer,
 }
-impl ::std::default::Default for BufferDeviceAddressInfoEXT {
-    fn default() -> BufferDeviceAddressInfoEXT {
-        BufferDeviceAddressInfoEXT {
-            s_type: StructureType::BUFFER_DEVICE_ADDRESS_INFO_EXT,
+impl ::std::default::Default for BufferDeviceAddressInfo {
+    fn default() -> BufferDeviceAddressInfo {
+        BufferDeviceAddressInfo {
+            s_type: StructureType::BUFFER_DEVICE_ADDRESS_INFO,
             p_next: ::std::ptr::null(),
             buffer: Buffer::default(),
         }
     }
 }
-impl BufferDeviceAddressInfoEXT {
-    pub fn builder<'a>() -> BufferDeviceAddressInfoEXTBuilder<'a> {
-        BufferDeviceAddressInfoEXTBuilder {
-            inner: BufferDeviceAddressInfoEXT::default(),
+impl BufferDeviceAddressInfo {
+    pub fn builder<'a>() -> BufferDeviceAddressInfoBuilder<'a> {
+        BufferDeviceAddressInfoBuilder {
+            inner: BufferDeviceAddressInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct BufferDeviceAddressInfoEXTBuilder<'a> {
-    inner: BufferDeviceAddressInfoEXT,
+pub struct BufferDeviceAddressInfoBuilder<'a> {
+    inner: BufferDeviceAddressInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsBufferDeviceAddressInfoEXT {}
-impl<'a> ::std::ops::Deref for BufferDeviceAddressInfoEXTBuilder<'a> {
-    type Target = BufferDeviceAddressInfoEXT;
+pub unsafe trait ExtendsBufferDeviceAddressInfo {}
+impl<'a> ::std::ops::Deref for BufferDeviceAddressInfoBuilder<'a> {
+    type Target = BufferDeviceAddressInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for BufferDeviceAddressInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for BufferDeviceAddressInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> BufferDeviceAddressInfoEXTBuilder<'a> {
-    pub fn buffer(mut self, buffer: Buffer) -> BufferDeviceAddressInfoEXTBuilder<'a> {
+impl<'a> BufferDeviceAddressInfoBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> BufferDeviceAddressInfoBuilder<'a> {
         self.inner.buffer = buffer;
         self
     }
@@ -42416,10 +43607,10 @@ impl<'a> BufferDeviceAddressInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBufferDeviceAddressInfoEXT>(
+    pub fn push_next<T: ExtendsBufferDeviceAddressInfo>(
         mut self,
         next: &'a mut T,
-    ) -> BufferDeviceAddressInfoEXTBuilder<'a> {
+    ) -> BufferDeviceAddressInfoBuilder<'a> {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -42431,7 +43622,65 @@ impl<'a> BufferDeviceAddressInfoEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> BufferDeviceAddressInfoEXT {
+    pub fn build(self) -> BufferDeviceAddressInfo {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferOpaqueCaptureAddressCreateInfo.html>"]
+pub struct BufferOpaqueCaptureAddressCreateInfo {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub opaque_capture_address: u64,
+}
+impl ::std::default::Default for BufferOpaqueCaptureAddressCreateInfo {
+    fn default() -> BufferOpaqueCaptureAddressCreateInfo {
+        BufferOpaqueCaptureAddressCreateInfo {
+            s_type: StructureType::BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO,
+            p_next: ::std::ptr::null(),
+            opaque_capture_address: u64::default(),
+        }
+    }
+}
+impl BufferOpaqueCaptureAddressCreateInfo {
+    pub fn builder<'a>() -> BufferOpaqueCaptureAddressCreateInfoBuilder<'a> {
+        BufferOpaqueCaptureAddressCreateInfoBuilder {
+            inner: BufferOpaqueCaptureAddressCreateInfo::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct BufferOpaqueCaptureAddressCreateInfoBuilder<'a> {
+    inner: BufferOpaqueCaptureAddressCreateInfo,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsBufferCreateInfo for BufferOpaqueCaptureAddressCreateInfoBuilder<'_> {}
+unsafe impl ExtendsBufferCreateInfo for BufferOpaqueCaptureAddressCreateInfo {}
+impl<'a> ::std::ops::Deref for BufferOpaqueCaptureAddressCreateInfoBuilder<'a> {
+    type Target = BufferOpaqueCaptureAddressCreateInfo;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for BufferOpaqueCaptureAddressCreateInfoBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> BufferOpaqueCaptureAddressCreateInfoBuilder<'a> {
+    pub fn opaque_capture_address(
+        mut self,
+        opaque_capture_address: u64,
+    ) -> BufferOpaqueCaptureAddressCreateInfoBuilder<'a> {
+        self.inner.opaque_capture_address = opaque_capture_address;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> BufferOpaqueCaptureAddressCreateInfo {
         self.inner
     }
 }
@@ -42626,112 +43875,112 @@ impl<'a> FilterCubicImageViewImageFormatPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceImagelessFramebufferFeaturesKHR.html>"]
-pub struct PhysicalDeviceImagelessFramebufferFeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceImagelessFramebufferFeatures.html>"]
+pub struct PhysicalDeviceImagelessFramebufferFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub imageless_framebuffer: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceImagelessFramebufferFeaturesKHR {
-    fn default() -> PhysicalDeviceImagelessFramebufferFeaturesKHR {
-        PhysicalDeviceImagelessFramebufferFeaturesKHR {
-            s_type: StructureType::PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES_KHR,
+impl ::std::default::Default for PhysicalDeviceImagelessFramebufferFeatures {
+    fn default() -> PhysicalDeviceImagelessFramebufferFeatures {
+        PhysicalDeviceImagelessFramebufferFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES,
             p_next: ::std::ptr::null_mut(),
             imageless_framebuffer: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceImagelessFramebufferFeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceImagelessFramebufferFeaturesKHRBuilder<'a> {
-        PhysicalDeviceImagelessFramebufferFeaturesKHRBuilder {
-            inner: PhysicalDeviceImagelessFramebufferFeaturesKHR::default(),
+impl PhysicalDeviceImagelessFramebufferFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceImagelessFramebufferFeaturesBuilder<'a> {
+        PhysicalDeviceImagelessFramebufferFeaturesBuilder {
+            inner: PhysicalDeviceImagelessFramebufferFeatures::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceImagelessFramebufferFeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceImagelessFramebufferFeaturesKHR,
+pub struct PhysicalDeviceImagelessFramebufferFeaturesBuilder<'a> {
+    inner: PhysicalDeviceImagelessFramebufferFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceImagelessFramebufferFeaturesKHRBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceImagelessFramebufferFeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceImagelessFramebufferFeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceImagelessFramebufferFeaturesKHR;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceImagelessFramebufferFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceImagelessFramebufferFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceImagelessFramebufferFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceImagelessFramebufferFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceImagelessFramebufferFeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceImagelessFramebufferFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceImagelessFramebufferFeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceImagelessFramebufferFeaturesBuilder<'a> {
     pub fn imageless_framebuffer(
         mut self,
         imageless_framebuffer: bool,
-    ) -> PhysicalDeviceImagelessFramebufferFeaturesKHRBuilder<'a> {
+    ) -> PhysicalDeviceImagelessFramebufferFeaturesBuilder<'a> {
         self.inner.imageless_framebuffer = imageless_framebuffer.into();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceImagelessFramebufferFeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceImagelessFramebufferFeatures {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebufferAttachmentsCreateInfoKHR.html>"]
-pub struct FramebufferAttachmentsCreateInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebufferAttachmentsCreateInfo.html>"]
+pub struct FramebufferAttachmentsCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub attachment_image_info_count: u32,
-    pub p_attachment_image_infos: *const FramebufferAttachmentImageInfoKHR,
+    pub p_attachment_image_infos: *const FramebufferAttachmentImageInfo,
 }
-impl ::std::default::Default for FramebufferAttachmentsCreateInfoKHR {
-    fn default() -> FramebufferAttachmentsCreateInfoKHR {
-        FramebufferAttachmentsCreateInfoKHR {
-            s_type: StructureType::FRAMEBUFFER_ATTACHMENTS_CREATE_INFO_KHR,
+impl ::std::default::Default for FramebufferAttachmentsCreateInfo {
+    fn default() -> FramebufferAttachmentsCreateInfo {
+        FramebufferAttachmentsCreateInfo {
+            s_type: StructureType::FRAMEBUFFER_ATTACHMENTS_CREATE_INFO,
             p_next: ::std::ptr::null(),
             attachment_image_info_count: u32::default(),
             p_attachment_image_infos: ::std::ptr::null(),
         }
     }
 }
-impl FramebufferAttachmentsCreateInfoKHR {
-    pub fn builder<'a>() -> FramebufferAttachmentsCreateInfoKHRBuilder<'a> {
-        FramebufferAttachmentsCreateInfoKHRBuilder {
-            inner: FramebufferAttachmentsCreateInfoKHR::default(),
+impl FramebufferAttachmentsCreateInfo {
+    pub fn builder<'a>() -> FramebufferAttachmentsCreateInfoBuilder<'a> {
+        FramebufferAttachmentsCreateInfoBuilder {
+            inner: FramebufferAttachmentsCreateInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct FramebufferAttachmentsCreateInfoKHRBuilder<'a> {
-    inner: FramebufferAttachmentsCreateInfoKHR,
+pub struct FramebufferAttachmentsCreateInfoBuilder<'a> {
+    inner: FramebufferAttachmentsCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsFramebufferCreateInfo for FramebufferAttachmentsCreateInfoKHRBuilder<'_> {}
-unsafe impl ExtendsFramebufferCreateInfo for FramebufferAttachmentsCreateInfoKHR {}
-impl<'a> ::std::ops::Deref for FramebufferAttachmentsCreateInfoKHRBuilder<'a> {
-    type Target = FramebufferAttachmentsCreateInfoKHR;
+unsafe impl ExtendsFramebufferCreateInfo for FramebufferAttachmentsCreateInfoBuilder<'_> {}
+unsafe impl ExtendsFramebufferCreateInfo for FramebufferAttachmentsCreateInfo {}
+impl<'a> ::std::ops::Deref for FramebufferAttachmentsCreateInfoBuilder<'a> {
+    type Target = FramebufferAttachmentsCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for FramebufferAttachmentsCreateInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for FramebufferAttachmentsCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> FramebufferAttachmentsCreateInfoKHRBuilder<'a> {
+impl<'a> FramebufferAttachmentsCreateInfoBuilder<'a> {
     pub fn attachment_image_infos(
         mut self,
-        attachment_image_infos: &'a [FramebufferAttachmentImageInfoKHR],
-    ) -> FramebufferAttachmentsCreateInfoKHRBuilder<'a> {
+        attachment_image_infos: &'a [FramebufferAttachmentImageInfo],
+    ) -> FramebufferAttachmentsCreateInfoBuilder<'a> {
         self.inner.attachment_image_info_count = attachment_image_infos.len() as _;
         self.inner.p_attachment_image_infos = attachment_image_infos.as_ptr();
         self
@@ -42739,14 +43988,14 @@ impl<'a> FramebufferAttachmentsCreateInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> FramebufferAttachmentsCreateInfoKHR {
+    pub fn build(self) -> FramebufferAttachmentsCreateInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebufferAttachmentImageInfoKHR.html>"]
-pub struct FramebufferAttachmentImageInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebufferAttachmentImageInfo.html>"]
+pub struct FramebufferAttachmentImageInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub flags: ImageCreateFlags,
@@ -42757,10 +44006,10 @@ pub struct FramebufferAttachmentImageInfoKHR {
     pub view_format_count: u32,
     pub p_view_formats: *const Format,
 }
-impl ::std::default::Default for FramebufferAttachmentImageInfoKHR {
-    fn default() -> FramebufferAttachmentImageInfoKHR {
-        FramebufferAttachmentImageInfoKHR {
-            s_type: StructureType::FRAMEBUFFER_ATTACHMENT_IMAGE_INFO_KHR,
+impl ::std::default::Default for FramebufferAttachmentImageInfo {
+    fn default() -> FramebufferAttachmentImageInfo {
+        FramebufferAttachmentImageInfo {
+            s_type: StructureType::FRAMEBUFFER_ATTACHMENT_IMAGE_INFO,
             p_next: ::std::ptr::null(),
             flags: ImageCreateFlags::default(),
             usage: ImageUsageFlags::default(),
@@ -42772,59 +44021,56 @@ impl ::std::default::Default for FramebufferAttachmentImageInfoKHR {
         }
     }
 }
-impl FramebufferAttachmentImageInfoKHR {
-    pub fn builder<'a>() -> FramebufferAttachmentImageInfoKHRBuilder<'a> {
-        FramebufferAttachmentImageInfoKHRBuilder {
-            inner: FramebufferAttachmentImageInfoKHR::default(),
+impl FramebufferAttachmentImageInfo {
+    pub fn builder<'a>() -> FramebufferAttachmentImageInfoBuilder<'a> {
+        FramebufferAttachmentImageInfoBuilder {
+            inner: FramebufferAttachmentImageInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct FramebufferAttachmentImageInfoKHRBuilder<'a> {
-    inner: FramebufferAttachmentImageInfoKHR,
+pub struct FramebufferAttachmentImageInfoBuilder<'a> {
+    inner: FramebufferAttachmentImageInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsFramebufferAttachmentImageInfoKHR {}
-impl<'a> ::std::ops::Deref for FramebufferAttachmentImageInfoKHRBuilder<'a> {
-    type Target = FramebufferAttachmentImageInfoKHR;
+pub unsafe trait ExtendsFramebufferAttachmentImageInfo {}
+impl<'a> ::std::ops::Deref for FramebufferAttachmentImageInfoBuilder<'a> {
+    type Target = FramebufferAttachmentImageInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for FramebufferAttachmentImageInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for FramebufferAttachmentImageInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> FramebufferAttachmentImageInfoKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: ImageCreateFlags,
-    ) -> FramebufferAttachmentImageInfoKHRBuilder<'a> {
+impl<'a> FramebufferAttachmentImageInfoBuilder<'a> {
+    pub fn flags(mut self, flags: ImageCreateFlags) -> FramebufferAttachmentImageInfoBuilder<'a> {
         self.inner.flags = flags;
         self
     }
-    pub fn usage(mut self, usage: ImageUsageFlags) -> FramebufferAttachmentImageInfoKHRBuilder<'a> {
+    pub fn usage(mut self, usage: ImageUsageFlags) -> FramebufferAttachmentImageInfoBuilder<'a> {
         self.inner.usage = usage;
         self
     }
-    pub fn width(mut self, width: u32) -> FramebufferAttachmentImageInfoKHRBuilder<'a> {
+    pub fn width(mut self, width: u32) -> FramebufferAttachmentImageInfoBuilder<'a> {
         self.inner.width = width;
         self
     }
-    pub fn height(mut self, height: u32) -> FramebufferAttachmentImageInfoKHRBuilder<'a> {
+    pub fn height(mut self, height: u32) -> FramebufferAttachmentImageInfoBuilder<'a> {
         self.inner.height = height;
         self
     }
-    pub fn layer_count(mut self, layer_count: u32) -> FramebufferAttachmentImageInfoKHRBuilder<'a> {
+    pub fn layer_count(mut self, layer_count: u32) -> FramebufferAttachmentImageInfoBuilder<'a> {
         self.inner.layer_count = layer_count;
         self
     }
     pub fn view_formats(
         mut self,
         view_formats: &'a [Format],
-    ) -> FramebufferAttachmentImageInfoKHRBuilder<'a> {
+    ) -> FramebufferAttachmentImageInfoBuilder<'a> {
         self.inner.view_format_count = view_formats.len() as _;
         self.inner.p_view_formats = view_formats.as_ptr();
         self
@@ -42834,10 +44080,10 @@ impl<'a> FramebufferAttachmentImageInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsFramebufferAttachmentImageInfoKHR>(
+    pub fn push_next<T: ExtendsFramebufferAttachmentImageInfo>(
         mut self,
         next: &'a mut T,
-    ) -> FramebufferAttachmentImageInfoKHRBuilder<'a> {
+    ) -> FramebufferAttachmentImageInfoBuilder<'a> {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -42849,60 +44095,60 @@ impl<'a> FramebufferAttachmentImageInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> FramebufferAttachmentImageInfoKHR {
+    pub fn build(self) -> FramebufferAttachmentImageInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassAttachmentBeginInfoKHR.html>"]
-pub struct RenderPassAttachmentBeginInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassAttachmentBeginInfo.html>"]
+pub struct RenderPassAttachmentBeginInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub attachment_count: u32,
     pub p_attachments: *const ImageView,
 }
-impl ::std::default::Default for RenderPassAttachmentBeginInfoKHR {
-    fn default() -> RenderPassAttachmentBeginInfoKHR {
-        RenderPassAttachmentBeginInfoKHR {
-            s_type: StructureType::RENDER_PASS_ATTACHMENT_BEGIN_INFO_KHR,
+impl ::std::default::Default for RenderPassAttachmentBeginInfo {
+    fn default() -> RenderPassAttachmentBeginInfo {
+        RenderPassAttachmentBeginInfo {
+            s_type: StructureType::RENDER_PASS_ATTACHMENT_BEGIN_INFO,
             p_next: ::std::ptr::null(),
             attachment_count: u32::default(),
             p_attachments: ::std::ptr::null(),
         }
     }
 }
-impl RenderPassAttachmentBeginInfoKHR {
-    pub fn builder<'a>() -> RenderPassAttachmentBeginInfoKHRBuilder<'a> {
-        RenderPassAttachmentBeginInfoKHRBuilder {
-            inner: RenderPassAttachmentBeginInfoKHR::default(),
+impl RenderPassAttachmentBeginInfo {
+    pub fn builder<'a>() -> RenderPassAttachmentBeginInfoBuilder<'a> {
+        RenderPassAttachmentBeginInfoBuilder {
+            inner: RenderPassAttachmentBeginInfo::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct RenderPassAttachmentBeginInfoKHRBuilder<'a> {
-    inner: RenderPassAttachmentBeginInfoKHR,
+pub struct RenderPassAttachmentBeginInfoBuilder<'a> {
+    inner: RenderPassAttachmentBeginInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsRenderPassBeginInfo for RenderPassAttachmentBeginInfoKHRBuilder<'_> {}
-unsafe impl ExtendsRenderPassBeginInfo for RenderPassAttachmentBeginInfoKHR {}
-impl<'a> ::std::ops::Deref for RenderPassAttachmentBeginInfoKHRBuilder<'a> {
-    type Target = RenderPassAttachmentBeginInfoKHR;
+unsafe impl ExtendsRenderPassBeginInfo for RenderPassAttachmentBeginInfoBuilder<'_> {}
+unsafe impl ExtendsRenderPassBeginInfo for RenderPassAttachmentBeginInfo {}
+impl<'a> ::std::ops::Deref for RenderPassAttachmentBeginInfoBuilder<'a> {
+    type Target = RenderPassAttachmentBeginInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for RenderPassAttachmentBeginInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for RenderPassAttachmentBeginInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> RenderPassAttachmentBeginInfoKHRBuilder<'a> {
+impl<'a> RenderPassAttachmentBeginInfoBuilder<'a> {
     pub fn attachments(
         mut self,
         attachments: &'a [ImageView],
-    ) -> RenderPassAttachmentBeginInfoKHRBuilder<'a> {
+    ) -> RenderPassAttachmentBeginInfoBuilder<'a> {
         self.inner.attachment_count = attachments.len() as _;
         self.inner.p_attachments = attachments.as_ptr();
         self
@@ -42910,7 +44156,7 @@ impl<'a> RenderPassAttachmentBeginInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> RenderPassAttachmentBeginInfoKHR {
+    pub fn build(self) -> RenderPassAttachmentBeginInfo {
         self.inner
     }
 }
@@ -42919,14 +44165,14 @@ impl<'a> RenderPassAttachmentBeginInfoKHRBuilder<'a> {
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT.html>"]
 pub struct PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {
     pub s_type: StructureType,
-    pub p_next: *const c_void,
+    pub p_next: *mut c_void,
     pub texture_compression_astc_hdr: Bool32,
 }
 impl ::std::default::Default for PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {
     fn default() -> PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {
         PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {
             s_type: StructureType::PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT,
-            p_next: ::std::ptr::null(),
+            p_next: ::std::ptr::null_mut(),
             texture_compression_astc_hdr: Bool32::default(),
         }
     }
@@ -43726,6 +44972,570 @@ impl<'a> SurfaceCapabilitiesFullScreenExclusiveEXTBuilder<'a> {
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
     pub fn build(self) -> SurfaceCapabilitiesFullScreenExclusiveEXT {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePerformanceQueryFeaturesKHR.html>"]
+pub struct PhysicalDevicePerformanceQueryFeaturesKHR {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub performance_counter_query_pools: Bool32,
+    pub performance_counter_multiple_query_pools: Bool32,
+}
+impl ::std::default::Default for PhysicalDevicePerformanceQueryFeaturesKHR {
+    fn default() -> PhysicalDevicePerformanceQueryFeaturesKHR {
+        PhysicalDevicePerformanceQueryFeaturesKHR {
+            s_type: StructureType::PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR,
+            p_next: ::std::ptr::null_mut(),
+            performance_counter_query_pools: Bool32::default(),
+            performance_counter_multiple_query_pools: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDevicePerformanceQueryFeaturesKHR {
+    pub fn builder<'a>() -> PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
+        PhysicalDevicePerformanceQueryFeaturesKHRBuilder {
+            inner: PhysicalDevicePerformanceQueryFeaturesKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
+    inner: PhysicalDevicePerformanceQueryFeaturesKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDevicePerformanceQueryFeaturesKHR {}
+impl<'a> ::std::ops::Deref for PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
+    type Target = PhysicalDevicePerformanceQueryFeaturesKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
+    pub fn performance_counter_query_pools(
+        mut self,
+        performance_counter_query_pools: bool,
+    ) -> PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
+        self.inner.performance_counter_query_pools = performance_counter_query_pools.into();
+        self
+    }
+    pub fn performance_counter_multiple_query_pools(
+        mut self,
+        performance_counter_multiple_query_pools: bool,
+    ) -> PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
+        self.inner.performance_counter_multiple_query_pools =
+            performance_counter_multiple_query_pools.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDevicePerformanceQueryFeaturesKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePerformanceQueryPropertiesKHR.html>"]
+pub struct PhysicalDevicePerformanceQueryPropertiesKHR {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub allow_command_buffer_query_copies: Bool32,
+}
+impl ::std::default::Default for PhysicalDevicePerformanceQueryPropertiesKHR {
+    fn default() -> PhysicalDevicePerformanceQueryPropertiesKHR {
+        PhysicalDevicePerformanceQueryPropertiesKHR {
+            s_type: StructureType::PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR,
+            p_next: ::std::ptr::null_mut(),
+            allow_command_buffer_query_copies: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDevicePerformanceQueryPropertiesKHR {
+    pub fn builder<'a>() -> PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'a> {
+        PhysicalDevicePerformanceQueryPropertiesKHRBuilder {
+            inner: PhysicalDevicePerformanceQueryPropertiesKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'a> {
+    inner: PhysicalDevicePerformanceQueryPropertiesKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsPhysicalDeviceProperties2
+    for PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'_>
+{
+}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDevicePerformanceQueryPropertiesKHR {}
+impl<'a> ::std::ops::Deref for PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'a> {
+    type Target = PhysicalDevicePerformanceQueryPropertiesKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'a> {
+    pub fn allow_command_buffer_query_copies(
+        mut self,
+        allow_command_buffer_query_copies: bool,
+    ) -> PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'a> {
+        self.inner.allow_command_buffer_query_copies = allow_command_buffer_query_copies.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDevicePerformanceQueryPropertiesKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterKHR.html>"]
+pub struct PerformanceCounterKHR {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub unit: PerformanceCounterUnitKHR,
+    pub scope: PerformanceCounterScopeKHR,
+    pub storage: PerformanceCounterStorageKHR,
+    pub uuid: [u8; UUID_SIZE],
+}
+impl ::std::default::Default for PerformanceCounterKHR {
+    fn default() -> PerformanceCounterKHR {
+        PerformanceCounterKHR {
+            s_type: StructureType::PERFORMANCE_COUNTER_KHR,
+            p_next: ::std::ptr::null(),
+            unit: PerformanceCounterUnitKHR::default(),
+            scope: PerformanceCounterScopeKHR::default(),
+            storage: PerformanceCounterStorageKHR::default(),
+            uuid: unsafe { ::std::mem::zeroed() },
+        }
+    }
+}
+impl PerformanceCounterKHR {
+    pub fn builder<'a>() -> PerformanceCounterKHRBuilder<'a> {
+        PerformanceCounterKHRBuilder {
+            inner: PerformanceCounterKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PerformanceCounterKHRBuilder<'a> {
+    inner: PerformanceCounterKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsPerformanceCounterKHR {}
+impl<'a> ::std::ops::Deref for PerformanceCounterKHRBuilder<'a> {
+    type Target = PerformanceCounterKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PerformanceCounterKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PerformanceCounterKHRBuilder<'a> {
+    pub fn unit(mut self, unit: PerformanceCounterUnitKHR) -> PerformanceCounterKHRBuilder<'a> {
+        self.inner.unit = unit;
+        self
+    }
+    pub fn scope(mut self, scope: PerformanceCounterScopeKHR) -> PerformanceCounterKHRBuilder<'a> {
+        self.inner.scope = scope;
+        self
+    }
+    pub fn storage(
+        mut self,
+        storage: PerformanceCounterStorageKHR,
+    ) -> PerformanceCounterKHRBuilder<'a> {
+        self.inner.storage = storage;
+        self
+    }
+    pub fn uuid(mut self, uuid: [u8; UUID_SIZE]) -> PerformanceCounterKHRBuilder<'a> {
+        self.inner.uuid = uuid;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsPerformanceCounterKHR>(
+        mut self,
+        next: &'a mut T,
+    ) -> PerformanceCounterKHRBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PerformanceCounterKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterDescriptionKHR.html>"]
+pub struct PerformanceCounterDescriptionKHR {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub flags: PerformanceCounterDescriptionFlagsKHR,
+    pub name: [c_char; MAX_DESCRIPTION_SIZE],
+    pub category: [c_char; MAX_DESCRIPTION_SIZE],
+    pub description: [c_char; MAX_DESCRIPTION_SIZE],
+}
+impl fmt::Debug for PerformanceCounterDescriptionKHR {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("PerformanceCounterDescriptionKHR")
+            .field("s_type", &self.s_type)
+            .field("p_next", &self.p_next)
+            .field("flags", &self.flags)
+            .field("name", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.name.as_ptr() as *const c_char)
+            })
+            .field("category", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.category.as_ptr() as *const c_char)
+            })
+            .field("description", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.description.as_ptr() as *const c_char)
+            })
+            .finish()
+    }
+}
+impl ::std::default::Default for PerformanceCounterDescriptionKHR {
+    fn default() -> PerformanceCounterDescriptionKHR {
+        PerformanceCounterDescriptionKHR {
+            s_type: StructureType::PERFORMANCE_COUNTER_DESCRIPTION_KHR,
+            p_next: ::std::ptr::null(),
+            flags: PerformanceCounterDescriptionFlagsKHR::default(),
+            name: unsafe { ::std::mem::zeroed() },
+            category: unsafe { ::std::mem::zeroed() },
+            description: unsafe { ::std::mem::zeroed() },
+        }
+    }
+}
+impl PerformanceCounterDescriptionKHR {
+    pub fn builder<'a>() -> PerformanceCounterDescriptionKHRBuilder<'a> {
+        PerformanceCounterDescriptionKHRBuilder {
+            inner: PerformanceCounterDescriptionKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PerformanceCounterDescriptionKHRBuilder<'a> {
+    inner: PerformanceCounterDescriptionKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsPerformanceCounterDescriptionKHR {}
+impl<'a> ::std::ops::Deref for PerformanceCounterDescriptionKHRBuilder<'a> {
+    type Target = PerformanceCounterDescriptionKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PerformanceCounterDescriptionKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PerformanceCounterDescriptionKHRBuilder<'a> {
+    pub fn flags(
+        mut self,
+        flags: PerformanceCounterDescriptionFlagsKHR,
+    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+        self.inner.flags = flags;
+        self
+    }
+    pub fn name(
+        mut self,
+        name: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+        self.inner.name = name;
+        self
+    }
+    pub fn category(
+        mut self,
+        category: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+        self.inner.category = category;
+        self
+    }
+    pub fn description(
+        mut self,
+        description: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+        self.inner.description = description;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsPerformanceCounterDescriptionKHR>(
+        mut self,
+        next: &'a mut T,
+    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PerformanceCounterDescriptionKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryPoolPerformanceCreateInfoKHR.html>"]
+pub struct QueryPoolPerformanceCreateInfoKHR {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub queue_family_index: u32,
+    pub counter_index_count: u32,
+    pub p_counter_indices: *const u32,
+}
+impl ::std::default::Default for QueryPoolPerformanceCreateInfoKHR {
+    fn default() -> QueryPoolPerformanceCreateInfoKHR {
+        QueryPoolPerformanceCreateInfoKHR {
+            s_type: StructureType::QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR,
+            p_next: ::std::ptr::null(),
+            queue_family_index: u32::default(),
+            counter_index_count: u32::default(),
+            p_counter_indices: ::std::ptr::null(),
+        }
+    }
+}
+impl QueryPoolPerformanceCreateInfoKHR {
+    pub fn builder<'a>() -> QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
+        QueryPoolPerformanceCreateInfoKHRBuilder {
+            inner: QueryPoolPerformanceCreateInfoKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
+    inner: QueryPoolPerformanceCreateInfoKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsQueryPoolCreateInfo for QueryPoolPerformanceCreateInfoKHRBuilder<'_> {}
+unsafe impl ExtendsQueryPoolCreateInfo for QueryPoolPerformanceCreateInfoKHR {}
+impl<'a> ::std::ops::Deref for QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
+    type Target = QueryPoolPerformanceCreateInfoKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
+    pub fn queue_family_index(
+        mut self,
+        queue_family_index: u32,
+    ) -> QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
+        self.inner.queue_family_index = queue_family_index;
+        self
+    }
+    pub fn counter_indices(
+        mut self,
+        counter_indices: &'a [u32],
+    ) -> QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
+        self.inner.counter_index_count = counter_indices.len() as _;
+        self.inner.p_counter_indices = counter_indices.as_ptr();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> QueryPoolPerformanceCreateInfoKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterResultKHR.html>"]
+pub union PerformanceCounterResultKHR {
+    pub int32: i32,
+    pub int64: i64,
+    pub uint32: u32,
+    pub uint64: u64,
+    pub float32: f32,
+    pub float64: double,
+}
+impl ::std::default::Default for PerformanceCounterResultKHR {
+    fn default() -> PerformanceCounterResultKHR {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAcquireProfilingLockInfoKHR.html>"]
+pub struct AcquireProfilingLockInfoKHR {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub flags: AcquireProfilingLockFlagsKHR,
+    pub timeout: u64,
+}
+impl ::std::default::Default for AcquireProfilingLockInfoKHR {
+    fn default() -> AcquireProfilingLockInfoKHR {
+        AcquireProfilingLockInfoKHR {
+            s_type: StructureType::ACQUIRE_PROFILING_LOCK_INFO_KHR,
+            p_next: ::std::ptr::null(),
+            flags: AcquireProfilingLockFlagsKHR::default(),
+            timeout: u64::default(),
+        }
+    }
+}
+impl AcquireProfilingLockInfoKHR {
+    pub fn builder<'a>() -> AcquireProfilingLockInfoKHRBuilder<'a> {
+        AcquireProfilingLockInfoKHRBuilder {
+            inner: AcquireProfilingLockInfoKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct AcquireProfilingLockInfoKHRBuilder<'a> {
+    inner: AcquireProfilingLockInfoKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsAcquireProfilingLockInfoKHR {}
+impl<'a> ::std::ops::Deref for AcquireProfilingLockInfoKHRBuilder<'a> {
+    type Target = AcquireProfilingLockInfoKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for AcquireProfilingLockInfoKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> AcquireProfilingLockInfoKHRBuilder<'a> {
+    pub fn flags(
+        mut self,
+        flags: AcquireProfilingLockFlagsKHR,
+    ) -> AcquireProfilingLockInfoKHRBuilder<'a> {
+        self.inner.flags = flags;
+        self
+    }
+    pub fn timeout(mut self, timeout: u64) -> AcquireProfilingLockInfoKHRBuilder<'a> {
+        self.inner.timeout = timeout;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsAcquireProfilingLockInfoKHR>(
+        mut self,
+        next: &'a mut T,
+    ) -> AcquireProfilingLockInfoKHRBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> AcquireProfilingLockInfoKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceQuerySubmitInfoKHR.html>"]
+pub struct PerformanceQuerySubmitInfoKHR {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub counter_pass_index: u32,
+}
+impl ::std::default::Default for PerformanceQuerySubmitInfoKHR {
+    fn default() -> PerformanceQuerySubmitInfoKHR {
+        PerformanceQuerySubmitInfoKHR {
+            s_type: StructureType::PERFORMANCE_QUERY_SUBMIT_INFO_KHR,
+            p_next: ::std::ptr::null(),
+            counter_pass_index: u32::default(),
+        }
+    }
+}
+impl PerformanceQuerySubmitInfoKHR {
+    pub fn builder<'a>() -> PerformanceQuerySubmitInfoKHRBuilder<'a> {
+        PerformanceQuerySubmitInfoKHRBuilder {
+            inner: PerformanceQuerySubmitInfoKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PerformanceQuerySubmitInfoKHRBuilder<'a> {
+    inner: PerformanceQuerySubmitInfoKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsSubmitInfo for PerformanceQuerySubmitInfoKHRBuilder<'_> {}
+unsafe impl ExtendsSubmitInfo for PerformanceQuerySubmitInfoKHR {}
+impl<'a> ::std::ops::Deref for PerformanceQuerySubmitInfoKHRBuilder<'a> {
+    type Target = PerformanceQuerySubmitInfoKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PerformanceQuerySubmitInfoKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PerformanceQuerySubmitInfoKHRBuilder<'a> {
+    pub fn counter_pass_index(
+        mut self,
+        counter_pass_index: u32,
+    ) -> PerformanceQuerySubmitInfoKHRBuilder<'a> {
+        self.inner.counter_pass_index = counter_pass_index;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PerformanceQuerySubmitInfoKHR {
         self.inner
     }
 }
@@ -44618,6 +46428,73 @@ impl<'a> PerformanceConfigurationAcquireInfoINTELBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderClockFeaturesKHR.html>"]
+pub struct PhysicalDeviceShaderClockFeaturesKHR {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub shader_subgroup_clock: Bool32,
+    pub shader_device_clock: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceShaderClockFeaturesKHR {
+    fn default() -> PhysicalDeviceShaderClockFeaturesKHR {
+        PhysicalDeviceShaderClockFeaturesKHR {
+            s_type: StructureType::PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR,
+            p_next: ::std::ptr::null_mut(),
+            shader_subgroup_clock: Bool32::default(),
+            shader_device_clock: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceShaderClockFeaturesKHR {
+    pub fn builder<'a>() -> PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
+        PhysicalDeviceShaderClockFeaturesKHRBuilder {
+            inner: PhysicalDeviceShaderClockFeaturesKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
+    inner: PhysicalDeviceShaderClockFeaturesKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderClockFeaturesKHRBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderClockFeaturesKHR {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
+    type Target = PhysicalDeviceShaderClockFeaturesKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
+    pub fn shader_subgroup_clock(
+        mut self,
+        shader_subgroup_clock: bool,
+    ) -> PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
+        self.inner.shader_subgroup_clock = shader_subgroup_clock.into();
+        self
+    }
+    pub fn shader_device_clock(
+        mut self,
+        shader_device_clock: bool,
+    ) -> PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
+        self.inner.shader_device_clock = shader_device_clock.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceShaderClockFeaturesKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceIndexTypeUint8FeaturesEXT.html>"]
 pub struct PhysicalDeviceIndexTypeUint8FeaturesEXT {
     pub s_type: StructureType,
@@ -44884,6 +46761,652 @@ impl<'a> PhysicalDeviceFragmentShaderInterlockFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures.html>"]
+pub struct PhysicalDeviceSeparateDepthStencilLayoutsFeatures {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub separate_depth_stencil_layouts: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceSeparateDepthStencilLayoutsFeatures {
+    fn default() -> PhysicalDeviceSeparateDepthStencilLayoutsFeatures {
+        PhysicalDeviceSeparateDepthStencilLayoutsFeatures {
+            s_type: StructureType::PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES,
+            p_next: ::std::ptr::null_mut(),
+            separate_depth_stencil_layouts: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceSeparateDepthStencilLayoutsFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'a> {
+        PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder {
+            inner: PhysicalDeviceSeparateDepthStencilLayoutsFeatures::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'a> {
+    inner: PhysicalDeviceSeparateDepthStencilLayoutsFeatures,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo
+    for PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'_>
+{
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSeparateDepthStencilLayoutsFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceSeparateDepthStencilLayoutsFeatures;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'a> {
+    pub fn separate_depth_stencil_layouts(
+        mut self,
+        separate_depth_stencil_layouts: bool,
+    ) -> PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'a> {
+        self.inner.separate_depth_stencil_layouts = separate_depth_stencil_layouts.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceSeparateDepthStencilLayoutsFeatures {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentReferenceStencilLayout.html>"]
+pub struct AttachmentReferenceStencilLayout {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub stencil_layout: ImageLayout,
+}
+impl ::std::default::Default for AttachmentReferenceStencilLayout {
+    fn default() -> AttachmentReferenceStencilLayout {
+        AttachmentReferenceStencilLayout {
+            s_type: StructureType::ATTACHMENT_REFERENCE_STENCIL_LAYOUT,
+            p_next: ::std::ptr::null_mut(),
+            stencil_layout: ImageLayout::default(),
+        }
+    }
+}
+impl AttachmentReferenceStencilLayout {
+    pub fn builder<'a>() -> AttachmentReferenceStencilLayoutBuilder<'a> {
+        AttachmentReferenceStencilLayoutBuilder {
+            inner: AttachmentReferenceStencilLayout::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct AttachmentReferenceStencilLayoutBuilder<'a> {
+    inner: AttachmentReferenceStencilLayout,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsAttachmentReference2 for AttachmentReferenceStencilLayoutBuilder<'_> {}
+unsafe impl ExtendsAttachmentReference2 for AttachmentReferenceStencilLayout {}
+impl<'a> ::std::ops::Deref for AttachmentReferenceStencilLayoutBuilder<'a> {
+    type Target = AttachmentReferenceStencilLayout;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for AttachmentReferenceStencilLayoutBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> AttachmentReferenceStencilLayoutBuilder<'a> {
+    pub fn stencil_layout(
+        mut self,
+        stencil_layout: ImageLayout,
+    ) -> AttachmentReferenceStencilLayoutBuilder<'a> {
+        self.inner.stencil_layout = stencil_layout;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> AttachmentReferenceStencilLayout {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentDescriptionStencilLayout.html>"]
+pub struct AttachmentDescriptionStencilLayout {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub stencil_initial_layout: ImageLayout,
+    pub stencil_final_layout: ImageLayout,
+}
+impl ::std::default::Default for AttachmentDescriptionStencilLayout {
+    fn default() -> AttachmentDescriptionStencilLayout {
+        AttachmentDescriptionStencilLayout {
+            s_type: StructureType::ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT,
+            p_next: ::std::ptr::null_mut(),
+            stencil_initial_layout: ImageLayout::default(),
+            stencil_final_layout: ImageLayout::default(),
+        }
+    }
+}
+impl AttachmentDescriptionStencilLayout {
+    pub fn builder<'a>() -> AttachmentDescriptionStencilLayoutBuilder<'a> {
+        AttachmentDescriptionStencilLayoutBuilder {
+            inner: AttachmentDescriptionStencilLayout::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct AttachmentDescriptionStencilLayoutBuilder<'a> {
+    inner: AttachmentDescriptionStencilLayout,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsAttachmentDescription2 for AttachmentDescriptionStencilLayoutBuilder<'_> {}
+unsafe impl ExtendsAttachmentDescription2 for AttachmentDescriptionStencilLayout {}
+impl<'a> ::std::ops::Deref for AttachmentDescriptionStencilLayoutBuilder<'a> {
+    type Target = AttachmentDescriptionStencilLayout;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for AttachmentDescriptionStencilLayoutBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> AttachmentDescriptionStencilLayoutBuilder<'a> {
+    pub fn stencil_initial_layout(
+        mut self,
+        stencil_initial_layout: ImageLayout,
+    ) -> AttachmentDescriptionStencilLayoutBuilder<'a> {
+        self.inner.stencil_initial_layout = stencil_initial_layout;
+        self
+    }
+    pub fn stencil_final_layout(
+        mut self,
+        stencil_final_layout: ImageLayout,
+    ) -> AttachmentDescriptionStencilLayoutBuilder<'a> {
+        self.inner.stencil_final_layout = stencil_final_layout;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> AttachmentDescriptionStencilLayout {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR.html>"]
+pub struct PhysicalDevicePipelineExecutablePropertiesFeaturesKHR {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub pipeline_executable_info: Bool32,
+}
+impl ::std::default::Default for PhysicalDevicePipelineExecutablePropertiesFeaturesKHR {
+    fn default() -> PhysicalDevicePipelineExecutablePropertiesFeaturesKHR {
+        PhysicalDevicePipelineExecutablePropertiesFeaturesKHR {
+            s_type: StructureType::PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR,
+            p_next: ::std::ptr::null_mut(),
+            pipeline_executable_info: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDevicePipelineExecutablePropertiesFeaturesKHR {
+    pub fn builder<'a>() -> PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'a> {
+        PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder {
+            inner: PhysicalDevicePipelineExecutablePropertiesFeaturesKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'a> {
+    inner: PhysicalDevicePipelineExecutablePropertiesFeaturesKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo
+    for PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'_>
+{
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDevicePipelineExecutablePropertiesFeaturesKHR {}
+impl<'a> ::std::ops::Deref for PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'a> {
+    type Target = PhysicalDevicePipelineExecutablePropertiesFeaturesKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'a> {
+    pub fn pipeline_executable_info(
+        mut self,
+        pipeline_executable_info: bool,
+    ) -> PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'a> {
+        self.inner.pipeline_executable_info = pipeline_executable_info.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDevicePipelineExecutablePropertiesFeaturesKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineInfoKHR.html>"]
+pub struct PipelineInfoKHR {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub pipeline: Pipeline,
+}
+impl ::std::default::Default for PipelineInfoKHR {
+    fn default() -> PipelineInfoKHR {
+        PipelineInfoKHR {
+            s_type: StructureType::PIPELINE_INFO_KHR,
+            p_next: ::std::ptr::null(),
+            pipeline: Pipeline::default(),
+        }
+    }
+}
+impl PipelineInfoKHR {
+    pub fn builder<'a>() -> PipelineInfoKHRBuilder<'a> {
+        PipelineInfoKHRBuilder {
+            inner: PipelineInfoKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PipelineInfoKHRBuilder<'a> {
+    inner: PipelineInfoKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsPipelineInfoKHR {}
+impl<'a> ::std::ops::Deref for PipelineInfoKHRBuilder<'a> {
+    type Target = PipelineInfoKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PipelineInfoKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PipelineInfoKHRBuilder<'a> {
+    pub fn pipeline(mut self, pipeline: Pipeline) -> PipelineInfoKHRBuilder<'a> {
+        self.inner.pipeline = pipeline;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsPipelineInfoKHR>(
+        mut self,
+        next: &'a mut T,
+    ) -> PipelineInfoKHRBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PipelineInfoKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutablePropertiesKHR.html>"]
+pub struct PipelineExecutablePropertiesKHR {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub stages: ShaderStageFlags,
+    pub name: [c_char; MAX_DESCRIPTION_SIZE],
+    pub description: [c_char; MAX_DESCRIPTION_SIZE],
+    pub subgroup_size: u32,
+}
+impl fmt::Debug for PipelineExecutablePropertiesKHR {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("PipelineExecutablePropertiesKHR")
+            .field("s_type", &self.s_type)
+            .field("p_next", &self.p_next)
+            .field("stages", &self.stages)
+            .field("name", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.name.as_ptr() as *const c_char)
+            })
+            .field("description", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.description.as_ptr() as *const c_char)
+            })
+            .field("subgroup_size", &self.subgroup_size)
+            .finish()
+    }
+}
+impl ::std::default::Default for PipelineExecutablePropertiesKHR {
+    fn default() -> PipelineExecutablePropertiesKHR {
+        PipelineExecutablePropertiesKHR {
+            s_type: StructureType::PIPELINE_EXECUTABLE_PROPERTIES_KHR,
+            p_next: ::std::ptr::null_mut(),
+            stages: ShaderStageFlags::default(),
+            name: unsafe { ::std::mem::zeroed() },
+            description: unsafe { ::std::mem::zeroed() },
+            subgroup_size: u32::default(),
+        }
+    }
+}
+impl PipelineExecutablePropertiesKHR {
+    pub fn builder<'a>() -> PipelineExecutablePropertiesKHRBuilder<'a> {
+        PipelineExecutablePropertiesKHRBuilder {
+            inner: PipelineExecutablePropertiesKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PipelineExecutablePropertiesKHRBuilder<'a> {
+    inner: PipelineExecutablePropertiesKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsPipelineExecutablePropertiesKHR {}
+impl<'a> ::std::ops::Deref for PipelineExecutablePropertiesKHRBuilder<'a> {
+    type Target = PipelineExecutablePropertiesKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PipelineExecutablePropertiesKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PipelineExecutablePropertiesKHRBuilder<'a> {
+    pub fn stages(
+        mut self,
+        stages: ShaderStageFlags,
+    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+        self.inner.stages = stages;
+        self
+    }
+    pub fn name(
+        mut self,
+        name: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+        self.inner.name = name;
+        self
+    }
+    pub fn description(
+        mut self,
+        description: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+        self.inner.description = description;
+        self
+    }
+    pub fn subgroup_size(
+        mut self,
+        subgroup_size: u32,
+    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+        self.inner.subgroup_size = subgroup_size;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsPipelineExecutablePropertiesKHR>(
+        mut self,
+        next: &'a mut T,
+    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PipelineExecutablePropertiesKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableInfoKHR.html>"]
+pub struct PipelineExecutableInfoKHR {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub pipeline: Pipeline,
+    pub executable_index: u32,
+}
+impl ::std::default::Default for PipelineExecutableInfoKHR {
+    fn default() -> PipelineExecutableInfoKHR {
+        PipelineExecutableInfoKHR {
+            s_type: StructureType::PIPELINE_EXECUTABLE_INFO_KHR,
+            p_next: ::std::ptr::null(),
+            pipeline: Pipeline::default(),
+            executable_index: u32::default(),
+        }
+    }
+}
+impl PipelineExecutableInfoKHR {
+    pub fn builder<'a>() -> PipelineExecutableInfoKHRBuilder<'a> {
+        PipelineExecutableInfoKHRBuilder {
+            inner: PipelineExecutableInfoKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PipelineExecutableInfoKHRBuilder<'a> {
+    inner: PipelineExecutableInfoKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsPipelineExecutableInfoKHR {}
+impl<'a> ::std::ops::Deref for PipelineExecutableInfoKHRBuilder<'a> {
+    type Target = PipelineExecutableInfoKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PipelineExecutableInfoKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PipelineExecutableInfoKHRBuilder<'a> {
+    pub fn pipeline(mut self, pipeline: Pipeline) -> PipelineExecutableInfoKHRBuilder<'a> {
+        self.inner.pipeline = pipeline;
+        self
+    }
+    pub fn executable_index(
+        mut self,
+        executable_index: u32,
+    ) -> PipelineExecutableInfoKHRBuilder<'a> {
+        self.inner.executable_index = executable_index;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsPipelineExecutableInfoKHR>(
+        mut self,
+        next: &'a mut T,
+    ) -> PipelineExecutableInfoKHRBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PipelineExecutableInfoKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableStatisticValueKHR.html>"]
+pub union PipelineExecutableStatisticValueKHR {
+    pub b32: Bool32,
+    pub i64: i64,
+    pub u64: u64,
+    pub f64: double,
+}
+impl ::std::default::Default for PipelineExecutableStatisticValueKHR {
+    fn default() -> PipelineExecutableStatisticValueKHR {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableStatisticKHR.html>"]
+pub struct PipelineExecutableStatisticKHR {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub name: [c_char; MAX_DESCRIPTION_SIZE],
+    pub description: [c_char; MAX_DESCRIPTION_SIZE],
+    pub format: PipelineExecutableStatisticFormatKHR,
+    pub value: PipelineExecutableStatisticValueKHR,
+}
+impl fmt::Debug for PipelineExecutableStatisticKHR {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("PipelineExecutableStatisticKHR")
+            .field("s_type", &self.s_type)
+            .field("p_next", &self.p_next)
+            .field("name", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.name.as_ptr() as *const c_char)
+            })
+            .field("description", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.description.as_ptr() as *const c_char)
+            })
+            .field("format", &self.format)
+            .field("value", &"union")
+            .finish()
+    }
+}
+impl ::std::default::Default for PipelineExecutableStatisticKHR {
+    fn default() -> PipelineExecutableStatisticKHR {
+        PipelineExecutableStatisticKHR {
+            s_type: StructureType::PIPELINE_EXECUTABLE_STATISTIC_KHR,
+            p_next: ::std::ptr::null_mut(),
+            name: unsafe { ::std::mem::zeroed() },
+            description: unsafe { ::std::mem::zeroed() },
+            format: PipelineExecutableStatisticFormatKHR::default(),
+            value: PipelineExecutableStatisticValueKHR::default(),
+        }
+    }
+}
+impl PipelineExecutableStatisticKHR {
+    pub fn builder<'a>() -> PipelineExecutableStatisticKHRBuilder<'a> {
+        PipelineExecutableStatisticKHRBuilder {
+            inner: PipelineExecutableStatisticKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PipelineExecutableStatisticKHRBuilder<'a> {
+    inner: PipelineExecutableStatisticKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsPipelineExecutableStatisticKHR {}
+impl<'a> ::std::ops::Deref for PipelineExecutableStatisticKHRBuilder<'a> {
+    type Target = PipelineExecutableStatisticKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PipelineExecutableStatisticKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PipelineExecutableStatisticKHRBuilder<'a> {
+    pub fn name(
+        mut self,
+        name: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+        self.inner.name = name;
+        self
+    }
+    pub fn description(
+        mut self,
+        description: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+        self.inner.description = description;
+        self
+    }
+    pub fn format(
+        mut self,
+        format: PipelineExecutableStatisticFormatKHR,
+    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+        self.inner.format = format;
+        self
+    }
+    pub fn value(
+        mut self,
+        value: PipelineExecutableStatisticValueKHR,
+    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+        self.inner.value = value;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsPipelineExecutableStatisticKHR>(
+        mut self,
+        next: &'a mut T,
+    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PipelineExecutableStatisticKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT.html>"]
 pub struct PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT {
     pub s_type: StructureType,
@@ -45099,6 +47622,73 @@ impl<'a> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT.html>"]
+pub struct PhysicalDeviceSubgroupSizeControlFeaturesEXT {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub subgroup_size_control: Bool32,
+    pub compute_full_subgroups: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceSubgroupSizeControlFeaturesEXT {
+    fn default() -> PhysicalDeviceSubgroupSizeControlFeaturesEXT {
+        PhysicalDeviceSubgroupSizeControlFeaturesEXT {
+            s_type: StructureType::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT,
+            p_next: ::std::ptr::null_mut(),
+            subgroup_size_control: Bool32::default(),
+            compute_full_subgroups: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceSubgroupSizeControlFeaturesEXT {
+    pub fn builder<'a>() -> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+        PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder {
+            inner: PhysicalDeviceSubgroupSizeControlFeaturesEXT::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+    inner: PhysicalDeviceSubgroupSizeControlFeaturesEXT,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSubgroupSizeControlFeaturesEXT {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+    type Target = PhysicalDeviceSubgroupSizeControlFeaturesEXT;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+    pub fn subgroup_size_control(
+        mut self,
+        subgroup_size_control: bool,
+    ) -> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+        self.inner.subgroup_size_control = subgroup_size_control.into();
+        self
+    }
+    pub fn compute_full_subgroups(
+        mut self,
+        compute_full_subgroups: bool,
+    ) -> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+        self.inner.compute_full_subgroups = compute_full_subgroups.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceSubgroupSizeControlFeaturesEXT {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT.html>"]
 pub struct PhysicalDeviceSubgroupSizeControlPropertiesEXT {
     pub s_type: StructureType,
@@ -45246,6 +47836,138 @@ impl<'a> PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
     pub fn build(self) -> PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryOpaqueCaptureAddressAllocateInfo.html>"]
+pub struct MemoryOpaqueCaptureAddressAllocateInfo {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub opaque_capture_address: u64,
+}
+impl ::std::default::Default for MemoryOpaqueCaptureAddressAllocateInfo {
+    fn default() -> MemoryOpaqueCaptureAddressAllocateInfo {
+        MemoryOpaqueCaptureAddressAllocateInfo {
+            s_type: StructureType::MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO,
+            p_next: ::std::ptr::null(),
+            opaque_capture_address: u64::default(),
+        }
+    }
+}
+impl MemoryOpaqueCaptureAddressAllocateInfo {
+    pub fn builder<'a>() -> MemoryOpaqueCaptureAddressAllocateInfoBuilder<'a> {
+        MemoryOpaqueCaptureAddressAllocateInfoBuilder {
+            inner: MemoryOpaqueCaptureAddressAllocateInfo::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct MemoryOpaqueCaptureAddressAllocateInfoBuilder<'a> {
+    inner: MemoryOpaqueCaptureAddressAllocateInfo,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsMemoryAllocateInfo for MemoryOpaqueCaptureAddressAllocateInfoBuilder<'_> {}
+unsafe impl ExtendsMemoryAllocateInfo for MemoryOpaqueCaptureAddressAllocateInfo {}
+impl<'a> ::std::ops::Deref for MemoryOpaqueCaptureAddressAllocateInfoBuilder<'a> {
+    type Target = MemoryOpaqueCaptureAddressAllocateInfo;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for MemoryOpaqueCaptureAddressAllocateInfoBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> MemoryOpaqueCaptureAddressAllocateInfoBuilder<'a> {
+    pub fn opaque_capture_address(
+        mut self,
+        opaque_capture_address: u64,
+    ) -> MemoryOpaqueCaptureAddressAllocateInfoBuilder<'a> {
+        self.inner.opaque_capture_address = opaque_capture_address;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> MemoryOpaqueCaptureAddressAllocateInfo {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceMemoryOpaqueCaptureAddressInfo.html>"]
+pub struct DeviceMemoryOpaqueCaptureAddressInfo {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub memory: DeviceMemory,
+}
+impl ::std::default::Default for DeviceMemoryOpaqueCaptureAddressInfo {
+    fn default() -> DeviceMemoryOpaqueCaptureAddressInfo {
+        DeviceMemoryOpaqueCaptureAddressInfo {
+            s_type: StructureType::DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO,
+            p_next: ::std::ptr::null(),
+            memory: DeviceMemory::default(),
+        }
+    }
+}
+impl DeviceMemoryOpaqueCaptureAddressInfo {
+    pub fn builder<'a>() -> DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
+        DeviceMemoryOpaqueCaptureAddressInfoBuilder {
+            inner: DeviceMemoryOpaqueCaptureAddressInfo::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
+    inner: DeviceMemoryOpaqueCaptureAddressInfo,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsDeviceMemoryOpaqueCaptureAddressInfo {}
+impl<'a> ::std::ops::Deref for DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
+    type Target = DeviceMemoryOpaqueCaptureAddressInfo;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
+    pub fn memory(
+        mut self,
+        memory: DeviceMemory,
+    ) -> DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
+        self.inner.memory = memory;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsDeviceMemoryOpaqueCaptureAddressInfo>(
+        mut self,
+        next: &'a mut T,
+    ) -> DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> DeviceMemoryOpaqueCaptureAddressInfo {
         self.inner
     }
 }
@@ -45501,6 +48223,1860 @@ impl<'a> PipelineRasterizationLineStateCreateInfoEXTBuilder<'a> {
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
     pub fn build(self) -> PipelineRasterizationLineStateCreateInfoEXT {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkan11Features.html>"]
+pub struct PhysicalDeviceVulkan11Features {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub storage_buffer16_bit_access: Bool32,
+    pub uniform_and_storage_buffer16_bit_access: Bool32,
+    pub storage_push_constant16: Bool32,
+    pub storage_input_output16: Bool32,
+    pub multiview: Bool32,
+    pub multiview_geometry_shader: Bool32,
+    pub multiview_tessellation_shader: Bool32,
+    pub variable_pointers_storage_buffer: Bool32,
+    pub variable_pointers: Bool32,
+    pub protected_memory: Bool32,
+    pub sampler_ycbcr_conversion: Bool32,
+    pub shader_draw_parameters: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceVulkan11Features {
+    fn default() -> PhysicalDeviceVulkan11Features {
+        PhysicalDeviceVulkan11Features {
+            s_type: StructureType::PHYSICAL_DEVICE_VULKAN_1_1_FEATURES,
+            p_next: ::std::ptr::null_mut(),
+            storage_buffer16_bit_access: Bool32::default(),
+            uniform_and_storage_buffer16_bit_access: Bool32::default(),
+            storage_push_constant16: Bool32::default(),
+            storage_input_output16: Bool32::default(),
+            multiview: Bool32::default(),
+            multiview_geometry_shader: Bool32::default(),
+            multiview_tessellation_shader: Bool32::default(),
+            variable_pointers_storage_buffer: Bool32::default(),
+            variable_pointers: Bool32::default(),
+            protected_memory: Bool32::default(),
+            sampler_ycbcr_conversion: Bool32::default(),
+            shader_draw_parameters: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceVulkan11Features {
+    pub fn builder<'a>() -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        PhysicalDeviceVulkan11FeaturesBuilder {
+            inner: PhysicalDeviceVulkan11Features::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    inner: PhysicalDeviceVulkan11Features,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkan11FeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkan11Features {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    type Target = PhysicalDeviceVulkan11Features;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn storage_buffer16_bit_access(
+        mut self,
+        storage_buffer16_bit_access: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.storage_buffer16_bit_access = storage_buffer16_bit_access.into();
+        self
+    }
+    pub fn uniform_and_storage_buffer16_bit_access(
+        mut self,
+        uniform_and_storage_buffer16_bit_access: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.uniform_and_storage_buffer16_bit_access =
+            uniform_and_storage_buffer16_bit_access.into();
+        self
+    }
+    pub fn storage_push_constant16(
+        mut self,
+        storage_push_constant16: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.storage_push_constant16 = storage_push_constant16.into();
+        self
+    }
+    pub fn storage_input_output16(
+        mut self,
+        storage_input_output16: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.storage_input_output16 = storage_input_output16.into();
+        self
+    }
+    pub fn multiview(mut self, multiview: bool) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.multiview = multiview.into();
+        self
+    }
+    pub fn multiview_geometry_shader(
+        mut self,
+        multiview_geometry_shader: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.multiview_geometry_shader = multiview_geometry_shader.into();
+        self
+    }
+    pub fn multiview_tessellation_shader(
+        mut self,
+        multiview_tessellation_shader: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.multiview_tessellation_shader = multiview_tessellation_shader.into();
+        self
+    }
+    pub fn variable_pointers_storage_buffer(
+        mut self,
+        variable_pointers_storage_buffer: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.variable_pointers_storage_buffer = variable_pointers_storage_buffer.into();
+        self
+    }
+    pub fn variable_pointers(
+        mut self,
+        variable_pointers: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.variable_pointers = variable_pointers.into();
+        self
+    }
+    pub fn protected_memory(
+        mut self,
+        protected_memory: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.protected_memory = protected_memory.into();
+        self
+    }
+    pub fn sampler_ycbcr_conversion(
+        mut self,
+        sampler_ycbcr_conversion: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.sampler_ycbcr_conversion = sampler_ycbcr_conversion.into();
+        self
+    }
+    pub fn shader_draw_parameters(
+        mut self,
+        shader_draw_parameters: bool,
+    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+        self.inner.shader_draw_parameters = shader_draw_parameters.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceVulkan11Features {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkan11Properties.html>"]
+pub struct PhysicalDeviceVulkan11Properties {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub device_uuid: [u8; UUID_SIZE],
+    pub driver_uuid: [u8; UUID_SIZE],
+    pub device_luid: [u8; LUID_SIZE],
+    pub device_node_mask: u32,
+    pub device_luid_valid: Bool32,
+    pub subgroup_size: u32,
+    pub subgroup_supported_stages: ShaderStageFlags,
+    pub subgroup_supported_operations: SubgroupFeatureFlags,
+    pub subgroup_quad_operations_in_all_stages: Bool32,
+    pub point_clipping_behavior: PointClippingBehavior,
+    pub max_multiview_view_count: u32,
+    pub max_multiview_instance_index: u32,
+    pub protected_no_fault: Bool32,
+    pub max_per_set_descriptors: u32,
+    pub max_memory_allocation_size: DeviceSize,
+}
+impl ::std::default::Default for PhysicalDeviceVulkan11Properties {
+    fn default() -> PhysicalDeviceVulkan11Properties {
+        PhysicalDeviceVulkan11Properties {
+            s_type: StructureType::PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES,
+            p_next: ::std::ptr::null_mut(),
+            device_uuid: unsafe { ::std::mem::zeroed() },
+            driver_uuid: unsafe { ::std::mem::zeroed() },
+            device_luid: unsafe { ::std::mem::zeroed() },
+            device_node_mask: u32::default(),
+            device_luid_valid: Bool32::default(),
+            subgroup_size: u32::default(),
+            subgroup_supported_stages: ShaderStageFlags::default(),
+            subgroup_supported_operations: SubgroupFeatureFlags::default(),
+            subgroup_quad_operations_in_all_stages: Bool32::default(),
+            point_clipping_behavior: PointClippingBehavior::default(),
+            max_multiview_view_count: u32::default(),
+            max_multiview_instance_index: u32::default(),
+            protected_no_fault: Bool32::default(),
+            max_per_set_descriptors: u32::default(),
+            max_memory_allocation_size: DeviceSize::default(),
+        }
+    }
+}
+impl PhysicalDeviceVulkan11Properties {
+    pub fn builder<'a>() -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        PhysicalDeviceVulkan11PropertiesBuilder {
+            inner: PhysicalDeviceVulkan11Properties::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    inner: PhysicalDeviceVulkan11Properties,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceVulkan11PropertiesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceVulkan11Properties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    type Target = PhysicalDeviceVulkan11Properties;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn device_uuid(
+        mut self,
+        device_uuid: [u8; UUID_SIZE],
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.device_uuid = device_uuid;
+        self
+    }
+    pub fn driver_uuid(
+        mut self,
+        driver_uuid: [u8; UUID_SIZE],
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.driver_uuid = driver_uuid;
+        self
+    }
+    pub fn device_luid(
+        mut self,
+        device_luid: [u8; LUID_SIZE],
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.device_luid = device_luid;
+        self
+    }
+    pub fn device_node_mask(
+        mut self,
+        device_node_mask: u32,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.device_node_mask = device_node_mask;
+        self
+    }
+    pub fn device_luid_valid(
+        mut self,
+        device_luid_valid: bool,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.device_luid_valid = device_luid_valid.into();
+        self
+    }
+    pub fn subgroup_size(
+        mut self,
+        subgroup_size: u32,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.subgroup_size = subgroup_size;
+        self
+    }
+    pub fn subgroup_supported_stages(
+        mut self,
+        subgroup_supported_stages: ShaderStageFlags,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.subgroup_supported_stages = subgroup_supported_stages;
+        self
+    }
+    pub fn subgroup_supported_operations(
+        mut self,
+        subgroup_supported_operations: SubgroupFeatureFlags,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.subgroup_supported_operations = subgroup_supported_operations;
+        self
+    }
+    pub fn subgroup_quad_operations_in_all_stages(
+        mut self,
+        subgroup_quad_operations_in_all_stages: bool,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.subgroup_quad_operations_in_all_stages =
+            subgroup_quad_operations_in_all_stages.into();
+        self
+    }
+    pub fn point_clipping_behavior(
+        mut self,
+        point_clipping_behavior: PointClippingBehavior,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.point_clipping_behavior = point_clipping_behavior;
+        self
+    }
+    pub fn max_multiview_view_count(
+        mut self,
+        max_multiview_view_count: u32,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.max_multiview_view_count = max_multiview_view_count;
+        self
+    }
+    pub fn max_multiview_instance_index(
+        mut self,
+        max_multiview_instance_index: u32,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.max_multiview_instance_index = max_multiview_instance_index;
+        self
+    }
+    pub fn protected_no_fault(
+        mut self,
+        protected_no_fault: bool,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.protected_no_fault = protected_no_fault.into();
+        self
+    }
+    pub fn max_per_set_descriptors(
+        mut self,
+        max_per_set_descriptors: u32,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.max_per_set_descriptors = max_per_set_descriptors;
+        self
+    }
+    pub fn max_memory_allocation_size(
+        mut self,
+        max_memory_allocation_size: DeviceSize,
+    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+        self.inner.max_memory_allocation_size = max_memory_allocation_size;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceVulkan11Properties {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkan12Features.html>"]
+pub struct PhysicalDeviceVulkan12Features {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub sampler_mirror_clamp_to_edge: Bool32,
+    pub draw_indirect_count: Bool32,
+    pub storage_buffer8_bit_access: Bool32,
+    pub uniform_and_storage_buffer8_bit_access: Bool32,
+    pub storage_push_constant8: Bool32,
+    pub shader_buffer_int64_atomics: Bool32,
+    pub shader_shared_int64_atomics: Bool32,
+    pub shader_float16: Bool32,
+    pub shader_int8: Bool32,
+    pub descriptor_indexing: Bool32,
+    pub shader_input_attachment_array_dynamic_indexing: Bool32,
+    pub shader_uniform_texel_buffer_array_dynamic_indexing: Bool32,
+    pub shader_storage_texel_buffer_array_dynamic_indexing: Bool32,
+    pub shader_uniform_buffer_array_non_uniform_indexing: Bool32,
+    pub shader_sampled_image_array_non_uniform_indexing: Bool32,
+    pub shader_storage_buffer_array_non_uniform_indexing: Bool32,
+    pub shader_storage_image_array_non_uniform_indexing: Bool32,
+    pub shader_input_attachment_array_non_uniform_indexing: Bool32,
+    pub shader_uniform_texel_buffer_array_non_uniform_indexing: Bool32,
+    pub shader_storage_texel_buffer_array_non_uniform_indexing: Bool32,
+    pub descriptor_binding_uniform_buffer_update_after_bind: Bool32,
+    pub descriptor_binding_sampled_image_update_after_bind: Bool32,
+    pub descriptor_binding_storage_image_update_after_bind: Bool32,
+    pub descriptor_binding_storage_buffer_update_after_bind: Bool32,
+    pub descriptor_binding_uniform_texel_buffer_update_after_bind: Bool32,
+    pub descriptor_binding_storage_texel_buffer_update_after_bind: Bool32,
+    pub descriptor_binding_update_unused_while_pending: Bool32,
+    pub descriptor_binding_partially_bound: Bool32,
+    pub descriptor_binding_variable_descriptor_count: Bool32,
+    pub runtime_descriptor_array: Bool32,
+    pub sampler_filter_minmax: Bool32,
+    pub scalar_block_layout: Bool32,
+    pub imageless_framebuffer: Bool32,
+    pub uniform_buffer_standard_layout: Bool32,
+    pub shader_subgroup_extended_types: Bool32,
+    pub separate_depth_stencil_layouts: Bool32,
+    pub host_query_reset: Bool32,
+    pub timeline_semaphore: Bool32,
+    pub buffer_device_address: Bool32,
+    pub buffer_device_address_capture_replay: Bool32,
+    pub buffer_device_address_multi_device: Bool32,
+    pub vulkan_memory_model: Bool32,
+    pub vulkan_memory_model_device_scope: Bool32,
+    pub vulkan_memory_model_availability_visibility_chains: Bool32,
+    pub shader_output_viewport_index: Bool32,
+    pub shader_output_layer: Bool32,
+    pub subgroup_broadcast_dynamic_id: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceVulkan12Features {
+    fn default() -> PhysicalDeviceVulkan12Features {
+        PhysicalDeviceVulkan12Features {
+            s_type: StructureType::PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
+            p_next: ::std::ptr::null_mut(),
+            sampler_mirror_clamp_to_edge: Bool32::default(),
+            draw_indirect_count: Bool32::default(),
+            storage_buffer8_bit_access: Bool32::default(),
+            uniform_and_storage_buffer8_bit_access: Bool32::default(),
+            storage_push_constant8: Bool32::default(),
+            shader_buffer_int64_atomics: Bool32::default(),
+            shader_shared_int64_atomics: Bool32::default(),
+            shader_float16: Bool32::default(),
+            shader_int8: Bool32::default(),
+            descriptor_indexing: Bool32::default(),
+            shader_input_attachment_array_dynamic_indexing: Bool32::default(),
+            shader_uniform_texel_buffer_array_dynamic_indexing: Bool32::default(),
+            shader_storage_texel_buffer_array_dynamic_indexing: Bool32::default(),
+            shader_uniform_buffer_array_non_uniform_indexing: Bool32::default(),
+            shader_sampled_image_array_non_uniform_indexing: Bool32::default(),
+            shader_storage_buffer_array_non_uniform_indexing: Bool32::default(),
+            shader_storage_image_array_non_uniform_indexing: Bool32::default(),
+            shader_input_attachment_array_non_uniform_indexing: Bool32::default(),
+            shader_uniform_texel_buffer_array_non_uniform_indexing: Bool32::default(),
+            shader_storage_texel_buffer_array_non_uniform_indexing: Bool32::default(),
+            descriptor_binding_uniform_buffer_update_after_bind: Bool32::default(),
+            descriptor_binding_sampled_image_update_after_bind: Bool32::default(),
+            descriptor_binding_storage_image_update_after_bind: Bool32::default(),
+            descriptor_binding_storage_buffer_update_after_bind: Bool32::default(),
+            descriptor_binding_uniform_texel_buffer_update_after_bind: Bool32::default(),
+            descriptor_binding_storage_texel_buffer_update_after_bind: Bool32::default(),
+            descriptor_binding_update_unused_while_pending: Bool32::default(),
+            descriptor_binding_partially_bound: Bool32::default(),
+            descriptor_binding_variable_descriptor_count: Bool32::default(),
+            runtime_descriptor_array: Bool32::default(),
+            sampler_filter_minmax: Bool32::default(),
+            scalar_block_layout: Bool32::default(),
+            imageless_framebuffer: Bool32::default(),
+            uniform_buffer_standard_layout: Bool32::default(),
+            shader_subgroup_extended_types: Bool32::default(),
+            separate_depth_stencil_layouts: Bool32::default(),
+            host_query_reset: Bool32::default(),
+            timeline_semaphore: Bool32::default(),
+            buffer_device_address: Bool32::default(),
+            buffer_device_address_capture_replay: Bool32::default(),
+            buffer_device_address_multi_device: Bool32::default(),
+            vulkan_memory_model: Bool32::default(),
+            vulkan_memory_model_device_scope: Bool32::default(),
+            vulkan_memory_model_availability_visibility_chains: Bool32::default(),
+            shader_output_viewport_index: Bool32::default(),
+            shader_output_layer: Bool32::default(),
+            subgroup_broadcast_dynamic_id: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceVulkan12Features {
+    pub fn builder<'a>() -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        PhysicalDeviceVulkan12FeaturesBuilder {
+            inner: PhysicalDeviceVulkan12Features::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    inner: PhysicalDeviceVulkan12Features,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkan12FeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkan12Features {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    type Target = PhysicalDeviceVulkan12Features;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn sampler_mirror_clamp_to_edge(
+        mut self,
+        sampler_mirror_clamp_to_edge: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.sampler_mirror_clamp_to_edge = sampler_mirror_clamp_to_edge.into();
+        self
+    }
+    pub fn draw_indirect_count(
+        mut self,
+        draw_indirect_count: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.draw_indirect_count = draw_indirect_count.into();
+        self
+    }
+    pub fn storage_buffer8_bit_access(
+        mut self,
+        storage_buffer8_bit_access: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.storage_buffer8_bit_access = storage_buffer8_bit_access.into();
+        self
+    }
+    pub fn uniform_and_storage_buffer8_bit_access(
+        mut self,
+        uniform_and_storage_buffer8_bit_access: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.uniform_and_storage_buffer8_bit_access =
+            uniform_and_storage_buffer8_bit_access.into();
+        self
+    }
+    pub fn storage_push_constant8(
+        mut self,
+        storage_push_constant8: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.storage_push_constant8 = storage_push_constant8.into();
+        self
+    }
+    pub fn shader_buffer_int64_atomics(
+        mut self,
+        shader_buffer_int64_atomics: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_buffer_int64_atomics = shader_buffer_int64_atomics.into();
+        self
+    }
+    pub fn shader_shared_int64_atomics(
+        mut self,
+        shader_shared_int64_atomics: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_shared_int64_atomics = shader_shared_int64_atomics.into();
+        self
+    }
+    pub fn shader_float16(
+        mut self,
+        shader_float16: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_float16 = shader_float16.into();
+        self
+    }
+    pub fn shader_int8(mut self, shader_int8: bool) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_int8 = shader_int8.into();
+        self
+    }
+    pub fn descriptor_indexing(
+        mut self,
+        descriptor_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.descriptor_indexing = descriptor_indexing.into();
+        self
+    }
+    pub fn shader_input_attachment_array_dynamic_indexing(
+        mut self,
+        shader_input_attachment_array_dynamic_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_input_attachment_array_dynamic_indexing =
+            shader_input_attachment_array_dynamic_indexing.into();
+        self
+    }
+    pub fn shader_uniform_texel_buffer_array_dynamic_indexing(
+        mut self,
+        shader_uniform_texel_buffer_array_dynamic_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .shader_uniform_texel_buffer_array_dynamic_indexing =
+            shader_uniform_texel_buffer_array_dynamic_indexing.into();
+        self
+    }
+    pub fn shader_storage_texel_buffer_array_dynamic_indexing(
+        mut self,
+        shader_storage_texel_buffer_array_dynamic_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .shader_storage_texel_buffer_array_dynamic_indexing =
+            shader_storage_texel_buffer_array_dynamic_indexing.into();
+        self
+    }
+    pub fn shader_uniform_buffer_array_non_uniform_indexing(
+        mut self,
+        shader_uniform_buffer_array_non_uniform_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_uniform_buffer_array_non_uniform_indexing =
+            shader_uniform_buffer_array_non_uniform_indexing.into();
+        self
+    }
+    pub fn shader_sampled_image_array_non_uniform_indexing(
+        mut self,
+        shader_sampled_image_array_non_uniform_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_sampled_image_array_non_uniform_indexing =
+            shader_sampled_image_array_non_uniform_indexing.into();
+        self
+    }
+    pub fn shader_storage_buffer_array_non_uniform_indexing(
+        mut self,
+        shader_storage_buffer_array_non_uniform_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_storage_buffer_array_non_uniform_indexing =
+            shader_storage_buffer_array_non_uniform_indexing.into();
+        self
+    }
+    pub fn shader_storage_image_array_non_uniform_indexing(
+        mut self,
+        shader_storage_image_array_non_uniform_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_storage_image_array_non_uniform_indexing =
+            shader_storage_image_array_non_uniform_indexing.into();
+        self
+    }
+    pub fn shader_input_attachment_array_non_uniform_indexing(
+        mut self,
+        shader_input_attachment_array_non_uniform_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .shader_input_attachment_array_non_uniform_indexing =
+            shader_input_attachment_array_non_uniform_indexing.into();
+        self
+    }
+    pub fn shader_uniform_texel_buffer_array_non_uniform_indexing(
+        mut self,
+        shader_uniform_texel_buffer_array_non_uniform_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .shader_uniform_texel_buffer_array_non_uniform_indexing =
+            shader_uniform_texel_buffer_array_non_uniform_indexing.into();
+        self
+    }
+    pub fn shader_storage_texel_buffer_array_non_uniform_indexing(
+        mut self,
+        shader_storage_texel_buffer_array_non_uniform_indexing: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .shader_storage_texel_buffer_array_non_uniform_indexing =
+            shader_storage_texel_buffer_array_non_uniform_indexing.into();
+        self
+    }
+    pub fn descriptor_binding_uniform_buffer_update_after_bind(
+        mut self,
+        descriptor_binding_uniform_buffer_update_after_bind: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .descriptor_binding_uniform_buffer_update_after_bind =
+            descriptor_binding_uniform_buffer_update_after_bind.into();
+        self
+    }
+    pub fn descriptor_binding_sampled_image_update_after_bind(
+        mut self,
+        descriptor_binding_sampled_image_update_after_bind: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .descriptor_binding_sampled_image_update_after_bind =
+            descriptor_binding_sampled_image_update_after_bind.into();
+        self
+    }
+    pub fn descriptor_binding_storage_image_update_after_bind(
+        mut self,
+        descriptor_binding_storage_image_update_after_bind: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .descriptor_binding_storage_image_update_after_bind =
+            descriptor_binding_storage_image_update_after_bind.into();
+        self
+    }
+    pub fn descriptor_binding_storage_buffer_update_after_bind(
+        mut self,
+        descriptor_binding_storage_buffer_update_after_bind: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .descriptor_binding_storage_buffer_update_after_bind =
+            descriptor_binding_storage_buffer_update_after_bind.into();
+        self
+    }
+    pub fn descriptor_binding_uniform_texel_buffer_update_after_bind(
+        mut self,
+        descriptor_binding_uniform_texel_buffer_update_after_bind: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .descriptor_binding_uniform_texel_buffer_update_after_bind =
+            descriptor_binding_uniform_texel_buffer_update_after_bind.into();
+        self
+    }
+    pub fn descriptor_binding_storage_texel_buffer_update_after_bind(
+        mut self,
+        descriptor_binding_storage_texel_buffer_update_after_bind: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .descriptor_binding_storage_texel_buffer_update_after_bind =
+            descriptor_binding_storage_texel_buffer_update_after_bind.into();
+        self
+    }
+    pub fn descriptor_binding_update_unused_while_pending(
+        mut self,
+        descriptor_binding_update_unused_while_pending: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.descriptor_binding_update_unused_while_pending =
+            descriptor_binding_update_unused_while_pending.into();
+        self
+    }
+    pub fn descriptor_binding_partially_bound(
+        mut self,
+        descriptor_binding_partially_bound: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.descriptor_binding_partially_bound = descriptor_binding_partially_bound.into();
+        self
+    }
+    pub fn descriptor_binding_variable_descriptor_count(
+        mut self,
+        descriptor_binding_variable_descriptor_count: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.descriptor_binding_variable_descriptor_count =
+            descriptor_binding_variable_descriptor_count.into();
+        self
+    }
+    pub fn runtime_descriptor_array(
+        mut self,
+        runtime_descriptor_array: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.runtime_descriptor_array = runtime_descriptor_array.into();
+        self
+    }
+    pub fn sampler_filter_minmax(
+        mut self,
+        sampler_filter_minmax: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.sampler_filter_minmax = sampler_filter_minmax.into();
+        self
+    }
+    pub fn scalar_block_layout(
+        mut self,
+        scalar_block_layout: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.scalar_block_layout = scalar_block_layout.into();
+        self
+    }
+    pub fn imageless_framebuffer(
+        mut self,
+        imageless_framebuffer: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.imageless_framebuffer = imageless_framebuffer.into();
+        self
+    }
+    pub fn uniform_buffer_standard_layout(
+        mut self,
+        uniform_buffer_standard_layout: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.uniform_buffer_standard_layout = uniform_buffer_standard_layout.into();
+        self
+    }
+    pub fn shader_subgroup_extended_types(
+        mut self,
+        shader_subgroup_extended_types: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_subgroup_extended_types = shader_subgroup_extended_types.into();
+        self
+    }
+    pub fn separate_depth_stencil_layouts(
+        mut self,
+        separate_depth_stencil_layouts: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.separate_depth_stencil_layouts = separate_depth_stencil_layouts.into();
+        self
+    }
+    pub fn host_query_reset(
+        mut self,
+        host_query_reset: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.host_query_reset = host_query_reset.into();
+        self
+    }
+    pub fn timeline_semaphore(
+        mut self,
+        timeline_semaphore: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.timeline_semaphore = timeline_semaphore.into();
+        self
+    }
+    pub fn buffer_device_address(
+        mut self,
+        buffer_device_address: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.buffer_device_address = buffer_device_address.into();
+        self
+    }
+    pub fn buffer_device_address_capture_replay(
+        mut self,
+        buffer_device_address_capture_replay: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.buffer_device_address_capture_replay =
+            buffer_device_address_capture_replay.into();
+        self
+    }
+    pub fn buffer_device_address_multi_device(
+        mut self,
+        buffer_device_address_multi_device: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.buffer_device_address_multi_device = buffer_device_address_multi_device.into();
+        self
+    }
+    pub fn vulkan_memory_model(
+        mut self,
+        vulkan_memory_model: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.vulkan_memory_model = vulkan_memory_model.into();
+        self
+    }
+    pub fn vulkan_memory_model_device_scope(
+        mut self,
+        vulkan_memory_model_device_scope: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.vulkan_memory_model_device_scope = vulkan_memory_model_device_scope.into();
+        self
+    }
+    pub fn vulkan_memory_model_availability_visibility_chains(
+        mut self,
+        vulkan_memory_model_availability_visibility_chains: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner
+            .vulkan_memory_model_availability_visibility_chains =
+            vulkan_memory_model_availability_visibility_chains.into();
+        self
+    }
+    pub fn shader_output_viewport_index(
+        mut self,
+        shader_output_viewport_index: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_output_viewport_index = shader_output_viewport_index.into();
+        self
+    }
+    pub fn shader_output_layer(
+        mut self,
+        shader_output_layer: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.shader_output_layer = shader_output_layer.into();
+        self
+    }
+    pub fn subgroup_broadcast_dynamic_id(
+        mut self,
+        subgroup_broadcast_dynamic_id: bool,
+    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+        self.inner.subgroup_broadcast_dynamic_id = subgroup_broadcast_dynamic_id.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceVulkan12Features {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkan12Properties.html>"]
+pub struct PhysicalDeviceVulkan12Properties {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub driver_id: DriverId,
+    pub driver_name: [c_char; MAX_DRIVER_NAME_SIZE],
+    pub driver_info: [c_char; MAX_DRIVER_INFO_SIZE],
+    pub conformance_version: ConformanceVersion,
+    pub denorm_behavior_independence: ShaderFloatControlsIndependence,
+    pub rounding_mode_independence: ShaderFloatControlsIndependence,
+    pub shader_signed_zero_inf_nan_preserve_float16: Bool32,
+    pub shader_signed_zero_inf_nan_preserve_float32: Bool32,
+    pub shader_signed_zero_inf_nan_preserve_float64: Bool32,
+    pub shader_denorm_preserve_float16: Bool32,
+    pub shader_denorm_preserve_float32: Bool32,
+    pub shader_denorm_preserve_float64: Bool32,
+    pub shader_denorm_flush_to_zero_float16: Bool32,
+    pub shader_denorm_flush_to_zero_float32: Bool32,
+    pub shader_denorm_flush_to_zero_float64: Bool32,
+    pub shader_rounding_mode_rte_float16: Bool32,
+    pub shader_rounding_mode_rte_float32: Bool32,
+    pub shader_rounding_mode_rte_float64: Bool32,
+    pub shader_rounding_mode_rtz_float16: Bool32,
+    pub shader_rounding_mode_rtz_float32: Bool32,
+    pub shader_rounding_mode_rtz_float64: Bool32,
+    pub max_update_after_bind_descriptors_in_all_pools: u32,
+    pub shader_uniform_buffer_array_non_uniform_indexing_native: Bool32,
+    pub shader_sampled_image_array_non_uniform_indexing_native: Bool32,
+    pub shader_storage_buffer_array_non_uniform_indexing_native: Bool32,
+    pub shader_storage_image_array_non_uniform_indexing_native: Bool32,
+    pub shader_input_attachment_array_non_uniform_indexing_native: Bool32,
+    pub robust_buffer_access_update_after_bind: Bool32,
+    pub quad_divergent_implicit_lod: Bool32,
+    pub max_per_stage_descriptor_update_after_bind_samplers: u32,
+    pub max_per_stage_descriptor_update_after_bind_uniform_buffers: u32,
+    pub max_per_stage_descriptor_update_after_bind_storage_buffers: u32,
+    pub max_per_stage_descriptor_update_after_bind_sampled_images: u32,
+    pub max_per_stage_descriptor_update_after_bind_storage_images: u32,
+    pub max_per_stage_descriptor_update_after_bind_input_attachments: u32,
+    pub max_per_stage_update_after_bind_resources: u32,
+    pub max_descriptor_set_update_after_bind_samplers: u32,
+    pub max_descriptor_set_update_after_bind_uniform_buffers: u32,
+    pub max_descriptor_set_update_after_bind_uniform_buffers_dynamic: u32,
+    pub max_descriptor_set_update_after_bind_storage_buffers: u32,
+    pub max_descriptor_set_update_after_bind_storage_buffers_dynamic: u32,
+    pub max_descriptor_set_update_after_bind_sampled_images: u32,
+    pub max_descriptor_set_update_after_bind_storage_images: u32,
+    pub max_descriptor_set_update_after_bind_input_attachments: u32,
+    pub supported_depth_resolve_modes: ResolveModeFlags,
+    pub supported_stencil_resolve_modes: ResolveModeFlags,
+    pub independent_resolve_none: Bool32,
+    pub independent_resolve: Bool32,
+    pub filter_minmax_single_component_formats: Bool32,
+    pub filter_minmax_image_component_mapping: Bool32,
+    pub max_timeline_semaphore_value_difference: u64,
+    pub framebuffer_integer_color_sample_counts: SampleCountFlags,
+}
+impl fmt::Debug for PhysicalDeviceVulkan12Properties {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("PhysicalDeviceVulkan12Properties")
+            .field("s_type", &self.s_type)
+            .field("p_next", &self.p_next)
+            .field("driver_id", &self.driver_id)
+            .field("driver_name", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.driver_name.as_ptr() as *const c_char)
+            })
+            .field("driver_info", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.driver_info.as_ptr() as *const c_char)
+            })
+            .field("conformance_version", &self.conformance_version)
+            .field(
+                "denorm_behavior_independence",
+                &self.denorm_behavior_independence,
+            )
+            .field(
+                "rounding_mode_independence",
+                &self.rounding_mode_independence,
+            )
+            .field(
+                "shader_signed_zero_inf_nan_preserve_float16",
+                &self.shader_signed_zero_inf_nan_preserve_float16,
+            )
+            .field(
+                "shader_signed_zero_inf_nan_preserve_float32",
+                &self.shader_signed_zero_inf_nan_preserve_float32,
+            )
+            .field(
+                "shader_signed_zero_inf_nan_preserve_float64",
+                &self.shader_signed_zero_inf_nan_preserve_float64,
+            )
+            .field(
+                "shader_denorm_preserve_float16",
+                &self.shader_denorm_preserve_float16,
+            )
+            .field(
+                "shader_denorm_preserve_float32",
+                &self.shader_denorm_preserve_float32,
+            )
+            .field(
+                "shader_denorm_preserve_float64",
+                &self.shader_denorm_preserve_float64,
+            )
+            .field(
+                "shader_denorm_flush_to_zero_float16",
+                &self.shader_denorm_flush_to_zero_float16,
+            )
+            .field(
+                "shader_denorm_flush_to_zero_float32",
+                &self.shader_denorm_flush_to_zero_float32,
+            )
+            .field(
+                "shader_denorm_flush_to_zero_float64",
+                &self.shader_denorm_flush_to_zero_float64,
+            )
+            .field(
+                "shader_rounding_mode_rte_float16",
+                &self.shader_rounding_mode_rte_float16,
+            )
+            .field(
+                "shader_rounding_mode_rte_float32",
+                &self.shader_rounding_mode_rte_float32,
+            )
+            .field(
+                "shader_rounding_mode_rte_float64",
+                &self.shader_rounding_mode_rte_float64,
+            )
+            .field(
+                "shader_rounding_mode_rtz_float16",
+                &self.shader_rounding_mode_rtz_float16,
+            )
+            .field(
+                "shader_rounding_mode_rtz_float32",
+                &self.shader_rounding_mode_rtz_float32,
+            )
+            .field(
+                "shader_rounding_mode_rtz_float64",
+                &self.shader_rounding_mode_rtz_float64,
+            )
+            .field(
+                "max_update_after_bind_descriptors_in_all_pools",
+                &self.max_update_after_bind_descriptors_in_all_pools,
+            )
+            .field(
+                "shader_uniform_buffer_array_non_uniform_indexing_native",
+                &self.shader_uniform_buffer_array_non_uniform_indexing_native,
+            )
+            .field(
+                "shader_sampled_image_array_non_uniform_indexing_native",
+                &self.shader_sampled_image_array_non_uniform_indexing_native,
+            )
+            .field(
+                "shader_storage_buffer_array_non_uniform_indexing_native",
+                &self.shader_storage_buffer_array_non_uniform_indexing_native,
+            )
+            .field(
+                "shader_storage_image_array_non_uniform_indexing_native",
+                &self.shader_storage_image_array_non_uniform_indexing_native,
+            )
+            .field(
+                "shader_input_attachment_array_non_uniform_indexing_native",
+                &self.shader_input_attachment_array_non_uniform_indexing_native,
+            )
+            .field(
+                "robust_buffer_access_update_after_bind",
+                &self.robust_buffer_access_update_after_bind,
+            )
+            .field(
+                "quad_divergent_implicit_lod",
+                &self.quad_divergent_implicit_lod,
+            )
+            .field(
+                "max_per_stage_descriptor_update_after_bind_samplers",
+                &self.max_per_stage_descriptor_update_after_bind_samplers,
+            )
+            .field(
+                "max_per_stage_descriptor_update_after_bind_uniform_buffers",
+                &self.max_per_stage_descriptor_update_after_bind_uniform_buffers,
+            )
+            .field(
+                "max_per_stage_descriptor_update_after_bind_storage_buffers",
+                &self.max_per_stage_descriptor_update_after_bind_storage_buffers,
+            )
+            .field(
+                "max_per_stage_descriptor_update_after_bind_sampled_images",
+                &self.max_per_stage_descriptor_update_after_bind_sampled_images,
+            )
+            .field(
+                "max_per_stage_descriptor_update_after_bind_storage_images",
+                &self.max_per_stage_descriptor_update_after_bind_storage_images,
+            )
+            .field(
+                "max_per_stage_descriptor_update_after_bind_input_attachments",
+                &self.max_per_stage_descriptor_update_after_bind_input_attachments,
+            )
+            .field(
+                "max_per_stage_update_after_bind_resources",
+                &self.max_per_stage_update_after_bind_resources,
+            )
+            .field(
+                "max_descriptor_set_update_after_bind_samplers",
+                &self.max_descriptor_set_update_after_bind_samplers,
+            )
+            .field(
+                "max_descriptor_set_update_after_bind_uniform_buffers",
+                &self.max_descriptor_set_update_after_bind_uniform_buffers,
+            )
+            .field(
+                "max_descriptor_set_update_after_bind_uniform_buffers_dynamic",
+                &self.max_descriptor_set_update_after_bind_uniform_buffers_dynamic,
+            )
+            .field(
+                "max_descriptor_set_update_after_bind_storage_buffers",
+                &self.max_descriptor_set_update_after_bind_storage_buffers,
+            )
+            .field(
+                "max_descriptor_set_update_after_bind_storage_buffers_dynamic",
+                &self.max_descriptor_set_update_after_bind_storage_buffers_dynamic,
+            )
+            .field(
+                "max_descriptor_set_update_after_bind_sampled_images",
+                &self.max_descriptor_set_update_after_bind_sampled_images,
+            )
+            .field(
+                "max_descriptor_set_update_after_bind_storage_images",
+                &self.max_descriptor_set_update_after_bind_storage_images,
+            )
+            .field(
+                "max_descriptor_set_update_after_bind_input_attachments",
+                &self.max_descriptor_set_update_after_bind_input_attachments,
+            )
+            .field(
+                "supported_depth_resolve_modes",
+                &self.supported_depth_resolve_modes,
+            )
+            .field(
+                "supported_stencil_resolve_modes",
+                &self.supported_stencil_resolve_modes,
+            )
+            .field("independent_resolve_none", &self.independent_resolve_none)
+            .field("independent_resolve", &self.independent_resolve)
+            .field(
+                "filter_minmax_single_component_formats",
+                &self.filter_minmax_single_component_formats,
+            )
+            .field(
+                "filter_minmax_image_component_mapping",
+                &self.filter_minmax_image_component_mapping,
+            )
+            .field(
+                "max_timeline_semaphore_value_difference",
+                &self.max_timeline_semaphore_value_difference,
+            )
+            .field(
+                "framebuffer_integer_color_sample_counts",
+                &self.framebuffer_integer_color_sample_counts,
+            )
+            .finish()
+    }
+}
+impl ::std::default::Default for PhysicalDeviceVulkan12Properties {
+    fn default() -> PhysicalDeviceVulkan12Properties {
+        PhysicalDeviceVulkan12Properties {
+            s_type: StructureType::PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES,
+            p_next: ::std::ptr::null_mut(),
+            driver_id: DriverId::default(),
+            driver_name: unsafe { ::std::mem::zeroed() },
+            driver_info: unsafe { ::std::mem::zeroed() },
+            conformance_version: ConformanceVersion::default(),
+            denorm_behavior_independence: ShaderFloatControlsIndependence::default(),
+            rounding_mode_independence: ShaderFloatControlsIndependence::default(),
+            shader_signed_zero_inf_nan_preserve_float16: Bool32::default(),
+            shader_signed_zero_inf_nan_preserve_float32: Bool32::default(),
+            shader_signed_zero_inf_nan_preserve_float64: Bool32::default(),
+            shader_denorm_preserve_float16: Bool32::default(),
+            shader_denorm_preserve_float32: Bool32::default(),
+            shader_denorm_preserve_float64: Bool32::default(),
+            shader_denorm_flush_to_zero_float16: Bool32::default(),
+            shader_denorm_flush_to_zero_float32: Bool32::default(),
+            shader_denorm_flush_to_zero_float64: Bool32::default(),
+            shader_rounding_mode_rte_float16: Bool32::default(),
+            shader_rounding_mode_rte_float32: Bool32::default(),
+            shader_rounding_mode_rte_float64: Bool32::default(),
+            shader_rounding_mode_rtz_float16: Bool32::default(),
+            shader_rounding_mode_rtz_float32: Bool32::default(),
+            shader_rounding_mode_rtz_float64: Bool32::default(),
+            max_update_after_bind_descriptors_in_all_pools: u32::default(),
+            shader_uniform_buffer_array_non_uniform_indexing_native: Bool32::default(),
+            shader_sampled_image_array_non_uniform_indexing_native: Bool32::default(),
+            shader_storage_buffer_array_non_uniform_indexing_native: Bool32::default(),
+            shader_storage_image_array_non_uniform_indexing_native: Bool32::default(),
+            shader_input_attachment_array_non_uniform_indexing_native: Bool32::default(),
+            robust_buffer_access_update_after_bind: Bool32::default(),
+            quad_divergent_implicit_lod: Bool32::default(),
+            max_per_stage_descriptor_update_after_bind_samplers: u32::default(),
+            max_per_stage_descriptor_update_after_bind_uniform_buffers: u32::default(),
+            max_per_stage_descriptor_update_after_bind_storage_buffers: u32::default(),
+            max_per_stage_descriptor_update_after_bind_sampled_images: u32::default(),
+            max_per_stage_descriptor_update_after_bind_storage_images: u32::default(),
+            max_per_stage_descriptor_update_after_bind_input_attachments: u32::default(),
+            max_per_stage_update_after_bind_resources: u32::default(),
+            max_descriptor_set_update_after_bind_samplers: u32::default(),
+            max_descriptor_set_update_after_bind_uniform_buffers: u32::default(),
+            max_descriptor_set_update_after_bind_uniform_buffers_dynamic: u32::default(),
+            max_descriptor_set_update_after_bind_storage_buffers: u32::default(),
+            max_descriptor_set_update_after_bind_storage_buffers_dynamic: u32::default(),
+            max_descriptor_set_update_after_bind_sampled_images: u32::default(),
+            max_descriptor_set_update_after_bind_storage_images: u32::default(),
+            max_descriptor_set_update_after_bind_input_attachments: u32::default(),
+            supported_depth_resolve_modes: ResolveModeFlags::default(),
+            supported_stencil_resolve_modes: ResolveModeFlags::default(),
+            independent_resolve_none: Bool32::default(),
+            independent_resolve: Bool32::default(),
+            filter_minmax_single_component_formats: Bool32::default(),
+            filter_minmax_image_component_mapping: Bool32::default(),
+            max_timeline_semaphore_value_difference: u64::default(),
+            framebuffer_integer_color_sample_counts: SampleCountFlags::default(),
+        }
+    }
+}
+impl PhysicalDeviceVulkan12Properties {
+    pub fn builder<'a>() -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        PhysicalDeviceVulkan12PropertiesBuilder {
+            inner: PhysicalDeviceVulkan12Properties::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    inner: PhysicalDeviceVulkan12Properties,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceVulkan12PropertiesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceVulkan12Properties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    type Target = PhysicalDeviceVulkan12Properties;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn driver_id(mut self, driver_id: DriverId) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.driver_id = driver_id;
+        self
+    }
+    pub fn driver_name(
+        mut self,
+        driver_name: [c_char; MAX_DRIVER_NAME_SIZE],
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.driver_name = driver_name;
+        self
+    }
+    pub fn driver_info(
+        mut self,
+        driver_info: [c_char; MAX_DRIVER_INFO_SIZE],
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.driver_info = driver_info;
+        self
+    }
+    pub fn conformance_version(
+        mut self,
+        conformance_version: ConformanceVersion,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.conformance_version = conformance_version;
+        self
+    }
+    pub fn denorm_behavior_independence(
+        mut self,
+        denorm_behavior_independence: ShaderFloatControlsIndependence,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.denorm_behavior_independence = denorm_behavior_independence;
+        self
+    }
+    pub fn rounding_mode_independence(
+        mut self,
+        rounding_mode_independence: ShaderFloatControlsIndependence,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.rounding_mode_independence = rounding_mode_independence;
+        self
+    }
+    pub fn shader_signed_zero_inf_nan_preserve_float16(
+        mut self,
+        shader_signed_zero_inf_nan_preserve_float16: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_signed_zero_inf_nan_preserve_float16 =
+            shader_signed_zero_inf_nan_preserve_float16.into();
+        self
+    }
+    pub fn shader_signed_zero_inf_nan_preserve_float32(
+        mut self,
+        shader_signed_zero_inf_nan_preserve_float32: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_signed_zero_inf_nan_preserve_float32 =
+            shader_signed_zero_inf_nan_preserve_float32.into();
+        self
+    }
+    pub fn shader_signed_zero_inf_nan_preserve_float64(
+        mut self,
+        shader_signed_zero_inf_nan_preserve_float64: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_signed_zero_inf_nan_preserve_float64 =
+            shader_signed_zero_inf_nan_preserve_float64.into();
+        self
+    }
+    pub fn shader_denorm_preserve_float16(
+        mut self,
+        shader_denorm_preserve_float16: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_denorm_preserve_float16 = shader_denorm_preserve_float16.into();
+        self
+    }
+    pub fn shader_denorm_preserve_float32(
+        mut self,
+        shader_denorm_preserve_float32: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_denorm_preserve_float32 = shader_denorm_preserve_float32.into();
+        self
+    }
+    pub fn shader_denorm_preserve_float64(
+        mut self,
+        shader_denorm_preserve_float64: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_denorm_preserve_float64 = shader_denorm_preserve_float64.into();
+        self
+    }
+    pub fn shader_denorm_flush_to_zero_float16(
+        mut self,
+        shader_denorm_flush_to_zero_float16: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_denorm_flush_to_zero_float16 = shader_denorm_flush_to_zero_float16.into();
+        self
+    }
+    pub fn shader_denorm_flush_to_zero_float32(
+        mut self,
+        shader_denorm_flush_to_zero_float32: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_denorm_flush_to_zero_float32 = shader_denorm_flush_to_zero_float32.into();
+        self
+    }
+    pub fn shader_denorm_flush_to_zero_float64(
+        mut self,
+        shader_denorm_flush_to_zero_float64: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_denorm_flush_to_zero_float64 = shader_denorm_flush_to_zero_float64.into();
+        self
+    }
+    pub fn shader_rounding_mode_rte_float16(
+        mut self,
+        shader_rounding_mode_rte_float16: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_rounding_mode_rte_float16 = shader_rounding_mode_rte_float16.into();
+        self
+    }
+    pub fn shader_rounding_mode_rte_float32(
+        mut self,
+        shader_rounding_mode_rte_float32: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_rounding_mode_rte_float32 = shader_rounding_mode_rte_float32.into();
+        self
+    }
+    pub fn shader_rounding_mode_rte_float64(
+        mut self,
+        shader_rounding_mode_rte_float64: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_rounding_mode_rte_float64 = shader_rounding_mode_rte_float64.into();
+        self
+    }
+    pub fn shader_rounding_mode_rtz_float16(
+        mut self,
+        shader_rounding_mode_rtz_float16: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_rounding_mode_rtz_float16 = shader_rounding_mode_rtz_float16.into();
+        self
+    }
+    pub fn shader_rounding_mode_rtz_float32(
+        mut self,
+        shader_rounding_mode_rtz_float32: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_rounding_mode_rtz_float32 = shader_rounding_mode_rtz_float32.into();
+        self
+    }
+    pub fn shader_rounding_mode_rtz_float64(
+        mut self,
+        shader_rounding_mode_rtz_float64: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.shader_rounding_mode_rtz_float64 = shader_rounding_mode_rtz_float64.into();
+        self
+    }
+    pub fn max_update_after_bind_descriptors_in_all_pools(
+        mut self,
+        max_update_after_bind_descriptors_in_all_pools: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.max_update_after_bind_descriptors_in_all_pools =
+            max_update_after_bind_descriptors_in_all_pools;
+        self
+    }
+    pub fn shader_uniform_buffer_array_non_uniform_indexing_native(
+        mut self,
+        shader_uniform_buffer_array_non_uniform_indexing_native: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .shader_uniform_buffer_array_non_uniform_indexing_native =
+            shader_uniform_buffer_array_non_uniform_indexing_native.into();
+        self
+    }
+    pub fn shader_sampled_image_array_non_uniform_indexing_native(
+        mut self,
+        shader_sampled_image_array_non_uniform_indexing_native: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .shader_sampled_image_array_non_uniform_indexing_native =
+            shader_sampled_image_array_non_uniform_indexing_native.into();
+        self
+    }
+    pub fn shader_storage_buffer_array_non_uniform_indexing_native(
+        mut self,
+        shader_storage_buffer_array_non_uniform_indexing_native: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .shader_storage_buffer_array_non_uniform_indexing_native =
+            shader_storage_buffer_array_non_uniform_indexing_native.into();
+        self
+    }
+    pub fn shader_storage_image_array_non_uniform_indexing_native(
+        mut self,
+        shader_storage_image_array_non_uniform_indexing_native: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .shader_storage_image_array_non_uniform_indexing_native =
+            shader_storage_image_array_non_uniform_indexing_native.into();
+        self
+    }
+    pub fn shader_input_attachment_array_non_uniform_indexing_native(
+        mut self,
+        shader_input_attachment_array_non_uniform_indexing_native: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .shader_input_attachment_array_non_uniform_indexing_native =
+            shader_input_attachment_array_non_uniform_indexing_native.into();
+        self
+    }
+    pub fn robust_buffer_access_update_after_bind(
+        mut self,
+        robust_buffer_access_update_after_bind: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.robust_buffer_access_update_after_bind =
+            robust_buffer_access_update_after_bind.into();
+        self
+    }
+    pub fn quad_divergent_implicit_lod(
+        mut self,
+        quad_divergent_implicit_lod: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.quad_divergent_implicit_lod = quad_divergent_implicit_lod.into();
+        self
+    }
+    pub fn max_per_stage_descriptor_update_after_bind_samplers(
+        mut self,
+        max_per_stage_descriptor_update_after_bind_samplers: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_per_stage_descriptor_update_after_bind_samplers =
+            max_per_stage_descriptor_update_after_bind_samplers;
+        self
+    }
+    pub fn max_per_stage_descriptor_update_after_bind_uniform_buffers(
+        mut self,
+        max_per_stage_descriptor_update_after_bind_uniform_buffers: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_per_stage_descriptor_update_after_bind_uniform_buffers =
+            max_per_stage_descriptor_update_after_bind_uniform_buffers;
+        self
+    }
+    pub fn max_per_stage_descriptor_update_after_bind_storage_buffers(
+        mut self,
+        max_per_stage_descriptor_update_after_bind_storage_buffers: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_per_stage_descriptor_update_after_bind_storage_buffers =
+            max_per_stage_descriptor_update_after_bind_storage_buffers;
+        self
+    }
+    pub fn max_per_stage_descriptor_update_after_bind_sampled_images(
+        mut self,
+        max_per_stage_descriptor_update_after_bind_sampled_images: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_per_stage_descriptor_update_after_bind_sampled_images =
+            max_per_stage_descriptor_update_after_bind_sampled_images;
+        self
+    }
+    pub fn max_per_stage_descriptor_update_after_bind_storage_images(
+        mut self,
+        max_per_stage_descriptor_update_after_bind_storage_images: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_per_stage_descriptor_update_after_bind_storage_images =
+            max_per_stage_descriptor_update_after_bind_storage_images;
+        self
+    }
+    pub fn max_per_stage_descriptor_update_after_bind_input_attachments(
+        mut self,
+        max_per_stage_descriptor_update_after_bind_input_attachments: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_per_stage_descriptor_update_after_bind_input_attachments =
+            max_per_stage_descriptor_update_after_bind_input_attachments;
+        self
+    }
+    pub fn max_per_stage_update_after_bind_resources(
+        mut self,
+        max_per_stage_update_after_bind_resources: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.max_per_stage_update_after_bind_resources =
+            max_per_stage_update_after_bind_resources;
+        self
+    }
+    pub fn max_descriptor_set_update_after_bind_samplers(
+        mut self,
+        max_descriptor_set_update_after_bind_samplers: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.max_descriptor_set_update_after_bind_samplers =
+            max_descriptor_set_update_after_bind_samplers;
+        self
+    }
+    pub fn max_descriptor_set_update_after_bind_uniform_buffers(
+        mut self,
+        max_descriptor_set_update_after_bind_uniform_buffers: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_descriptor_set_update_after_bind_uniform_buffers =
+            max_descriptor_set_update_after_bind_uniform_buffers;
+        self
+    }
+    pub fn max_descriptor_set_update_after_bind_uniform_buffers_dynamic(
+        mut self,
+        max_descriptor_set_update_after_bind_uniform_buffers_dynamic: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_descriptor_set_update_after_bind_uniform_buffers_dynamic =
+            max_descriptor_set_update_after_bind_uniform_buffers_dynamic;
+        self
+    }
+    pub fn max_descriptor_set_update_after_bind_storage_buffers(
+        mut self,
+        max_descriptor_set_update_after_bind_storage_buffers: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_descriptor_set_update_after_bind_storage_buffers =
+            max_descriptor_set_update_after_bind_storage_buffers;
+        self
+    }
+    pub fn max_descriptor_set_update_after_bind_storage_buffers_dynamic(
+        mut self,
+        max_descriptor_set_update_after_bind_storage_buffers_dynamic: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_descriptor_set_update_after_bind_storage_buffers_dynamic =
+            max_descriptor_set_update_after_bind_storage_buffers_dynamic;
+        self
+    }
+    pub fn max_descriptor_set_update_after_bind_sampled_images(
+        mut self,
+        max_descriptor_set_update_after_bind_sampled_images: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_descriptor_set_update_after_bind_sampled_images =
+            max_descriptor_set_update_after_bind_sampled_images;
+        self
+    }
+    pub fn max_descriptor_set_update_after_bind_storage_images(
+        mut self,
+        max_descriptor_set_update_after_bind_storage_images: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_descriptor_set_update_after_bind_storage_images =
+            max_descriptor_set_update_after_bind_storage_images;
+        self
+    }
+    pub fn max_descriptor_set_update_after_bind_input_attachments(
+        mut self,
+        max_descriptor_set_update_after_bind_input_attachments: u32,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner
+            .max_descriptor_set_update_after_bind_input_attachments =
+            max_descriptor_set_update_after_bind_input_attachments;
+        self
+    }
+    pub fn supported_depth_resolve_modes(
+        mut self,
+        supported_depth_resolve_modes: ResolveModeFlags,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.supported_depth_resolve_modes = supported_depth_resolve_modes;
+        self
+    }
+    pub fn supported_stencil_resolve_modes(
+        mut self,
+        supported_stencil_resolve_modes: ResolveModeFlags,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.supported_stencil_resolve_modes = supported_stencil_resolve_modes;
+        self
+    }
+    pub fn independent_resolve_none(
+        mut self,
+        independent_resolve_none: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.independent_resolve_none = independent_resolve_none.into();
+        self
+    }
+    pub fn independent_resolve(
+        mut self,
+        independent_resolve: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.independent_resolve = independent_resolve.into();
+        self
+    }
+    pub fn filter_minmax_single_component_formats(
+        mut self,
+        filter_minmax_single_component_formats: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.filter_minmax_single_component_formats =
+            filter_minmax_single_component_formats.into();
+        self
+    }
+    pub fn filter_minmax_image_component_mapping(
+        mut self,
+        filter_minmax_image_component_mapping: bool,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.filter_minmax_image_component_mapping =
+            filter_minmax_image_component_mapping.into();
+        self
+    }
+    pub fn max_timeline_semaphore_value_difference(
+        mut self,
+        max_timeline_semaphore_value_difference: u64,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.max_timeline_semaphore_value_difference =
+            max_timeline_semaphore_value_difference;
+        self
+    }
+    pub fn framebuffer_integer_color_sample_counts(
+        mut self,
+        framebuffer_integer_color_sample_counts: SampleCountFlags,
+    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+        self.inner.framebuffer_integer_color_sample_counts =
+            framebuffer_integer_color_sample_counts;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceVulkan12Properties {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCompilerControlCreateInfoAMD.html>"]
+pub struct PipelineCompilerControlCreateInfoAMD {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub compiler_control_flags: PipelineCompilerControlFlagsAMD,
+}
+impl ::std::default::Default for PipelineCompilerControlCreateInfoAMD {
+    fn default() -> PipelineCompilerControlCreateInfoAMD {
+        PipelineCompilerControlCreateInfoAMD {
+            s_type: StructureType::PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD,
+            p_next: ::std::ptr::null(),
+            compiler_control_flags: PipelineCompilerControlFlagsAMD::default(),
+        }
+    }
+}
+impl PipelineCompilerControlCreateInfoAMD {
+    pub fn builder<'a>() -> PipelineCompilerControlCreateInfoAMDBuilder<'a> {
+        PipelineCompilerControlCreateInfoAMDBuilder {
+            inner: PipelineCompilerControlCreateInfoAMD::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PipelineCompilerControlCreateInfoAMDBuilder<'a> {
+    inner: PipelineCompilerControlCreateInfoAMD,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineCompilerControlCreateInfoAMDBuilder<'_> {}
+unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineCompilerControlCreateInfoAMD {}
+unsafe impl ExtendsComputePipelineCreateInfo for PipelineCompilerControlCreateInfoAMDBuilder<'_> {}
+unsafe impl ExtendsComputePipelineCreateInfo for PipelineCompilerControlCreateInfoAMD {}
+impl<'a> ::std::ops::Deref for PipelineCompilerControlCreateInfoAMDBuilder<'a> {
+    type Target = PipelineCompilerControlCreateInfoAMD;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PipelineCompilerControlCreateInfoAMDBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PipelineCompilerControlCreateInfoAMDBuilder<'a> {
+    pub fn compiler_control_flags(
+        mut self,
+        compiler_control_flags: PipelineCompilerControlFlagsAMD,
+    ) -> PipelineCompilerControlCreateInfoAMDBuilder<'a> {
+        self.inner.compiler_control_flags = compiler_control_flags;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PipelineCompilerControlCreateInfoAMD {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceCoherentMemoryFeaturesAMD.html>"]
+pub struct PhysicalDeviceCoherentMemoryFeaturesAMD {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub device_coherent_memory: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceCoherentMemoryFeaturesAMD {
+    fn default() -> PhysicalDeviceCoherentMemoryFeaturesAMD {
+        PhysicalDeviceCoherentMemoryFeaturesAMD {
+            s_type: StructureType::PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD,
+            p_next: ::std::ptr::null_mut(),
+            device_coherent_memory: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceCoherentMemoryFeaturesAMD {
+    pub fn builder<'a>() -> PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
+        PhysicalDeviceCoherentMemoryFeaturesAMDBuilder {
+            inner: PhysicalDeviceCoherentMemoryFeaturesAMD::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
+    inner: PhysicalDeviceCoherentMemoryFeaturesAMD,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceCoherentMemoryFeaturesAMD {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
+    type Target = PhysicalDeviceCoherentMemoryFeaturesAMD;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
+    pub fn device_coherent_memory(
+        mut self,
+        device_coherent_memory: bool,
+    ) -> PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
+        self.inner.device_coherent_memory = device_coherent_memory.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceCoherentMemoryFeaturesAMD {
+        self.inner
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceToolPropertiesEXT.html>"]
+pub struct PhysicalDeviceToolPropertiesEXT {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub name: [c_char; MAX_EXTENSION_NAME_SIZE],
+    pub version: [c_char; MAX_EXTENSION_NAME_SIZE],
+    pub purposes: ToolPurposeFlagsEXT,
+    pub description: [c_char; MAX_DESCRIPTION_SIZE],
+    pub layer: [c_char; MAX_EXTENSION_NAME_SIZE],
+}
+impl fmt::Debug for PhysicalDeviceToolPropertiesEXT {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("PhysicalDeviceToolPropertiesEXT")
+            .field("s_type", &self.s_type)
+            .field("p_next", &self.p_next)
+            .field("name", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.name.as_ptr() as *const c_char)
+            })
+            .field("version", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.version.as_ptr() as *const c_char)
+            })
+            .field("purposes", &self.purposes)
+            .field("description", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.description.as_ptr() as *const c_char)
+            })
+            .field("layer", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.layer.as_ptr() as *const c_char)
+            })
+            .finish()
+    }
+}
+impl ::std::default::Default for PhysicalDeviceToolPropertiesEXT {
+    fn default() -> PhysicalDeviceToolPropertiesEXT {
+        PhysicalDeviceToolPropertiesEXT {
+            s_type: StructureType::PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT,
+            p_next: ::std::ptr::null_mut(),
+            name: unsafe { ::std::mem::zeroed() },
+            version: unsafe { ::std::mem::zeroed() },
+            purposes: ToolPurposeFlagsEXT::default(),
+            description: unsafe { ::std::mem::zeroed() },
+            layer: unsafe { ::std::mem::zeroed() },
+        }
+    }
+}
+impl PhysicalDeviceToolPropertiesEXT {
+    pub fn builder<'a>() -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+        PhysicalDeviceToolPropertiesEXTBuilder {
+            inner: PhysicalDeviceToolPropertiesEXT::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    inner: PhysicalDeviceToolPropertiesEXT,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsPhysicalDeviceToolPropertiesEXT {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    type Target = PhysicalDeviceToolPropertiesEXT;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    pub fn name(
+        mut self,
+        name: [c_char; MAX_EXTENSION_NAME_SIZE],
+    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+        self.inner.name = name;
+        self
+    }
+    pub fn version(
+        mut self,
+        version: [c_char; MAX_EXTENSION_NAME_SIZE],
+    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+        self.inner.version = version;
+        self
+    }
+    pub fn purposes(
+        mut self,
+        purposes: ToolPurposeFlagsEXT,
+    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+        self.inner.purposes = purposes;
+        self
+    }
+    pub fn description(
+        mut self,
+        description: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+        self.inner.description = description;
+        self
+    }
+    pub fn layer(
+        mut self,
+        layer: [c_char; MAX_EXTENSION_NAME_SIZE],
+    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+        self.inner.layer = layer;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsPhysicalDeviceToolPropertiesEXT>(
+        mut self,
+        next: &'a mut T,
+    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceToolPropertiesEXT {
         self.inner
     }
 }
@@ -46420,6 +50996,8 @@ impl Result {
     pub const ERROR_FORMAT_NOT_SUPPORTED: Self = Result(-11);
     #[doc = "A requested pool allocation has failed due to fragmentation of the pool\'s memory"]
     pub const ERROR_FRAGMENTED_POOL: Self = Result(-12);
+    #[doc = "An unknown error has occurred, due to an implementation or application bug"]
+    pub const ERROR_UNKNOWN: Self = Result(-13);
 }
 impl ::std::error::Error for Result {
     fn description(&self) -> &str {
@@ -46452,6 +51030,9 @@ impl ::std::error::Error for Result {
             Result::ERROR_FRAGMENTED_POOL => Some(
                 "A requested pool allocation has failed due to fragmentation of the pool\'s memory",
             ),
+            Result::ERROR_UNKNOWN => {
+                Some("An unknown error has occurred, due to an implementation or application bug")
+            }
             _ => None,
         };
         name.unwrap_or("unknown error")
@@ -46488,6 +51069,9 @@ impl fmt::Display for Result {
             Result::ERROR_FRAGMENTED_POOL => Some(
                 "A requested pool allocation has failed due to fragmentation of the pool\'s memory",
             ),
+            Result::ERROR_UNKNOWN => {
+                Some("An unknown error has occurred, due to an implementation or application bug")
+            }
             _ => None,
         };
         if let Some(x) = name {
@@ -46600,6 +51184,22 @@ impl ObjectType {
     pub const FRAMEBUFFER: Self = ObjectType(24);
     #[doc = "VkCommandPool"]
     pub const COMMAND_POOL: Self = ObjectType(25);
+}
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreType.html>"]
+pub struct SemaphoreType(pub(crate) i32);
+impl SemaphoreType {
+    pub fn from_raw(x: i32) -> Self {
+        SemaphoreType(x)
+    }
+    pub fn as_raw(self) -> i32 {
+        self.0
+    }
+}
+impl SemaphoreType {
+    pub const BINARY: Self = SemaphoreType(0);
+    pub const TIMELINE: Self = SemaphoreType(1);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -46747,6 +51347,7 @@ impl ValidationFeatureEnableEXT {
 impl ValidationFeatureEnableEXT {
     pub const GPU_ASSISTED: Self = ValidationFeatureEnableEXT(0);
     pub const GPU_ASSISTED_RESERVE_BINDING_SLOT: Self = ValidationFeatureEnableEXT(1);
+    pub const BEST_PRACTICES: Self = ValidationFeatureEnableEXT(2);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -46913,20 +51514,20 @@ impl PointClippingBehavior {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerReductionModeEXT.html>"]
-pub struct SamplerReductionModeEXT(pub(crate) i32);
-impl SamplerReductionModeEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerReductionMode.html>"]
+pub struct SamplerReductionMode(pub(crate) i32);
+impl SamplerReductionMode {
     pub fn from_raw(x: i32) -> Self {
-        SamplerReductionModeEXT(x)
+        SamplerReductionMode(x)
     }
     pub fn as_raw(self) -> i32 {
         self.0
     }
 }
-impl SamplerReductionModeEXT {
-    pub const WEIGHTED_AVERAGE: Self = SamplerReductionModeEXT(0);
-    pub const MIN: Self = SamplerReductionModeEXT(1);
-    pub const MAX: Self = SamplerReductionModeEXT(2);
+impl SamplerReductionMode {
+    pub const WEIGHTED_AVERAGE: Self = SamplerReductionMode(0);
+    pub const MIN: Self = SamplerReductionMode(1);
+    pub const MAX: Self = SamplerReductionMode(2);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -47141,41 +51742,41 @@ impl VendorId {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDriverIdKHR.html>"]
-pub struct DriverIdKHR(pub(crate) i32);
-impl DriverIdKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDriverId.html>"]
+pub struct DriverId(pub(crate) i32);
+impl DriverId {
     pub fn from_raw(x: i32) -> Self {
-        DriverIdKHR(x)
+        DriverId(x)
     }
     pub fn as_raw(self) -> i32 {
         self.0
     }
 }
-impl DriverIdKHR {
+impl DriverId {
     #[doc = "Advanced Micro Devices, Inc."]
-    pub const AMD_PROPRIETARY: Self = DriverIdKHR(1);
+    pub const AMD_PROPRIETARY: Self = DriverId(1);
     #[doc = "Advanced Micro Devices, Inc."]
-    pub const AMD_OPEN_SOURCE: Self = DriverIdKHR(2);
+    pub const AMD_OPEN_SOURCE: Self = DriverId(2);
     #[doc = "Mesa open source project"]
-    pub const MESA_RADV: Self = DriverIdKHR(3);
+    pub const MESA_RADV: Self = DriverId(3);
     #[doc = "NVIDIA Corporation"]
-    pub const NVIDIA_PROPRIETARY: Self = DriverIdKHR(4);
+    pub const NVIDIA_PROPRIETARY: Self = DriverId(4);
     #[doc = "Intel Corporation"]
-    pub const INTEL_PROPRIETARY_WINDOWS: Self = DriverIdKHR(5);
+    pub const INTEL_PROPRIETARY_WINDOWS: Self = DriverId(5);
     #[doc = "Intel Corporation"]
-    pub const INTEL_OPEN_SOURCE_MESA: Self = DriverIdKHR(6);
+    pub const INTEL_OPEN_SOURCE_MESA: Self = DriverId(6);
     #[doc = "Imagination Technologies"]
-    pub const IMAGINATION_PROPRIETARY: Self = DriverIdKHR(7);
+    pub const IMAGINATION_PROPRIETARY: Self = DriverId(7);
     #[doc = "Qualcomm Technologies, Inc."]
-    pub const QUALCOMM_PROPRIETARY: Self = DriverIdKHR(8);
+    pub const QUALCOMM_PROPRIETARY: Self = DriverId(8);
     #[doc = "Arm Limited"]
-    pub const ARM_PROPRIETARY: Self = DriverIdKHR(9);
+    pub const ARM_PROPRIETARY: Self = DriverId(9);
     #[doc = "Google LLC"]
-    pub const GOOGLE_SWIFTSHADER: Self = DriverIdKHR(10);
+    pub const GOOGLE_SWIFTSHADER: Self = DriverId(10);
     #[doc = "Google LLC"]
-    pub const GGP_PROPRIETARY: Self = DriverIdKHR(11);
+    pub const GGP_PROPRIETARY: Self = DriverId(11);
     #[doc = "Broadcom Inc."]
-    pub const BROADCOM_PROPRIETARY: Self = DriverIdKHR(12);
+    pub const BROADCOM_PROPRIETARY: Self = DriverId(12);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -47383,6 +51984,68 @@ impl FullScreenExclusiveEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterScopeKHR.html>"]
+pub struct PerformanceCounterScopeKHR(pub(crate) i32);
+impl PerformanceCounterScopeKHR {
+    pub fn from_raw(x: i32) -> Self {
+        PerformanceCounterScopeKHR(x)
+    }
+    pub fn as_raw(self) -> i32 {
+        self.0
+    }
+}
+impl PerformanceCounterScopeKHR {
+    pub const COMMAND_BUFFER: Self = PerformanceCounterScopeKHR(0);
+    pub const RENDER_PASS: Self = PerformanceCounterScopeKHR(1);
+    pub const COMMAND: Self = PerformanceCounterScopeKHR(2);
+}
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterUnitKHR.html>"]
+pub struct PerformanceCounterUnitKHR(pub(crate) i32);
+impl PerformanceCounterUnitKHR {
+    pub fn from_raw(x: i32) -> Self {
+        PerformanceCounterUnitKHR(x)
+    }
+    pub fn as_raw(self) -> i32 {
+        self.0
+    }
+}
+impl PerformanceCounterUnitKHR {
+    pub const GENERIC: Self = PerformanceCounterUnitKHR(0);
+    pub const PERCENTAGE: Self = PerformanceCounterUnitKHR(1);
+    pub const NANOSECONDS: Self = PerformanceCounterUnitKHR(2);
+    pub const BYTES: Self = PerformanceCounterUnitKHR(3);
+    pub const BYTES_PER_SECOND: Self = PerformanceCounterUnitKHR(4);
+    pub const KELVIN: Self = PerformanceCounterUnitKHR(5);
+    pub const WATTS: Self = PerformanceCounterUnitKHR(6);
+    pub const VOLTS: Self = PerformanceCounterUnitKHR(7);
+    pub const AMPS: Self = PerformanceCounterUnitKHR(8);
+    pub const HERTZ: Self = PerformanceCounterUnitKHR(9);
+    pub const CYCLES: Self = PerformanceCounterUnitKHR(10);
+}
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterStorageKHR.html>"]
+pub struct PerformanceCounterStorageKHR(pub(crate) i32);
+impl PerformanceCounterStorageKHR {
+    pub fn from_raw(x: i32) -> Self {
+        PerformanceCounterStorageKHR(x)
+    }
+    pub fn as_raw(self) -> i32 {
+        self.0
+    }
+}
+impl PerformanceCounterStorageKHR {
+    pub const INT32: Self = PerformanceCounterStorageKHR(0);
+    pub const INT64: Self = PerformanceCounterStorageKHR(1);
+    pub const UINT32: Self = PerformanceCounterStorageKHR(2);
+    pub const UINT64: Self = PerformanceCounterStorageKHR(3);
+    pub const FLOAT32: Self = PerformanceCounterStorageKHR(4);
+    pub const FLOAT64: Self = PerformanceCounterStorageKHR(5);
+}
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceConfigurationTypeINTEL.html>"]
 pub struct PerformanceConfigurationTypeINTEL(pub(crate) i32);
 impl PerformanceConfigurationTypeINTEL {
@@ -47468,20 +52131,38 @@ impl PerformanceValueTypeINTEL {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderFloatControlsIndependenceKHR.html>"]
-pub struct ShaderFloatControlsIndependenceKHR(pub(crate) i32);
-impl ShaderFloatControlsIndependenceKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderFloatControlsIndependence.html>"]
+pub struct ShaderFloatControlsIndependence(pub(crate) i32);
+impl ShaderFloatControlsIndependence {
     pub fn from_raw(x: i32) -> Self {
-        ShaderFloatControlsIndependenceKHR(x)
+        ShaderFloatControlsIndependence(x)
     }
     pub fn as_raw(self) -> i32 {
         self.0
     }
 }
-impl ShaderFloatControlsIndependenceKHR {
-    pub const TYPE_32_ONLY: Self = ShaderFloatControlsIndependenceKHR(0);
-    pub const ALL: Self = ShaderFloatControlsIndependenceKHR(1);
-    pub const NONE: Self = ShaderFloatControlsIndependenceKHR(2);
+impl ShaderFloatControlsIndependence {
+    pub const TYPE_32_ONLY: Self = ShaderFloatControlsIndependence(0);
+    pub const ALL: Self = ShaderFloatControlsIndependence(1);
+    pub const NONE: Self = ShaderFloatControlsIndependence(2);
+}
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableStatisticFormatKHR.html>"]
+pub struct PipelineExecutableStatisticFormatKHR(pub(crate) i32);
+impl PipelineExecutableStatisticFormatKHR {
+    pub fn from_raw(x: i32) -> Self {
+        PipelineExecutableStatisticFormatKHR(x)
+    }
+    pub fn as_raw(self) -> i32 {
+        self.0
+    }
+}
+impl PipelineExecutableStatisticFormatKHR {
+    pub const BOOL32: Self = PipelineExecutableStatisticFormatKHR(0);
+    pub const INT64: Self = PipelineExecutableStatisticFormatKHR(1);
+    pub const UINT64: Self = PipelineExecutableStatisticFormatKHR(2);
+    pub const FLOAT64: Self = PipelineExecutableStatisticFormatKHR(3);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -47752,6 +52433,12 @@ impl FenceCreateFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreCreateFlagBits.html>"]
+pub struct SemaphoreCreateFlags(pub(crate) Flags);
+vk_bitflags_wrapped!(SemaphoreCreateFlags, 0b0, Flags);
+impl SemaphoreCreateFlags {}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFormatFeatureFlagBits.html>"]
 pub struct FormatFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(FormatFeatureFlags, 0b1_1111_1111_1111, Flags);
@@ -48012,6 +52699,14 @@ vk_bitflags_wrapped!(DependencyFlags, 0b1, Flags);
 impl DependencyFlags {
     #[doc = "Dependency is per pixel region "]
     pub const BY_REGION: Self = DependencyFlags(0b1);
+}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreWaitFlagBits.html>"]
+pub struct SemaphoreWaitFlags(pub(crate) Flags);
+vk_bitflags_wrapped!(SemaphoreWaitFlags, 0b1, Flags);
+impl SemaphoreWaitFlags {
+    pub const ANY: Self = SemaphoreWaitFlags(0b1);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -48319,14 +53014,14 @@ impl DebugUtilsMessageTypeFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorBindingFlagBitsEXT.html>"]
-pub struct DescriptorBindingFlagsEXT(pub(crate) Flags);
-vk_bitflags_wrapped!(DescriptorBindingFlagsEXT, 0b1111, Flags);
-impl DescriptorBindingFlagsEXT {
-    pub const UPDATE_AFTER_BIND: Self = DescriptorBindingFlagsEXT(0b1);
-    pub const UPDATE_UNUSED_WHILE_PENDING: Self = DescriptorBindingFlagsEXT(0b10);
-    pub const PARTIALLY_BOUND: Self = DescriptorBindingFlagsEXT(0b100);
-    pub const VARIABLE_DESCRIPTOR_COUNT: Self = DescriptorBindingFlagsEXT(0b1000);
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorBindingFlagBits.html>"]
+pub struct DescriptorBindingFlags(pub(crate) Flags);
+vk_bitflags_wrapped!(DescriptorBindingFlags, 0b1111, Flags);
+impl DescriptorBindingFlags {
+    pub const UPDATE_AFTER_BIND: Self = DescriptorBindingFlags(0b1);
+    pub const UPDATE_UNUSED_WHILE_PENDING: Self = DescriptorBindingFlags(0b10);
+    pub const PARTIALLY_BOUND: Self = DescriptorBindingFlags(0b100);
+    pub const VARIABLE_DESCRIPTOR_COUNT: Self = DescriptorBindingFlags(0b1000);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -48338,15 +53033,15 @@ impl ConditionalRenderingFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkResolveModeFlagBitsKHR.html>"]
-pub struct ResolveModeFlagsKHR(pub(crate) Flags);
-vk_bitflags_wrapped!(ResolveModeFlagsKHR, 0b1111, Flags);
-impl ResolveModeFlagsKHR {
-    pub const NONE: Self = ResolveModeFlagsKHR(0);
-    pub const SAMPLE_ZERO: Self = ResolveModeFlagsKHR(0b1);
-    pub const AVERAGE: Self = ResolveModeFlagsKHR(0b10);
-    pub const MIN: Self = ResolveModeFlagsKHR(0b100);
-    pub const MAX: Self = ResolveModeFlagsKHR(0b1000);
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkResolveModeFlagBits.html>"]
+pub struct ResolveModeFlags(pub(crate) Flags);
+vk_bitflags_wrapped!(ResolveModeFlags, 0b1111, Flags);
+impl ResolveModeFlags {
+    pub const NONE: Self = ResolveModeFlags(0);
+    pub const SAMPLE_ZERO: Self = ResolveModeFlags(0b1);
+    pub const AVERAGE: Self = ResolveModeFlags(0b10);
+    pub const MIN: Self = ResolveModeFlags(0b100);
+    pub const MAX: Self = ResolveModeFlags(0b1000);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -48398,10 +53093,49 @@ impl PipelineCreationFeedbackFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterDescriptionFlagBitsKHR.html>"]
+pub struct PerformanceCounterDescriptionFlagsKHR(pub(crate) Flags);
+vk_bitflags_wrapped!(PerformanceCounterDescriptionFlagsKHR, 0b11, Flags);
+impl PerformanceCounterDescriptionFlagsKHR {
+    pub const PERFORMANCE_IMPACTING: Self = PerformanceCounterDescriptionFlagsKHR(0b1);
+    pub const CONCURRENTLY_IMPACTED: Self = PerformanceCounterDescriptionFlagsKHR(0b10);
+}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAcquireProfilingLockFlagBitsKHR.html>"]
+pub struct AcquireProfilingLockFlagsKHR(pub(crate) Flags);
+vk_bitflags_wrapped!(AcquireProfilingLockFlagsKHR, 0b0, Flags);
+impl AcquireProfilingLockFlagsKHR {}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderCorePropertiesFlagBitsAMD.html>"]
+pub struct ShaderCorePropertiesFlagsAMD(pub(crate) Flags);
+vk_bitflags_wrapped!(ShaderCorePropertiesFlagsAMD, 0b0, Flags);
+impl ShaderCorePropertiesFlagsAMD {}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderModuleCreateFlagBits.html>"]
 pub struct ShaderModuleCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ShaderModuleCreateFlags, 0b0, Flags);
 impl ShaderModuleCreateFlags {}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCompilerControlFlagBitsAMD.html>"]
+pub struct PipelineCompilerControlFlagsAMD(pub(crate) Flags);
+vk_bitflags_wrapped!(PipelineCompilerControlFlagsAMD, 0b0, Flags);
+impl PipelineCompilerControlFlagsAMD {}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkToolPurposeFlagBitsEXT.html>"]
+pub struct ToolPurposeFlagsEXT(pub(crate) Flags);
+vk_bitflags_wrapped!(ToolPurposeFlagsEXT, 0b1_1111, Flags);
+impl ToolPurposeFlagsEXT {
+    pub const VALIDATION: Self = ToolPurposeFlagsEXT(0b1);
+    pub const PROFILING: Self = ToolPurposeFlagsEXT(0b10);
+    pub const TRACING: Self = ToolPurposeFlagsEXT(0b100);
+    pub const ADDITIONAL_FEATURES: Self = ToolPurposeFlagsEXT(0b1000);
+    pub const MODIFYING_FEATURES: Self = ToolPurposeFlagsEXT(0b1_0000);
+}
 pub const MAX_PHYSICAL_DEVICE_NAME_SIZE: usize = 256;
 pub const UUID_SIZE: usize = 16;
 pub const LUID_SIZE: usize = 8;
@@ -48421,8 +53155,8 @@ pub const QUEUE_FAMILY_EXTERNAL: u32 = !0 - 1;
 pub const QUEUE_FAMILY_FOREIGN_EXT: u32 = !0 - 2;
 pub const SUBPASS_EXTERNAL: u32 = !0;
 pub const MAX_DEVICE_GROUP_SIZE: usize = 32;
-pub const MAX_DRIVER_NAME_SIZE_KHR: usize = 256;
-pub const MAX_DRIVER_INFO_SIZE_KHR: usize = 256;
+pub const MAX_DRIVER_NAME_SIZE: usize = 256;
+pub const MAX_DRIVER_INFO_SIZE: usize = 256;
 pub const SHADER_UNUSED_NV: u32 = !0;
 impl KhrSurfaceFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -53990,10 +58724,6 @@ impl KhrShaderFloat16Int8Fn {
         KhrShaderFloat16Int8Fn {}
     }
 }
-#[doc = "Generated from \'VK_KHR_shader_float16_int8\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR: Self = StructureType(1_000_082_000);
-}
 impl Khr16bitStorageFn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_16bit_storage\0")
@@ -55744,89 +60474,18 @@ impl KhrImagelessFramebufferFn {
         KhrImagelessFramebufferFn {}
     }
 }
-#[doc = "Generated from \'VK_KHR_imageless_framebuffer\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES_KHR: Self =
-        StructureType(1_000_108_000);
-}
-#[doc = "Generated from \'VK_KHR_imageless_framebuffer\'"]
-impl StructureType {
-    pub const FRAMEBUFFER_ATTACHMENTS_CREATE_INFO_KHR: Self = StructureType(1_000_108_001);
-}
-#[doc = "Generated from \'VK_KHR_imageless_framebuffer\'"]
-impl StructureType {
-    pub const FRAMEBUFFER_ATTACHMENT_IMAGE_INFO_KHR: Self = StructureType(1_000_108_002);
-}
-#[doc = "Generated from \'VK_KHR_imageless_framebuffer\'"]
-impl StructureType {
-    pub const RENDER_PASS_ATTACHMENT_BEGIN_INFO_KHR: Self = StructureType(1_000_108_003);
-}
-#[doc = "Generated from \'VK_KHR_imageless_framebuffer\'"]
-impl FramebufferCreateFlags {
-    pub const IMAGELESS_KHR: Self = FramebufferCreateFlags(0b1);
-}
 impl KhrCreateRenderpass2Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_create_renderpass2\0")
             .expect("Wrong extension string")
     }
 }
-#[allow(non_camel_case_types)]
-pub type PFN_vkCreateRenderPass2KHR = extern "system" fn(
-    device: Device,
-    p_create_info: *const RenderPassCreateInfo2KHR,
-    p_allocator: *const AllocationCallbacks,
-    p_render_pass: *mut RenderPass,
-) -> Result;
-#[allow(non_camel_case_types)]
-pub type PFN_vkCmdBeginRenderPass2KHR = extern "system" fn(
-    command_buffer: CommandBuffer,
-    p_render_pass_begin: *const RenderPassBeginInfo,
-    p_subpass_begin_info: *const SubpassBeginInfoKHR,
-) -> c_void;
-#[allow(non_camel_case_types)]
-pub type PFN_vkCmdNextSubpass2KHR = extern "system" fn(
-    command_buffer: CommandBuffer,
-    p_subpass_begin_info: *const SubpassBeginInfoKHR,
-    p_subpass_end_info: *const SubpassEndInfoKHR,
-) -> c_void;
-#[allow(non_camel_case_types)]
-pub type PFN_vkCmdEndRenderPass2KHR = extern "system" fn(
-    command_buffer: CommandBuffer,
-    p_subpass_end_info: *const SubpassEndInfoKHR,
-) -> c_void;
-pub struct KhrCreateRenderpass2Fn {
-    pub create_render_pass2_khr: extern "system" fn(
-        device: Device,
-        p_create_info: *const RenderPassCreateInfo2KHR,
-        p_allocator: *const AllocationCallbacks,
-        p_render_pass: *mut RenderPass,
-    ) -> Result,
-    pub cmd_begin_render_pass2_khr: extern "system" fn(
-        command_buffer: CommandBuffer,
-        p_render_pass_begin: *const RenderPassBeginInfo,
-        p_subpass_begin_info: *const SubpassBeginInfoKHR,
-    ) -> c_void,
-    pub cmd_next_subpass2_khr: extern "system" fn(
-        command_buffer: CommandBuffer,
-        p_subpass_begin_info: *const SubpassBeginInfoKHR,
-        p_subpass_end_info: *const SubpassEndInfoKHR,
-    ) -> c_void,
-    pub cmd_end_render_pass2_khr: extern "system" fn(
-        command_buffer: CommandBuffer,
-        p_subpass_end_info: *const SubpassEndInfoKHR,
-    ) -> c_void,
-}
+pub struct KhrCreateRenderpass2Fn {}
 unsafe impl Send for KhrCreateRenderpass2Fn {}
 unsafe impl Sync for KhrCreateRenderpass2Fn {}
 impl ::std::clone::Clone for KhrCreateRenderpass2Fn {
     fn clone(&self) -> Self {
-        KhrCreateRenderpass2Fn {
-            create_render_pass2_khr: self.create_render_pass2_khr,
-            cmd_begin_render_pass2_khr: self.cmd_begin_render_pass2_khr,
-            cmd_next_subpass2_khr: self.cmd_next_subpass2_khr,
-            cmd_end_render_pass2_khr: self.cmd_end_render_pass2_khr,
-        }
+        KhrCreateRenderpass2Fn {}
     }
 }
 impl KhrCreateRenderpass2Fn {
@@ -55834,153 +60493,8 @@ impl KhrCreateRenderpass2Fn {
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        KhrCreateRenderpass2Fn {
-            create_render_pass2_khr: unsafe {
-                extern "system" fn create_render_pass2_khr(
-                    _device: Device,
-                    _p_create_info: *const RenderPassCreateInfo2KHR,
-                    _p_allocator: *const AllocationCallbacks,
-                    _p_render_pass: *mut RenderPass,
-                ) -> Result {
-                    panic!(concat!(
-                        "Unable to load ",
-                        stringify!(create_render_pass2_khr)
-                    ))
-                }
-                let raw_name = stringify!(vkCreateRenderPass2KHR);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
-                if val.is_null() {
-                    create_render_pass2_khr
-                } else {
-                    ::std::mem::transmute(val)
-                }
-            },
-            cmd_begin_render_pass2_khr: unsafe {
-                extern "system" fn cmd_begin_render_pass2_khr(
-                    _command_buffer: CommandBuffer,
-                    _p_render_pass_begin: *const RenderPassBeginInfo,
-                    _p_subpass_begin_info: *const SubpassBeginInfoKHR,
-                ) -> c_void {
-                    panic!(concat!(
-                        "Unable to load ",
-                        stringify!(cmd_begin_render_pass2_khr)
-                    ))
-                }
-                let raw_name = stringify!(vkCmdBeginRenderPass2KHR);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
-                if val.is_null() {
-                    cmd_begin_render_pass2_khr
-                } else {
-                    ::std::mem::transmute(val)
-                }
-            },
-            cmd_next_subpass2_khr: unsafe {
-                extern "system" fn cmd_next_subpass2_khr(
-                    _command_buffer: CommandBuffer,
-                    _p_subpass_begin_info: *const SubpassBeginInfoKHR,
-                    _p_subpass_end_info: *const SubpassEndInfoKHR,
-                ) -> c_void {
-                    panic!(concat!(
-                        "Unable to load ",
-                        stringify!(cmd_next_subpass2_khr)
-                    ))
-                }
-                let raw_name = stringify!(vkCmdNextSubpass2KHR);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
-                if val.is_null() {
-                    cmd_next_subpass2_khr
-                } else {
-                    ::std::mem::transmute(val)
-                }
-            },
-            cmd_end_render_pass2_khr: unsafe {
-                extern "system" fn cmd_end_render_pass2_khr(
-                    _command_buffer: CommandBuffer,
-                    _p_subpass_end_info: *const SubpassEndInfoKHR,
-                ) -> c_void {
-                    panic!(concat!(
-                        "Unable to load ",
-                        stringify!(cmd_end_render_pass2_khr)
-                    ))
-                }
-                let raw_name = stringify!(vkCmdEndRenderPass2KHR);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
-                if val.is_null() {
-                    cmd_end_render_pass2_khr
-                } else {
-                    ::std::mem::transmute(val)
-                }
-            },
-        }
+        KhrCreateRenderpass2Fn {}
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateRenderPass2KHR.html>"]
-    pub unsafe fn create_render_pass2_khr(
-        &self,
-        device: Device,
-        p_create_info: *const RenderPassCreateInfo2KHR,
-        p_allocator: *const AllocationCallbacks,
-        p_render_pass: *mut RenderPass,
-    ) -> Result {
-        (self.create_render_pass2_khr)(device, p_create_info, p_allocator, p_render_pass)
-    }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBeginRenderPass2KHR.html>"]
-    pub unsafe fn cmd_begin_render_pass2_khr(
-        &self,
-        command_buffer: CommandBuffer,
-        p_render_pass_begin: *const RenderPassBeginInfo,
-        p_subpass_begin_info: *const SubpassBeginInfoKHR,
-    ) -> c_void {
-        (self.cmd_begin_render_pass2_khr)(command_buffer, p_render_pass_begin, p_subpass_begin_info)
-    }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdNextSubpass2KHR.html>"]
-    pub unsafe fn cmd_next_subpass2_khr(
-        &self,
-        command_buffer: CommandBuffer,
-        p_subpass_begin_info: *const SubpassBeginInfoKHR,
-        p_subpass_end_info: *const SubpassEndInfoKHR,
-    ) -> c_void {
-        (self.cmd_next_subpass2_khr)(command_buffer, p_subpass_begin_info, p_subpass_end_info)
-    }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdEndRenderPass2KHR.html>"]
-    pub unsafe fn cmd_end_render_pass2_khr(
-        &self,
-        command_buffer: CommandBuffer,
-        p_subpass_end_info: *const SubpassEndInfoKHR,
-    ) -> c_void {
-        (self.cmd_end_render_pass2_khr)(command_buffer, p_subpass_end_info)
-    }
-}
-#[doc = "Generated from \'VK_KHR_create_renderpass2\'"]
-impl StructureType {
-    pub const ATTACHMENT_DESCRIPTION_2_KHR: Self = StructureType(1_000_109_000);
-}
-#[doc = "Generated from \'VK_KHR_create_renderpass2\'"]
-impl StructureType {
-    pub const ATTACHMENT_REFERENCE_2_KHR: Self = StructureType(1_000_109_001);
-}
-#[doc = "Generated from \'VK_KHR_create_renderpass2\'"]
-impl StructureType {
-    pub const SUBPASS_DESCRIPTION_2_KHR: Self = StructureType(1_000_109_002);
-}
-#[doc = "Generated from \'VK_KHR_create_renderpass2\'"]
-impl StructureType {
-    pub const SUBPASS_DEPENDENCY_2_KHR: Self = StructureType(1_000_109_003);
-}
-#[doc = "Generated from \'VK_KHR_create_renderpass2\'"]
-impl StructureType {
-    pub const RENDER_PASS_CREATE_INFO_2_KHR: Self = StructureType(1_000_109_004);
-}
-#[doc = "Generated from \'VK_KHR_create_renderpass2\'"]
-impl StructureType {
-    pub const SUBPASS_BEGIN_INFO_KHR: Self = StructureType(1_000_109_005);
-}
-#[doc = "Generated from \'VK_KHR_create_renderpass2\'"]
-impl StructureType {
-    pub const SUBPASS_END_INFO_KHR: Self = StructureType(1_000_109_006);
 }
 impl ImgExtension111Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -56342,27 +60856,228 @@ impl StructureType {
 impl StructureType {
     pub const FENCE_GET_FD_INFO_KHR: Self = StructureType(1_000_115_001);
 }
-impl KhrExtension117Fn {
+impl KhrPerformanceQueryFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_extension_117\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_performance_query\0")
             .expect("Wrong extension string")
     }
 }
-pub struct KhrExtension117Fn {}
-unsafe impl Send for KhrExtension117Fn {}
-unsafe impl Sync for KhrExtension117Fn {}
-impl ::std::clone::Clone for KhrExtension117Fn {
+#[allow(non_camel_case_types)]
+pub type PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+    extern "system" fn(
+        physical_device: PhysicalDevice,
+        queue_family_index: u32,
+        p_counter_count: *mut u32,
+        p_counters: *mut PerformanceCounterKHR,
+        p_counter_descriptions: *mut PerformanceCounterDescriptionKHR,
+    ) -> Result;
+#[allow(non_camel_case_types)]
+pub type PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR = extern "system" fn(
+    physical_device: PhysicalDevice,
+    p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
+    p_num_passes: *mut u32,
+)
+    -> c_void;
+#[allow(non_camel_case_types)]
+pub type PFN_vkAcquireProfilingLockKHR =
+    extern "system" fn(device: Device, p_info: *const AcquireProfilingLockInfoKHR) -> Result;
+#[allow(non_camel_case_types)]
+pub type PFN_vkReleaseProfilingLockKHR = extern "system" fn(device: Device) -> c_void;
+pub struct KhrPerformanceQueryFn {
+    pub enumerate_physical_device_queue_family_performance_query_counters_khr:
+        extern "system" fn(
+            physical_device: PhysicalDevice,
+            queue_family_index: u32,
+            p_counter_count: *mut u32,
+            p_counters: *mut PerformanceCounterKHR,
+            p_counter_descriptions: *mut PerformanceCounterDescriptionKHR,
+        ) -> Result,
+    pub get_physical_device_queue_family_performance_query_passes_khr: extern "system" fn(
+        physical_device: PhysicalDevice,
+        p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
+        p_num_passes: *mut u32,
+    )
+        -> c_void,
+    pub acquire_profiling_lock_khr:
+        extern "system" fn(device: Device, p_info: *const AcquireProfilingLockInfoKHR) -> Result,
+    pub release_profiling_lock_khr: extern "system" fn(device: Device) -> c_void,
+}
+unsafe impl Send for KhrPerformanceQueryFn {}
+unsafe impl Sync for KhrPerformanceQueryFn {}
+impl ::std::clone::Clone for KhrPerformanceQueryFn {
     fn clone(&self) -> Self {
-        KhrExtension117Fn {}
+        KhrPerformanceQueryFn {
+            enumerate_physical_device_queue_family_performance_query_counters_khr: self
+                .enumerate_physical_device_queue_family_performance_query_counters_khr,
+            get_physical_device_queue_family_performance_query_passes_khr: self
+                .get_physical_device_queue_family_performance_query_passes_khr,
+            acquire_profiling_lock_khr: self.acquire_profiling_lock_khr,
+            release_profiling_lock_khr: self.release_profiling_lock_khr,
+        }
     }
 }
-impl KhrExtension117Fn {
+impl KhrPerformanceQueryFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        KhrExtension117Fn {}
+        KhrPerformanceQueryFn {
+            enumerate_physical_device_queue_family_performance_query_counters_khr: unsafe {
+                extern "system" fn enumerate_physical_device_queue_family_performance_query_counters_khr(
+                    _physical_device: PhysicalDevice,
+                    _queue_family_index: u32,
+                    _p_counter_count: *mut u32,
+                    _p_counters: *mut PerformanceCounterKHR,
+                    _p_counter_descriptions: *mut PerformanceCounterDescriptionKHR,
+                ) -> Result {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(
+                            enumerate_physical_device_queue_family_performance_query_counters_khr
+                        )
+                    ))
+                }
+                let raw_name =
+                    stringify!(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    enumerate_physical_device_queue_family_performance_query_counters_khr
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_physical_device_queue_family_performance_query_passes_khr: unsafe {
+                extern "system" fn get_physical_device_queue_family_performance_query_passes_khr(
+                    _physical_device: PhysicalDevice,
+                    _p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
+                    _p_num_passes: *mut u32,
+                ) -> c_void {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_physical_device_queue_family_performance_query_passes_khr)
+                    ))
+                }
+                let raw_name = stringify!(vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    get_physical_device_queue_family_performance_query_passes_khr
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            acquire_profiling_lock_khr: unsafe {
+                extern "system" fn acquire_profiling_lock_khr(
+                    _device: Device,
+                    _p_info: *const AcquireProfilingLockInfoKHR,
+                ) -> Result {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(acquire_profiling_lock_khr)
+                    ))
+                }
+                let raw_name = stringify!(vkAcquireProfilingLockKHR);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    acquire_profiling_lock_khr
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            release_profiling_lock_khr: unsafe {
+                extern "system" fn release_profiling_lock_khr(_device: Device) -> c_void {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(release_profiling_lock_khr)
+                    ))
+                }
+                let raw_name = stringify!(vkReleaseProfilingLockKHR);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    release_profiling_lock_khr
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+        }
     }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR.html>"]
+    pub unsafe fn enumerate_physical_device_queue_family_performance_query_counters_khr(
+        &self,
+        physical_device: PhysicalDevice,
+        queue_family_index: u32,
+        p_counter_count: *mut u32,
+        p_counters: *mut PerformanceCounterKHR,
+        p_counter_descriptions: *mut PerformanceCounterDescriptionKHR,
+    ) -> Result {
+        (self.enumerate_physical_device_queue_family_performance_query_counters_khr)(
+            physical_device,
+            queue_family_index,
+            p_counter_count,
+            p_counters,
+            p_counter_descriptions,
+        )
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR.html>"]
+    pub unsafe fn get_physical_device_queue_family_performance_query_passes_khr(
+        &self,
+        physical_device: PhysicalDevice,
+        p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
+        p_num_passes: *mut u32,
+    ) -> c_void {
+        (self.get_physical_device_queue_family_performance_query_passes_khr)(
+            physical_device,
+            p_performance_query_create_info,
+            p_num_passes,
+        )
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAcquireProfilingLockKHR.html>"]
+    pub unsafe fn acquire_profiling_lock_khr(
+        &self,
+        device: Device,
+        p_info: *const AcquireProfilingLockInfoKHR,
+    ) -> Result {
+        (self.acquire_profiling_lock_khr)(device, p_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkReleaseProfilingLockKHR.html>"]
+    pub unsafe fn release_profiling_lock_khr(&self, device: Device) -> c_void {
+        (self.release_profiling_lock_khr)(device)
+    }
+}
+#[doc = "Generated from \'VK_KHR_performance_query\'"]
+impl QueryType {
+    pub const PERFORMANCE_QUERY_KHR: Self = QueryType(1_000_116_000);
+}
+#[doc = "Generated from \'VK_KHR_performance_query\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR: Self = StructureType(1_000_116_000);
+}
+#[doc = "Generated from \'VK_KHR_performance_query\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR: Self = StructureType(1_000_116_001);
+}
+#[doc = "Generated from \'VK_KHR_performance_query\'"]
+impl StructureType {
+    pub const QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR: Self = StructureType(1_000_116_002);
+}
+#[doc = "Generated from \'VK_KHR_performance_query\'"]
+impl StructureType {
+    pub const PERFORMANCE_QUERY_SUBMIT_INFO_KHR: Self = StructureType(1_000_116_003);
+}
+#[doc = "Generated from \'VK_KHR_performance_query\'"]
+impl StructureType {
+    pub const ACQUIRE_PROFILING_LOCK_INFO_KHR: Self = StructureType(1_000_116_004);
+}
+#[doc = "Generated from \'VK_KHR_performance_query\'"]
+impl StructureType {
+    pub const PERFORMANCE_COUNTER_KHR: Self = StructureType(1_000_116_005);
+}
+#[doc = "Generated from \'VK_KHR_performance_query\'"]
+impl StructureType {
+    pub const PERFORMANCE_COUNTER_DESCRIPTION_KHR: Self = StructureType(1_000_116_006);
 }
 impl KhrMaintenance2Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -57642,19 +62357,6 @@ impl ExtSamplerFilterMinmaxFn {
         ExtSamplerFilterMinmaxFn {}
     }
 }
-#[doc = "Generated from \'VK_EXT_sampler_filter_minmax\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT: Self =
-        StructureType(1_000_130_000);
-}
-#[doc = "Generated from \'VK_EXT_sampler_filter_minmax\'"]
-impl StructureType {
-    pub const SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT: Self = StructureType(1_000_130_001);
-}
-#[doc = "Generated from \'VK_EXT_sampler_filter_minmax\'"]
-impl FormatFeatureFlags {
-    pub const SAMPLED_IMAGE_FILTER_MINMAX_EXT: Self = FormatFeatureFlags(0b1_0000_0000_0000_0000);
-}
 impl KhrStorageBufferStorageClassFn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_storage_buffer_storage_class\0")
@@ -58144,10 +62846,6 @@ impl KhrImageFormatListFn {
         KhrImageFormatListFn {}
     }
 }
-#[doc = "Generated from \'VK_KHR_image_format_list\'"]
-impl StructureType {
-    pub const IMAGE_FORMAT_LIST_CREATE_INFO_KHR: Self = StructureType(1_000_147_000);
-}
 impl ExtBlendOperationAdvancedFn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_blend_operation_advanced\0")
@@ -58420,6 +63118,30 @@ impl NvExtension151Fn {
     {
         NvExtension151Fn {}
     }
+}
+#[doc = "Generated from \'VK_NV_extension_151\'"]
+impl PipelineCreateFlags {
+    pub const EXTENSION_1510_NV: Self = PipelineCreateFlags(0b1000_0000_0000);
+}
+#[doc = "Generated from \'VK_NV_extension_151\'"]
+impl FormatFeatureFlags {
+    pub const RESERVED_29_NV: Self = FormatFeatureFlags(0b10_0000_0000_0000_0000_0000_0000_0000);
+}
+#[doc = "Generated from \'VK_NV_extension_151\'"]
+impl PipelineCreateFlags {
+    pub const EXTENSION_1511_NV: Self = PipelineCreateFlags(0b100_0000_0000_0000);
+}
+#[doc = "Generated from \'VK_NV_extension_151\'"]
+impl PipelineCreateFlags {
+    pub const EXTENSION_1512_NV: Self = PipelineCreateFlags(0b1000_0000_0000_0000);
+}
+#[doc = "Generated from \'VK_NV_extension_151\'"]
+impl PipelineCreateFlags {
+    pub const EXTENSION_1513_NV: Self = PipelineCreateFlags(0b1_0000_0000_0000_0000);
+}
+#[doc = "Generated from \'VK_NV_extension_151\'"]
+impl PipelineCreateFlags {
+    pub const EXTENSION_1514_NV: Self = PipelineCreateFlags(0b10_0000_0000_0000_0000);
 }
 impl NvExtension152Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -58965,42 +63687,6 @@ impl ExtDescriptorIndexingFn {
     {
         ExtDescriptorIndexingFn {}
     }
-}
-#[doc = "Generated from \'VK_EXT_descriptor_indexing\'"]
-impl StructureType {
-    pub const DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT: Self =
-        StructureType(1_000_161_000);
-}
-#[doc = "Generated from \'VK_EXT_descriptor_indexing\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT: Self = StructureType(1_000_161_001);
-}
-#[doc = "Generated from \'VK_EXT_descriptor_indexing\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT: Self =
-        StructureType(1_000_161_002);
-}
-#[doc = "Generated from \'VK_EXT_descriptor_indexing\'"]
-impl StructureType {
-    pub const DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT: Self =
-        StructureType(1_000_161_003);
-}
-#[doc = "Generated from \'VK_EXT_descriptor_indexing\'"]
-impl StructureType {
-    pub const DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT_EXT: Self =
-        StructureType(1_000_161_004);
-}
-#[doc = "Generated from \'VK_EXT_descriptor_indexing\'"]
-impl DescriptorPoolCreateFlags {
-    pub const UPDATE_AFTER_BIND_EXT: Self = DescriptorPoolCreateFlags(0b10);
-}
-#[doc = "Generated from \'VK_EXT_descriptor_indexing\'"]
-impl DescriptorSetLayoutCreateFlags {
-    pub const UPDATE_AFTER_BIND_POOL_EXT: Self = DescriptorSetLayoutCreateFlags(0b10);
-}
-#[doc = "Generated from \'VK_EXT_descriptor_indexing\'"]
-impl Result {
-    pub const ERROR_FRAGMENTATION_EXT: Self = Result(-1_000_161_000);
 }
 impl ExtShaderViewportIndexLayerFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -60142,54 +64828,12 @@ impl KhrDrawIndirectCountFn {
             .expect("Wrong extension string")
     }
 }
-#[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawIndirectCountKHR = extern "system" fn(
-    command_buffer: CommandBuffer,
-    buffer: Buffer,
-    offset: DeviceSize,
-    count_buffer: Buffer,
-    count_buffer_offset: DeviceSize,
-    max_draw_count: u32,
-    stride: u32,
-) -> c_void;
-#[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawIndexedIndirectCountKHR = extern "system" fn(
-    command_buffer: CommandBuffer,
-    buffer: Buffer,
-    offset: DeviceSize,
-    count_buffer: Buffer,
-    count_buffer_offset: DeviceSize,
-    max_draw_count: u32,
-    stride: u32,
-) -> c_void;
-pub struct KhrDrawIndirectCountFn {
-    pub cmd_draw_indirect_count_khr: extern "system" fn(
-        command_buffer: CommandBuffer,
-        buffer: Buffer,
-        offset: DeviceSize,
-        count_buffer: Buffer,
-        count_buffer_offset: DeviceSize,
-        max_draw_count: u32,
-        stride: u32,
-    ) -> c_void,
-    pub cmd_draw_indexed_indirect_count_khr: extern "system" fn(
-        command_buffer: CommandBuffer,
-        buffer: Buffer,
-        offset: DeviceSize,
-        count_buffer: Buffer,
-        count_buffer_offset: DeviceSize,
-        max_draw_count: u32,
-        stride: u32,
-    ) -> c_void,
-}
+pub struct KhrDrawIndirectCountFn {}
 unsafe impl Send for KhrDrawIndirectCountFn {}
 unsafe impl Sync for KhrDrawIndirectCountFn {}
 impl ::std::clone::Clone for KhrDrawIndirectCountFn {
     fn clone(&self) -> Self {
-        KhrDrawIndirectCountFn {
-            cmd_draw_indirect_count_khr: self.cmd_draw_indirect_count_khr,
-            cmd_draw_indexed_indirect_count_khr: self.cmd_draw_indexed_indirect_count_khr,
-        }
+        KhrDrawIndirectCountFn {}
     }
 }
 impl KhrDrawIndirectCountFn {
@@ -60197,98 +64841,7 @@ impl KhrDrawIndirectCountFn {
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        KhrDrawIndirectCountFn {
-            cmd_draw_indirect_count_khr: unsafe {
-                extern "system" fn cmd_draw_indirect_count_khr(
-                    _command_buffer: CommandBuffer,
-                    _buffer: Buffer,
-                    _offset: DeviceSize,
-                    _count_buffer: Buffer,
-                    _count_buffer_offset: DeviceSize,
-                    _max_draw_count: u32,
-                    _stride: u32,
-                ) -> c_void {
-                    panic!(concat!(
-                        "Unable to load ",
-                        stringify!(cmd_draw_indirect_count_khr)
-                    ))
-                }
-                let raw_name = stringify!(vkCmdDrawIndirectCountKHR);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
-                if val.is_null() {
-                    cmd_draw_indirect_count_khr
-                } else {
-                    ::std::mem::transmute(val)
-                }
-            },
-            cmd_draw_indexed_indirect_count_khr: unsafe {
-                extern "system" fn cmd_draw_indexed_indirect_count_khr(
-                    _command_buffer: CommandBuffer,
-                    _buffer: Buffer,
-                    _offset: DeviceSize,
-                    _count_buffer: Buffer,
-                    _count_buffer_offset: DeviceSize,
-                    _max_draw_count: u32,
-                    _stride: u32,
-                ) -> c_void {
-                    panic!(concat!(
-                        "Unable to load ",
-                        stringify!(cmd_draw_indexed_indirect_count_khr)
-                    ))
-                }
-                let raw_name = stringify!(vkCmdDrawIndexedIndirectCountKHR);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
-                if val.is_null() {
-                    cmd_draw_indexed_indirect_count_khr
-                } else {
-                    ::std::mem::transmute(val)
-                }
-            },
-        }
-    }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndirectCountKHR.html>"]
-    pub unsafe fn cmd_draw_indirect_count_khr(
-        &self,
-        command_buffer: CommandBuffer,
-        buffer: Buffer,
-        offset: DeviceSize,
-        count_buffer: Buffer,
-        count_buffer_offset: DeviceSize,
-        max_draw_count: u32,
-        stride: u32,
-    ) -> c_void {
-        (self.cmd_draw_indirect_count_khr)(
-            command_buffer,
-            buffer,
-            offset,
-            count_buffer,
-            count_buffer_offset,
-            max_draw_count,
-            stride,
-        )
-    }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndexedIndirectCountKHR.html>"]
-    pub unsafe fn cmd_draw_indexed_indirect_count_khr(
-        &self,
-        command_buffer: CommandBuffer,
-        buffer: Buffer,
-        offset: DeviceSize,
-        count_buffer: Buffer,
-        count_buffer_offset: DeviceSize,
-        max_draw_count: u32,
-        stride: u32,
-    ) -> c_void {
-        (self.cmd_draw_indexed_indirect_count_khr)(
-            command_buffer,
-            buffer,
-            offset,
-            count_buffer,
-            count_buffer_offset,
-            max_draw_count,
-            stride,
-        )
+        KhrDrawIndirectCountFn {}
     }
 }
 impl ExtFilterCubicFn {
@@ -60374,6 +64927,18 @@ impl QcomExtension173Fn {
         QcomExtension173Fn {}
     }
 }
+#[doc = "Generated from \'VK_QCOM_extension_173\'"]
+impl BufferUsageFlags {
+    pub const RESERVED_18_QCOM: Self = BufferUsageFlags(0b100_0000_0000_0000_0000);
+}
+#[doc = "Generated from \'VK_QCOM_extension_173\'"]
+impl ImageUsageFlags {
+    pub const RESERVED_16_QCOM: Self = ImageUsageFlags(0b1_0000_0000_0000_0000);
+}
+#[doc = "Generated from \'VK_QCOM_extension_173\'"]
+impl ImageUsageFlags {
+    pub const RESERVED_17_QCOM: Self = ImageUsageFlags(0b10_0000_0000_0000_0000);
+}
 impl QcomExtension174Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_QCOM_extension_174\0")
@@ -60426,26 +64991,26 @@ impl StructureType {
 impl Result {
     pub const ERROR_NOT_PERMITTED_EXT: Self = Result(-1_000_174_001);
 }
-impl ExtExtension176Fn {
+impl KhrShaderSubgroupExtendedTypesFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_extension_176\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_shader_subgroup_extended_types\0")
             .expect("Wrong extension string")
     }
 }
-pub struct ExtExtension176Fn {}
-unsafe impl Send for ExtExtension176Fn {}
-unsafe impl Sync for ExtExtension176Fn {}
-impl ::std::clone::Clone for ExtExtension176Fn {
+pub struct KhrShaderSubgroupExtendedTypesFn {}
+unsafe impl Send for KhrShaderSubgroupExtendedTypesFn {}
+unsafe impl Sync for KhrShaderSubgroupExtendedTypesFn {}
+impl ::std::clone::Clone for KhrShaderSubgroupExtendedTypesFn {
     fn clone(&self) -> Self {
-        ExtExtension176Fn {}
+        KhrShaderSubgroupExtendedTypesFn {}
     }
 }
-impl ExtExtension176Fn {
+impl KhrShaderSubgroupExtendedTypesFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        ExtExtension176Fn {}
+        KhrShaderSubgroupExtendedTypesFn {}
     }
 }
 impl ExtExtension177Fn {
@@ -60491,10 +65056,6 @@ impl Khr8bitStorageFn {
     {
         Khr8bitStorageFn {}
     }
-}
-#[doc = "Generated from \'VK_KHR_8bit_storage\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR: Self = StructureType(1_000_177_000);
 }
 impl ExtExternalMemoryHostFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -60696,31 +65257,31 @@ impl KhrShaderAtomicInt64Fn {
         KhrShaderAtomicInt64Fn {}
     }
 }
-#[doc = "Generated from \'VK_KHR_shader_atomic_int64\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR: Self = StructureType(1_000_180_000);
-}
-impl AmdExtension182Fn {
+impl KhrShaderClockFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_AMD_extension_182\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_shader_clock\0")
             .expect("Wrong extension string")
     }
 }
-pub struct AmdExtension182Fn {}
-unsafe impl Send for AmdExtension182Fn {}
-unsafe impl Sync for AmdExtension182Fn {}
-impl ::std::clone::Clone for AmdExtension182Fn {
+pub struct KhrShaderClockFn {}
+unsafe impl Send for KhrShaderClockFn {}
+unsafe impl Sync for KhrShaderClockFn {}
+impl ::std::clone::Clone for KhrShaderClockFn {
     fn clone(&self) -> Self {
-        AmdExtension182Fn {}
+        KhrShaderClockFn {}
     }
 }
-impl AmdExtension182Fn {
+impl KhrShaderClockFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        AmdExtension182Fn {}
+        KhrShaderClockFn {}
     }
+}
+#[doc = "Generated from \'VK_KHR_shader_clock\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR: Self = StructureType(1_000_181_000);
 }
 impl AmdExtension183Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -60744,27 +65305,31 @@ impl AmdExtension183Fn {
         AmdExtension183Fn {}
     }
 }
-impl AmdExtension184Fn {
+impl AmdPipelineCompilerControlFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_AMD_extension_184\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_AMD_pipeline_compiler_control\0")
             .expect("Wrong extension string")
     }
 }
-pub struct AmdExtension184Fn {}
-unsafe impl Send for AmdExtension184Fn {}
-unsafe impl Sync for AmdExtension184Fn {}
-impl ::std::clone::Clone for AmdExtension184Fn {
+pub struct AmdPipelineCompilerControlFn {}
+unsafe impl Send for AmdPipelineCompilerControlFn {}
+unsafe impl Sync for AmdPipelineCompilerControlFn {}
+impl ::std::clone::Clone for AmdPipelineCompilerControlFn {
     fn clone(&self) -> Self {
-        AmdExtension184Fn {}
+        AmdPipelineCompilerControlFn {}
     }
 }
-impl AmdExtension184Fn {
+impl AmdPipelineCompilerControlFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        AmdExtension184Fn {}
+        AmdPipelineCompilerControlFn {}
     }
+}
+#[doc = "Generated from \'VK_AMD_pipeline_compiler_control\'"]
+impl StructureType {
+    pub const PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD: Self = StructureType(1_000_183_000);
 }
 impl ExtCalibratedTimestampsFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -61191,10 +65756,6 @@ impl KhrDriverPropertiesFn {
         KhrDriverPropertiesFn {}
     }
 }
-#[doc = "Generated from \'VK_KHR_driver_properties\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR: Self = StructureType(1_000_196_000);
-}
 impl KhrShaderFloatControlsFn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_shader_float_controls\0")
@@ -61216,10 +65777,6 @@ impl KhrShaderFloatControlsFn {
     {
         KhrShaderFloatControlsFn {}
     }
-}
-#[doc = "Generated from \'VK_KHR_shader_float_controls\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR: Self = StructureType(1_000_197_000);
 }
 impl NvShaderSubgroupPartitionedFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -61268,15 +65825,6 @@ impl KhrDepthStencilResolveFn {
     {
         KhrDepthStencilResolveFn {}
     }
-}
-#[doc = "Generated from \'VK_KHR_depth_stencil_resolve\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES_KHR: Self =
-        StructureType(1_000_199_000);
-}
-#[doc = "Generated from \'VK_KHR_depth_stencil_resolve\'"]
-impl StructureType {
-    pub const SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE_KHR: Self = StructureType(1_000_199_001);
 }
 impl KhrSwapchainMutableFormatFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -61783,26 +66331,26 @@ impl StructureType {
 impl StructureType {
     pub const QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV: Self = StructureType(1_000_206_001);
 }
-impl KhrExtension208Fn {
+impl KhrTimelineSemaphoreFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_extension_208\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_timeline_semaphore\0")
             .expect("Wrong extension string")
     }
 }
-pub struct KhrExtension208Fn {}
-unsafe impl Send for KhrExtension208Fn {}
-unsafe impl Sync for KhrExtension208Fn {}
-impl ::std::clone::Clone for KhrExtension208Fn {
+pub struct KhrTimelineSemaphoreFn {}
+unsafe impl Send for KhrTimelineSemaphoreFn {}
+unsafe impl Sync for KhrTimelineSemaphoreFn {}
+impl ::std::clone::Clone for KhrTimelineSemaphoreFn {
     fn clone(&self) -> Self {
-        KhrExtension208Fn {}
+        KhrTimelineSemaphoreFn {}
     }
 }
-impl KhrExtension208Fn {
+impl KhrTimelineSemaphoreFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        KhrExtension208Fn {}
+        KhrTimelineSemaphoreFn {}
     }
 }
 impl KhrExtension209Fn {
@@ -62254,10 +66802,6 @@ impl KhrVulkanMemoryModelFn {
         KhrVulkanMemoryModelFn {}
     }
 }
-#[doc = "Generated from \'VK_KHR_vulkan_memory_model\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR: Self = StructureType(1_000_211_000);
-}
 impl ExtPciBusInfoFn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_pci_bus_info\0")
@@ -62698,10 +67242,6 @@ impl ExtScalarBlockLayoutFn {
         ExtScalarBlockLayoutFn {}
     }
 }
-#[doc = "Generated from \'VK_EXT_scalar_block_layout\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT: Self = StructureType(1_000_221_000);
-}
 impl ExtExtension223Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_extension_223\0")
@@ -62801,6 +67341,11 @@ impl StructureType {
         StructureType(1_000_225_001);
 }
 #[doc = "Generated from \'VK_EXT_subgroup_size_control\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT: Self =
+        StructureType(1_000_225_002);
+}
+#[doc = "Generated from \'VK_EXT_subgroup_size_control\'"]
 impl PipelineShaderStageCreateFlags {
     pub const ALLOW_VARYING_SUBGROUP_SIZE_EXT: Self = PipelineShaderStageCreateFlags(0b1);
 }
@@ -62830,27 +67375,31 @@ impl AmdExtension227Fn {
         AmdExtension227Fn {}
     }
 }
-impl AmdExtension228Fn {
+impl AmdShaderCoreProperties2Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_AMD_extension_228\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_AMD_shader_core_properties2\0")
             .expect("Wrong extension string")
     }
 }
-pub struct AmdExtension228Fn {}
-unsafe impl Send for AmdExtension228Fn {}
-unsafe impl Sync for AmdExtension228Fn {}
-impl ::std::clone::Clone for AmdExtension228Fn {
+pub struct AmdShaderCoreProperties2Fn {}
+unsafe impl Send for AmdShaderCoreProperties2Fn {}
+unsafe impl Sync for AmdShaderCoreProperties2Fn {}
+impl ::std::clone::Clone for AmdShaderCoreProperties2Fn {
     fn clone(&self) -> Self {
-        AmdExtension228Fn {}
+        AmdShaderCoreProperties2Fn {}
     }
 }
-impl AmdExtension228Fn {
+impl AmdShaderCoreProperties2Fn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        AmdExtension228Fn {}
+        AmdShaderCoreProperties2Fn {}
     }
+}
+#[doc = "Generated from \'VK_AMD_shader_core_properties2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD: Self = StructureType(1_000_227_000);
 }
 impl AmdExtension229Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -62874,27 +67423,39 @@ impl AmdExtension229Fn {
         AmdExtension229Fn {}
     }
 }
-impl AmdExtension230Fn {
+impl AmdDeviceCoherentMemoryFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_AMD_extension_230\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_AMD_device_coherent_memory\0")
             .expect("Wrong extension string")
     }
 }
-pub struct AmdExtension230Fn {}
-unsafe impl Send for AmdExtension230Fn {}
-unsafe impl Sync for AmdExtension230Fn {}
-impl ::std::clone::Clone for AmdExtension230Fn {
+pub struct AmdDeviceCoherentMemoryFn {}
+unsafe impl Send for AmdDeviceCoherentMemoryFn {}
+unsafe impl Sync for AmdDeviceCoherentMemoryFn {}
+impl ::std::clone::Clone for AmdDeviceCoherentMemoryFn {
     fn clone(&self) -> Self {
-        AmdExtension230Fn {}
+        AmdDeviceCoherentMemoryFn {}
     }
 }
-impl AmdExtension230Fn {
+impl AmdDeviceCoherentMemoryFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        AmdExtension230Fn {}
+        AmdDeviceCoherentMemoryFn {}
     }
+}
+#[doc = "Generated from \'VK_AMD_device_coherent_memory\'"]
+impl MemoryPropertyFlags {
+    pub const DEVICE_COHERENT_AMD: Self = MemoryPropertyFlags(0b100_0000);
+}
+#[doc = "Generated from \'VK_AMD_device_coherent_memory\'"]
+impl MemoryPropertyFlags {
+    pub const DEVICE_UNCACHED_AMD: Self = MemoryPropertyFlags(0b1000_0000);
+}
+#[doc = "Generated from \'VK_AMD_device_coherent_memory\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD: Self = StructureType(1_000_229_000);
 }
 impl AmdExtension231Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -63028,26 +67589,26 @@ impl AmdExtension236Fn {
         AmdExtension236Fn {}
     }
 }
-impl KhrExtension237Fn {
+impl KhrSpirv14Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_extension_237\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_spirv_1_4\0")
             .expect("Wrong extension string")
     }
 }
-pub struct KhrExtension237Fn {}
-unsafe impl Send for KhrExtension237Fn {}
-unsafe impl Sync for KhrExtension237Fn {}
-impl ::std::clone::Clone for KhrExtension237Fn {
+pub struct KhrSpirv14Fn {}
+unsafe impl Send for KhrSpirv14Fn {}
+unsafe impl Sync for KhrSpirv14Fn {}
+impl ::std::clone::Clone for KhrSpirv14Fn {
     fn clone(&self) -> Self {
-        KhrExtension237Fn {}
+        KhrSpirv14Fn {}
     }
 }
-impl KhrExtension237Fn {
+impl KhrSpirv14Fn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        KhrExtension237Fn {}
+        KhrSpirv14Fn {}
     }
 }
 impl ExtMemoryBudgetFn {
@@ -63159,26 +67720,26 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV: Self =
         StructureType(1_000_240_000);
 }
-impl NvExtension242Fn {
+impl KhrSeparateDepthStencilLayoutsFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_NV_extension_242\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_separate_depth_stencil_layouts\0")
             .expect("Wrong extension string")
     }
 }
-pub struct NvExtension242Fn {}
-unsafe impl Send for NvExtension242Fn {}
-unsafe impl Sync for NvExtension242Fn {}
-impl ::std::clone::Clone for NvExtension242Fn {
+pub struct KhrSeparateDepthStencilLayoutsFn {}
+unsafe impl Send for KhrSeparateDepthStencilLayoutsFn {}
+unsafe impl Sync for KhrSeparateDepthStencilLayoutsFn {}
+impl ::std::clone::Clone for KhrSeparateDepthStencilLayoutsFn {
     fn clone(&self) -> Self {
-        NvExtension242Fn {}
+        KhrSeparateDepthStencilLayoutsFn {}
     }
 }
-impl NvExtension242Fn {
+impl KhrSeparateDepthStencilLayoutsFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        NvExtension242Fn {}
+        KhrSeparateDepthStencilLayoutsFn {}
     }
 }
 impl IntelExtension243Fn {
@@ -63231,22 +67792,12 @@ impl ExtBufferDeviceAddressFn {
             .expect("Wrong extension string")
     }
 }
-#[allow(non_camel_case_types)]
-pub type PFN_vkGetBufferDeviceAddressEXT =
-    extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfoEXT) -> DeviceAddress;
-pub struct ExtBufferDeviceAddressFn {
-    pub get_buffer_device_address_ext: extern "system" fn(
-        device: Device,
-        p_info: *const BufferDeviceAddressInfoEXT,
-    ) -> DeviceAddress,
-}
+pub struct ExtBufferDeviceAddressFn {}
 unsafe impl Send for ExtBufferDeviceAddressFn {}
 unsafe impl Sync for ExtBufferDeviceAddressFn {}
 impl ::std::clone::Clone for ExtBufferDeviceAddressFn {
     fn clone(&self) -> Self {
-        ExtBufferDeviceAddressFn {
-            get_buffer_device_address_ext: self.get_buffer_device_address_ext,
-        }
+        ExtBufferDeviceAddressFn {}
     }
 }
 impl ExtBufferDeviceAddressFn {
@@ -63254,35 +67805,7 @@ impl ExtBufferDeviceAddressFn {
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        ExtBufferDeviceAddressFn {
-            get_buffer_device_address_ext: unsafe {
-                extern "system" fn get_buffer_device_address_ext(
-                    _device: Device,
-                    _p_info: *const BufferDeviceAddressInfoEXT,
-                ) -> DeviceAddress {
-                    panic!(concat!(
-                        "Unable to load ",
-                        stringify!(get_buffer_device_address_ext)
-                    ))
-                }
-                let raw_name = stringify!(vkGetBufferDeviceAddressEXT);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
-                if val.is_null() {
-                    get_buffer_device_address_ext
-                } else {
-                    ::std::mem::transmute(val)
-                }
-            },
-        }
-    }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetBufferDeviceAddressEXT.html>"]
-    pub unsafe fn get_buffer_device_address_ext(
-        &self,
-        device: Device,
-        p_info: *const BufferDeviceAddressInfoEXT,
-    ) -> DeviceAddress {
-        (self.get_buffer_device_address_ext)(device, p_info)
+        ExtBufferDeviceAddressFn {}
     }
 }
 #[doc = "Generated from \'VK_EXT_buffer_device_address\'"]
@@ -63292,45 +67815,89 @@ impl StructureType {
 }
 #[doc = "Generated from \'VK_EXT_buffer_device_address\'"]
 impl StructureType {
-    pub const BUFFER_DEVICE_ADDRESS_INFO_EXT: Self = StructureType(1_000_244_001);
-}
-#[doc = "Generated from \'VK_EXT_buffer_device_address\'"]
-impl StructureType {
     pub const BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT: Self = StructureType(1_000_244_002);
 }
-#[doc = "Generated from \'VK_EXT_buffer_device_address\'"]
-impl BufferUsageFlags {
-    pub const SHADER_DEVICE_ADDRESS_EXT: Self = BufferUsageFlags(0b10_0000_0000_0000_0000);
-}
-#[doc = "Generated from \'VK_EXT_buffer_device_address\'"]
-impl BufferCreateFlags {
-    pub const DEVICE_ADDRESS_CAPTURE_REPLAY_EXT: Self = BufferCreateFlags(0b1_0000);
-}
-#[doc = "Generated from \'VK_EXT_buffer_device_address\'"]
-impl Result {
-    pub const ERROR_INVALID_DEVICE_ADDRESS_EXT: Self = Result(-1_000_244_000);
-}
-impl ExtExtension246Fn {
+impl ExtToolingInfoFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_extension_246\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_tooling_info\0")
             .expect("Wrong extension string")
     }
 }
-pub struct ExtExtension246Fn {}
-unsafe impl Send for ExtExtension246Fn {}
-unsafe impl Sync for ExtExtension246Fn {}
-impl ::std::clone::Clone for ExtExtension246Fn {
+#[allow(non_camel_case_types)]
+pub type PFN_vkGetPhysicalDeviceToolPropertiesEXT = extern "system" fn(
+    physical_device: PhysicalDevice,
+    p_tool_count: *mut u32,
+    p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
+) -> Result;
+pub struct ExtToolingInfoFn {
+    pub get_physical_device_tool_properties_ext: extern "system" fn(
+        physical_device: PhysicalDevice,
+        p_tool_count: *mut u32,
+        p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
+    ) -> Result,
+}
+unsafe impl Send for ExtToolingInfoFn {}
+unsafe impl Sync for ExtToolingInfoFn {}
+impl ::std::clone::Clone for ExtToolingInfoFn {
     fn clone(&self) -> Self {
-        ExtExtension246Fn {}
+        ExtToolingInfoFn {
+            get_physical_device_tool_properties_ext: self.get_physical_device_tool_properties_ext,
+        }
     }
 }
-impl ExtExtension246Fn {
+impl ExtToolingInfoFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        ExtExtension246Fn {}
+        ExtToolingInfoFn {
+            get_physical_device_tool_properties_ext: unsafe {
+                extern "system" fn get_physical_device_tool_properties_ext(
+                    _physical_device: PhysicalDevice,
+                    _p_tool_count: *mut u32,
+                    _p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
+                ) -> Result {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_physical_device_tool_properties_ext)
+                    ))
+                }
+                let raw_name = stringify!(vkGetPhysicalDeviceToolPropertiesEXT);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    get_physical_device_tool_properties_ext
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+        }
     }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceToolPropertiesEXT.html>"]
+    pub unsafe fn get_physical_device_tool_properties_ext(
+        &self,
+        physical_device: PhysicalDevice,
+        p_tool_count: *mut u32,
+        p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
+    ) -> Result {
+        (self.get_physical_device_tool_properties_ext)(
+            physical_device,
+            p_tool_count,
+            p_tool_properties,
+        )
+    }
+}
+#[doc = "Generated from \'VK_EXT_tooling_info\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT: Self = StructureType(1_000_245_000);
+}
+#[doc = "Generated from \'VK_EXT_tooling_info\'"]
+impl ToolPurposeFlagsEXT {
+    pub const DEBUG_REPORTING: Self = ToolPurposeFlagsEXT(0b10_0000);
+}
+#[doc = "Generated from \'VK_EXT_tooling_info\'"]
+impl ToolPurposeFlagsEXT {
+    pub const DEBUG_MARKERS: Self = ToolPurposeFlagsEXT(0b100_0000);
 }
 impl ExtSeparateStencilUsageFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -63353,10 +67920,6 @@ impl ExtSeparateStencilUsageFn {
     {
         ExtSeparateStencilUsageFn {}
     }
-}
-#[doc = "Generated from \'VK_EXT_separate_stencil_usage\'"]
-impl StructureType {
-    pub const IMAGE_STENCIL_USAGE_CREATE_INFO_EXT: Self = StructureType(1_000_246_000);
 }
 impl ExtValidationFeaturesFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -63652,11 +68215,6 @@ impl KhrUniformBufferStandardLayoutFn {
     {
         KhrUniformBufferStandardLayoutFn {}
     }
-}
-#[doc = "Generated from \'VK_KHR_uniform_buffer_standard_layout\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR: Self =
-        StructureType(1_000_253_000);
 }
 impl ExtExtension255Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -63954,26 +68512,26 @@ impl ExtHeadlessSurfaceFn {
 impl StructureType {
     pub const HEADLESS_SURFACE_CREATE_INFO_EXT: Self = StructureType(1_000_256_000);
 }
-impl ExtExtension258Fn {
+impl KhrBufferDeviceAddressFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_extension_258\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_buffer_device_address\0")
             .expect("Wrong extension string")
     }
 }
-pub struct ExtExtension258Fn {}
-unsafe impl Send for ExtExtension258Fn {}
-unsafe impl Sync for ExtExtension258Fn {}
-impl ::std::clone::Clone for ExtExtension258Fn {
+pub struct KhrBufferDeviceAddressFn {}
+unsafe impl Send for KhrBufferDeviceAddressFn {}
+unsafe impl Sync for KhrBufferDeviceAddressFn {}
+impl ::std::clone::Clone for KhrBufferDeviceAddressFn {
     fn clone(&self) -> Self {
-        ExtExtension258Fn {}
+        KhrBufferDeviceAddressFn {}
     }
 }
-impl ExtExtension258Fn {
+impl KhrBufferDeviceAddressFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        ExtExtension258Fn {}
+        KhrBufferDeviceAddressFn {}
     }
 }
 impl ExtExtension259Fn {
@@ -64110,28 +68668,12 @@ impl ExtHostQueryResetFn {
             .expect("Wrong extension string")
     }
 }
-#[allow(non_camel_case_types)]
-pub type PFN_vkResetQueryPoolEXT = extern "system" fn(
-    device: Device,
-    query_pool: QueryPool,
-    first_query: u32,
-    query_count: u32,
-) -> c_void;
-pub struct ExtHostQueryResetFn {
-    pub reset_query_pool_ext: extern "system" fn(
-        device: Device,
-        query_pool: QueryPool,
-        first_query: u32,
-        query_count: u32,
-    ) -> c_void,
-}
+pub struct ExtHostQueryResetFn {}
 unsafe impl Send for ExtHostQueryResetFn {}
 unsafe impl Sync for ExtHostQueryResetFn {}
 impl ::std::clone::Clone for ExtHostQueryResetFn {
     fn clone(&self) -> Self {
-        ExtHostQueryResetFn {
-            reset_query_pool_ext: self.reset_query_pool_ext,
-        }
+        ExtHostQueryResetFn {}
     }
 }
 impl ExtHostQueryResetFn {
@@ -64139,41 +68681,8 @@ impl ExtHostQueryResetFn {
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        ExtHostQueryResetFn {
-            reset_query_pool_ext: unsafe {
-                extern "system" fn reset_query_pool_ext(
-                    _device: Device,
-                    _query_pool: QueryPool,
-                    _first_query: u32,
-                    _query_count: u32,
-                ) -> c_void {
-                    panic!(concat!("Unable to load ", stringify!(reset_query_pool_ext)))
-                }
-                let raw_name = stringify!(vkResetQueryPoolEXT);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
-                if val.is_null() {
-                    reset_query_pool_ext
-                } else {
-                    ::std::mem::transmute(val)
-                }
-            },
-        }
+        ExtHostQueryResetFn {}
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkResetQueryPoolEXT.html>"]
-    pub unsafe fn reset_query_pool_ext(
-        &self,
-        device: Device,
-        query_pool: QueryPool,
-        first_query: u32,
-        query_count: u32,
-    ) -> c_void {
-        (self.reset_query_pool_ext)(device, query_pool, first_query, query_count)
-    }
-}
-#[doc = "Generated from \'VK_EXT_host_query_reset\'"]
-impl StructureType {
-    pub const PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT: Self = StructureType(1_000_261_000);
 }
 impl GgpExtension263Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -64337,27 +68846,214 @@ impl KhrExtension269Fn {
         KhrExtension269Fn {}
     }
 }
-impl IntelExtension270Fn {
+impl KhrPipelineExecutablePropertiesFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        ::std::ffi::CStr::from_bytes_with_nul(b"VK_INTEL_extension_270\0")
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_pipeline_executable_properties\0")
             .expect("Wrong extension string")
     }
 }
-pub struct IntelExtension270Fn {}
-unsafe impl Send for IntelExtension270Fn {}
-unsafe impl Sync for IntelExtension270Fn {}
-impl ::std::clone::Clone for IntelExtension270Fn {
+#[allow(non_camel_case_types)]
+pub type PFN_vkGetPipelineExecutablePropertiesKHR = extern "system" fn(
+    device: Device,
+    p_pipeline_info: *const PipelineInfoKHR,
+    p_executable_count: *mut u32,
+    p_properties: *mut PipelineExecutablePropertiesKHR,
+) -> Result;
+#[allow(non_camel_case_types)]
+pub type PFN_vkGetPipelineExecutableStatisticsKHR = extern "system" fn(
+    device: Device,
+    p_executable_info: *const PipelineExecutableInfoKHR,
+    p_statistic_count: *mut u32,
+    p_statistics: *mut PipelineExecutableStatisticKHR,
+) -> Result;
+#[allow(non_camel_case_types)]
+pub type PFN_vkGetPipelineExecutableInternalRepresentationsKHR = extern "system" fn(
+    device: Device,
+    p_executable_info: *const PipelineExecutableInfoKHR,
+    p_internal_representation_count: *mut u32,
+    p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR,
+) -> Result;
+pub struct KhrPipelineExecutablePropertiesFn {
+    pub get_pipeline_executable_properties_khr: extern "system" fn(
+        device: Device,
+        p_pipeline_info: *const PipelineInfoKHR,
+        p_executable_count: *mut u32,
+        p_properties: *mut PipelineExecutablePropertiesKHR,
+    ) -> Result,
+    pub get_pipeline_executable_statistics_khr: extern "system" fn(
+        device: Device,
+        p_executable_info: *const PipelineExecutableInfoKHR,
+        p_statistic_count: *mut u32,
+        p_statistics: *mut PipelineExecutableStatisticKHR,
+    ) -> Result,
+    pub get_pipeline_executable_internal_representations_khr: extern "system" fn(
+        device: Device,
+        p_executable_info: *const PipelineExecutableInfoKHR,
+        p_internal_representation_count: *mut u32,
+        p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR,
+    ) -> Result,
+}
+unsafe impl Send for KhrPipelineExecutablePropertiesFn {}
+unsafe impl Sync for KhrPipelineExecutablePropertiesFn {}
+impl ::std::clone::Clone for KhrPipelineExecutablePropertiesFn {
     fn clone(&self) -> Self {
-        IntelExtension270Fn {}
+        KhrPipelineExecutablePropertiesFn {
+            get_pipeline_executable_properties_khr: self.get_pipeline_executable_properties_khr,
+            get_pipeline_executable_statistics_khr: self.get_pipeline_executable_statistics_khr,
+            get_pipeline_executable_internal_representations_khr: self
+                .get_pipeline_executable_internal_representations_khr,
+        }
     }
 }
-impl IntelExtension270Fn {
+impl KhrPipelineExecutablePropertiesFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
-        IntelExtension270Fn {}
+        KhrPipelineExecutablePropertiesFn {
+            get_pipeline_executable_properties_khr: unsafe {
+                extern "system" fn get_pipeline_executable_properties_khr(
+                    _device: Device,
+                    _p_pipeline_info: *const PipelineInfoKHR,
+                    _p_executable_count: *mut u32,
+                    _p_properties: *mut PipelineExecutablePropertiesKHR,
+                ) -> Result {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_pipeline_executable_properties_khr)
+                    ))
+                }
+                let raw_name = stringify!(vkGetPipelineExecutablePropertiesKHR);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    get_pipeline_executable_properties_khr
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_pipeline_executable_statistics_khr: unsafe {
+                extern "system" fn get_pipeline_executable_statistics_khr(
+                    _device: Device,
+                    _p_executable_info: *const PipelineExecutableInfoKHR,
+                    _p_statistic_count: *mut u32,
+                    _p_statistics: *mut PipelineExecutableStatisticKHR,
+                ) -> Result {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_pipeline_executable_statistics_khr)
+                    ))
+                }
+                let raw_name = stringify!(vkGetPipelineExecutableStatisticsKHR);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    get_pipeline_executable_statistics_khr
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_pipeline_executable_internal_representations_khr: unsafe {
+                extern "system" fn get_pipeline_executable_internal_representations_khr(
+                    _device: Device,
+                    _p_executable_info: *const PipelineExecutableInfoKHR,
+                    _p_internal_representation_count: *mut u32,
+                    _p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR,
+                ) -> Result {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_pipeline_executable_internal_representations_khr)
+                    ))
+                }
+                let raw_name = stringify!(vkGetPipelineExecutableInternalRepresentationsKHR);
+                let cname = ::std::ffi::CString::new(raw_name).unwrap();
+                let val = _f(&cname);
+                if val.is_null() {
+                    get_pipeline_executable_internal_representations_khr
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+        }
     }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPipelineExecutablePropertiesKHR.html>"]
+    pub unsafe fn get_pipeline_executable_properties_khr(
+        &self,
+        device: Device,
+        p_pipeline_info: *const PipelineInfoKHR,
+        p_executable_count: *mut u32,
+        p_properties: *mut PipelineExecutablePropertiesKHR,
+    ) -> Result {
+        (self.get_pipeline_executable_properties_khr)(
+            device,
+            p_pipeline_info,
+            p_executable_count,
+            p_properties,
+        )
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPipelineExecutableStatisticsKHR.html>"]
+    pub unsafe fn get_pipeline_executable_statistics_khr(
+        &self,
+        device: Device,
+        p_executable_info: *const PipelineExecutableInfoKHR,
+        p_statistic_count: *mut u32,
+        p_statistics: *mut PipelineExecutableStatisticKHR,
+    ) -> Result {
+        (self.get_pipeline_executable_statistics_khr)(
+            device,
+            p_executable_info,
+            p_statistic_count,
+            p_statistics,
+        )
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPipelineExecutableInternalRepresentationsKHR.html>"]
+    pub unsafe fn get_pipeline_executable_internal_representations_khr(
+        &self,
+        device: Device,
+        p_executable_info: *const PipelineExecutableInfoKHR,
+        p_internal_representation_count: *mut u32,
+        p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR,
+    ) -> Result {
+        (self.get_pipeline_executable_internal_representations_khr)(
+            device,
+            p_executable_info,
+            p_internal_representation_count,
+            p_internal_representations,
+        )
+    }
+}
+#[doc = "Generated from \'VK_KHR_pipeline_executable_properties\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR: Self =
+        StructureType(1_000_269_000);
+}
+#[doc = "Generated from \'VK_KHR_pipeline_executable_properties\'"]
+impl StructureType {
+    pub const PIPELINE_INFO_KHR: Self = StructureType(1_000_269_001);
+}
+#[doc = "Generated from \'VK_KHR_pipeline_executable_properties\'"]
+impl StructureType {
+    pub const PIPELINE_EXECUTABLE_PROPERTIES_KHR: Self = StructureType(1_000_269_002);
+}
+#[doc = "Generated from \'VK_KHR_pipeline_executable_properties\'"]
+impl StructureType {
+    pub const PIPELINE_EXECUTABLE_INFO_KHR: Self = StructureType(1_000_269_003);
+}
+#[doc = "Generated from \'VK_KHR_pipeline_executable_properties\'"]
+impl StructureType {
+    pub const PIPELINE_EXECUTABLE_STATISTIC_KHR: Self = StructureType(1_000_269_004);
+}
+#[doc = "Generated from \'VK_KHR_pipeline_executable_properties\'"]
+impl StructureType {
+    pub const PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR: Self = StructureType(1_000_269_005);
+}
+#[doc = "Generated from \'VK_KHR_pipeline_executable_properties\'"]
+impl PipelineCreateFlags {
+    pub const CAPTURE_STATISTICS_KHR: Self = PipelineCreateFlags(0b100_0000);
+}
+#[doc = "Generated from \'VK_KHR_pipeline_executable_properties\'"]
+impl PipelineCreateFlags {
+    pub const CAPTURE_INTERNAL_REPRESENTATIONS_KHR: Self = PipelineCreateFlags(0b1000_0000);
 }
 impl IntelExtension271Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -64729,6 +69425,544 @@ impl ExtExtension286Fn {
     {
         ExtExtension286Fn {}
     }
+}
+impl NvxExtension287Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_NVX_extension_287\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct NvxExtension287Fn {}
+unsafe impl Send for NvxExtension287Fn {}
+unsafe impl Sync for NvxExtension287Fn {}
+impl ::std::clone::Clone for NvxExtension287Fn {
+    fn clone(&self) -> Self {
+        NvxExtension287Fn {}
+    }
+}
+impl NvxExtension287Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        NvxExtension287Fn {}
+    }
+}
+impl NvxExtension288Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_NVX_extension_288\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct NvxExtension288Fn {}
+unsafe impl Send for NvxExtension288Fn {}
+unsafe impl Sync for NvxExtension288Fn {}
+impl ::std::clone::Clone for NvxExtension288Fn {
+    fn clone(&self) -> Self {
+        NvxExtension288Fn {}
+    }
+}
+impl NvxExtension288Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        NvxExtension288Fn {}
+    }
+}
+impl ExtExtension289Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_extension_289\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct ExtExtension289Fn {}
+unsafe impl Send for ExtExtension289Fn {}
+unsafe impl Sync for ExtExtension289Fn {}
+impl ::std::clone::Clone for ExtExtension289Fn {
+    fn clone(&self) -> Self {
+        ExtExtension289Fn {}
+    }
+}
+impl ExtExtension289Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        ExtExtension289Fn {}
+    }
+}
+impl GoogleUserTypeFn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_GOOGLE_user_type\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct GoogleUserTypeFn {}
+unsafe impl Send for GoogleUserTypeFn {}
+unsafe impl Sync for GoogleUserTypeFn {}
+impl ::std::clone::Clone for GoogleUserTypeFn {
+    fn clone(&self) -> Self {
+        GoogleUserTypeFn {}
+    }
+}
+impl GoogleUserTypeFn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        GoogleUserTypeFn {}
+    }
+}
+impl NvExtension291Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_NV_extension_291\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct NvExtension291Fn {}
+unsafe impl Send for NvExtension291Fn {}
+unsafe impl Sync for NvExtension291Fn {}
+impl ::std::clone::Clone for NvExtension291Fn {
+    fn clone(&self) -> Self {
+        NvExtension291Fn {}
+    }
+}
+impl NvExtension291Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        NvExtension291Fn {}
+    }
+}
+#[doc = "Generated from \'VK_NV_extension_291\'"]
+impl PipelineCreateFlags {
+    pub const EXTENSION_2910_NV: Self = PipelineCreateFlags(0b1_0000_0000_0000);
+}
+#[doc = "Generated from \'VK_NV_extension_291\'"]
+impl PipelineCreateFlags {
+    pub const EXTENSION_2911_NV: Self = PipelineCreateFlags(0b10_0000_0000_0000);
+}
+impl NvExtension292Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_NV_extension_292\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct NvExtension292Fn {}
+unsafe impl Send for NvExtension292Fn {}
+unsafe impl Sync for NvExtension292Fn {}
+impl ::std::clone::Clone for NvExtension292Fn {
+    fn clone(&self) -> Self {
+        NvExtension292Fn {}
+    }
+}
+impl NvExtension292Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        NvExtension292Fn {}
+    }
+}
+impl NvExtension293Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_NV_extension_293\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct NvExtension293Fn {}
+unsafe impl Send for NvExtension293Fn {}
+unsafe impl Sync for NvExtension293Fn {}
+impl ::std::clone::Clone for NvExtension293Fn {
+    fn clone(&self) -> Self {
+        NvExtension293Fn {}
+    }
+}
+impl NvExtension293Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        NvExtension293Fn {}
+    }
+}
+impl KhrExtension294Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_extension_294\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct KhrExtension294Fn {}
+unsafe impl Send for KhrExtension294Fn {}
+unsafe impl Sync for KhrExtension294Fn {}
+impl ::std::clone::Clone for KhrExtension294Fn {
+    fn clone(&self) -> Self {
+        KhrExtension294Fn {}
+    }
+}
+impl KhrExtension294Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        KhrExtension294Fn {}
+    }
+}
+impl KhrExtension295Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_extension_295\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct KhrExtension295Fn {}
+unsafe impl Send for KhrExtension295Fn {}
+unsafe impl Sync for KhrExtension295Fn {}
+impl ::std::clone::Clone for KhrExtension295Fn {
+    fn clone(&self) -> Self {
+        KhrExtension295Fn {}
+    }
+}
+impl KhrExtension295Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        KhrExtension295Fn {}
+    }
+}
+impl NvExtension296Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_NV_extension_296\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct NvExtension296Fn {}
+unsafe impl Send for NvExtension296Fn {}
+unsafe impl Sync for NvExtension296Fn {}
+impl ::std::clone::Clone for NvExtension296Fn {
+    fn clone(&self) -> Self {
+        NvExtension296Fn {}
+    }
+}
+impl NvExtension296Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        NvExtension296Fn {}
+    }
+}
+impl KhrExtension297Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_extension_297\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct KhrExtension297Fn {}
+unsafe impl Send for KhrExtension297Fn {}
+unsafe impl Sync for KhrExtension297Fn {}
+impl ::std::clone::Clone for KhrExtension297Fn {
+    fn clone(&self) -> Self {
+        KhrExtension297Fn {}
+    }
+}
+impl KhrExtension297Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        KhrExtension297Fn {}
+    }
+}
+#[doc = "Generated from \'VK_KHR_extension_297\'"]
+impl PipelineShaderStageCreateFlags {
+    pub const RESERVED_3_KHR: Self = PipelineShaderStageCreateFlags(0b1000);
+}
+impl ExtExtension298Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_extension_298\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct ExtExtension298Fn {}
+unsafe impl Send for ExtExtension298Fn {}
+unsafe impl Sync for ExtExtension298Fn {}
+impl ::std::clone::Clone for ExtExtension298Fn {
+    fn clone(&self) -> Self {
+        ExtExtension298Fn {}
+    }
+}
+impl ExtExtension298Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        ExtExtension298Fn {}
+    }
+}
+#[doc = "Generated from \'VK_EXT_extension_298\'"]
+impl PipelineCreateFlags {
+    pub const RESERVED_8_EXT: Self = PipelineCreateFlags(0b1_0000_0000);
+}
+#[doc = "Generated from \'VK_EXT_extension_298\'"]
+impl PipelineCreateFlags {
+    pub const RESERVED_9_EXT: Self = PipelineCreateFlags(0b10_0000_0000);
+}
+#[doc = "Generated from \'VK_EXT_extension_298\'"]
+impl PipelineCreateFlags {
+    pub const RESERVED_10_EXT: Self = PipelineCreateFlags(0b100_0000_0000);
+}
+#[doc = "Generated from \'VK_EXT_extension_298\'"]
+impl Result {
+    pub const EXT_298_RESERVED_VALUE_0_EXT: Self = Result(1_000_297_000);
+}
+impl KhrExtension299Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_extension_299\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct KhrExtension299Fn {}
+unsafe impl Send for KhrExtension299Fn {}
+unsafe impl Sync for KhrExtension299Fn {}
+impl ::std::clone::Clone for KhrExtension299Fn {
+    fn clone(&self) -> Self {
+        KhrExtension299Fn {}
+    }
+}
+impl KhrExtension299Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        KhrExtension299Fn {}
+    }
+}
+impl KhrExtension300Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_extension_300\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct KhrExtension300Fn {}
+unsafe impl Send for KhrExtension300Fn {}
+unsafe impl Sync for KhrExtension300Fn {}
+impl ::std::clone::Clone for KhrExtension300Fn {
+    fn clone(&self) -> Self {
+        KhrExtension300Fn {}
+    }
+}
+impl KhrExtension300Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        KhrExtension300Fn {}
+    }
+}
+impl NvExtension301Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_NV_extension_301\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct NvExtension301Fn {}
+unsafe impl Send for NvExtension301Fn {}
+unsafe impl Sync for NvExtension301Fn {}
+impl ::std::clone::Clone for NvExtension301Fn {
+    fn clone(&self) -> Self {
+        NvExtension301Fn {}
+    }
+}
+impl NvExtension301Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        NvExtension301Fn {}
+    }
+}
+impl QcomExtension302Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_QCOM_extension_302\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct QcomExtension302Fn {}
+unsafe impl Send for QcomExtension302Fn {}
+unsafe impl Sync for QcomExtension302Fn {}
+impl ::std::clone::Clone for QcomExtension302Fn {
+    fn clone(&self) -> Self {
+        QcomExtension302Fn {}
+    }
+}
+impl QcomExtension302Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        QcomExtension302Fn {}
+    }
+}
+impl QcomExtension303Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_QCOM_extension_303\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct QcomExtension303Fn {}
+unsafe impl Send for QcomExtension303Fn {}
+unsafe impl Sync for QcomExtension303Fn {}
+impl ::std::clone::Clone for QcomExtension303Fn {
+    fn clone(&self) -> Self {
+        QcomExtension303Fn {}
+    }
+}
+impl QcomExtension303Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        QcomExtension303Fn {}
+    }
+}
+impl QcomExtension304Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_QCOM_extension_304\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct QcomExtension304Fn {}
+unsafe impl Send for QcomExtension304Fn {}
+unsafe impl Sync for QcomExtension304Fn {}
+impl ::std::clone::Clone for QcomExtension304Fn {
+    fn clone(&self) -> Self {
+        QcomExtension304Fn {}
+    }
+}
+impl QcomExtension304Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        QcomExtension304Fn {}
+    }
+}
+impl QcomExtension305Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_QCOM_extension_305\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct QcomExtension305Fn {}
+unsafe impl Send for QcomExtension305Fn {}
+unsafe impl Sync for QcomExtension305Fn {}
+impl ::std::clone::Clone for QcomExtension305Fn {
+    fn clone(&self) -> Self {
+        QcomExtension305Fn {}
+    }
+}
+impl QcomExtension305Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        QcomExtension305Fn {}
+    }
+}
+impl QcomExtension306Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_QCOM_extension_306\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct QcomExtension306Fn {}
+unsafe impl Send for QcomExtension306Fn {}
+unsafe impl Sync for QcomExtension306Fn {}
+impl ::std::clone::Clone for QcomExtension306Fn {
+    fn clone(&self) -> Self {
+        QcomExtension306Fn {}
+    }
+}
+impl QcomExtension306Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        QcomExtension306Fn {}
+    }
+}
+impl QcomExtension307Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_QCOM_extension_307\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct QcomExtension307Fn {}
+unsafe impl Send for QcomExtension307Fn {}
+unsafe impl Sync for QcomExtension307Fn {}
+impl ::std::clone::Clone for QcomExtension307Fn {
+    fn clone(&self) -> Self {
+        QcomExtension307Fn {}
+    }
+}
+impl QcomExtension307Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        QcomExtension307Fn {}
+    }
+}
+impl NvExtension308Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_NV_extension_308\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct NvExtension308Fn {}
+unsafe impl Send for NvExtension308Fn {}
+unsafe impl Sync for NvExtension308Fn {}
+impl ::std::clone::Clone for NvExtension308Fn {
+    fn clone(&self) -> Self {
+        NvExtension308Fn {}
+    }
+}
+impl NvExtension308Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        NvExtension308Fn {}
+    }
+}
+impl KhrExtension309Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        ::std::ffi::CStr::from_bytes_with_nul(b"VK_KHR_extension_309\0")
+            .expect("Wrong extension string")
+    }
+}
+pub struct KhrExtension309Fn {}
+unsafe impl Send for KhrExtension309Fn {}
+unsafe impl Sync for KhrExtension309Fn {}
+impl ::std::clone::Clone for KhrExtension309Fn {
+    fn clone(&self) -> Self {
+        KhrExtension309Fn {}
+    }
+}
+impl KhrExtension309Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        KhrExtension309Fn {}
+    }
+}
+#[doc = "Generated from \'VK_KHR_extension_309\'"]
+impl MemoryHeapFlags {
+    pub const RESERVED_2_KHR: Self = MemoryHeapFlags(0b100);
 }
 #[doc = "Generated from \'VK_VERSION_1_1\'"]
 impl StructureType {
@@ -65272,6 +70506,251 @@ impl StructureType {
 impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES: Self = StructureType(1_000_063_000);
 }
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const IMAGE_FORMAT_LIST_CREATE_INFO: Self = StructureType(1_000_147_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const ATTACHMENT_DESCRIPTION_2: Self = StructureType(1_000_109_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const ATTACHMENT_REFERENCE_2: Self = StructureType(1_000_109_001);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const SUBPASS_DESCRIPTION_2: Self = StructureType(1_000_109_002);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const SUBPASS_DEPENDENCY_2: Self = StructureType(1_000_109_003);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const RENDER_PASS_CREATE_INFO_2: Self = StructureType(1_000_109_004);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const SUBPASS_BEGIN_INFO: Self = StructureType(1_000_109_005);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const SUBPASS_END_INFO: Self = StructureType(1_000_109_006);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES: Self = StructureType(1_000_177_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_DRIVER_PROPERTIES: Self = StructureType(1_000_196_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES: Self = StructureType(1_000_180_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES: Self = StructureType(1_000_082_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES: Self = StructureType(1_000_197_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO: Self = StructureType(1_000_161_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES: Self = StructureType(1_000_161_001);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES: Self = StructureType(1_000_161_002);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO: Self =
+        StructureType(1_000_161_003);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT: Self =
+        StructureType(1_000_161_004);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl DescriptorPoolCreateFlags {
+    pub const UPDATE_AFTER_BIND: Self = DescriptorPoolCreateFlags(0b10);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl DescriptorSetLayoutCreateFlags {
+    pub const UPDATE_AFTER_BIND_POOL: Self = DescriptorSetLayoutCreateFlags(0b10);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl Result {
+    pub const ERROR_FRAGMENTATION: Self = Result(-1_000_161_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES: Self = StructureType(1_000_199_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE: Self = StructureType(1_000_199_001);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES: Self = StructureType(1_000_221_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const IMAGE_STENCIL_USAGE_CREATE_INFO: Self = StructureType(1_000_246_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES: Self = StructureType(1_000_130_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const SAMPLER_REDUCTION_MODE_CREATE_INFO: Self = StructureType(1_000_130_001);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl FormatFeatureFlags {
+    pub const SAMPLED_IMAGE_FILTER_MINMAX: Self = FormatFeatureFlags(0b1_0000_0000_0000_0000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES: Self = StructureType(1_000_211_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES: Self = StructureType(1_000_108_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const FRAMEBUFFER_ATTACHMENTS_CREATE_INFO: Self = StructureType(1_000_108_001);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const FRAMEBUFFER_ATTACHMENT_IMAGE_INFO: Self = StructureType(1_000_108_002);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const RENDER_PASS_ATTACHMENT_BEGIN_INFO: Self = StructureType(1_000_108_003);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl FramebufferCreateFlags {
+    pub const IMAGELESS: Self = FramebufferCreateFlags(0b1);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES: Self =
+        StructureType(1_000_253_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES: Self =
+        StructureType(1_000_175_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES: Self =
+        StructureType(1_000_241_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const ATTACHMENT_REFERENCE_STENCIL_LAYOUT: Self = StructureType(1_000_241_001);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT: Self = StructureType(1_000_241_002);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl ImageLayout {
+    pub const DEPTH_ATTACHMENT_OPTIMAL: Self = ImageLayout(1_000_241_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl ImageLayout {
+    pub const DEPTH_READ_ONLY_OPTIMAL: Self = ImageLayout(1_000_241_001);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl ImageLayout {
+    pub const STENCIL_ATTACHMENT_OPTIMAL: Self = ImageLayout(1_000_241_002);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl ImageLayout {
+    pub const STENCIL_READ_ONLY_OPTIMAL: Self = ImageLayout(1_000_241_003);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES: Self = StructureType(1_000_261_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES: Self = StructureType(1_000_207_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES: Self = StructureType(1_000_207_001);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const SEMAPHORE_TYPE_CREATE_INFO: Self = StructureType(1_000_207_002);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const TIMELINE_SEMAPHORE_SUBMIT_INFO: Self = StructureType(1_000_207_003);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const SEMAPHORE_WAIT_INFO: Self = StructureType(1_000_207_004);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const SEMAPHORE_SIGNAL_INFO: Self = StructureType(1_000_207_005);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES: Self = StructureType(1_000_257_000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const BUFFER_DEVICE_ADDRESS_INFO: Self = StructureType(1_000_244_001);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO: Self = StructureType(1_000_257_002);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO: Self = StructureType(1_000_257_003);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO: Self = StructureType(1_000_257_004);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl BufferUsageFlags {
+    pub const SHADER_DEVICE_ADDRESS: Self = BufferUsageFlags(0b10_0000_0000_0000_0000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl BufferCreateFlags {
+    pub const DEVICE_ADDRESS_CAPTURE_REPLAY: Self = BufferCreateFlags(0b1_0000);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl MemoryAllocateFlags {
+    pub const DEVICE_ADDRESS: Self = MemoryAllocateFlags(0b10);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl MemoryAllocateFlags {
+    pub const DEVICE_ADDRESS_CAPTURE_REPLAY: Self = MemoryAllocateFlags(0b100);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl Result {
+    pub const ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS: Self = Result(-1_000_257_000);
+}
 pub(crate) fn debug_flags(
     f: &mut fmt::Formatter,
     known: &[(Flags, &'static str)],
@@ -65416,6 +70895,12 @@ impl fmt::Debug for AccessFlags {
                 "FRAGMENT_DENSITY_MAP_READ_EXT",
             ),
         ];
+        debug_flags(f, KNOWN, self.0)
+    }
+}
+impl fmt::Debug for AcquireProfilingLockFlagsKHR {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
     }
 }
@@ -65593,11 +71078,11 @@ impl fmt::Debug for BufferCreateFlags {
             (BufferCreateFlags::SPARSE_BINDING.0, "SPARSE_BINDING"),
             (BufferCreateFlags::SPARSE_RESIDENCY.0, "SPARSE_RESIDENCY"),
             (BufferCreateFlags::SPARSE_ALIASED.0, "SPARSE_ALIASED"),
-            (
-                BufferCreateFlags::DEVICE_ADDRESS_CAPTURE_REPLAY_EXT.0,
-                "DEVICE_ADDRESS_CAPTURE_REPLAY_EXT",
-            ),
             (BufferCreateFlags::PROTECTED.0, "PROTECTED"),
+            (
+                BufferCreateFlags::DEVICE_ADDRESS_CAPTURE_REPLAY.0,
+                "DEVICE_ADDRESS_CAPTURE_REPLAY",
+            ),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -65637,9 +71122,10 @@ impl fmt::Debug for BufferUsageFlags {
                 "CONDITIONAL_RENDERING_EXT",
             ),
             (BufferUsageFlags::RAY_TRACING_NV.0, "RAY_TRACING_NV"),
+            (BufferUsageFlags::RESERVED_18_QCOM.0, "RESERVED_18_QCOM"),
             (
-                BufferUsageFlags::SHADER_DEVICE_ADDRESS_EXT.0,
-                "SHADER_DEVICE_ADDRESS_EXT",
+                BufferUsageFlags::SHADER_DEVICE_ADDRESS.0,
+                "SHADER_DEVICE_ADDRESS",
             ),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -66073,23 +71559,20 @@ impl fmt::Debug for DependencyFlags {
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for DescriptorBindingFlagsEXT {
+impl fmt::Debug for DescriptorBindingFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
-                DescriptorBindingFlagsEXT::UPDATE_AFTER_BIND.0,
+                DescriptorBindingFlags::UPDATE_AFTER_BIND.0,
                 "UPDATE_AFTER_BIND",
             ),
             (
-                DescriptorBindingFlagsEXT::UPDATE_UNUSED_WHILE_PENDING.0,
+                DescriptorBindingFlags::UPDATE_UNUSED_WHILE_PENDING.0,
                 "UPDATE_UNUSED_WHILE_PENDING",
             ),
+            (DescriptorBindingFlags::PARTIALLY_BOUND.0, "PARTIALLY_BOUND"),
             (
-                DescriptorBindingFlagsEXT::PARTIALLY_BOUND.0,
-                "PARTIALLY_BOUND",
-            ),
-            (
-                DescriptorBindingFlagsEXT::VARIABLE_DESCRIPTOR_COUNT.0,
+                DescriptorBindingFlags::VARIABLE_DESCRIPTOR_COUNT.0,
                 "VARIABLE_DESCRIPTOR_COUNT",
             ),
         ];
@@ -66104,8 +71587,8 @@ impl fmt::Debug for DescriptorPoolCreateFlags {
                 "FREE_DESCRIPTOR_SET",
             ),
             (
-                DescriptorPoolCreateFlags::UPDATE_AFTER_BIND_EXT.0,
-                "UPDATE_AFTER_BIND_EXT",
+                DescriptorPoolCreateFlags::UPDATE_AFTER_BIND.0,
+                "UPDATE_AFTER_BIND",
             ),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -66125,8 +71608,8 @@ impl fmt::Debug for DescriptorSetLayoutCreateFlags {
                 "PUSH_DESCRIPTOR_KHR",
             ),
             (
-                DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND_POOL_EXT.0,
-                "UPDATE_AFTER_BIND_POOL_EXT",
+                DescriptorSetLayoutCreateFlags::UPDATE_AFTER_BIND_POOL.0,
+                "UPDATE_AFTER_BIND_POOL",
             ),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -66283,7 +71766,7 @@ impl fmt::Debug for DisplaySurfaceCreateFlagsKHR {
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for DriverIdKHR {
+impl fmt::Debug for DriverId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
             Self::AMD_PROPRIETARY => Some("AMD_PROPRIETARY"),
@@ -66798,14 +72281,13 @@ impl fmt::Debug for Format {
 }
 impl fmt::Debug for FormatFeatureFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN : & [ ( Flags , & str ) ] = & [ ( FormatFeatureFlags :: SAMPLED_IMAGE . 0 , "SAMPLED_IMAGE" ) , ( FormatFeatureFlags :: STORAGE_IMAGE . 0 , "STORAGE_IMAGE" ) , ( FormatFeatureFlags :: STORAGE_IMAGE_ATOMIC . 0 , "STORAGE_IMAGE_ATOMIC" ) , ( FormatFeatureFlags :: UNIFORM_TEXEL_BUFFER . 0 , "UNIFORM_TEXEL_BUFFER" ) , ( FormatFeatureFlags :: STORAGE_TEXEL_BUFFER . 0 , "STORAGE_TEXEL_BUFFER" ) , ( FormatFeatureFlags :: STORAGE_TEXEL_BUFFER_ATOMIC . 0 , "STORAGE_TEXEL_BUFFER_ATOMIC" ) , ( FormatFeatureFlags :: VERTEX_BUFFER . 0 , "VERTEX_BUFFER" ) , ( FormatFeatureFlags :: COLOR_ATTACHMENT . 0 , "COLOR_ATTACHMENT" ) , ( FormatFeatureFlags :: COLOR_ATTACHMENT_BLEND . 0 , "COLOR_ATTACHMENT_BLEND" ) , ( FormatFeatureFlags :: DEPTH_STENCIL_ATTACHMENT . 0 , "DEPTH_STENCIL_ATTACHMENT" ) , ( FormatFeatureFlags :: BLIT_SRC . 0 , "BLIT_SRC" ) , ( FormatFeatureFlags :: BLIT_DST . 0 , "BLIT_DST" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_FILTER_LINEAR . 0 , "SAMPLED_IMAGE_FILTER_LINEAR" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_FILTER_CUBIC_IMG . 0 , "SAMPLED_IMAGE_FILTER_CUBIC_IMG" ) , ( FormatFeatureFlags :: RESERVED_27_KHR . 0 , "RESERVED_27_KHR" ) , ( FormatFeatureFlags :: RESERVED_28_KHR . 0 , "RESERVED_28_KHR" ) , ( FormatFeatureFlags :: RESERVED_25_KHR . 0 , "RESERVED_25_KHR" ) , ( FormatFeatureFlags :: RESERVED_26_KHR . 0 , "RESERVED_26_KHR" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_FILTER_MINMAX_EXT . 0 , "SAMPLED_IMAGE_FILTER_MINMAX_EXT" ) , ( FormatFeatureFlags :: FRAGMENT_DENSITY_MAP_EXT . 0 , "FRAGMENT_DENSITY_MAP_EXT" ) , ( FormatFeatureFlags :: TRANSFER_SRC . 0 , "TRANSFER_SRC" ) , ( FormatFeatureFlags :: TRANSFER_DST . 0 , "TRANSFER_DST" ) , ( FormatFeatureFlags :: MIDPOINT_CHROMA_SAMPLES . 0 , "MIDPOINT_CHROMA_SAMPLES" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE" ) , ( FormatFeatureFlags :: DISJOINT . 0 , "DISJOINT" ) , ( FormatFeatureFlags :: COSITED_CHROMA_SAMPLES . 0 , "COSITED_CHROMA_SAMPLES" ) ] ;
+        const KNOWN : & [ ( Flags , & str ) ] = & [ ( FormatFeatureFlags :: SAMPLED_IMAGE . 0 , "SAMPLED_IMAGE" ) , ( FormatFeatureFlags :: STORAGE_IMAGE . 0 , "STORAGE_IMAGE" ) , ( FormatFeatureFlags :: STORAGE_IMAGE_ATOMIC . 0 , "STORAGE_IMAGE_ATOMIC" ) , ( FormatFeatureFlags :: UNIFORM_TEXEL_BUFFER . 0 , "UNIFORM_TEXEL_BUFFER" ) , ( FormatFeatureFlags :: STORAGE_TEXEL_BUFFER . 0 , "STORAGE_TEXEL_BUFFER" ) , ( FormatFeatureFlags :: STORAGE_TEXEL_BUFFER_ATOMIC . 0 , "STORAGE_TEXEL_BUFFER_ATOMIC" ) , ( FormatFeatureFlags :: VERTEX_BUFFER . 0 , "VERTEX_BUFFER" ) , ( FormatFeatureFlags :: COLOR_ATTACHMENT . 0 , "COLOR_ATTACHMENT" ) , ( FormatFeatureFlags :: COLOR_ATTACHMENT_BLEND . 0 , "COLOR_ATTACHMENT_BLEND" ) , ( FormatFeatureFlags :: DEPTH_STENCIL_ATTACHMENT . 0 , "DEPTH_STENCIL_ATTACHMENT" ) , ( FormatFeatureFlags :: BLIT_SRC . 0 , "BLIT_SRC" ) , ( FormatFeatureFlags :: BLIT_DST . 0 , "BLIT_DST" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_FILTER_LINEAR . 0 , "SAMPLED_IMAGE_FILTER_LINEAR" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_FILTER_CUBIC_IMG . 0 , "SAMPLED_IMAGE_FILTER_CUBIC_IMG" ) , ( FormatFeatureFlags :: RESERVED_27_KHR . 0 , "RESERVED_27_KHR" ) , ( FormatFeatureFlags :: RESERVED_28_KHR . 0 , "RESERVED_28_KHR" ) , ( FormatFeatureFlags :: RESERVED_25_KHR . 0 , "RESERVED_25_KHR" ) , ( FormatFeatureFlags :: RESERVED_26_KHR . 0 , "RESERVED_26_KHR" ) , ( FormatFeatureFlags :: RESERVED_29_NV . 0 , "RESERVED_29_NV" ) , ( FormatFeatureFlags :: FRAGMENT_DENSITY_MAP_EXT . 0 , "FRAGMENT_DENSITY_MAP_EXT" ) , ( FormatFeatureFlags :: TRANSFER_SRC . 0 , "TRANSFER_SRC" ) , ( FormatFeatureFlags :: TRANSFER_DST . 0 , "TRANSFER_DST" ) , ( FormatFeatureFlags :: MIDPOINT_CHROMA_SAMPLES . 0 , "MIDPOINT_CHROMA_SAMPLES" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE" ) , ( FormatFeatureFlags :: DISJOINT . 0 , "DISJOINT" ) , ( FormatFeatureFlags :: COSITED_CHROMA_SAMPLES . 0 , "COSITED_CHROMA_SAMPLES" ) , ( FormatFeatureFlags :: SAMPLED_IMAGE_FILTER_MINMAX . 0 , "SAMPLED_IMAGE_FILTER_MINMAX" ) ] ;
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for FramebufferCreateFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN: &[(Flags, &str)] =
-            &[(FramebufferCreateFlags::IMAGELESS_KHR.0, "IMAGELESS_KHR")];
+        const KNOWN: &[(Flags, &str)] = &[(FramebufferCreateFlags::IMAGELESS.0, "IMAGELESS")];
         debug_flags(f, KNOWN, self.0)
     }
 }
@@ -66971,6 +72453,10 @@ impl fmt::Debug for ImageLayout {
             Self::DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL => {
                 Some("DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL")
             }
+            Self::DEPTH_ATTACHMENT_OPTIMAL => Some("DEPTH_ATTACHMENT_OPTIMAL"),
+            Self::DEPTH_READ_ONLY_OPTIMAL => Some("DEPTH_READ_ONLY_OPTIMAL"),
+            Self::STENCIL_ATTACHMENT_OPTIMAL => Some("STENCIL_ATTACHMENT_OPTIMAL"),
+            Self::STENCIL_READ_ONLY_OPTIMAL => Some("STENCIL_READ_ONLY_OPTIMAL"),
             _ => None,
         };
         if let Some(x) = name {
@@ -67043,6 +72529,8 @@ impl fmt::Debug for ImageUsageFlags {
                 ImageUsageFlags::SHADING_RATE_IMAGE_NV.0,
                 "SHADING_RATE_IMAGE_NV",
             ),
+            (ImageUsageFlags::RESERVED_16_QCOM.0, "RESERVED_16_QCOM"),
+            (ImageUsageFlags::RESERVED_17_QCOM.0, "RESERVED_17_QCOM"),
             (
                 ImageUsageFlags::FRAGMENT_DENSITY_MAP_EXT.0,
                 "FRAGMENT_DENSITY_MAP_EXT",
@@ -67209,7 +72697,14 @@ impl fmt::Debug for MacOSSurfaceCreateFlagsMVK {
 }
 impl fmt::Debug for MemoryAllocateFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN: &[(Flags, &str)] = &[(MemoryAllocateFlags::DEVICE_MASK.0, "DEVICE_MASK")];
+        const KNOWN: &[(Flags, &str)] = &[
+            (MemoryAllocateFlags::DEVICE_MASK.0, "DEVICE_MASK"),
+            (MemoryAllocateFlags::DEVICE_ADDRESS.0, "DEVICE_ADDRESS"),
+            (
+                MemoryAllocateFlags::DEVICE_ADDRESS_CAPTURE_REPLAY.0,
+                "DEVICE_ADDRESS_CAPTURE_REPLAY",
+            ),
+        ];
         debug_flags(f, KNOWN, self.0)
     }
 }
@@ -67217,6 +72712,7 @@ impl fmt::Debug for MemoryHeapFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (MemoryHeapFlags::DEVICE_LOCAL.0, "DEVICE_LOCAL"),
+            (MemoryHeapFlags::RESERVED_2_KHR.0, "RESERVED_2_KHR"),
             (MemoryHeapFlags::MULTI_INSTANCE.0, "MULTI_INSTANCE"),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -67251,6 +72747,14 @@ impl fmt::Debug for MemoryPropertyFlags {
             (MemoryPropertyFlags::HOST_COHERENT.0, "HOST_COHERENT"),
             (MemoryPropertyFlags::HOST_CACHED.0, "HOST_CACHED"),
             (MemoryPropertyFlags::LAZILY_ALLOCATED.0, "LAZILY_ALLOCATED"),
+            (
+                MemoryPropertyFlags::DEVICE_COHERENT_AMD.0,
+                "DEVICE_COHERENT_AMD",
+            ),
+            (
+                MemoryPropertyFlags::DEVICE_UNCACHED_AMD.0,
+                "DEVICE_UNCACHED_AMD",
+            ),
             (MemoryPropertyFlags::PROTECTED.0, "PROTECTED"),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -67353,6 +72857,77 @@ impl fmt::Debug for PeerMemoryFeatureFlags {
 impl fmt::Debug for PerformanceConfigurationTypeINTEL {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match * self { Self :: PERFORMANCE_CONFIGURATION_TYPE_COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED_INTEL => Some ( "PERFORMANCE_CONFIGURATION_TYPE_COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED_INTEL" ) , _ => None , } ;
+        if let Some(x) = name {
+            f.write_str(x)
+        } else {
+            self.0.fmt(f)
+        }
+    }
+}
+impl fmt::Debug for PerformanceCounterDescriptionFlagsKHR {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const KNOWN: &[(Flags, &str)] = &[
+            (
+                PerformanceCounterDescriptionFlagsKHR::PERFORMANCE_IMPACTING.0,
+                "PERFORMANCE_IMPACTING",
+            ),
+            (
+                PerformanceCounterDescriptionFlagsKHR::CONCURRENTLY_IMPACTED.0,
+                "CONCURRENTLY_IMPACTED",
+            ),
+        ];
+        debug_flags(f, KNOWN, self.0)
+    }
+}
+impl fmt::Debug for PerformanceCounterScopeKHR {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match *self {
+            Self::COMMAND_BUFFER => Some("COMMAND_BUFFER"),
+            Self::RENDER_PASS => Some("RENDER_PASS"),
+            Self::COMMAND => Some("COMMAND"),
+            _ => None,
+        };
+        if let Some(x) = name {
+            f.write_str(x)
+        } else {
+            self.0.fmt(f)
+        }
+    }
+}
+impl fmt::Debug for PerformanceCounterStorageKHR {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match *self {
+            Self::INT32 => Some("INT32"),
+            Self::INT64 => Some("INT64"),
+            Self::UINT32 => Some("UINT32"),
+            Self::UINT64 => Some("UINT64"),
+            Self::FLOAT32 => Some("FLOAT32"),
+            Self::FLOAT64 => Some("FLOAT64"),
+            _ => None,
+        };
+        if let Some(x) = name {
+            f.write_str(x)
+        } else {
+            self.0.fmt(f)
+        }
+    }
+}
+impl fmt::Debug for PerformanceCounterUnitKHR {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match *self {
+            Self::GENERIC => Some("GENERIC"),
+            Self::PERCENTAGE => Some("PERCENTAGE"),
+            Self::NANOSECONDS => Some("NANOSECONDS"),
+            Self::BYTES => Some("BYTES"),
+            Self::BYTES_PER_SECOND => Some("BYTES_PER_SECOND"),
+            Self::KELVIN => Some("KELVIN"),
+            Self::WATTS => Some("WATTS"),
+            Self::VOLTS => Some("VOLTS"),
+            Self::AMPS => Some("AMPS"),
+            Self::HERTZ => Some("HERTZ"),
+            Self::CYCLES => Some("CYCLES"),
+            _ => None,
+        };
         if let Some(x) = name {
             f.write_str(x)
         } else {
@@ -67476,6 +73051,12 @@ impl fmt::Debug for PipelineColorBlendStateCreateFlags {
         debug_flags(f, KNOWN, self.0)
     }
 }
+impl fmt::Debug for PipelineCompilerControlFlagsAMD {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const KNOWN: &[(Flags, &str)] = &[];
+        debug_flags(f, KNOWN, self.0)
+    }
+}
 impl fmt::Debug for PipelineCoverageModulationStateCreateFlagsNV {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
@@ -67506,7 +73087,46 @@ impl fmt::Debug for PipelineCreateFlags {
                 "ALLOW_DERIVATIVES",
             ),
             (PipelineCreateFlags::DERIVATIVE.0, "DERIVATIVE"),
+            (
+                PipelineCreateFlags::EXTENSION_1510_NV.0,
+                "EXTENSION_1510_NV",
+            ),
+            (
+                PipelineCreateFlags::EXTENSION_1511_NV.0,
+                "EXTENSION_1511_NV",
+            ),
+            (
+                PipelineCreateFlags::EXTENSION_1512_NV.0,
+                "EXTENSION_1512_NV",
+            ),
+            (
+                PipelineCreateFlags::EXTENSION_1513_NV.0,
+                "EXTENSION_1513_NV",
+            ),
+            (
+                PipelineCreateFlags::EXTENSION_1514_NV.0,
+                "EXTENSION_1514_NV",
+            ),
             (PipelineCreateFlags::DEFER_COMPILE_NV.0, "DEFER_COMPILE_NV"),
+            (
+                PipelineCreateFlags::CAPTURE_STATISTICS_KHR.0,
+                "CAPTURE_STATISTICS_KHR",
+            ),
+            (
+                PipelineCreateFlags::CAPTURE_INTERNAL_REPRESENTATIONS_KHR.0,
+                "CAPTURE_INTERNAL_REPRESENTATIONS_KHR",
+            ),
+            (
+                PipelineCreateFlags::EXTENSION_2910_NV.0,
+                "EXTENSION_2910_NV",
+            ),
+            (
+                PipelineCreateFlags::EXTENSION_2911_NV.0,
+                "EXTENSION_2911_NV",
+            ),
+            (PipelineCreateFlags::RESERVED_8_EXT.0, "RESERVED_8_EXT"),
+            (PipelineCreateFlags::RESERVED_9_EXT.0, "RESERVED_9_EXT"),
+            (PipelineCreateFlags::RESERVED_10_EXT.0, "RESERVED_10_EXT"),
             (
                 PipelineCreateFlags::VIEW_INDEX_FROM_DEVICE_INDEX.0,
                 "VIEW_INDEX_FROM_DEVICE_INDEX",
@@ -67548,6 +73168,22 @@ impl fmt::Debug for PipelineDynamicStateCreateFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
+    }
+}
+impl fmt::Debug for PipelineExecutableStatisticFormatKHR {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match *self {
+            Self::BOOL32 => Some("BOOL32"),
+            Self::INT64 => Some("INT64"),
+            Self::UINT64 => Some("UINT64"),
+            Self::FLOAT64 => Some("FLOAT64"),
+            _ => None,
+        };
+        if let Some(x) = name {
+            f.write_str(x)
+        } else {
+            self.0.fmt(f)
+        }
     }
 }
 impl fmt::Debug for PipelineInputAssemblyStateCreateFlags {
@@ -67606,6 +73242,10 @@ impl fmt::Debug for PipelineShaderStageCreateFlags {
             (
                 PipelineShaderStageCreateFlags::REQUIRE_FULL_SUBGROUPS_EXT.0,
                 "REQUIRE_FULL_SUBGROUPS_EXT",
+            ),
+            (
+                PipelineShaderStageCreateFlags::RESERVED_3_KHR.0,
+                "RESERVED_3_KHR",
             ),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -67875,6 +73515,7 @@ impl fmt::Debug for QueryType {
             Self::RESERVED_8 => Some("RESERVED_8"),
             Self::RESERVED_4 => Some("RESERVED_4"),
             Self::TRANSFORM_FEEDBACK_STREAM_EXT => Some("TRANSFORM_FEEDBACK_STREAM_EXT"),
+            Self::PERFORMANCE_QUERY_KHR => Some("PERFORMANCE_QUERY_KHR"),
             Self::ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV => {
                 Some("ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV")
             }
@@ -67959,14 +73600,14 @@ impl fmt::Debug for RenderPassCreateFlags {
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for ResolveModeFlagsKHR {
+impl fmt::Debug for ResolveModeFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
-            (ResolveModeFlagsKHR::NONE.0, "NONE"),
-            (ResolveModeFlagsKHR::SAMPLE_ZERO.0, "SAMPLE_ZERO"),
-            (ResolveModeFlagsKHR::AVERAGE.0, "AVERAGE"),
-            (ResolveModeFlagsKHR::MIN.0, "MIN"),
-            (ResolveModeFlagsKHR::MAX.0, "MAX"),
+            (ResolveModeFlags::NONE.0, "NONE"),
+            (ResolveModeFlags::SAMPLE_ZERO.0, "SAMPLE_ZERO"),
+            (ResolveModeFlags::AVERAGE.0, "AVERAGE"),
+            (ResolveModeFlags::MIN.0, "MIN"),
+            (ResolveModeFlags::MAX.0, "MAX"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -67992,6 +73633,7 @@ impl fmt::Debug for Result {
             Self::ERROR_TOO_MANY_OBJECTS => Some("ERROR_TOO_MANY_OBJECTS"),
             Self::ERROR_FORMAT_NOT_SUPPORTED => Some("ERROR_FORMAT_NOT_SUPPORTED"),
             Self::ERROR_FRAGMENTED_POOL => Some("ERROR_FRAGMENTED_POOL"),
+            Self::ERROR_UNKNOWN => Some("ERROR_UNKNOWN"),
             Self::ERROR_SURFACE_LOST_KHR => Some("ERROR_SURFACE_LOST_KHR"),
             Self::ERROR_NATIVE_WINDOW_IN_USE_KHR => Some("ERROR_NATIVE_WINDOW_IN_USE_KHR"),
             Self::SUBOPTIMAL_KHR => Some("SUBOPTIMAL_KHR"),
@@ -68002,14 +73644,17 @@ impl fmt::Debug for Result {
             Self::ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT => {
                 Some("ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT")
             }
-            Self::ERROR_FRAGMENTATION_EXT => Some("ERROR_FRAGMENTATION_EXT"),
             Self::ERROR_NOT_PERMITTED_EXT => Some("ERROR_NOT_PERMITTED_EXT"),
-            Self::ERROR_INVALID_DEVICE_ADDRESS_EXT => Some("ERROR_INVALID_DEVICE_ADDRESS_EXT"),
             Self::ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT => {
                 Some("ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT")
             }
+            Self::EXT_298_RESERVED_VALUE_0_EXT => Some("EXT_298_RESERVED_VALUE_0_EXT"),
             Self::ERROR_OUT_OF_POOL_MEMORY => Some("ERROR_OUT_OF_POOL_MEMORY"),
             Self::ERROR_INVALID_EXTERNAL_HANDLE => Some("ERROR_INVALID_EXTERNAL_HANDLE"),
+            Self::ERROR_FRAGMENTATION => Some("ERROR_FRAGMENTATION"),
+            Self::ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS => {
+                Some("ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS")
+            }
             _ => None,
         };
         if let Some(x) = name {
@@ -68075,7 +73720,7 @@ impl fmt::Debug for SamplerMipmapMode {
         }
     }
 }
-impl fmt::Debug for SamplerReductionModeEXT {
+impl fmt::Debug for SamplerReductionMode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
             Self::WEIGHTED_AVERAGE => Some("WEIGHTED_AVERAGE"),
@@ -68149,7 +73794,33 @@ impl fmt::Debug for SemaphoreImportFlags {
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for ShaderFloatControlsIndependenceKHR {
+impl fmt::Debug for SemaphoreType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match *self {
+            Self::BINARY => Some("BINARY"),
+            Self::TIMELINE => Some("TIMELINE"),
+            _ => None,
+        };
+        if let Some(x) = name {
+            f.write_str(x)
+        } else {
+            self.0.fmt(f)
+        }
+    }
+}
+impl fmt::Debug for SemaphoreWaitFlags {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const KNOWN: &[(Flags, &str)] = &[(SemaphoreWaitFlags::ANY.0, "ANY")];
+        debug_flags(f, KNOWN, self.0)
+    }
+}
+impl fmt::Debug for ShaderCorePropertiesFlagsAMD {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const KNOWN: &[(Flags, &str)] = &[];
+        debug_flags(f, KNOWN, self.0)
+    }
+}
+impl fmt::Debug for ShaderFloatControlsIndependence {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
             Self::TYPE_32_ONLY => Some("TYPE_32_ONLY"),
@@ -68501,9 +74172,6 @@ impl fmt::Debug for StructureType {
             Self::CONDITIONAL_RENDERING_BEGIN_INFO_EXT => {
                 Some("CONDITIONAL_RENDERING_BEGIN_INFO_EXT")
             }
-            Self::PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR")
-            }
             Self::PRESENT_REGIONS_KHR => Some("PRESENT_REGIONS_KHR"),
             Self::OBJECT_TABLE_CREATE_INFO_NVX => Some("OBJECT_TABLE_CREATE_INFO_NVX"),
             Self::INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX => {
@@ -68553,25 +74221,6 @@ impl fmt::Debug for StructureType {
                 Some("PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT")
             }
             Self::HDR_METADATA_EXT => Some("HDR_METADATA_EXT"),
-            Self::PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES_KHR")
-            }
-            Self::FRAMEBUFFER_ATTACHMENTS_CREATE_INFO_KHR => {
-                Some("FRAMEBUFFER_ATTACHMENTS_CREATE_INFO_KHR")
-            }
-            Self::FRAMEBUFFER_ATTACHMENT_IMAGE_INFO_KHR => {
-                Some("FRAMEBUFFER_ATTACHMENT_IMAGE_INFO_KHR")
-            }
-            Self::RENDER_PASS_ATTACHMENT_BEGIN_INFO_KHR => {
-                Some("RENDER_PASS_ATTACHMENT_BEGIN_INFO_KHR")
-            }
-            Self::ATTACHMENT_DESCRIPTION_2_KHR => Some("ATTACHMENT_DESCRIPTION_2_KHR"),
-            Self::ATTACHMENT_REFERENCE_2_KHR => Some("ATTACHMENT_REFERENCE_2_KHR"),
-            Self::SUBPASS_DESCRIPTION_2_KHR => Some("SUBPASS_DESCRIPTION_2_KHR"),
-            Self::SUBPASS_DEPENDENCY_2_KHR => Some("SUBPASS_DEPENDENCY_2_KHR"),
-            Self::RENDER_PASS_CREATE_INFO_2_KHR => Some("RENDER_PASS_CREATE_INFO_2_KHR"),
-            Self::SUBPASS_BEGIN_INFO_KHR => Some("SUBPASS_BEGIN_INFO_KHR"),
-            Self::SUBPASS_END_INFO_KHR => Some("SUBPASS_END_INFO_KHR"),
             Self::SHARED_PRESENT_SURFACE_CAPABILITIES_KHR => {
                 Some("SHARED_PRESENT_SURFACE_CAPABILITIES_KHR")
             }
@@ -68580,6 +74229,21 @@ impl fmt::Debug for StructureType {
             Self::FENCE_GET_WIN32_HANDLE_INFO_KHR => Some("FENCE_GET_WIN32_HANDLE_INFO_KHR"),
             Self::IMPORT_FENCE_FD_INFO_KHR => Some("IMPORT_FENCE_FD_INFO_KHR"),
             Self::FENCE_GET_FD_INFO_KHR => Some("FENCE_GET_FD_INFO_KHR"),
+            Self::PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR => {
+                Some("PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR")
+            }
+            Self::PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR => {
+                Some("PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR")
+            }
+            Self::QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR => {
+                Some("QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR")
+            }
+            Self::PERFORMANCE_QUERY_SUBMIT_INFO_KHR => Some("PERFORMANCE_QUERY_SUBMIT_INFO_KHR"),
+            Self::ACQUIRE_PROFILING_LOCK_INFO_KHR => Some("ACQUIRE_PROFILING_LOCK_INFO_KHR"),
+            Self::PERFORMANCE_COUNTER_KHR => Some("PERFORMANCE_COUNTER_KHR"),
+            Self::PERFORMANCE_COUNTER_DESCRIPTION_KHR => {
+                Some("PERFORMANCE_COUNTER_DESCRIPTION_KHR")
+            }
             Self::PHYSICAL_DEVICE_SURFACE_INFO_2_KHR => Some("PHYSICAL_DEVICE_SURFACE_INFO_2_KHR"),
             Self::SURFACE_CAPABILITIES_2_KHR => Some("SURFACE_CAPABILITIES_2_KHR"),
             Self::SURFACE_FORMAT_2_KHR => Some("SURFACE_FORMAT_2_KHR"),
@@ -68615,12 +74279,6 @@ impl fmt::Debug for StructureType {
                 Some("MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID")
             }
             Self::EXTERNAL_FORMAT_ANDROID => Some("EXTERNAL_FORMAT_ANDROID"),
-            Self::PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT => {
-                Some("PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT")
-            }
-            Self::SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT => {
-                Some("SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT")
-            }
             Self::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT")
             }
@@ -68644,7 +74302,6 @@ impl fmt::Debug for StructureType {
                 Some("PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT")
             }
             Self::MULTISAMPLE_PROPERTIES_EXT => Some("MULTISAMPLE_PROPERTIES_EXT"),
-            Self::IMAGE_FORMAT_LIST_CREATE_INFO_KHR => Some("IMAGE_FORMAT_LIST_CREATE_INFO_KHR"),
             Self::PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT")
             }
@@ -68685,21 +74342,6 @@ impl fmt::Debug for StructureType {
             Self::VALIDATION_CACHE_CREATE_INFO_EXT => Some("VALIDATION_CACHE_CREATE_INFO_EXT"),
             Self::SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT => {
                 Some("SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT")
-            }
-            Self::DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT => {
-                Some("DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT")
-            }
-            Self::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT")
-            }
-            Self::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT => {
-                Some("PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT")
-            }
-            Self::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT => {
-                Some("DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT")
-            }
-            Self::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT_EXT => {
-                Some("DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT_EXT")
             }
             Self::PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV => {
                 Some("PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV")
@@ -68753,9 +74395,6 @@ impl fmt::Debug for StructureType {
             Self::DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT => {
                 Some("DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT")
             }
-            Self::PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR")
-            }
             Self::IMPORT_MEMORY_HOST_POINTER_INFO_EXT => {
                 Some("IMPORT_MEMORY_HOST_POINTER_INFO_EXT")
             }
@@ -68763,8 +74402,11 @@ impl fmt::Debug for StructureType {
             Self::PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT => {
                 Some("PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT")
             }
-            Self::PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR")
+            Self::PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR => {
+                Some("PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR")
+            }
+            Self::PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD => {
+                Some("PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD")
             }
             Self::CALIBRATED_TIMESTAMP_INFO_EXT => Some("CALIBRATED_TIMESTAMP_INFO_EXT"),
             Self::PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD => {
@@ -68785,18 +74427,6 @@ impl fmt::Debug for StructureType {
             Self::PRESENT_FRAME_TOKEN_GGP => Some("PRESENT_FRAME_TOKEN_GGP"),
             Self::PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT => {
                 Some("PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT")
-            }
-            Self::PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR => {
-                Some("PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR")
-            }
-            Self::PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR => {
-                Some("PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR")
-            }
-            Self::PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES_KHR => {
-                Some("PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES_KHR")
-            }
-            Self::SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE_KHR => {
-                Some("SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE_KHR")
             }
             Self::PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV => {
                 Some("PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV")
@@ -68838,9 +74468,6 @@ impl fmt::Debug for StructureType {
             Self::PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL => {
                 Some("PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL")
             }
-            Self::PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR")
-            }
             Self::PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT => {
                 Some("PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT")
             }
@@ -68863,14 +74490,20 @@ impl fmt::Debug for StructureType {
             Self::RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT => {
                 Some("RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT")
             }
-            Self::PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT")
-            }
             Self::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT => {
                 Some("PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT")
             }
             Self::PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT => {
                 Some("PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT")
+            }
+            Self::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT => {
+                Some("PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT")
+            }
+            Self::PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD => {
+                Some("PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD")
+            }
+            Self::PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD => {
+                Some("PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD")
             }
             Self::PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT => {
                 Some("PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT")
@@ -68886,12 +74519,11 @@ impl fmt::Debug for StructureType {
             Self::PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT")
             }
-            Self::BUFFER_DEVICE_ADDRESS_INFO_EXT => Some("BUFFER_DEVICE_ADDRESS_INFO_EXT"),
             Self::BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT => {
                 Some("BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT")
             }
-            Self::IMAGE_STENCIL_USAGE_CREATE_INFO_EXT => {
-                Some("IMAGE_STENCIL_USAGE_CREATE_INFO_EXT")
+            Self::PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT => {
+                Some("PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT")
             }
             Self::VALIDATION_FEATURES_EXT => Some("VALIDATION_FEATURES_EXT"),
             Self::PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV => {
@@ -68916,9 +74548,6 @@ impl fmt::Debug for StructureType {
             Self::PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT")
             }
-            Self::PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES_KHR")
-            }
             Self::SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT => {
                 Some("SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT")
             }
@@ -68938,11 +74567,18 @@ impl fmt::Debug for StructureType {
             Self::PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT => {
                 Some("PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT")
             }
-            Self::PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES_EXT")
-            }
             Self::PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT")
+            }
+            Self::PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR => {
+                Some("PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR")
+            }
+            Self::PIPELINE_INFO_KHR => Some("PIPELINE_INFO_KHR"),
+            Self::PIPELINE_EXECUTABLE_PROPERTIES_KHR => Some("PIPELINE_EXECUTABLE_PROPERTIES_KHR"),
+            Self::PIPELINE_EXECUTABLE_INFO_KHR => Some("PIPELINE_EXECUTABLE_INFO_KHR"),
+            Self::PIPELINE_EXECUTABLE_STATISTIC_KHR => Some("PIPELINE_EXECUTABLE_STATISTIC_KHR"),
+            Self::PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR => {
+                Some("PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR")
             }
             Self::PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT")
@@ -69073,6 +74709,108 @@ impl fmt::Debug for StructureType {
             Self::DESCRIPTOR_SET_LAYOUT_SUPPORT => Some("DESCRIPTOR_SET_LAYOUT_SUPPORT"),
             Self::PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES => {
                 Some("PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES")
+            }
+            Self::IMAGE_FORMAT_LIST_CREATE_INFO => Some("IMAGE_FORMAT_LIST_CREATE_INFO"),
+            Self::ATTACHMENT_DESCRIPTION_2 => Some("ATTACHMENT_DESCRIPTION_2"),
+            Self::ATTACHMENT_REFERENCE_2 => Some("ATTACHMENT_REFERENCE_2"),
+            Self::SUBPASS_DESCRIPTION_2 => Some("SUBPASS_DESCRIPTION_2"),
+            Self::SUBPASS_DEPENDENCY_2 => Some("SUBPASS_DEPENDENCY_2"),
+            Self::RENDER_PASS_CREATE_INFO_2 => Some("RENDER_PASS_CREATE_INFO_2"),
+            Self::SUBPASS_BEGIN_INFO => Some("SUBPASS_BEGIN_INFO"),
+            Self::SUBPASS_END_INFO => Some("SUBPASS_END_INFO"),
+            Self::PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES => {
+                Some("PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_DRIVER_PROPERTIES => Some("PHYSICAL_DEVICE_DRIVER_PROPERTIES"),
+            Self::PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES => {
+                Some("PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES => {
+                Some("PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES")
+            }
+            Self::DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO => {
+                Some("DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO")
+            }
+            Self::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES => {
+                Some("PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES")
+            }
+            Self::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO => {
+                Some("DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO")
+            }
+            Self::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT => {
+                Some("DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT")
+            }
+            Self::PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES")
+            }
+            Self::SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE => {
+                Some("SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE")
+            }
+            Self::PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES => {
+                Some("PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES")
+            }
+            Self::IMAGE_STENCIL_USAGE_CREATE_INFO => Some("IMAGE_STENCIL_USAGE_CREATE_INFO"),
+            Self::PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES")
+            }
+            Self::SAMPLER_REDUCTION_MODE_CREATE_INFO => Some("SAMPLER_REDUCTION_MODE_CREATE_INFO"),
+            Self::PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES => {
+                Some("PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES => {
+                Some("PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES")
+            }
+            Self::FRAMEBUFFER_ATTACHMENTS_CREATE_INFO => {
+                Some("FRAMEBUFFER_ATTACHMENTS_CREATE_INFO")
+            }
+            Self::FRAMEBUFFER_ATTACHMENT_IMAGE_INFO => Some("FRAMEBUFFER_ATTACHMENT_IMAGE_INFO"),
+            Self::RENDER_PASS_ATTACHMENT_BEGIN_INFO => Some("RENDER_PASS_ATTACHMENT_BEGIN_INFO"),
+            Self::PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES => {
+                Some("PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES => {
+                Some("PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES => {
+                Some("PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES")
+            }
+            Self::ATTACHMENT_REFERENCE_STENCIL_LAYOUT => {
+                Some("ATTACHMENT_REFERENCE_STENCIL_LAYOUT")
+            }
+            Self::ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT => {
+                Some("ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT")
+            }
+            Self::PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES => {
+                Some("PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES => {
+                Some("PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES")
+            }
+            Self::SEMAPHORE_TYPE_CREATE_INFO => Some("SEMAPHORE_TYPE_CREATE_INFO"),
+            Self::TIMELINE_SEMAPHORE_SUBMIT_INFO => Some("TIMELINE_SEMAPHORE_SUBMIT_INFO"),
+            Self::SEMAPHORE_WAIT_INFO => Some("SEMAPHORE_WAIT_INFO"),
+            Self::SEMAPHORE_SIGNAL_INFO => Some("SEMAPHORE_SIGNAL_INFO"),
+            Self::PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES => {
+                Some("PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES")
+            }
+            Self::BUFFER_DEVICE_ADDRESS_INFO => Some("BUFFER_DEVICE_ADDRESS_INFO"),
+            Self::BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO => {
+                Some("BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO")
+            }
+            Self::MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO => {
+                Some("MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO")
+            }
+            Self::DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO => {
+                Some("DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO")
             }
             _ => None,
         };
@@ -69236,6 +74974,26 @@ impl fmt::Debug for TimeDomainEXT {
         }
     }
 }
+impl fmt::Debug for ToolPurposeFlagsEXT {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const KNOWN: &[(Flags, &str)] = &[
+            (ToolPurposeFlagsEXT::VALIDATION.0, "VALIDATION"),
+            (ToolPurposeFlagsEXT::PROFILING.0, "PROFILING"),
+            (ToolPurposeFlagsEXT::TRACING.0, "TRACING"),
+            (
+                ToolPurposeFlagsEXT::ADDITIONAL_FEATURES.0,
+                "ADDITIONAL_FEATURES",
+            ),
+            (
+                ToolPurposeFlagsEXT::MODIFYING_FEATURES.0,
+                "MODIFYING_FEATURES",
+            ),
+            (ToolPurposeFlagsEXT::DEBUG_REPORTING.0, "DEBUG_REPORTING"),
+            (ToolPurposeFlagsEXT::DEBUG_MARKERS.0, "DEBUG_MARKERS"),
+        ];
+        debug_flags(f, KNOWN, self.0)
+    }
+}
 impl fmt::Debug for ValidationCacheCreateFlagsEXT {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
@@ -69293,6 +75051,7 @@ impl fmt::Debug for ValidationFeatureEnableEXT {
         let name = match *self {
             Self::GPU_ASSISTED => Some("GPU_ASSISTED"),
             Self::GPU_ASSISTED_RESERVE_BINDING_SLOT => Some("GPU_ASSISTED_RESERVE_BINDING_SLOT"),
+            Self::BEST_PRACTICES => Some("BEST_PRACTICES"),
             _ => None,
         };
         if let Some(x) = name {
@@ -69382,6 +75141,7 @@ impl fmt::Debug for XlibSurfaceCreateFlagsKHR {
     }
 }
 pub type DescriptorUpdateTemplateCreateFlagsKHR = DescriptorUpdateTemplateCreateFlags;
+pub type SemaphoreWaitFlagsKHR = SemaphoreWaitFlags;
 pub type PeerMemoryFeatureFlagsKHR = PeerMemoryFeatureFlags;
 pub type MemoryAllocateFlagsKHR = MemoryAllocateFlags;
 pub type CommandPoolTrimFlagsKHR = CommandPoolTrimFlags;
@@ -69393,14 +75153,20 @@ pub type SemaphoreImportFlagsKHR = SemaphoreImportFlags;
 pub type ExternalFenceHandleTypeFlagsKHR = ExternalFenceHandleTypeFlags;
 pub type ExternalFenceFeatureFlagsKHR = ExternalFenceFeatureFlags;
 pub type FenceImportFlagsKHR = FenceImportFlags;
+pub type DescriptorBindingFlagsEXT = DescriptorBindingFlags;
+pub type ResolveModeFlagsKHR = ResolveModeFlags;
 pub type DescriptorUpdateTemplateKHR = DescriptorUpdateTemplate;
 pub type SamplerYcbcrConversionKHR = SamplerYcbcrConversion;
 pub type DescriptorUpdateTemplateTypeKHR = DescriptorUpdateTemplateType;
 pub type PointClippingBehaviorKHR = PointClippingBehavior;
+pub type SemaphoreTypeKHR = SemaphoreType;
 pub type TessellationDomainOriginKHR = TessellationDomainOrigin;
 pub type SamplerYcbcrModelConversionKHR = SamplerYcbcrModelConversion;
 pub type SamplerYcbcrRangeKHR = SamplerYcbcrRange;
 pub type ChromaLocationKHR = ChromaLocation;
+pub type SamplerReductionModeEXT = SamplerReductionMode;
+pub type ShaderFloatControlsIndependenceKHR = ShaderFloatControlsIndependence;
+pub type DriverIdKHR = DriverId;
 pub type PhysicalDeviceFeatures2KHR = PhysicalDeviceFeatures2;
 pub type PhysicalDeviceProperties2KHR = PhysicalDeviceProperties2;
 pub type FormatProperties2KHR = FormatProperties2;
@@ -69410,6 +75176,8 @@ pub type QueueFamilyProperties2KHR = QueueFamilyProperties2;
 pub type PhysicalDeviceMemoryProperties2KHR = PhysicalDeviceMemoryProperties2;
 pub type SparseImageFormatProperties2KHR = SparseImageFormatProperties2;
 pub type PhysicalDeviceSparseImageFormatInfo2KHR = PhysicalDeviceSparseImageFormatInfo2;
+pub type ConformanceVersionKHR = ConformanceVersion;
+pub type PhysicalDeviceDriverPropertiesKHR = PhysicalDeviceDriverProperties;
 pub type PhysicalDeviceVariablePointersFeaturesKHR = PhysicalDeviceVariablePointersFeatures;
 pub type PhysicalDeviceVariablePointerFeaturesKHR = PhysicalDeviceVariablePointersFeatures;
 pub type PhysicalDeviceVariablePointerFeatures = PhysicalDeviceVariablePointersFeatures;
@@ -69447,6 +75215,8 @@ pub type DescriptorUpdateTemplateCreateInfoKHR = DescriptorUpdateTemplateCreateI
 pub type InputAttachmentAspectReferenceKHR = InputAttachmentAspectReference;
 pub type RenderPassInputAttachmentAspectCreateInfoKHR = RenderPassInputAttachmentAspectCreateInfo;
 pub type PhysicalDevice16BitStorageFeaturesKHR = PhysicalDevice16BitStorageFeatures;
+pub type PhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR =
+    PhysicalDeviceShaderSubgroupExtendedTypesFeatures;
 pub type BufferMemoryRequirementsInfo2KHR = BufferMemoryRequirementsInfo2;
 pub type ImageMemoryRequirementsInfo2KHR = ImageMemoryRequirementsInfo2;
 pub type ImageSparseMemoryRequirementsInfo2KHR = ImageSparseMemoryRequirementsInfo2;
@@ -69466,8 +75236,59 @@ pub type PhysicalDeviceSamplerYcbcrConversionFeaturesKHR =
     PhysicalDeviceSamplerYcbcrConversionFeatures;
 pub type SamplerYcbcrConversionImageFormatPropertiesKHR =
     SamplerYcbcrConversionImageFormatProperties;
+pub type PhysicalDeviceSamplerFilterMinmaxPropertiesEXT =
+    PhysicalDeviceSamplerFilterMinmaxProperties;
+pub type SamplerReductionModeCreateInfoEXT = SamplerReductionModeCreateInfo;
+pub type ImageFormatListCreateInfoKHR = ImageFormatListCreateInfo;
 pub type PhysicalDeviceMaintenance3PropertiesKHR = PhysicalDeviceMaintenance3Properties;
 pub type DescriptorSetLayoutSupportKHR = DescriptorSetLayoutSupport;
 pub type PhysicalDeviceShaderDrawParameterFeatures = PhysicalDeviceShaderDrawParametersFeatures;
-pub type PhysicalDeviceFloat16Int8FeaturesKHR = PhysicalDeviceShaderFloat16Int8FeaturesKHR;
+pub type PhysicalDeviceShaderFloat16Int8FeaturesKHR = PhysicalDeviceShaderFloat16Int8Features;
+pub type PhysicalDeviceFloat16Int8FeaturesKHR = PhysicalDeviceShaderFloat16Int8Features;
+pub type PhysicalDeviceFloatControlsPropertiesKHR = PhysicalDeviceFloatControlsProperties;
+pub type PhysicalDeviceHostQueryResetFeaturesEXT = PhysicalDeviceHostQueryResetFeatures;
+pub type PhysicalDeviceDescriptorIndexingFeaturesEXT = PhysicalDeviceDescriptorIndexingFeatures;
+pub type PhysicalDeviceDescriptorIndexingPropertiesEXT = PhysicalDeviceDescriptorIndexingProperties;
+pub type DescriptorSetLayoutBindingFlagsCreateInfoEXT = DescriptorSetLayoutBindingFlagsCreateInfo;
+pub type DescriptorSetVariableDescriptorCountAllocateInfoEXT =
+    DescriptorSetVariableDescriptorCountAllocateInfo;
+pub type DescriptorSetVariableDescriptorCountLayoutSupportEXT =
+    DescriptorSetVariableDescriptorCountLayoutSupport;
+pub type AttachmentDescription2KHR = AttachmentDescription2;
+pub type AttachmentReference2KHR = AttachmentReference2;
+pub type SubpassDescription2KHR = SubpassDescription2;
+pub type SubpassDependency2KHR = SubpassDependency2;
+pub type RenderPassCreateInfo2KHR = RenderPassCreateInfo2;
+pub type SubpassBeginInfoKHR = SubpassBeginInfo;
+pub type SubpassEndInfoKHR = SubpassEndInfo;
+pub type PhysicalDeviceTimelineSemaphoreFeaturesKHR = PhysicalDeviceTimelineSemaphoreFeatures;
+pub type PhysicalDeviceTimelineSemaphorePropertiesKHR = PhysicalDeviceTimelineSemaphoreProperties;
+pub type SemaphoreTypeCreateInfoKHR = SemaphoreTypeCreateInfo;
+pub type TimelineSemaphoreSubmitInfoKHR = TimelineSemaphoreSubmitInfo;
+pub type SemaphoreWaitInfoKHR = SemaphoreWaitInfo;
+pub type SemaphoreSignalInfoKHR = SemaphoreSignalInfo;
+pub type PhysicalDevice8BitStorageFeaturesKHR = PhysicalDevice8BitStorageFeatures;
+pub type PhysicalDeviceVulkanMemoryModelFeaturesKHR = PhysicalDeviceVulkanMemoryModelFeatures;
+pub type PhysicalDeviceShaderAtomicInt64FeaturesKHR = PhysicalDeviceShaderAtomicInt64Features;
+pub type PhysicalDeviceDepthStencilResolvePropertiesKHR =
+    PhysicalDeviceDepthStencilResolveProperties;
+pub type SubpassDescriptionDepthStencilResolveKHR = SubpassDescriptionDepthStencilResolve;
+pub type ImageStencilUsageCreateInfoEXT = ImageStencilUsageCreateInfo;
+pub type PhysicalDeviceScalarBlockLayoutFeaturesEXT = PhysicalDeviceScalarBlockLayoutFeatures;
+pub type PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR =
+    PhysicalDeviceUniformBufferStandardLayoutFeatures;
+pub type PhysicalDeviceBufferDeviceAddressFeaturesKHR = PhysicalDeviceBufferDeviceAddressFeatures;
 pub type PhysicalDeviceBufferAddressFeaturesEXT = PhysicalDeviceBufferDeviceAddressFeaturesEXT;
+pub type BufferDeviceAddressInfoKHR = BufferDeviceAddressInfo;
+pub type BufferDeviceAddressInfoEXT = BufferDeviceAddressInfo;
+pub type BufferOpaqueCaptureAddressCreateInfoKHR = BufferOpaqueCaptureAddressCreateInfo;
+pub type PhysicalDeviceImagelessFramebufferFeaturesKHR = PhysicalDeviceImagelessFramebufferFeatures;
+pub type FramebufferAttachmentsCreateInfoKHR = FramebufferAttachmentsCreateInfo;
+pub type FramebufferAttachmentImageInfoKHR = FramebufferAttachmentImageInfo;
+pub type RenderPassAttachmentBeginInfoKHR = RenderPassAttachmentBeginInfo;
+pub type PhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR =
+    PhysicalDeviceSeparateDepthStencilLayoutsFeatures;
+pub type AttachmentReferenceStencilLayoutKHR = AttachmentReferenceStencilLayout;
+pub type AttachmentDescriptionStencilLayoutKHR = AttachmentDescriptionStencilLayout;
+pub type MemoryOpaqueCaptureAddressAllocateInfoKHR = MemoryOpaqueCaptureAddressAllocateInfo;
+pub type DeviceMemoryOpaqueCaptureAddressInfoKHR = DeviceMemoryOpaqueCaptureAddressInfo;

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::too_many_arguments, clippy::cognitive_complexity)]
+#![allow(
+    clippy::too_many_arguments,
+    clippy::cognitive_complexity,
+    clippy::wrong_self_convention
+)]
 use std::fmt;
 use std::os::raw::*;
 #[doc = r" Iterates through the pointer chain. Includes the item that is passed into the function."]
@@ -20,19 +24,19 @@ pub trait Handle {
     fn as_raw(self) -> u64;
     fn from_raw(_: u64) -> Self;
 }
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_MAKE_VERSION.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_MAKE_VERSION.html>"]
 pub const fn make_version(major: u32, minor: u32, patch: u32) -> u32 {
     (major << 22) | (minor << 12) | patch
 }
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_VERSION_MAJOR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_VERSION_MAJOR.html>"]
 pub const fn version_major(version: u32) -> u32 {
     version >> 22
 }
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_VERSION_MINOR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_VERSION_MINOR.html>"]
 pub const fn version_minor(version: u32) -> u32 {
     (version >> 12) & 0x3ff
 }
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_VERSION_PATCH.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_VERSION_PATCH.html>"]
 pub const fn version_patch(version: u32) -> u32 {
     version & 0xfff
 }
@@ -295,7 +299,7 @@ impl StaticFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetInstanceProcAddr.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetInstanceProcAddr.html>"]
     pub unsafe fn get_instance_proc_addr(
         &self,
         instance: Instance,
@@ -410,7 +414,7 @@ impl EntryFnV1_0 {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateInstance.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>"]
     pub unsafe fn create_instance(
         &self,
         p_create_info: *const InstanceCreateInfo,
@@ -419,7 +423,7 @@ impl EntryFnV1_0 {
     ) -> Result {
         (self.create_instance)(p_create_info, p_allocator, p_instance)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumerateInstanceExtensionProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateInstanceExtensionProperties.html>"]
     pub unsafe fn enumerate_instance_extension_properties(
         &self,
         p_layer_name: *const c_char,
@@ -428,7 +432,7 @@ impl EntryFnV1_0 {
     ) -> Result {
         (self.enumerate_instance_extension_properties)(p_layer_name, p_property_count, p_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumerateInstanceLayerProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateInstanceLayerProperties.html>"]
     pub unsafe fn enumerate_instance_layer_properties(
         &self,
         p_property_count: *mut u32,
@@ -875,7 +879,7 @@ impl InstanceFnV1_0 {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyInstance.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyInstance.html>"]
     pub unsafe fn destroy_instance(
         &self,
         instance: Instance,
@@ -883,7 +887,7 @@ impl InstanceFnV1_0 {
     ) -> c_void {
         (self.destroy_instance)(instance, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumeratePhysicalDevices.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumeratePhysicalDevices.html>"]
     pub unsafe fn enumerate_physical_devices(
         &self,
         instance: Instance,
@@ -892,7 +896,7 @@ impl InstanceFnV1_0 {
     ) -> Result {
         (self.enumerate_physical_devices)(instance, p_physical_device_count, p_physical_devices)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceFeatures.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceFeatures.html>"]
     pub unsafe fn get_physical_device_features(
         &self,
         physical_device: PhysicalDevice,
@@ -900,7 +904,7 @@ impl InstanceFnV1_0 {
     ) -> c_void {
         (self.get_physical_device_features)(physical_device, p_features)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceFormatProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceFormatProperties.html>"]
     pub unsafe fn get_physical_device_format_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -909,7 +913,7 @@ impl InstanceFnV1_0 {
     ) -> c_void {
         (self.get_physical_device_format_properties)(physical_device, format, p_format_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceImageFormatProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceImageFormatProperties.html>"]
     pub unsafe fn get_physical_device_image_format_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -930,7 +934,7 @@ impl InstanceFnV1_0 {
             p_image_format_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceProperties.html>"]
     pub unsafe fn get_physical_device_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -938,7 +942,7 @@ impl InstanceFnV1_0 {
     ) -> c_void {
         (self.get_physical_device_properties)(physical_device, p_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceQueueFamilyProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceQueueFamilyProperties.html>"]
     pub unsafe fn get_physical_device_queue_family_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -951,7 +955,7 @@ impl InstanceFnV1_0 {
             p_queue_family_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceMemoryProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceMemoryProperties.html>"]
     pub unsafe fn get_physical_device_memory_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -959,7 +963,7 @@ impl InstanceFnV1_0 {
     ) -> c_void {
         (self.get_physical_device_memory_properties)(physical_device, p_memory_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceProcAddr.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceProcAddr.html>"]
     pub unsafe fn get_device_proc_addr(
         &self,
         device: Device,
@@ -967,7 +971,7 @@ impl InstanceFnV1_0 {
     ) -> PFN_vkVoidFunction {
         (self.get_device_proc_addr)(device, p_name)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDevice.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>"]
     pub unsafe fn create_device(
         &self,
         physical_device: PhysicalDevice,
@@ -977,7 +981,7 @@ impl InstanceFnV1_0 {
     ) -> Result {
         (self.create_device)(physical_device, p_create_info, p_allocator, p_device)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumerateDeviceExtensionProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateDeviceExtensionProperties.html>"]
     pub unsafe fn enumerate_device_extension_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -992,7 +996,7 @@ impl InstanceFnV1_0 {
             p_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumerateDeviceLayerProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateDeviceLayerProperties.html>"]
     pub unsafe fn enumerate_device_layer_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -1001,7 +1005,7 @@ impl InstanceFnV1_0 {
     ) -> Result {
         (self.enumerate_device_layer_properties)(physical_device, p_property_count, p_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSparseImageFormatProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSparseImageFormatProperties.html>"]
     pub unsafe fn get_physical_device_sparse_image_format_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -4872,7 +4876,7 @@ impl DeviceFnV1_0 {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyDevice.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDevice.html>"]
     pub unsafe fn destroy_device(
         &self,
         device: Device,
@@ -4880,7 +4884,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_device)(device, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceQueue.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceQueue.html>"]
     pub unsafe fn get_device_queue(
         &self,
         device: Device,
@@ -4890,7 +4894,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.get_device_queue)(device, queue_family_index, queue_index, p_queue)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkQueueSubmit.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueSubmit.html>"]
     pub unsafe fn queue_submit(
         &self,
         queue: Queue,
@@ -4900,15 +4904,15 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.queue_submit)(queue, submit_count, p_submits, fence)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkQueueWaitIdle.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueWaitIdle.html>"]
     pub unsafe fn queue_wait_idle(&self, queue: Queue) -> Result {
         (self.queue_wait_idle)(queue)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDeviceWaitIdle.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDeviceWaitIdle.html>"]
     pub unsafe fn device_wait_idle(&self, device: Device) -> Result {
         (self.device_wait_idle)(device)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAllocateMemory.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAllocateMemory.html>"]
     pub unsafe fn allocate_memory(
         &self,
         device: Device,
@@ -4918,7 +4922,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.allocate_memory)(device, p_allocate_info, p_allocator, p_memory)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkFreeMemory.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkFreeMemory.html>"]
     pub unsafe fn free_memory(
         &self,
         device: Device,
@@ -4927,7 +4931,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.free_memory)(device, memory, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkMapMemory.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkMapMemory.html>"]
     pub unsafe fn map_memory(
         &self,
         device: Device,
@@ -4939,11 +4943,11 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.map_memory)(device, memory, offset, size, flags, pp_data)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkUnmapMemory.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkUnmapMemory.html>"]
     pub unsafe fn unmap_memory(&self, device: Device, memory: DeviceMemory) -> c_void {
         (self.unmap_memory)(device, memory)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkFlushMappedMemoryRanges.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkFlushMappedMemoryRanges.html>"]
     pub unsafe fn flush_mapped_memory_ranges(
         &self,
         device: Device,
@@ -4952,7 +4956,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.flush_mapped_memory_ranges)(device, memory_range_count, p_memory_ranges)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkInvalidateMappedMemoryRanges.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkInvalidateMappedMemoryRanges.html>"]
     pub unsafe fn invalidate_mapped_memory_ranges(
         &self,
         device: Device,
@@ -4961,7 +4965,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.invalidate_mapped_memory_ranges)(device, memory_range_count, p_memory_ranges)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceMemoryCommitment.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceMemoryCommitment.html>"]
     pub unsafe fn get_device_memory_commitment(
         &self,
         device: Device,
@@ -4970,7 +4974,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.get_device_memory_commitment)(device, memory, p_committed_memory_in_bytes)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkBindBufferMemory.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBindBufferMemory.html>"]
     pub unsafe fn bind_buffer_memory(
         &self,
         device: Device,
@@ -4980,7 +4984,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.bind_buffer_memory)(device, buffer, memory, memory_offset)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkBindImageMemory.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBindImageMemory.html>"]
     pub unsafe fn bind_image_memory(
         &self,
         device: Device,
@@ -4990,7 +4994,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.bind_image_memory)(device, image, memory, memory_offset)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetBufferMemoryRequirements.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferMemoryRequirements.html>"]
     pub unsafe fn get_buffer_memory_requirements(
         &self,
         device: Device,
@@ -4999,7 +5003,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.get_buffer_memory_requirements)(device, buffer, p_memory_requirements)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetImageMemoryRequirements.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageMemoryRequirements.html>"]
     pub unsafe fn get_image_memory_requirements(
         &self,
         device: Device,
@@ -5008,7 +5012,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.get_image_memory_requirements)(device, image, p_memory_requirements)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetImageSparseMemoryRequirements.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageSparseMemoryRequirements.html>"]
     pub unsafe fn get_image_sparse_memory_requirements(
         &self,
         device: Device,
@@ -5023,7 +5027,7 @@ impl DeviceFnV1_0 {
             p_sparse_memory_requirements,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkQueueBindSparse.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueBindSparse.html>"]
     pub unsafe fn queue_bind_sparse(
         &self,
         queue: Queue,
@@ -5033,7 +5037,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.queue_bind_sparse)(queue, bind_info_count, p_bind_info, fence)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateFence.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateFence.html>"]
     pub unsafe fn create_fence(
         &self,
         device: Device,
@@ -5043,7 +5047,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_fence)(device, p_create_info, p_allocator, p_fence)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyFence.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyFence.html>"]
     pub unsafe fn destroy_fence(
         &self,
         device: Device,
@@ -5052,7 +5056,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_fence)(device, fence, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkResetFences.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetFences.html>"]
     pub unsafe fn reset_fences(
         &self,
         device: Device,
@@ -5061,11 +5065,11 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.reset_fences)(device, fence_count, p_fences)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetFenceStatus.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetFenceStatus.html>"]
     pub unsafe fn get_fence_status(&self, device: Device, fence: Fence) -> Result {
         (self.get_fence_status)(device, fence)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkWaitForFences.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkWaitForFences.html>"]
     pub unsafe fn wait_for_fences(
         &self,
         device: Device,
@@ -5076,7 +5080,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.wait_for_fences)(device, fence_count, p_fences, wait_all, timeout)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateSemaphore.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateSemaphore.html>"]
     pub unsafe fn create_semaphore(
         &self,
         device: Device,
@@ -5086,7 +5090,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_semaphore)(device, p_create_info, p_allocator, p_semaphore)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroySemaphore.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroySemaphore.html>"]
     pub unsafe fn destroy_semaphore(
         &self,
         device: Device,
@@ -5095,7 +5099,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_semaphore)(device, semaphore, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateEvent.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateEvent.html>"]
     pub unsafe fn create_event(
         &self,
         device: Device,
@@ -5105,7 +5109,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_event)(device, p_create_info, p_allocator, p_event)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyEvent.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyEvent.html>"]
     pub unsafe fn destroy_event(
         &self,
         device: Device,
@@ -5114,19 +5118,19 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_event)(device, event, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetEventStatus.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetEventStatus.html>"]
     pub unsafe fn get_event_status(&self, device: Device, event: Event) -> Result {
         (self.get_event_status)(device, event)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkSetEvent.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSetEvent.html>"]
     pub unsafe fn set_event(&self, device: Device, event: Event) -> Result {
         (self.set_event)(device, event)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkResetEvent.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetEvent.html>"]
     pub unsafe fn reset_event(&self, device: Device, event: Event) -> Result {
         (self.reset_event)(device, event)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateQueryPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateQueryPool.html>"]
     pub unsafe fn create_query_pool(
         &self,
         device: Device,
@@ -5136,7 +5140,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_query_pool)(device, p_create_info, p_allocator, p_query_pool)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyQueryPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyQueryPool.html>"]
     pub unsafe fn destroy_query_pool(
         &self,
         device: Device,
@@ -5145,7 +5149,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_query_pool)(device, query_pool, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetQueryPoolResults.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetQueryPoolResults.html>"]
     pub unsafe fn get_query_pool_results(
         &self,
         device: Device,
@@ -5168,7 +5172,7 @@ impl DeviceFnV1_0 {
             flags,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateBuffer.html>"]
     pub unsafe fn create_buffer(
         &self,
         device: Device,
@@ -5178,7 +5182,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_buffer)(device, p_create_info, p_allocator, p_buffer)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyBuffer.html>"]
     pub unsafe fn destroy_buffer(
         &self,
         device: Device,
@@ -5187,7 +5191,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_buffer)(device, buffer, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateBufferView.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateBufferView.html>"]
     pub unsafe fn create_buffer_view(
         &self,
         device: Device,
@@ -5197,7 +5201,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_buffer_view)(device, p_create_info, p_allocator, p_view)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyBufferView.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyBufferView.html>"]
     pub unsafe fn destroy_buffer_view(
         &self,
         device: Device,
@@ -5206,7 +5210,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_buffer_view)(device, buffer_view, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateImage.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateImage.html>"]
     pub unsafe fn create_image(
         &self,
         device: Device,
@@ -5216,7 +5220,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_image)(device, p_create_info, p_allocator, p_image)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyImage.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyImage.html>"]
     pub unsafe fn destroy_image(
         &self,
         device: Device,
@@ -5225,7 +5229,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_image)(device, image, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetImageSubresourceLayout.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageSubresourceLayout.html>"]
     pub unsafe fn get_image_subresource_layout(
         &self,
         device: Device,
@@ -5235,7 +5239,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.get_image_subresource_layout)(device, image, p_subresource, p_layout)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateImageView.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateImageView.html>"]
     pub unsafe fn create_image_view(
         &self,
         device: Device,
@@ -5245,7 +5249,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_image_view)(device, p_create_info, p_allocator, p_view)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyImageView.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyImageView.html>"]
     pub unsafe fn destroy_image_view(
         &self,
         device: Device,
@@ -5254,7 +5258,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_image_view)(device, image_view, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateShaderModule.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateShaderModule.html>"]
     pub unsafe fn create_shader_module(
         &self,
         device: Device,
@@ -5264,7 +5268,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_shader_module)(device, p_create_info, p_allocator, p_shader_module)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyShaderModule.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyShaderModule.html>"]
     pub unsafe fn destroy_shader_module(
         &self,
         device: Device,
@@ -5273,7 +5277,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_shader_module)(device, shader_module, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreatePipelineCache.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreatePipelineCache.html>"]
     pub unsafe fn create_pipeline_cache(
         &self,
         device: Device,
@@ -5283,7 +5287,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_pipeline_cache)(device, p_create_info, p_allocator, p_pipeline_cache)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyPipelineCache.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyPipelineCache.html>"]
     pub unsafe fn destroy_pipeline_cache(
         &self,
         device: Device,
@@ -5292,7 +5296,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_pipeline_cache)(device, pipeline_cache, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPipelineCacheData.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineCacheData.html>"]
     pub unsafe fn get_pipeline_cache_data(
         &self,
         device: Device,
@@ -5302,7 +5306,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.get_pipeline_cache_data)(device, pipeline_cache, p_data_size, p_data)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkMergePipelineCaches.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkMergePipelineCaches.html>"]
     pub unsafe fn merge_pipeline_caches(
         &self,
         device: Device,
@@ -5312,7 +5316,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.merge_pipeline_caches)(device, dst_cache, src_cache_count, p_src_caches)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateGraphicsPipelines.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateGraphicsPipelines.html>"]
     pub unsafe fn create_graphics_pipelines(
         &self,
         device: Device,
@@ -5331,7 +5335,7 @@ impl DeviceFnV1_0 {
             p_pipelines,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateComputePipelines.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateComputePipelines.html>"]
     pub unsafe fn create_compute_pipelines(
         &self,
         device: Device,
@@ -5350,7 +5354,7 @@ impl DeviceFnV1_0 {
             p_pipelines,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyPipeline.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyPipeline.html>"]
     pub unsafe fn destroy_pipeline(
         &self,
         device: Device,
@@ -5359,7 +5363,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_pipeline)(device, pipeline, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreatePipelineLayout.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreatePipelineLayout.html>"]
     pub unsafe fn create_pipeline_layout(
         &self,
         device: Device,
@@ -5369,7 +5373,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_pipeline_layout)(device, p_create_info, p_allocator, p_pipeline_layout)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyPipelineLayout.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyPipelineLayout.html>"]
     pub unsafe fn destroy_pipeline_layout(
         &self,
         device: Device,
@@ -5378,7 +5382,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_pipeline_layout)(device, pipeline_layout, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateSampler.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateSampler.html>"]
     pub unsafe fn create_sampler(
         &self,
         device: Device,
@@ -5388,7 +5392,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_sampler)(device, p_create_info, p_allocator, p_sampler)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroySampler.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroySampler.html>"]
     pub unsafe fn destroy_sampler(
         &self,
         device: Device,
@@ -5397,7 +5401,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_sampler)(device, sampler, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDescriptorSetLayout.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDescriptorSetLayout.html>"]
     pub unsafe fn create_descriptor_set_layout(
         &self,
         device: Device,
@@ -5407,7 +5411,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_descriptor_set_layout)(device, p_create_info, p_allocator, p_set_layout)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyDescriptorSetLayout.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDescriptorSetLayout.html>"]
     pub unsafe fn destroy_descriptor_set_layout(
         &self,
         device: Device,
@@ -5416,7 +5420,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_descriptor_set_layout)(device, descriptor_set_layout, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDescriptorPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDescriptorPool.html>"]
     pub unsafe fn create_descriptor_pool(
         &self,
         device: Device,
@@ -5426,7 +5430,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_descriptor_pool)(device, p_create_info, p_allocator, p_descriptor_pool)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyDescriptorPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDescriptorPool.html>"]
     pub unsafe fn destroy_descriptor_pool(
         &self,
         device: Device,
@@ -5435,7 +5439,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_descriptor_pool)(device, descriptor_pool, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkResetDescriptorPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetDescriptorPool.html>"]
     pub unsafe fn reset_descriptor_pool(
         &self,
         device: Device,
@@ -5444,7 +5448,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.reset_descriptor_pool)(device, descriptor_pool, flags)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAllocateDescriptorSets.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAllocateDescriptorSets.html>"]
     pub unsafe fn allocate_descriptor_sets(
         &self,
         device: Device,
@@ -5453,7 +5457,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.allocate_descriptor_sets)(device, p_allocate_info, p_descriptor_sets)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkFreeDescriptorSets.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkFreeDescriptorSets.html>"]
     pub unsafe fn free_descriptor_sets(
         &self,
         device: Device,
@@ -5468,7 +5472,7 @@ impl DeviceFnV1_0 {
             p_descriptor_sets,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkUpdateDescriptorSets.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkUpdateDescriptorSets.html>"]
     pub unsafe fn update_descriptor_sets(
         &self,
         device: Device,
@@ -5485,7 +5489,7 @@ impl DeviceFnV1_0 {
             p_descriptor_copies,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateFramebuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateFramebuffer.html>"]
     pub unsafe fn create_framebuffer(
         &self,
         device: Device,
@@ -5495,7 +5499,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_framebuffer)(device, p_create_info, p_allocator, p_framebuffer)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyFramebuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyFramebuffer.html>"]
     pub unsafe fn destroy_framebuffer(
         &self,
         device: Device,
@@ -5504,7 +5508,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_framebuffer)(device, framebuffer, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateRenderPass.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateRenderPass.html>"]
     pub unsafe fn create_render_pass(
         &self,
         device: Device,
@@ -5514,7 +5518,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_render_pass)(device, p_create_info, p_allocator, p_render_pass)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyRenderPass.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyRenderPass.html>"]
     pub unsafe fn destroy_render_pass(
         &self,
         device: Device,
@@ -5523,7 +5527,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_render_pass)(device, render_pass, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetRenderAreaGranularity.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetRenderAreaGranularity.html>"]
     pub unsafe fn get_render_area_granularity(
         &self,
         device: Device,
@@ -5532,7 +5536,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.get_render_area_granularity)(device, render_pass, p_granularity)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateCommandPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateCommandPool.html>"]
     pub unsafe fn create_command_pool(
         &self,
         device: Device,
@@ -5542,7 +5546,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.create_command_pool)(device, p_create_info, p_allocator, p_command_pool)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyCommandPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyCommandPool.html>"]
     pub unsafe fn destroy_command_pool(
         &self,
         device: Device,
@@ -5551,7 +5555,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.destroy_command_pool)(device, command_pool, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkResetCommandPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetCommandPool.html>"]
     pub unsafe fn reset_command_pool(
         &self,
         device: Device,
@@ -5560,7 +5564,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.reset_command_pool)(device, command_pool, flags)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAllocateCommandBuffers.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAllocateCommandBuffers.html>"]
     pub unsafe fn allocate_command_buffers(
         &self,
         device: Device,
@@ -5569,7 +5573,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.allocate_command_buffers)(device, p_allocate_info, p_command_buffers)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkFreeCommandBuffers.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkFreeCommandBuffers.html>"]
     pub unsafe fn free_command_buffers(
         &self,
         device: Device,
@@ -5584,7 +5588,7 @@ impl DeviceFnV1_0 {
             p_command_buffers,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkBeginCommandBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBeginCommandBuffer.html>"]
     pub unsafe fn begin_command_buffer(
         &self,
         command_buffer: CommandBuffer,
@@ -5592,11 +5596,11 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.begin_command_buffer)(command_buffer, p_begin_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEndCommandBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEndCommandBuffer.html>"]
     pub unsafe fn end_command_buffer(&self, command_buffer: CommandBuffer) -> Result {
         (self.end_command_buffer)(command_buffer)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkResetCommandBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetCommandBuffer.html>"]
     pub unsafe fn reset_command_buffer(
         &self,
         command_buffer: CommandBuffer,
@@ -5604,7 +5608,7 @@ impl DeviceFnV1_0 {
     ) -> Result {
         (self.reset_command_buffer)(command_buffer, flags)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBindPipeline.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBindPipeline.html>"]
     pub unsafe fn cmd_bind_pipeline(
         &self,
         command_buffer: CommandBuffer,
@@ -5613,7 +5617,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_bind_pipeline)(command_buffer, pipeline_bind_point, pipeline)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetViewport.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetViewport.html>"]
     pub unsafe fn cmd_set_viewport(
         &self,
         command_buffer: CommandBuffer,
@@ -5623,7 +5627,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_set_viewport)(command_buffer, first_viewport, viewport_count, p_viewports)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetScissor.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetScissor.html>"]
     pub unsafe fn cmd_set_scissor(
         &self,
         command_buffer: CommandBuffer,
@@ -5633,7 +5637,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_set_scissor)(command_buffer, first_scissor, scissor_count, p_scissors)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetLineWidth.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetLineWidth.html>"]
     pub unsafe fn cmd_set_line_width(
         &self,
         command_buffer: CommandBuffer,
@@ -5641,7 +5645,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_set_line_width)(command_buffer, line_width)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetDepthBias.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetDepthBias.html>"]
     pub unsafe fn cmd_set_depth_bias(
         &self,
         command_buffer: CommandBuffer,
@@ -5656,7 +5660,7 @@ impl DeviceFnV1_0 {
             depth_bias_slope_factor,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetBlendConstants.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetBlendConstants.html>"]
     pub unsafe fn cmd_set_blend_constants(
         &self,
         command_buffer: CommandBuffer,
@@ -5664,7 +5668,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_set_blend_constants)(command_buffer, blend_constants)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetDepthBounds.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetDepthBounds.html>"]
     pub unsafe fn cmd_set_depth_bounds(
         &self,
         command_buffer: CommandBuffer,
@@ -5673,7 +5677,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_set_depth_bounds)(command_buffer, min_depth_bounds, max_depth_bounds)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetStencilCompareMask.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetStencilCompareMask.html>"]
     pub unsafe fn cmd_set_stencil_compare_mask(
         &self,
         command_buffer: CommandBuffer,
@@ -5682,7 +5686,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_set_stencil_compare_mask)(command_buffer, face_mask, compare_mask)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetStencilWriteMask.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetStencilWriteMask.html>"]
     pub unsafe fn cmd_set_stencil_write_mask(
         &self,
         command_buffer: CommandBuffer,
@@ -5691,7 +5695,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_set_stencil_write_mask)(command_buffer, face_mask, write_mask)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetStencilReference.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetStencilReference.html>"]
     pub unsafe fn cmd_set_stencil_reference(
         &self,
         command_buffer: CommandBuffer,
@@ -5700,7 +5704,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_set_stencil_reference)(command_buffer, face_mask, reference)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBindDescriptorSets.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBindDescriptorSets.html>"]
     pub unsafe fn cmd_bind_descriptor_sets(
         &self,
         command_buffer: CommandBuffer,
@@ -5723,7 +5727,7 @@ impl DeviceFnV1_0 {
             p_dynamic_offsets,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBindIndexBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBindIndexBuffer.html>"]
     pub unsafe fn cmd_bind_index_buffer(
         &self,
         command_buffer: CommandBuffer,
@@ -5733,7 +5737,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_bind_index_buffer)(command_buffer, buffer, offset, index_type)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBindVertexBuffers.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBindVertexBuffers.html>"]
     pub unsafe fn cmd_bind_vertex_buffers(
         &self,
         command_buffer: CommandBuffer,
@@ -5750,7 +5754,7 @@ impl DeviceFnV1_0 {
             p_offsets,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDraw.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDraw.html>"]
     pub unsafe fn cmd_draw(
         &self,
         command_buffer: CommandBuffer,
@@ -5767,7 +5771,7 @@ impl DeviceFnV1_0 {
             first_instance,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndexed.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawIndexed.html>"]
     pub unsafe fn cmd_draw_indexed(
         &self,
         command_buffer: CommandBuffer,
@@ -5786,7 +5790,7 @@ impl DeviceFnV1_0 {
             first_instance,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndirect.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawIndirect.html>"]
     pub unsafe fn cmd_draw_indirect(
         &self,
         command_buffer: CommandBuffer,
@@ -5797,7 +5801,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_draw_indirect)(command_buffer, buffer, offset, draw_count, stride)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndexedIndirect.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawIndexedIndirect.html>"]
     pub unsafe fn cmd_draw_indexed_indirect(
         &self,
         command_buffer: CommandBuffer,
@@ -5808,7 +5812,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_draw_indexed_indirect)(command_buffer, buffer, offset, draw_count, stride)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDispatch.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDispatch.html>"]
     pub unsafe fn cmd_dispatch(
         &self,
         command_buffer: CommandBuffer,
@@ -5818,7 +5822,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_dispatch)(command_buffer, group_count_x, group_count_y, group_count_z)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDispatchIndirect.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDispatchIndirect.html>"]
     pub unsafe fn cmd_dispatch_indirect(
         &self,
         command_buffer: CommandBuffer,
@@ -5827,7 +5831,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_dispatch_indirect)(command_buffer, buffer, offset)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdCopyBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdCopyBuffer.html>"]
     pub unsafe fn cmd_copy_buffer(
         &self,
         command_buffer: CommandBuffer,
@@ -5844,7 +5848,7 @@ impl DeviceFnV1_0 {
             p_regions,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdCopyImage.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdCopyImage.html>"]
     pub unsafe fn cmd_copy_image(
         &self,
         command_buffer: CommandBuffer,
@@ -5865,7 +5869,7 @@ impl DeviceFnV1_0 {
             p_regions,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBlitImage.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBlitImage.html>"]
     pub unsafe fn cmd_blit_image(
         &self,
         command_buffer: CommandBuffer,
@@ -5888,7 +5892,7 @@ impl DeviceFnV1_0 {
             filter,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdCopyBufferToImage.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdCopyBufferToImage.html>"]
     pub unsafe fn cmd_copy_buffer_to_image(
         &self,
         command_buffer: CommandBuffer,
@@ -5907,7 +5911,7 @@ impl DeviceFnV1_0 {
             p_regions,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdCopyImageToBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdCopyImageToBuffer.html>"]
     pub unsafe fn cmd_copy_image_to_buffer(
         &self,
         command_buffer: CommandBuffer,
@@ -5926,7 +5930,7 @@ impl DeviceFnV1_0 {
             p_regions,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdUpdateBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdUpdateBuffer.html>"]
     pub unsafe fn cmd_update_buffer(
         &self,
         command_buffer: CommandBuffer,
@@ -5937,7 +5941,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_update_buffer)(command_buffer, dst_buffer, dst_offset, data_size, p_data)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdFillBuffer.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdFillBuffer.html>"]
     pub unsafe fn cmd_fill_buffer(
         &self,
         command_buffer: CommandBuffer,
@@ -5948,7 +5952,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_fill_buffer)(command_buffer, dst_buffer, dst_offset, size, data)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdClearColorImage.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdClearColorImage.html>"]
     pub unsafe fn cmd_clear_color_image(
         &self,
         command_buffer: CommandBuffer,
@@ -5967,7 +5971,7 @@ impl DeviceFnV1_0 {
             p_ranges,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdClearDepthStencilImage.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdClearDepthStencilImage.html>"]
     pub unsafe fn cmd_clear_depth_stencil_image(
         &self,
         command_buffer: CommandBuffer,
@@ -5986,7 +5990,7 @@ impl DeviceFnV1_0 {
             p_ranges,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdClearAttachments.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdClearAttachments.html>"]
     pub unsafe fn cmd_clear_attachments(
         &self,
         command_buffer: CommandBuffer,
@@ -6003,7 +6007,7 @@ impl DeviceFnV1_0 {
             p_rects,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdResolveImage.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdResolveImage.html>"]
     pub unsafe fn cmd_resolve_image(
         &self,
         command_buffer: CommandBuffer,
@@ -6024,7 +6028,7 @@ impl DeviceFnV1_0 {
             p_regions,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetEvent.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetEvent.html>"]
     pub unsafe fn cmd_set_event(
         &self,
         command_buffer: CommandBuffer,
@@ -6033,7 +6037,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_set_event)(command_buffer, event, stage_mask)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdResetEvent.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdResetEvent.html>"]
     pub unsafe fn cmd_reset_event(
         &self,
         command_buffer: CommandBuffer,
@@ -6042,7 +6046,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_reset_event)(command_buffer, event, stage_mask)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdWaitEvents.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdWaitEvents.html>"]
     pub unsafe fn cmd_wait_events(
         &self,
         command_buffer: CommandBuffer,
@@ -6071,7 +6075,7 @@ impl DeviceFnV1_0 {
             p_image_memory_barriers,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdPipelineBarrier.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdPipelineBarrier.html>"]
     pub unsafe fn cmd_pipeline_barrier(
         &self,
         command_buffer: CommandBuffer,
@@ -6098,7 +6102,7 @@ impl DeviceFnV1_0 {
             p_image_memory_barriers,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBeginQuery.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginQuery.html>"]
     pub unsafe fn cmd_begin_query(
         &self,
         command_buffer: CommandBuffer,
@@ -6108,7 +6112,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_begin_query)(command_buffer, query_pool, query, flags)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdEndQuery.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndQuery.html>"]
     pub unsafe fn cmd_end_query(
         &self,
         command_buffer: CommandBuffer,
@@ -6117,7 +6121,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_end_query)(command_buffer, query_pool, query)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdResetQueryPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdResetQueryPool.html>"]
     pub unsafe fn cmd_reset_query_pool(
         &self,
         command_buffer: CommandBuffer,
@@ -6127,7 +6131,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_reset_query_pool)(command_buffer, query_pool, first_query, query_count)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdWriteTimestamp.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdWriteTimestamp.html>"]
     pub unsafe fn cmd_write_timestamp(
         &self,
         command_buffer: CommandBuffer,
@@ -6137,7 +6141,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_write_timestamp)(command_buffer, pipeline_stage, query_pool, query)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdCopyQueryPoolResults.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdCopyQueryPoolResults.html>"]
     pub unsafe fn cmd_copy_query_pool_results(
         &self,
         command_buffer: CommandBuffer,
@@ -6160,7 +6164,7 @@ impl DeviceFnV1_0 {
             flags,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdPushConstants.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdPushConstants.html>"]
     pub unsafe fn cmd_push_constants(
         &self,
         command_buffer: CommandBuffer,
@@ -6172,7 +6176,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_push_constants)(command_buffer, layout, stage_flags, offset, size, p_values)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBeginRenderPass.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginRenderPass.html>"]
     pub unsafe fn cmd_begin_render_pass(
         &self,
         command_buffer: CommandBuffer,
@@ -6181,7 +6185,7 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_begin_render_pass)(command_buffer, p_render_pass_begin, contents)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdNextSubpass.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdNextSubpass.html>"]
     pub unsafe fn cmd_next_subpass(
         &self,
         command_buffer: CommandBuffer,
@@ -6189,11 +6193,11 @@ impl DeviceFnV1_0 {
     ) -> c_void {
         (self.cmd_next_subpass)(command_buffer, contents)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdEndRenderPass.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndRenderPass.html>"]
     pub unsafe fn cmd_end_render_pass(&self, command_buffer: CommandBuffer) -> c_void {
         (self.cmd_end_render_pass)(command_buffer)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdExecuteCommands.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdExecuteCommands.html>"]
     pub unsafe fn cmd_execute_commands(
         &self,
         command_buffer: CommandBuffer,
@@ -6241,7 +6245,7 @@ impl EntryFnV1_1 {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumerateInstanceVersion.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateInstanceVersion.html>"]
     pub unsafe fn enumerate_instance_version(&self, p_api_version: *mut u32) -> Result {
         (self.enumerate_instance_version)(p_api_version)
     }
@@ -6616,7 +6620,7 @@ impl InstanceFnV1_1 {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumeratePhysicalDeviceGroups.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumeratePhysicalDeviceGroups.html>"]
     pub unsafe fn enumerate_physical_device_groups(
         &self,
         instance: Instance,
@@ -6629,7 +6633,7 @@ impl InstanceFnV1_1 {
             p_physical_device_group_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceFeatures2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceFeatures2.html>"]
     pub unsafe fn get_physical_device_features2(
         &self,
         physical_device: PhysicalDevice,
@@ -6637,7 +6641,7 @@ impl InstanceFnV1_1 {
     ) -> c_void {
         (self.get_physical_device_features2)(physical_device, p_features)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceProperties2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceProperties2.html>"]
     pub unsafe fn get_physical_device_properties2(
         &self,
         physical_device: PhysicalDevice,
@@ -6645,7 +6649,7 @@ impl InstanceFnV1_1 {
     ) -> c_void {
         (self.get_physical_device_properties2)(physical_device, p_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceFormatProperties2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceFormatProperties2.html>"]
     pub unsafe fn get_physical_device_format_properties2(
         &self,
         physical_device: PhysicalDevice,
@@ -6654,7 +6658,7 @@ impl InstanceFnV1_1 {
     ) -> c_void {
         (self.get_physical_device_format_properties2)(physical_device, format, p_format_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceImageFormatProperties2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceImageFormatProperties2.html>"]
     pub unsafe fn get_physical_device_image_format_properties2(
         &self,
         physical_device: PhysicalDevice,
@@ -6667,7 +6671,7 @@ impl InstanceFnV1_1 {
             p_image_format_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceQueueFamilyProperties2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceQueueFamilyProperties2.html>"]
     pub unsafe fn get_physical_device_queue_family_properties2(
         &self,
         physical_device: PhysicalDevice,
@@ -6680,7 +6684,7 @@ impl InstanceFnV1_1 {
             p_queue_family_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceMemoryProperties2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceMemoryProperties2.html>"]
     pub unsafe fn get_physical_device_memory_properties2(
         &self,
         physical_device: PhysicalDevice,
@@ -6688,7 +6692,7 @@ impl InstanceFnV1_1 {
     ) -> c_void {
         (self.get_physical_device_memory_properties2)(physical_device, p_memory_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSparseImageFormatProperties2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSparseImageFormatProperties2.html>"]
     pub unsafe fn get_physical_device_sparse_image_format_properties2(
         &self,
         physical_device: PhysicalDevice,
@@ -6703,7 +6707,7 @@ impl InstanceFnV1_1 {
             p_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceExternalBufferProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceExternalBufferProperties.html>"]
     pub unsafe fn get_physical_device_external_buffer_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -6716,7 +6720,7 @@ impl InstanceFnV1_1 {
             p_external_buffer_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceExternalFenceProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceExternalFenceProperties.html>"]
     pub unsafe fn get_physical_device_external_fence_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -6729,7 +6733,7 @@ impl InstanceFnV1_1 {
             p_external_fence_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceExternalSemaphoreProperties.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceExternalSemaphoreProperties.html>"]
     pub unsafe fn get_physical_device_external_semaphore_properties(
         &self,
         physical_device: PhysicalDevice,
@@ -7278,7 +7282,7 @@ impl DeviceFnV1_1 {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkBindBufferMemory2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBindBufferMemory2.html>"]
     pub unsafe fn bind_buffer_memory2(
         &self,
         device: Device,
@@ -7287,7 +7291,7 @@ impl DeviceFnV1_1 {
     ) -> Result {
         (self.bind_buffer_memory2)(device, bind_info_count, p_bind_infos)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkBindImageMemory2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBindImageMemory2.html>"]
     pub unsafe fn bind_image_memory2(
         &self,
         device: Device,
@@ -7296,7 +7300,7 @@ impl DeviceFnV1_1 {
     ) -> Result {
         (self.bind_image_memory2)(device, bind_info_count, p_bind_infos)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceGroupPeerMemoryFeatures.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceGroupPeerMemoryFeatures.html>"]
     pub unsafe fn get_device_group_peer_memory_features(
         &self,
         device: Device,
@@ -7313,7 +7317,7 @@ impl DeviceFnV1_1 {
             p_peer_memory_features,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetDeviceMask.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetDeviceMask.html>"]
     pub unsafe fn cmd_set_device_mask(
         &self,
         command_buffer: CommandBuffer,
@@ -7321,7 +7325,7 @@ impl DeviceFnV1_1 {
     ) -> c_void {
         (self.cmd_set_device_mask)(command_buffer, device_mask)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDispatchBase.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDispatchBase.html>"]
     pub unsafe fn cmd_dispatch_base(
         &self,
         command_buffer: CommandBuffer,
@@ -7342,7 +7346,7 @@ impl DeviceFnV1_1 {
             group_count_z,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetImageMemoryRequirements2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageMemoryRequirements2.html>"]
     pub unsafe fn get_image_memory_requirements2(
         &self,
         device: Device,
@@ -7351,7 +7355,7 @@ impl DeviceFnV1_1 {
     ) -> c_void {
         (self.get_image_memory_requirements2)(device, p_info, p_memory_requirements)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetBufferMemoryRequirements2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferMemoryRequirements2.html>"]
     pub unsafe fn get_buffer_memory_requirements2(
         &self,
         device: Device,
@@ -7360,7 +7364,7 @@ impl DeviceFnV1_1 {
     ) -> c_void {
         (self.get_buffer_memory_requirements2)(device, p_info, p_memory_requirements)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetImageSparseMemoryRequirements2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageSparseMemoryRequirements2.html>"]
     pub unsafe fn get_image_sparse_memory_requirements2(
         &self,
         device: Device,
@@ -7375,7 +7379,7 @@ impl DeviceFnV1_1 {
             p_sparse_memory_requirements,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkTrimCommandPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkTrimCommandPool.html>"]
     pub unsafe fn trim_command_pool(
         &self,
         device: Device,
@@ -7384,7 +7388,7 @@ impl DeviceFnV1_1 {
     ) -> c_void {
         (self.trim_command_pool)(device, command_pool, flags)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceQueue2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceQueue2.html>"]
     pub unsafe fn get_device_queue2(
         &self,
         device: Device,
@@ -7393,7 +7397,7 @@ impl DeviceFnV1_1 {
     ) -> c_void {
         (self.get_device_queue2)(device, p_queue_info, p_queue)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateSamplerYcbcrConversion.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateSamplerYcbcrConversion.html>"]
     pub unsafe fn create_sampler_ycbcr_conversion(
         &self,
         device: Device,
@@ -7408,7 +7412,7 @@ impl DeviceFnV1_1 {
             p_ycbcr_conversion,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroySamplerYcbcrConversion.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroySamplerYcbcrConversion.html>"]
     pub unsafe fn destroy_sampler_ycbcr_conversion(
         &self,
         device: Device,
@@ -7417,7 +7421,7 @@ impl DeviceFnV1_1 {
     ) -> c_void {
         (self.destroy_sampler_ycbcr_conversion)(device, ycbcr_conversion, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDescriptorUpdateTemplate.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDescriptorUpdateTemplate.html>"]
     pub unsafe fn create_descriptor_update_template(
         &self,
         device: Device,
@@ -7432,7 +7436,7 @@ impl DeviceFnV1_1 {
             p_descriptor_update_template,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyDescriptorUpdateTemplate.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDescriptorUpdateTemplate.html>"]
     pub unsafe fn destroy_descriptor_update_template(
         &self,
         device: Device,
@@ -7441,7 +7445,7 @@ impl DeviceFnV1_1 {
     ) -> c_void {
         (self.destroy_descriptor_update_template)(device, descriptor_update_template, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkUpdateDescriptorSetWithTemplate.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkUpdateDescriptorSetWithTemplate.html>"]
     pub unsafe fn update_descriptor_set_with_template(
         &self,
         device: Device,
@@ -7456,7 +7460,7 @@ impl DeviceFnV1_1 {
             p_data,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDescriptorSetLayoutSupport.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDescriptorSetLayoutSupport.html>"]
     pub unsafe fn get_descriptor_set_layout_support(
         &self,
         device: Device,
@@ -7909,7 +7913,7 @@ impl DeviceFnV1_2 {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndirectCount.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawIndirectCount.html>"]
     pub unsafe fn cmd_draw_indirect_count(
         &self,
         command_buffer: CommandBuffer,
@@ -7930,7 +7934,7 @@ impl DeviceFnV1_2 {
             stride,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndexedIndirectCount.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawIndexedIndirectCount.html>"]
     pub unsafe fn cmd_draw_indexed_indirect_count(
         &self,
         command_buffer: CommandBuffer,
@@ -7951,7 +7955,7 @@ impl DeviceFnV1_2 {
             stride,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateRenderPass2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateRenderPass2.html>"]
     pub unsafe fn create_render_pass2(
         &self,
         device: Device,
@@ -7961,7 +7965,7 @@ impl DeviceFnV1_2 {
     ) -> Result {
         (self.create_render_pass2)(device, p_create_info, p_allocator, p_render_pass)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBeginRenderPass2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginRenderPass2.html>"]
     pub unsafe fn cmd_begin_render_pass2(
         &self,
         command_buffer: CommandBuffer,
@@ -7970,7 +7974,7 @@ impl DeviceFnV1_2 {
     ) -> c_void {
         (self.cmd_begin_render_pass2)(command_buffer, p_render_pass_begin, p_subpass_begin_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdNextSubpass2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdNextSubpass2.html>"]
     pub unsafe fn cmd_next_subpass2(
         &self,
         command_buffer: CommandBuffer,
@@ -7979,7 +7983,7 @@ impl DeviceFnV1_2 {
     ) -> c_void {
         (self.cmd_next_subpass2)(command_buffer, p_subpass_begin_info, p_subpass_end_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdEndRenderPass2.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndRenderPass2.html>"]
     pub unsafe fn cmd_end_render_pass2(
         &self,
         command_buffer: CommandBuffer,
@@ -7987,7 +7991,7 @@ impl DeviceFnV1_2 {
     ) -> c_void {
         (self.cmd_end_render_pass2)(command_buffer, p_subpass_end_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkResetQueryPool.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetQueryPool.html>"]
     pub unsafe fn reset_query_pool(
         &self,
         device: Device,
@@ -7997,7 +8001,7 @@ impl DeviceFnV1_2 {
     ) -> c_void {
         (self.reset_query_pool)(device, query_pool, first_query, query_count)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetSemaphoreCounterValue.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSemaphoreCounterValue.html>"]
     pub unsafe fn get_semaphore_counter_value(
         &self,
         device: Device,
@@ -8006,7 +8010,7 @@ impl DeviceFnV1_2 {
     ) -> Result {
         (self.get_semaphore_counter_value)(device, semaphore, p_value)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkWaitSemaphores.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkWaitSemaphores.html>"]
     pub unsafe fn wait_semaphores(
         &self,
         device: Device,
@@ -8015,7 +8019,7 @@ impl DeviceFnV1_2 {
     ) -> Result {
         (self.wait_semaphores)(device, p_wait_info, timeout)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkSignalSemaphore.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSignalSemaphore.html>"]
     pub unsafe fn signal_semaphore(
         &self,
         device: Device,
@@ -8023,7 +8027,7 @@ impl DeviceFnV1_2 {
     ) -> Result {
         (self.signal_semaphore)(device, p_signal_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetBufferDeviceAddress.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferDeviceAddress.html>"]
     pub unsafe fn get_buffer_device_address(
         &self,
         device: Device,
@@ -8031,7 +8035,7 @@ impl DeviceFnV1_2 {
     ) -> DeviceAddress {
         (self.get_buffer_device_address)(device, p_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetBufferOpaqueCaptureAddress.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferOpaqueCaptureAddress.html>"]
     pub unsafe fn get_buffer_opaque_capture_address(
         &self,
         device: Device,
@@ -8039,7 +8043,7 @@ impl DeviceFnV1_2 {
     ) -> u64 {
         (self.get_buffer_opaque_capture_address)(device, p_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceMemoryOpaqueCaptureAddress.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceMemoryOpaqueCaptureAddress.html>"]
     pub unsafe fn get_device_memory_opaque_capture_address(
         &self,
         device: Device,
@@ -8048,229 +8052,229 @@ impl DeviceFnV1_2 {
         (self.get_device_memory_opaque_capture_address)(device, p_info)
     }
 }
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSampleMask.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSampleMask.html>"]
 pub type SampleMask = u32;
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBool32.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBool32.html>"]
 pub type Bool32 = u32;
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFlags.html>"]
 pub type Flags = u32;
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceSize.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceSize.html>"]
 pub type DeviceSize = u64;
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceAddress.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceAddress.html>"]
 pub type DeviceAddress = u64;
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryPoolCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPoolCreateFlags.html>"]
 pub struct QueryPoolCreateFlags(Flags);
 vk_bitflags_wrapped!(QueryPoolCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineLayoutCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineLayoutCreateFlags.html>"]
 pub struct PipelineLayoutCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineLayoutCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCacheCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCacheCreateFlags.html>"]
 pub struct PipelineCacheCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineCacheCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineDepthStencilStateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDepthStencilStateCreateFlags.html>"]
 pub struct PipelineDepthStencilStateCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineDepthStencilStateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineDynamicStateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDynamicStateCreateFlags.html>"]
 pub struct PipelineDynamicStateCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineDynamicStateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineColorBlendStateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineColorBlendStateCreateFlags.html>"]
 pub struct PipelineColorBlendStateCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineColorBlendStateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineMultisampleStateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineMultisampleStateCreateFlags.html>"]
 pub struct PipelineMultisampleStateCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineMultisampleStateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationStateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationStateCreateFlags.html>"]
 pub struct PipelineRasterizationStateCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineRasterizationStateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineViewportStateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportStateCreateFlags.html>"]
 pub struct PipelineViewportStateCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineViewportStateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineTessellationStateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineTessellationStateCreateFlags.html>"]
 pub struct PipelineTessellationStateCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineTessellationStateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineInputAssemblyStateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineInputAssemblyStateCreateFlags.html>"]
 pub struct PipelineInputAssemblyStateCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineInputAssemblyStateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineVertexInputStateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineVertexInputStateCreateFlags.html>"]
 pub struct PipelineVertexInputStateCreateFlags(Flags);
 vk_bitflags_wrapped!(PipelineVertexInputStateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferViewCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferViewCreateFlags.html>"]
 pub struct BufferViewCreateFlags(Flags);
 vk_bitflags_wrapped!(BufferViewCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkInstanceCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkInstanceCreateFlags.html>"]
 pub struct InstanceCreateFlags(Flags);
 vk_bitflags_wrapped!(InstanceCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceCreateFlags.html>"]
 pub struct DeviceCreateFlags(Flags);
 vk_bitflags_wrapped!(DeviceCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkEventCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkEventCreateFlags.html>"]
 pub struct EventCreateFlags(Flags);
 vk_bitflags_wrapped!(EventCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryMapFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryMapFlags.html>"]
 pub struct MemoryMapFlags(Flags);
 vk_bitflags_wrapped!(MemoryMapFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorPoolResetFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorPoolResetFlags.html>"]
 pub struct DescriptorPoolResetFlags(Flags);
 vk_bitflags_wrapped!(DescriptorPoolResetFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorUpdateTemplateCreateFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorUpdateTemplateCreateFlags.html>"]
 pub struct DescriptorUpdateTemplateCreateFlags(Flags);
 vk_bitflags_wrapped!(DescriptorUpdateTemplateCreateFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayModeCreateFlagsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayModeCreateFlagsKHR.html>"]
 pub struct DisplayModeCreateFlagsKHR(Flags);
 vk_bitflags_wrapped!(DisplayModeCreateFlagsKHR, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplaySurfaceCreateFlagsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplaySurfaceCreateFlagsKHR.html>"]
 pub struct DisplaySurfaceCreateFlagsKHR(Flags);
 vk_bitflags_wrapped!(DisplaySurfaceCreateFlagsKHR, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAndroidSurfaceCreateFlagsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAndroidSurfaceCreateFlagsKHR.html>"]
 pub struct AndroidSurfaceCreateFlagsKHR(Flags);
 vk_bitflags_wrapped!(AndroidSurfaceCreateFlagsKHR, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkViSurfaceCreateFlagsNN.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkViSurfaceCreateFlagsNN.html>"]
 pub struct ViSurfaceCreateFlagsNN(Flags);
 vk_bitflags_wrapped!(ViSurfaceCreateFlagsNN, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkWaylandSurfaceCreateFlagsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWaylandSurfaceCreateFlagsKHR.html>"]
 pub struct WaylandSurfaceCreateFlagsKHR(Flags);
 vk_bitflags_wrapped!(WaylandSurfaceCreateFlagsKHR, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkWin32SurfaceCreateFlagsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWin32SurfaceCreateFlagsKHR.html>"]
 pub struct Win32SurfaceCreateFlagsKHR(Flags);
 vk_bitflags_wrapped!(Win32SurfaceCreateFlagsKHR, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkXlibSurfaceCreateFlagsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkXlibSurfaceCreateFlagsKHR.html>"]
 pub struct XlibSurfaceCreateFlagsKHR(Flags);
 vk_bitflags_wrapped!(XlibSurfaceCreateFlagsKHR, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkXcbSurfaceCreateFlagsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkXcbSurfaceCreateFlagsKHR.html>"]
 pub struct XcbSurfaceCreateFlagsKHR(Flags);
 vk_bitflags_wrapped!(XcbSurfaceCreateFlagsKHR, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkIOSSurfaceCreateFlagsMVK.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIOSSurfaceCreateFlagsMVK.html>"]
 pub struct IOSSurfaceCreateFlagsMVK(Flags);
 vk_bitflags_wrapped!(IOSSurfaceCreateFlagsMVK, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMacOSSurfaceCreateFlagsMVK.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMacOSSurfaceCreateFlagsMVK.html>"]
 pub struct MacOSSurfaceCreateFlagsMVK(Flags);
 vk_bitflags_wrapped!(MacOSSurfaceCreateFlagsMVK, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMetalSurfaceCreateFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMetalSurfaceCreateFlagsEXT.html>"]
 pub struct MetalSurfaceCreateFlagsEXT(Flags);
 vk_bitflags_wrapped!(MetalSurfaceCreateFlagsEXT, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImagePipeSurfaceCreateFlagsFUCHSIA.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImagePipeSurfaceCreateFlagsFUCHSIA.html>"]
 pub struct ImagePipeSurfaceCreateFlagsFUCHSIA(Flags);
 vk_bitflags_wrapped!(ImagePipeSurfaceCreateFlagsFUCHSIA, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkStreamDescriptorSurfaceCreateFlagsGGP.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStreamDescriptorSurfaceCreateFlagsGGP.html>"]
 pub struct StreamDescriptorSurfaceCreateFlagsGGP(Flags);
 vk_bitflags_wrapped!(StreamDescriptorSurfaceCreateFlagsGGP, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkHeadlessSurfaceCreateFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkHeadlessSurfaceCreateFlagsEXT.html>"]
 pub struct HeadlessSurfaceCreateFlagsEXT(Flags);
 vk_bitflags_wrapped!(HeadlessSurfaceCreateFlagsEXT, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandPoolTrimFlags.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandPoolTrimFlags.html>"]
 pub struct CommandPoolTrimFlags(Flags);
 vk_bitflags_wrapped!(CommandPoolTrimFlags, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineViewportSwizzleStateCreateFlagsNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportSwizzleStateCreateFlagsNV.html>"]
 pub struct PipelineViewportSwizzleStateCreateFlagsNV(Flags);
 vk_bitflags_wrapped!(PipelineViewportSwizzleStateCreateFlagsNV, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineDiscardRectangleStateCreateFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDiscardRectangleStateCreateFlagsEXT.html>"]
 pub struct PipelineDiscardRectangleStateCreateFlagsEXT(Flags);
 vk_bitflags_wrapped!(PipelineDiscardRectangleStateCreateFlagsEXT, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCoverageToColorStateCreateFlagsNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCoverageToColorStateCreateFlagsNV.html>"]
 pub struct PipelineCoverageToColorStateCreateFlagsNV(Flags);
 vk_bitflags_wrapped!(PipelineCoverageToColorStateCreateFlagsNV, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCoverageModulationStateCreateFlagsNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCoverageModulationStateCreateFlagsNV.html>"]
 pub struct PipelineCoverageModulationStateCreateFlagsNV(Flags);
 vk_bitflags_wrapped!(PipelineCoverageModulationStateCreateFlagsNV, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCoverageReductionStateCreateFlagsNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCoverageReductionStateCreateFlagsNV.html>"]
 pub struct PipelineCoverageReductionStateCreateFlagsNV(Flags);
 vk_bitflags_wrapped!(PipelineCoverageReductionStateCreateFlagsNV, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkValidationCacheCreateFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationCacheCreateFlagsEXT.html>"]
 pub struct ValidationCacheCreateFlagsEXT(Flags);
 vk_bitflags_wrapped!(ValidationCacheCreateFlagsEXT, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsMessengerCreateFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessengerCreateFlagsEXT.html>"]
 pub struct DebugUtilsMessengerCreateFlagsEXT(Flags);
 vk_bitflags_wrapped!(DebugUtilsMessengerCreateFlagsEXT, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsMessengerCallbackDataFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessengerCallbackDataFlagsEXT.html>"]
 pub struct DebugUtilsMessengerCallbackDataFlagsEXT(Flags);
 vk_bitflags_wrapped!(DebugUtilsMessengerCallbackDataFlagsEXT, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationConservativeStateCreateFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationConservativeStateCreateFlagsEXT.html>"]
 pub struct PipelineRasterizationConservativeStateCreateFlagsEXT(Flags);
 vk_bitflags_wrapped!(
     PipelineRasterizationConservativeStateCreateFlagsEXT,
@@ -8279,12 +8283,12 @@ vk_bitflags_wrapped!(
 );
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationStateStreamCreateFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationStateStreamCreateFlagsEXT.html>"]
 pub struct PipelineRasterizationStateStreamCreateFlagsEXT(Flags);
 vk_bitflags_wrapped!(PipelineRasterizationStateStreamCreateFlagsEXT, 0b0, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationDepthClipStateCreateFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationDepthClipStateCreateFlagsEXT.html>"]
 pub struct PipelineRasterizationDepthClipStateCreateFlagsEXT(Flags);
 vk_bitflags_wrapped!(
     PipelineRasterizationDepthClipStateCreateFlagsEXT,
@@ -8294,114 +8298,114 @@ vk_bitflags_wrapped!(
 define_handle!(
     Instance,
     INSTANCE,
-    doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkInstance.html>"
+    doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkInstance.html>"
 );
-define_handle ! ( PhysicalDevice , PHYSICAL_DEVICE , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevice.html>" ) ;
+define_handle ! ( PhysicalDevice , PHYSICAL_DEVICE , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevice.html>" ) ;
 define_handle!(
     Device,
     DEVICE,
-    doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDevice.html>"
+    doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDevice.html>"
 );
 define_handle!(
     Queue,
     QUEUE,
-    doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueue.html>"
+    doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueue.html>"
 );
-define_handle ! ( CommandBuffer , COMMAND_BUFFER , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandBuffer.html>" ) ;
-handle_nondispatchable ! ( DeviceMemory , DEVICE_MEMORY , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceMemory.html>" ) ;
-handle_nondispatchable ! ( CommandPool , COMMAND_POOL , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandPool.html>" ) ;
+define_handle ! ( CommandBuffer , COMMAND_BUFFER , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBuffer.html>" ) ;
+handle_nondispatchable ! ( DeviceMemory , DEVICE_MEMORY , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceMemory.html>" ) ;
+handle_nondispatchable ! ( CommandPool , COMMAND_POOL , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandPool.html>" ) ;
 handle_nondispatchable!(
     Buffer,
     BUFFER,
-    doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBuffer.html>"
+    doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBuffer.html>"
 );
 handle_nondispatchable!(
     BufferView,
     BUFFER_VIEW,
     doc =
-        "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferView.html>"
+        "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferView.html>"
 );
 handle_nondispatchable!(
     Image,
     IMAGE,
-    doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImage.html>"
+    doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImage.html>"
 );
 handle_nondispatchable!(
     ImageView,
     IMAGE_VIEW,
     doc =
-        "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageView.html>"
+        "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageView.html>"
 );
-handle_nondispatchable ! ( ShaderModule , SHADER_MODULE , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderModule.html>" ) ;
+handle_nondispatchable ! ( ShaderModule , SHADER_MODULE , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderModule.html>" ) ;
 handle_nondispatchable!(
     Pipeline,
     PIPELINE,
-    doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipeline.html>"
+    doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipeline.html>"
 );
-handle_nondispatchable ! ( PipelineLayout , PIPELINE_LAYOUT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineLayout.html>" ) ;
+handle_nondispatchable ! ( PipelineLayout , PIPELINE_LAYOUT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineLayout.html>" ) ;
 handle_nondispatchable!(
     Sampler,
     SAMPLER,
-    doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSampler.html>"
+    doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSampler.html>"
 );
-handle_nondispatchable ! ( DescriptorSet , DESCRIPTOR_SET , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSet.html>" ) ;
-handle_nondispatchable ! ( DescriptorSetLayout , DESCRIPTOR_SET_LAYOUT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetLayout.html>" ) ;
-handle_nondispatchable ! ( DescriptorPool , DESCRIPTOR_POOL , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorPool.html>" ) ;
+handle_nondispatchable ! ( DescriptorSet , DESCRIPTOR_SET , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSet.html>" ) ;
+handle_nondispatchable ! ( DescriptorSetLayout , DESCRIPTOR_SET_LAYOUT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetLayout.html>" ) ;
+handle_nondispatchable ! ( DescriptorPool , DESCRIPTOR_POOL , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorPool.html>" ) ;
 handle_nondispatchable!(
     Fence,
     FENCE,
-    doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFence.html>"
+    doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFence.html>"
 );
 handle_nondispatchable!(
     Semaphore,
     SEMAPHORE,
     doc =
-        "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphore.html>"
+        "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphore.html>"
 );
 handle_nondispatchable!(
     Event,
     EVENT,
-    doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkEvent.html>"
+    doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkEvent.html>"
 );
 handle_nondispatchable!(
     QueryPool,
     QUERY_POOL,
     doc =
-        "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryPool.html>"
+        "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPool.html>"
 );
-handle_nondispatchable ! ( Framebuffer , FRAMEBUFFER , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebuffer.html>" ) ;
+handle_nondispatchable ! ( Framebuffer , FRAMEBUFFER , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFramebuffer.html>" ) ;
 handle_nondispatchable!(
     RenderPass,
     RENDER_PASS,
     doc =
-        "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPass.html>"
+        "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPass.html>"
 );
-handle_nondispatchable ! ( PipelineCache , PIPELINE_CACHE , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCache.html>" ) ;
-handle_nondispatchable ! ( ObjectTableNVX , OBJECT_TABLE_NVX , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectTableNVX.html>" ) ;
-handle_nondispatchable ! ( IndirectCommandsLayoutNVX , INDIRECT_COMMANDS_LAYOUT_NVX , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkIndirectCommandsLayoutNVX.html>" ) ;
-handle_nondispatchable ! ( DescriptorUpdateTemplate , DESCRIPTOR_UPDATE_TEMPLATE , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorUpdateTemplate.html>" ) ;
-handle_nondispatchable ! ( SamplerYcbcrConversion , SAMPLER_YCBCR_CONVERSION , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerYcbcrConversion.html>" ) ;
-handle_nondispatchable ! ( ValidationCacheEXT , VALIDATION_CACHE_EXT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkValidationCacheEXT.html>" ) ;
-handle_nondispatchable ! ( AccelerationStructureNV , ACCELERATION_STRUCTURE_NV , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAccelerationStructureNV.html>" ) ;
-handle_nondispatchable ! ( PerformanceConfigurationINTEL , PERFORMANCE_CONFIGURATION_INTEL , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceConfigurationINTEL.html>" ) ;
+handle_nondispatchable ! ( PipelineCache , PIPELINE_CACHE , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCache.html>" ) ;
+handle_nondispatchable ! ( ObjectTableNVX , OBJECT_TABLE_NVX , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectTableNVX.html>" ) ;
+handle_nondispatchable ! ( IndirectCommandsLayoutNVX , INDIRECT_COMMANDS_LAYOUT_NVX , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndirectCommandsLayoutNVX.html>" ) ;
+handle_nondispatchable ! ( DescriptorUpdateTemplate , DESCRIPTOR_UPDATE_TEMPLATE , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorUpdateTemplate.html>" ) ;
+handle_nondispatchable ! ( SamplerYcbcrConversion , SAMPLER_YCBCR_CONVERSION , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerYcbcrConversion.html>" ) ;
+handle_nondispatchable ! ( ValidationCacheEXT , VALIDATION_CACHE_EXT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationCacheEXT.html>" ) ;
+handle_nondispatchable ! ( AccelerationStructureNV , ACCELERATION_STRUCTURE_NV , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureNV.html>" ) ;
+handle_nondispatchable ! ( PerformanceConfigurationINTEL , PERFORMANCE_CONFIGURATION_INTEL , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceConfigurationINTEL.html>" ) ;
 handle_nondispatchable!(
     DisplayKHR,
     DISPLAY_KHR,
     doc =
-        "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayKHR.html>"
+        "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayKHR.html>"
 );
-handle_nondispatchable ! ( DisplayModeKHR , DISPLAY_MODE_KHR , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayModeKHR.html>" ) ;
+handle_nondispatchable ! ( DisplayModeKHR , DISPLAY_MODE_KHR , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayModeKHR.html>" ) ;
 handle_nondispatchable!(
     SurfaceKHR,
     SURFACE_KHR,
     doc =
-        "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceKHR.html>"
+        "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceKHR.html>"
 );
-handle_nondispatchable ! ( SwapchainKHR , SWAPCHAIN_KHR , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSwapchainKHR.html>" ) ;
-handle_nondispatchable ! ( DebugReportCallbackEXT , DEBUG_REPORT_CALLBACK_EXT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugReportCallbackEXT.html>" ) ;
-handle_nondispatchable ! ( DebugUtilsMessengerEXT , DEBUG_UTILS_MESSENGER_EXT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsMessengerEXT.html>" ) ;
+handle_nondispatchable ! ( SwapchainKHR , SWAPCHAIN_KHR , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSwapchainKHR.html>" ) ;
+handle_nondispatchable ! ( DebugReportCallbackEXT , DEBUG_REPORT_CALLBACK_EXT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugReportCallbackEXT.html>" ) ;
+handle_nondispatchable ! ( DebugUtilsMessengerEXT , DEBUG_UTILS_MESSENGER_EXT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessengerEXT.html>" ) ;
 #[allow(non_camel_case_types)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/PFN_vkInternalAllocationNotification.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/PFN_vkInternalAllocationNotification.html>"]
 pub type PFN_vkInternalAllocationNotification = Option<
     unsafe extern "system" fn(
         p_user_data: *mut c_void,
@@ -8411,7 +8415,7 @@ pub type PFN_vkInternalAllocationNotification = Option<
     ) -> c_void,
 >;
 #[allow(non_camel_case_types)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/PFN_vkInternalFreeNotification.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/PFN_vkInternalFreeNotification.html>"]
 pub type PFN_vkInternalFreeNotification = Option<
     unsafe extern "system" fn(
         p_user_data: *mut c_void,
@@ -8421,7 +8425,7 @@ pub type PFN_vkInternalFreeNotification = Option<
     ) -> c_void,
 >;
 #[allow(non_camel_case_types)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/PFN_vkReallocationFunction.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/PFN_vkReallocationFunction.html>"]
 pub type PFN_vkReallocationFunction = Option<
     unsafe extern "system" fn(
         p_user_data: *mut c_void,
@@ -8432,7 +8436,7 @@ pub type PFN_vkReallocationFunction = Option<
     ) -> *mut c_void,
 >;
 #[allow(non_camel_case_types)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/PFN_vkAllocationFunction.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/PFN_vkAllocationFunction.html>"]
 pub type PFN_vkAllocationFunction = Option<
     unsafe extern "system" fn(
         p_user_data: *mut c_void,
@@ -8442,14 +8446,14 @@ pub type PFN_vkAllocationFunction = Option<
     ) -> *mut c_void,
 >;
 #[allow(non_camel_case_types)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/PFN_vkFreeFunction.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/PFN_vkFreeFunction.html>"]
 pub type PFN_vkFreeFunction =
     Option<unsafe extern "system" fn(p_user_data: *mut c_void, p_memory: *mut c_void) -> c_void>;
 #[allow(non_camel_case_types)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/PFN_vkVoidFunction.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/PFN_vkVoidFunction.html>"]
 pub type PFN_vkVoidFunction = Option<unsafe extern "system" fn() -> c_void>;
 #[allow(non_camel_case_types)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/PFN_vkDebugReportCallbackEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/PFN_vkDebugReportCallbackEXT.html>"]
 pub type PFN_vkDebugReportCallbackEXT = Option<
     unsafe extern "system" fn(
         flags: DebugReportFlagsEXT,
@@ -8463,7 +8467,7 @@ pub type PFN_vkDebugReportCallbackEXT = Option<
     ) -> Bool32,
 >;
 #[allow(non_camel_case_types)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/PFN_vkDebugUtilsMessengerCallbackEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/PFN_vkDebugUtilsMessengerCallbackEXT.html>"]
 pub type PFN_vkDebugUtilsMessengerCallbackEXT = Option<
     unsafe extern "system" fn(
         message_severity: DebugUtilsMessageSeverityFlagsEXT,
@@ -8474,7 +8478,7 @@ pub type PFN_vkDebugUtilsMessengerCallbackEXT = Option<
 >;
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBaseOutStructure.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBaseOutStructure.html>"]
 pub struct BaseOutStructure {
     pub s_type: StructureType,
     pub p_next: *mut BaseOutStructure,
@@ -8489,7 +8493,7 @@ impl ::std::default::Default for BaseOutStructure {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBaseInStructure.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBaseInStructure.html>"]
 pub struct BaseInStructure {
     pub s_type: StructureType,
     pub p_next: *const BaseInStructure,
@@ -8504,7 +8508,7 @@ impl ::std::default::Default for BaseInStructure {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkOffset2D.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkOffset2D.html>"]
 pub struct Offset2D {
     pub x: i32,
     pub y: i32,
@@ -8551,7 +8555,7 @@ impl<'a> Offset2DBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkOffset3D.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkOffset3D.html>"]
 pub struct Offset3D {
     pub x: i32,
     pub y: i32,
@@ -8603,7 +8607,7 @@ impl<'a> Offset3DBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExtent2D.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExtent2D.html>"]
 pub struct Extent2D {
     pub width: u32,
     pub height: u32,
@@ -8650,7 +8654,7 @@ impl<'a> Extent2DBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExtent3D.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExtent3D.html>"]
 pub struct Extent3D {
     pub width: u32,
     pub height: u32,
@@ -8702,7 +8706,7 @@ impl<'a> Extent3DBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkViewport.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkViewport.html>"]
 pub struct Viewport {
     pub x: f32,
     pub y: f32,
@@ -8769,7 +8773,7 @@ impl<'a> ViewportBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRect2D.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRect2D.html>"]
 pub struct Rect2D {
     pub offset: Offset2D,
     pub extent: Extent2D,
@@ -8816,7 +8820,7 @@ impl<'a> Rect2DBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkClearRect.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkClearRect.html>"]
 pub struct ClearRect {
     pub rect: Rect2D,
     pub base_array_layer: u32,
@@ -8868,7 +8872,7 @@ impl<'a> ClearRectBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkComponentMapping.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkComponentMapping.html>"]
 pub struct ComponentMapping {
     pub r: ComponentSwizzle,
     pub g: ComponentSwizzle,
@@ -8925,7 +8929,7 @@ impl<'a> ComponentMappingBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceProperties.html>"]
 pub struct PhysicalDeviceProperties {
     pub api_version: u32,
     pub driver_version: u32,
@@ -9051,7 +9055,7 @@ impl<'a> PhysicalDevicePropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExtensionProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExtensionProperties.html>"]
 pub struct ExtensionProperties {
     pub extension_name: [c_char; MAX_EXTENSION_NAME_SIZE],
     pub spec_version: u32,
@@ -9119,7 +9123,7 @@ impl<'a> ExtensionPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkLayerProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkLayerProperties.html>"]
 pub struct LayerProperties {
     pub layer_name: [c_char; MAX_EXTENSION_NAME_SIZE],
     pub spec_version: u32,
@@ -9209,7 +9213,7 @@ impl<'a> LayerPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkApplicationInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkApplicationInfo.html>"]
 pub struct ApplicationInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -9307,7 +9311,7 @@ impl<'a> ApplicationInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAllocationCallbacks.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAllocationCallbacks.html>"]
 pub struct AllocationCallbacks {
     pub p_user_data: *mut c_void,
     pub pfn_allocation: PFN_vkAllocationFunction,
@@ -9422,7 +9426,7 @@ impl<'a> AllocationCallbacksBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceQueueCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceQueueCreateInfo.html>"]
 pub struct DeviceQueueCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -9514,7 +9518,7 @@ impl<'a> DeviceQueueCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceCreateInfo.html>"]
 pub struct DeviceCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -9630,7 +9634,7 @@ impl<'a> DeviceCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkInstanceCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkInstanceCreateInfo.html>"]
 pub struct InstanceCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -9734,7 +9738,7 @@ impl<'a> InstanceCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueueFamilyProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueueFamilyProperties.html>"]
 pub struct QueueFamilyProperties {
     pub queue_flags: QueueFlags,
     pub queue_count: u32,
@@ -9797,7 +9801,7 @@ impl<'a> QueueFamilyPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMemoryProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMemoryProperties.html>"]
 pub struct PhysicalDeviceMemoryProperties {
     pub memory_type_count: u32,
     pub memory_types: [MemoryType; MAX_MEMORY_TYPES],
@@ -9876,7 +9880,7 @@ impl<'a> PhysicalDeviceMemoryPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryAllocateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryAllocateInfo.html>"]
 pub struct MemoryAllocateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -9953,7 +9957,7 @@ impl<'a> MemoryAllocateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryRequirements.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryRequirements.html>"]
 pub struct MemoryRequirements {
     pub size: DeviceSize,
     pub alignment: DeviceSize,
@@ -10005,7 +10009,7 @@ impl<'a> MemoryRequirementsBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseImageFormatProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseImageFormatProperties.html>"]
 pub struct SparseImageFormatProperties {
     pub aspect_mask: ImageAspectFlags,
     pub image_granularity: Extent3D,
@@ -10066,7 +10070,7 @@ impl<'a> SparseImageFormatPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseImageMemoryRequirements.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseImageMemoryRequirements.html>"]
 pub struct SparseImageMemoryRequirements {
     pub format_properties: SparseImageFormatProperties,
     pub image_mip_tail_first_lod: u32,
@@ -10143,7 +10147,7 @@ impl<'a> SparseImageMemoryRequirementsBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryType.html>"]
 pub struct MemoryType {
     pub property_flags: MemoryPropertyFlags,
     pub heap_index: u32,
@@ -10190,7 +10194,7 @@ impl<'a> MemoryTypeBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryHeap.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryHeap.html>"]
 pub struct MemoryHeap {
     pub size: DeviceSize,
     pub flags: MemoryHeapFlags,
@@ -10237,7 +10241,7 @@ impl<'a> MemoryHeapBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMappedMemoryRange.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMappedMemoryRange.html>"]
 pub struct MappedMemoryRange {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -10320,7 +10324,7 @@ impl<'a> MappedMemoryRangeBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFormatProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFormatProperties.html>"]
 pub struct FormatProperties {
     pub linear_tiling_features: FormatFeatureFlags,
     pub optimal_tiling_features: FormatFeatureFlags,
@@ -10381,7 +10385,7 @@ impl<'a> FormatPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageFormatProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageFormatProperties.html>"]
 pub struct ImageFormatProperties {
     pub max_extent: Extent3D,
     pub max_mip_levels: u32,
@@ -10449,7 +10453,7 @@ impl<'a> ImageFormatPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorBufferInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorBufferInfo.html>"]
 pub struct DescriptorBufferInfo {
     pub buffer: Buffer,
     pub offset: DeviceSize,
@@ -10501,7 +10505,7 @@ impl<'a> DescriptorBufferInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorImageInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorImageInfo.html>"]
 pub struct DescriptorImageInfo {
     pub sampler: Sampler,
     pub image_view: ImageView,
@@ -10553,7 +10557,7 @@ impl<'a> DescriptorImageInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkWriteDescriptorSet.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWriteDescriptorSet.html>"]
 pub struct WriteDescriptorSet {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -10677,7 +10681,7 @@ impl<'a> WriteDescriptorSetBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCopyDescriptorSet.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCopyDescriptorSet.html>"]
 pub struct CopyDescriptorSet {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -10784,7 +10788,7 @@ impl<'a> CopyDescriptorSetBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferCreateInfo.html>"]
 pub struct BufferCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -10885,7 +10889,7 @@ impl<'a> BufferCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferViewCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferViewCreateInfo.html>"]
 pub struct BufferViewCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -10980,7 +10984,7 @@ impl<'a> BufferViewCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageSubresource.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageSubresource.html>"]
 pub struct ImageSubresource {
     pub aspect_mask: ImageAspectFlags,
     pub mip_level: u32,
@@ -11032,7 +11036,7 @@ impl<'a> ImageSubresourceBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageSubresourceLayers.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageSubresourceLayers.html>"]
 pub struct ImageSubresourceLayers {
     pub aspect_mask: ImageAspectFlags,
     pub mip_level: u32,
@@ -11092,7 +11096,7 @@ impl<'a> ImageSubresourceLayersBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageSubresourceRange.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageSubresourceRange.html>"]
 pub struct ImageSubresourceRange {
     pub aspect_mask: ImageAspectFlags,
     pub base_mip_level: u32,
@@ -11157,7 +11161,7 @@ impl<'a> ImageSubresourceRangeBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryBarrier.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryBarrier.html>"]
 pub struct MemoryBarrier {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -11234,7 +11238,7 @@ impl<'a> MemoryBarrierBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferMemoryBarrier.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferMemoryBarrier.html>"]
 pub struct BufferMemoryBarrier {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -11353,7 +11357,7 @@ impl<'a> BufferMemoryBarrierBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageMemoryBarrier.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageMemoryBarrier.html>"]
 pub struct ImageMemoryBarrier {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -11481,7 +11485,7 @@ impl<'a> ImageMemoryBarrierBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageCreateInfo.html>"]
 pub struct ImageCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -11624,7 +11628,7 @@ impl<'a> ImageCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubresourceLayout.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubresourceLayout.html>"]
 pub struct SubresourceLayout {
     pub offset: DeviceSize,
     pub size: DeviceSize,
@@ -11686,7 +11690,7 @@ impl<'a> SubresourceLayoutBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageViewCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageViewCreateInfo.html>"]
 pub struct ImageViewCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -11790,7 +11794,7 @@ impl<'a> ImageViewCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferCopy.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferCopy.html>"]
 pub struct BufferCopy {
     pub src_offset: DeviceSize,
     pub dst_offset: DeviceSize,
@@ -11842,7 +11846,7 @@ impl<'a> BufferCopyBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseMemoryBind.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseMemoryBind.html>"]
 pub struct SparseMemoryBind {
     pub resource_offset: DeviceSize,
     pub size: DeviceSize,
@@ -11904,7 +11908,7 @@ impl<'a> SparseMemoryBindBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseImageMemoryBind.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseImageMemoryBind.html>"]
 pub struct SparseImageMemoryBind {
     pub subresource: ImageSubresource,
     pub offset: Offset3D,
@@ -11974,7 +11978,7 @@ impl<'a> SparseImageMemoryBindBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseBufferMemoryBindInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseBufferMemoryBindInfo.html>"]
 pub struct SparseBufferMemoryBindInfo {
     pub buffer: Buffer,
     pub bind_count: u32,
@@ -12032,7 +12036,7 @@ impl<'a> SparseBufferMemoryBindInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseImageOpaqueMemoryBindInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseImageOpaqueMemoryBindInfo.html>"]
 pub struct SparseImageOpaqueMemoryBindInfo {
     pub image: Image,
     pub bind_count: u32,
@@ -12093,7 +12097,7 @@ impl<'a> SparseImageOpaqueMemoryBindInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseImageMemoryBindInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseImageMemoryBindInfo.html>"]
 pub struct SparseImageMemoryBindInfo {
     pub image: Image,
     pub bind_count: u32,
@@ -12154,7 +12158,7 @@ impl<'a> SparseImageMemoryBindInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBindSparseInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBindSparseInfo.html>"]
 pub struct BindSparseInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -12279,7 +12283,7 @@ impl<'a> BindSparseInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageCopy.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageCopy.html>"]
 pub struct ImageCopy {
     pub src_subresource: ImageSubresourceLayers,
     pub src_offset: Offset3D,
@@ -12347,7 +12351,7 @@ impl<'a> ImageCopyBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageBlit.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageBlit.html>"]
 pub struct ImageBlit {
     pub src_subresource: ImageSubresourceLayers,
     pub src_offsets: [Offset3D; 2],
@@ -12420,7 +12424,7 @@ impl<'a> ImageBlitBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferImageCopy.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferImageCopy.html>"]
 pub struct BufferImageCopy {
     pub buffer_offset: DeviceSize,
     pub buffer_row_length: u32,
@@ -12490,7 +12494,7 @@ impl<'a> BufferImageCopyBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageResolve.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageResolve.html>"]
 pub struct ImageResolve {
     pub src_subresource: ImageSubresourceLayers,
     pub src_offset: Offset3D,
@@ -12558,7 +12562,7 @@ impl<'a> ImageResolveBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderModuleCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderModuleCreateInfo.html>"]
 pub struct ShaderModuleCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -12638,7 +12642,7 @@ impl<'a> ShaderModuleCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetLayoutBinding.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetLayoutBinding.html>"]
 pub struct DescriptorSetLayoutBinding {
     pub binding: u32,
     pub descriptor_type: DescriptorType,
@@ -12724,7 +12728,7 @@ impl<'a> DescriptorSetLayoutBindingBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetLayoutCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetLayoutCreateInfo.html>"]
 pub struct DescriptorSetLayoutCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -12810,7 +12814,7 @@ impl<'a> DescriptorSetLayoutCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorPoolSize.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorPoolSize.html>"]
 pub struct DescriptorPoolSize {
     pub ty: DescriptorType,
     pub descriptor_count: u32,
@@ -12857,7 +12861,7 @@ impl<'a> DescriptorPoolSizeBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorPoolCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorPoolCreateInfo.html>"]
 pub struct DescriptorPoolCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -12949,7 +12953,7 @@ impl<'a> DescriptorPoolCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetAllocateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetAllocateInfo.html>"]
 pub struct DescriptorSetAllocateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -13035,7 +13039,7 @@ impl<'a> DescriptorSetAllocateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSpecializationMapEntry.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSpecializationMapEntry.html>"]
 pub struct SpecializationMapEntry {
     pub constant_id: u32,
     pub offset: u32,
@@ -13087,7 +13091,7 @@ impl<'a> SpecializationMapEntryBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSpecializationInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSpecializationInfo.html>"]
 pub struct SpecializationInfo {
     pub map_entry_count: u32,
     pub p_map_entries: *const SpecializationMapEntry,
@@ -13151,7 +13155,7 @@ impl<'a> SpecializationInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineShaderStageCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineShaderStageCreateInfo.html>"]
 pub struct PipelineShaderStageCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -13252,7 +13256,7 @@ impl<'a> PipelineShaderStageCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkComputePipelineCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkComputePipelineCreateInfo.html>"]
 pub struct ComputePipelineCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -13356,7 +13360,7 @@ impl<'a> ComputePipelineCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkVertexInputBindingDescription.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVertexInputBindingDescription.html>"]
 pub struct VertexInputBindingDescription {
     pub binding: u32,
     pub stride: u32,
@@ -13411,7 +13415,7 @@ impl<'a> VertexInputBindingDescriptionBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkVertexInputAttributeDescription.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVertexInputAttributeDescription.html>"]
 pub struct VertexInputAttributeDescription {
     pub location: u32,
     pub binding: u32,
@@ -13468,7 +13472,7 @@ impl<'a> VertexInputAttributeDescriptionBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineVertexInputStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineVertexInputStateCreateInfo.html>"]
 pub struct PipelineVertexInputStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -13566,7 +13570,7 @@ impl<'a> PipelineVertexInputStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineInputAssemblyStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineInputAssemblyStateCreateInfo.html>"]
 pub struct PipelineInputAssemblyStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -13658,7 +13662,7 @@ impl<'a> PipelineInputAssemblyStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineTessellationStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineTessellationStateCreateInfo.html>"]
 pub struct PipelineTessellationStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -13741,7 +13745,7 @@ impl<'a> PipelineTessellationStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineViewportStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportStateCreateInfo.html>"]
 pub struct PipelineViewportStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -13853,7 +13857,7 @@ impl<'a> PipelineViewportStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationStateCreateInfo.html>"]
 pub struct PipelineRasterizationStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -14017,7 +14021,7 @@ impl<'a> PipelineRasterizationStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineMultisampleStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineMultisampleStateCreateInfo.html>"]
 pub struct PipelineMultisampleStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -14145,7 +14149,7 @@ impl<'a> PipelineMultisampleStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineColorBlendAttachmentState.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineColorBlendAttachmentState.html>"]
 pub struct PipelineColorBlendAttachmentState {
     pub blend_enable: Bool32,
     pub src_color_blend_factor: BlendFactor,
@@ -14246,7 +14250,7 @@ impl<'a> PipelineColorBlendAttachmentStateBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineColorBlendStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineColorBlendStateCreateInfo.html>"]
 pub struct PipelineColorBlendStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -14356,7 +14360,7 @@ impl<'a> PipelineColorBlendStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineDynamicStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDynamicStateCreateInfo.html>"]
 pub struct PipelineDynamicStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -14442,7 +14446,7 @@ impl<'a> PipelineDynamicStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkStencilOpState.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStencilOpState.html>"]
 pub struct StencilOpState {
     pub fail_op: StencilOp,
     pub pass_op: StencilOp,
@@ -14514,7 +14518,7 @@ impl<'a> StencilOpStateBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineDepthStencilStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDepthStencilStateCreateInfo.html>"]
 pub struct PipelineDepthStencilStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -14666,7 +14670,7 @@ impl<'a> PipelineDepthStencilStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkGraphicsPipelineCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGraphicsPipelineCreateInfo.html>"]
 pub struct GraphicsPipelineCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -14866,7 +14870,7 @@ impl<'a> GraphicsPipelineCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCacheCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCacheCreateInfo.html>"]
 pub struct PipelineCacheCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -14946,7 +14950,7 @@ impl<'a> PipelineCacheCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPushConstantRange.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPushConstantRange.html>"]
 pub struct PushConstantRange {
     pub stage_flags: ShaderStageFlags,
     pub offset: u32,
@@ -14998,7 +15002,7 @@ impl<'a> PushConstantRangeBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineLayoutCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineLayoutCreateInfo.html>"]
 pub struct PipelineLayoutCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -15096,7 +15100,7 @@ impl<'a> PipelineLayoutCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerCreateInfo.html>"]
 pub struct SamplerCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -15269,7 +15273,7 @@ impl<'a> SamplerCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandPoolCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandPoolCreateInfo.html>"]
 pub struct CommandPoolCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -15349,7 +15353,7 @@ impl<'a> CommandPoolCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandBufferAllocateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferAllocateInfo.html>"]
 pub struct CommandBufferAllocateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -15438,7 +15442,7 @@ impl<'a> CommandBufferAllocateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandBufferInheritanceInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferInheritanceInfo.html>"]
 pub struct CommandBufferInheritanceInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -15554,7 +15558,7 @@ impl<'a> CommandBufferInheritanceInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandBufferBeginInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferBeginInfo.html>"]
 pub struct CommandBufferBeginInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -15634,7 +15638,7 @@ impl<'a> CommandBufferBeginInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassBeginInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassBeginInfo.html>"]
 pub struct RenderPassBeginInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -15742,7 +15746,7 @@ impl<'a> RenderPassBeginInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkClearColorValue.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkClearColorValue.html>"]
 pub union ClearColorValue {
     pub float32: [f32; 4],
     pub int32: [i32; 4],
@@ -15755,7 +15759,7 @@ impl ::std::default::Default for ClearColorValue {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkClearDepthStencilValue.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkClearDepthStencilValue.html>"]
 pub struct ClearDepthStencilValue {
     pub depth: f32,
     pub stencil: u32,
@@ -15802,7 +15806,7 @@ impl<'a> ClearDepthStencilValueBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkClearValue.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkClearValue.html>"]
 pub union ClearValue {
     pub color: ClearColorValue,
     pub depth_stencil: ClearDepthStencilValue,
@@ -15814,7 +15818,7 @@ impl ::std::default::Default for ClearValue {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkClearAttachment.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkClearAttachment.html>"]
 pub struct ClearAttachment {
     pub aspect_mask: ImageAspectFlags,
     pub color_attachment: u32,
@@ -15875,7 +15879,7 @@ impl<'a> ClearAttachmentBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentDescription.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentDescription.html>"]
 pub struct AttachmentDescription {
     pub flags: AttachmentDescriptionFlags,
     pub format: Format,
@@ -15966,7 +15970,7 @@ impl<'a> AttachmentDescriptionBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentReference.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentReference.html>"]
 pub struct AttachmentReference {
     pub attachment: u32,
     pub layout: ImageLayout,
@@ -16013,7 +16017,7 @@ impl<'a> AttachmentReferenceBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDescription.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassDescription.html>"]
 pub struct SubpassDescription {
     pub flags: SubpassDescriptionFlags,
     pub pipeline_bind_point: PipelineBindPoint,
@@ -16126,7 +16130,7 @@ impl<'a> SubpassDescriptionBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDependency.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassDependency.html>"]
 pub struct SubpassDependency {
     pub src_subpass: u32,
     pub dst_subpass: u32,
@@ -16207,7 +16211,7 @@ impl<'a> SubpassDependencyBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassCreateInfo.html>"]
 pub struct RenderPassCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -16314,7 +16318,7 @@ impl<'a> RenderPassCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkEventCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkEventCreateInfo.html>"]
 pub struct EventCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -16385,7 +16389,7 @@ impl<'a> EventCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFenceCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFenceCreateInfo.html>"]
 pub struct FenceCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -16456,7 +16460,7 @@ impl<'a> FenceCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceFeatures.html>"]
 pub struct PhysicalDeviceFeatures {
     pub robust_buffer_access: Bool32,
     pub full_draw_index_uint32: Bool32,
@@ -16896,7 +16900,7 @@ impl<'a> PhysicalDeviceFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSparseProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSparseProperties.html>"]
 pub struct PhysicalDeviceSparseProperties {
     pub residency_standard2_d_block_shape: Bool32,
     pub residency_standard2_d_multisample_block_shape: Bool32,
@@ -16974,7 +16978,7 @@ impl<'a> PhysicalDeviceSparsePropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceLimits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceLimits.html>"]
 pub struct PhysicalDeviceLimits {
     pub max_image_dimension1_d: u32,
     pub max_image_dimension2_d: u32,
@@ -17974,7 +17978,7 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreCreateInfo.html>"]
 pub struct SemaphoreCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -18045,7 +18049,7 @@ impl<'a> SemaphoreCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryPoolCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPoolCreateInfo.html>"]
 pub struct QueryPoolCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -18137,7 +18141,7 @@ impl<'a> QueryPoolCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebufferCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFramebufferCreateInfo.html>"]
 pub struct FramebufferCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -18241,7 +18245,7 @@ impl<'a> FramebufferCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDrawIndirectCommand.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDrawIndirectCommand.html>"]
 pub struct DrawIndirectCommand {
     pub vertex_count: u32,
     pub instance_count: u32,
@@ -18298,7 +18302,7 @@ impl<'a> DrawIndirectCommandBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDrawIndexedIndirectCommand.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDrawIndexedIndirectCommand.html>"]
 pub struct DrawIndexedIndirectCommand {
     pub index_count: u32,
     pub instance_count: u32,
@@ -18360,7 +18364,7 @@ impl<'a> DrawIndexedIndirectCommandBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDispatchIndirectCommand.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDispatchIndirectCommand.html>"]
 pub struct DispatchIndirectCommand {
     pub x: u32,
     pub y: u32,
@@ -18412,7 +18416,7 @@ impl<'a> DispatchIndirectCommandBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubmitInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubmitInfo.html>"]
 pub struct SubmitInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -18517,7 +18521,7 @@ impl<'a> SubmitInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPropertiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPropertiesKHR.html>"]
 pub struct DisplayPropertiesKHR {
     pub display: DisplayKHR,
     pub display_name: *const c_char,
@@ -18617,7 +18621,7 @@ impl<'a> DisplayPropertiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPlanePropertiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPlanePropertiesKHR.html>"]
 pub struct DisplayPlanePropertiesKHR {
     pub current_display: DisplayKHR,
     pub current_stack_index: u32,
@@ -18670,7 +18674,7 @@ impl<'a> DisplayPlanePropertiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayModeParametersKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayModeParametersKHR.html>"]
 pub struct DisplayModeParametersKHR {
     pub visible_region: Extent2D,
     pub refresh_rate: u32,
@@ -18720,7 +18724,7 @@ impl<'a> DisplayModeParametersKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayModePropertiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayModePropertiesKHR.html>"]
 pub struct DisplayModePropertiesKHR {
     pub display_mode: DisplayModeKHR,
     pub parameters: DisplayModeParametersKHR,
@@ -18773,7 +18777,7 @@ impl<'a> DisplayModePropertiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayModeCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayModeCreateInfoKHR.html>"]
 pub struct DisplayModeCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -18856,7 +18860,7 @@ impl<'a> DisplayModeCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPlaneCapabilitiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPlaneCapabilitiesKHR.html>"]
 pub struct DisplayPlaneCapabilitiesKHR {
     pub supported_alpha: DisplayPlaneAlphaFlagsKHR,
     pub min_src_position: Offset2D,
@@ -18965,7 +18969,7 @@ impl<'a> DisplayPlaneCapabilitiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplaySurfaceCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplaySurfaceCreateInfoKHR.html>"]
 pub struct DisplaySurfaceCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19096,7 +19100,7 @@ impl<'a> DisplaySurfaceCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPresentInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPresentInfoKHR.html>"]
 pub struct DisplayPresentInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19163,7 +19167,7 @@ impl<'a> DisplayPresentInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceCapabilitiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceCapabilitiesKHR.html>"]
 pub struct SurfaceCapabilitiesKHR {
     pub min_image_count: u32,
     pub max_image_count: u32,
@@ -19271,7 +19275,7 @@ impl<'a> SurfaceCapabilitiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAndroidSurfaceCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAndroidSurfaceCreateInfoKHR.html>"]
 pub struct AndroidSurfaceCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19351,7 +19355,7 @@ impl<'a> AndroidSurfaceCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkViSurfaceCreateInfoNN.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkViSurfaceCreateInfoNN.html>"]
 pub struct ViSurfaceCreateInfoNN {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19428,7 +19432,7 @@ impl<'a> ViSurfaceCreateInfoNNBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkWaylandSurfaceCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWaylandSurfaceCreateInfoKHR.html>"]
 pub struct WaylandSurfaceCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19514,7 +19518,7 @@ impl<'a> WaylandSurfaceCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkWin32SurfaceCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWin32SurfaceCreateInfoKHR.html>"]
 pub struct Win32SurfaceCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19600,7 +19604,7 @@ impl<'a> Win32SurfaceCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkXlibSurfaceCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkXlibSurfaceCreateInfoKHR.html>"]
 pub struct XlibSurfaceCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19686,7 +19690,7 @@ impl<'a> XlibSurfaceCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkXcbSurfaceCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkXcbSurfaceCreateInfoKHR.html>"]
 pub struct XcbSurfaceCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19772,7 +19776,7 @@ impl<'a> XcbSurfaceCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImagePipeSurfaceCreateInfoFUCHSIA.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImagePipeSurfaceCreateInfoFUCHSIA.html>"]
 pub struct ImagePipeSurfaceCreateInfoFUCHSIA {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19855,7 +19859,7 @@ impl<'a> ImagePipeSurfaceCreateInfoFUCHSIABuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkStreamDescriptorSurfaceCreateInfoGGP.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStreamDescriptorSurfaceCreateInfoGGP.html>"]
 pub struct StreamDescriptorSurfaceCreateInfoGGP {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -19938,7 +19942,7 @@ impl<'a> StreamDescriptorSurfaceCreateInfoGGPBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceFormatKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceFormatKHR.html>"]
 pub struct SurfaceFormatKHR {
     pub format: Format,
     pub color_space: ColorSpaceKHR,
@@ -19985,7 +19989,7 @@ impl<'a> SurfaceFormatKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSwapchainCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSwapchainCreateInfoKHR.html>"]
 pub struct SwapchainCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20170,7 +20174,7 @@ impl<'a> SwapchainCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPresentInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentInfoKHR.html>"]
 pub struct PresentInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20270,7 +20274,7 @@ impl<'a> PresentInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugReportCallbackCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugReportCallbackCreateInfoEXT.html>"]
 pub struct DebugReportCallbackCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20357,7 +20361,7 @@ impl<'a> DebugReportCallbackCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkValidationFlagsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationFlagsEXT.html>"]
 pub struct ValidationFlagsEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20418,7 +20422,7 @@ impl<'a> ValidationFlagsEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkValidationFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationFeaturesEXT.html>"]
 pub struct ValidationFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20491,7 +20495,7 @@ impl<'a> ValidationFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationStateRasterizationOrderAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationStateRasterizationOrderAMD.html>"]
 pub struct PipelineRasterizationStateRasterizationOrderAMD {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20555,7 +20559,7 @@ impl<'a> PipelineRasterizationStateRasterizationOrderAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugMarkerObjectNameInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugMarkerObjectNameInfoEXT.html>"]
 pub struct DebugMarkerObjectNameInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20644,7 +20648,7 @@ impl<'a> DebugMarkerObjectNameInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugMarkerObjectTagInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugMarkerObjectTagInfoEXT.html>"]
 pub struct DebugMarkerObjectTagInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20739,7 +20743,7 @@ impl<'a> DebugMarkerObjectTagInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugMarkerMarkerInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugMarkerMarkerInfoEXT.html>"]
 pub struct DebugMarkerMarkerInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20819,7 +20823,7 @@ impl<'a> DebugMarkerMarkerInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDedicatedAllocationImageCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDedicatedAllocationImageCreateInfoNV.html>"]
 pub struct DedicatedAllocationImageCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20877,7 +20881,7 @@ impl<'a> DedicatedAllocationImageCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDedicatedAllocationBufferCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDedicatedAllocationBufferCreateInfoNV.html>"]
 pub struct DedicatedAllocationBufferCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20935,7 +20939,7 @@ impl<'a> DedicatedAllocationBufferCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDedicatedAllocationMemoryAllocateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDedicatedAllocationMemoryAllocateInfoNV.html>"]
 pub struct DedicatedAllocationMemoryAllocateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -20996,7 +21000,7 @@ impl<'a> DedicatedAllocationMemoryAllocateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalImageFormatPropertiesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalImageFormatPropertiesNV.html>"]
 pub struct ExternalImageFormatPropertiesNV {
     pub image_format_properties: ImageFormatProperties,
     pub external_memory_features: ExternalMemoryFeatureFlagsNV,
@@ -21065,7 +21069,7 @@ impl<'a> ExternalImageFormatPropertiesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalMemoryImageCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryImageCreateInfoNV.html>"]
 pub struct ExternalMemoryImageCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -21123,7 +21127,7 @@ impl<'a> ExternalMemoryImageCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExportMemoryAllocateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExportMemoryAllocateInfoNV.html>"]
 pub struct ExportMemoryAllocateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -21181,7 +21185,7 @@ impl<'a> ExportMemoryAllocateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImportMemoryWin32HandleInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImportMemoryWin32HandleInfoNV.html>"]
 pub struct ImportMemoryWin32HandleInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -21245,7 +21249,7 @@ impl<'a> ImportMemoryWin32HandleInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExportMemoryWin32HandleInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExportMemoryWin32HandleInfoNV.html>"]
 pub struct ExportMemoryWin32HandleInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -21309,7 +21313,7 @@ impl<'a> ExportMemoryWin32HandleInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkWin32KeyedMutexAcquireReleaseInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWin32KeyedMutexAcquireReleaseInfoNV.html>"]
 pub struct Win32KeyedMutexAcquireReleaseInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -21412,7 +21416,7 @@ impl<'a> Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGeneratedCommandsFeaturesNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGeneratedCommandsFeaturesNVX.html>"]
 pub struct DeviceGeneratedCommandsFeaturesNVX {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -21486,7 +21490,7 @@ impl<'a> DeviceGeneratedCommandsFeaturesNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGeneratedCommandsLimitsNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGeneratedCommandsLimitsNVX.html>"]
 pub struct DeviceGeneratedCommandsLimitsNVX {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -21600,7 +21604,7 @@ impl<'a> DeviceGeneratedCommandsLimitsNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkIndirectCommandsTokenNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndirectCommandsTokenNVX.html>"]
 pub struct IndirectCommandsTokenNVX {
     pub token_type: IndirectCommandsTokenTypeNVX,
     pub buffer: Buffer,
@@ -21655,7 +21659,7 @@ impl<'a> IndirectCommandsTokenNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkIndirectCommandsLayoutTokenNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndirectCommandsLayoutTokenNVX.html>"]
 pub struct IndirectCommandsLayoutTokenNVX {
     pub token_type: IndirectCommandsTokenTypeNVX,
     pub binding_unit: u32,
@@ -21718,7 +21722,7 @@ impl<'a> IndirectCommandsLayoutTokenNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkIndirectCommandsLayoutCreateInfoNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndirectCommandsLayoutCreateInfoNVX.html>"]
 pub struct IndirectCommandsLayoutCreateInfoNVX {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -21813,7 +21817,7 @@ impl<'a> IndirectCommandsLayoutCreateInfoNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCmdProcessCommandsInfoNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCmdProcessCommandsInfoNVX.html>"]
 pub struct CmdProcessCommandsInfoNVX {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -21962,7 +21966,7 @@ impl<'a> CmdProcessCommandsInfoNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCmdReserveSpaceForCommandsInfoNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCmdReserveSpaceForCommandsInfoNVX.html>"]
 pub struct CmdReserveSpaceForCommandsInfoNVX {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -22054,7 +22058,7 @@ impl<'a> CmdReserveSpaceForCommandsInfoNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectTableCreateInfoNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectTableCreateInfoNVX.html>"]
 pub struct ObjectTableCreateInfoNVX {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -22196,7 +22200,7 @@ impl<'a> ObjectTableCreateInfoNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectTableEntryNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectTableEntryNVX.html>"]
 pub struct ObjectTableEntryNVX {
     pub ty: ObjectEntryTypeNVX,
     pub flags: ObjectEntryUsageFlagsNVX,
@@ -22243,7 +22247,7 @@ impl<'a> ObjectTableEntryNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectTablePipelineEntryNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectTablePipelineEntryNVX.html>"]
 pub struct ObjectTablePipelineEntryNVX {
     pub ty: ObjectEntryTypeNVX,
     pub flags: ObjectEntryUsageFlagsNVX,
@@ -22298,7 +22302,7 @@ impl<'a> ObjectTablePipelineEntryNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectTableDescriptorSetEntryNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectTableDescriptorSetEntryNVX.html>"]
 pub struct ObjectTableDescriptorSetEntryNVX {
     pub ty: ObjectEntryTypeNVX,
     pub flags: ObjectEntryUsageFlagsNVX,
@@ -22364,7 +22368,7 @@ impl<'a> ObjectTableDescriptorSetEntryNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectTableVertexBufferEntryNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectTableVertexBufferEntryNVX.html>"]
 pub struct ObjectTableVertexBufferEntryNVX {
     pub ty: ObjectEntryTypeNVX,
     pub flags: ObjectEntryUsageFlagsNVX,
@@ -22419,7 +22423,7 @@ impl<'a> ObjectTableVertexBufferEntryNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectTableIndexBufferEntryNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectTableIndexBufferEntryNVX.html>"]
 pub struct ObjectTableIndexBufferEntryNVX {
     pub ty: ObjectEntryTypeNVX,
     pub flags: ObjectEntryUsageFlagsNVX,
@@ -22482,7 +22486,7 @@ impl<'a> ObjectTableIndexBufferEntryNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectTablePushConstantEntryNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectTablePushConstantEntryNVX.html>"]
 pub struct ObjectTablePushConstantEntryNVX {
     pub ty: ObjectEntryTypeNVX,
     pub flags: ObjectEntryUsageFlagsNVX,
@@ -22548,7 +22552,7 @@ impl<'a> ObjectTablePushConstantEntryNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceFeatures2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceFeatures2.html>"]
 pub struct PhysicalDeviceFeatures2 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -22606,7 +22610,7 @@ impl<'a> PhysicalDeviceFeatures2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceProperties2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceProperties2.html>"]
 pub struct PhysicalDeviceProperties2 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -22680,7 +22684,7 @@ impl<'a> PhysicalDeviceProperties2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFormatProperties2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFormatProperties2.html>"]
 pub struct FormatProperties2 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -22754,7 +22758,7 @@ impl<'a> FormatProperties2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageFormatProperties2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageFormatProperties2.html>"]
 pub struct ImageFormatProperties2 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -22828,7 +22832,7 @@ impl<'a> ImageFormatProperties2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceImageFormatInfo2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceImageFormatInfo2.html>"]
 pub struct PhysicalDeviceImageFormatInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -22923,7 +22927,7 @@ impl<'a> PhysicalDeviceImageFormatInfo2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueueFamilyProperties2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueueFamilyProperties2.html>"]
 pub struct QueueFamilyProperties2 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -22997,7 +23001,7 @@ impl<'a> QueueFamilyProperties2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMemoryProperties2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMemoryProperties2.html>"]
 pub struct PhysicalDeviceMemoryProperties2 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -23071,7 +23075,7 @@ impl<'a> PhysicalDeviceMemoryProperties2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseImageFormatProperties2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseImageFormatProperties2.html>"]
 pub struct SparseImageFormatProperties2 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -23145,7 +23149,7 @@ impl<'a> SparseImageFormatProperties2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSparseImageFormatInfo2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSparseImageFormatInfo2.html>"]
 pub struct PhysicalDeviceSparseImageFormatInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -23249,7 +23253,7 @@ impl<'a> PhysicalDeviceSparseImageFormatInfo2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePushDescriptorPropertiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevicePushDescriptorPropertiesKHR.html>"]
 pub struct PhysicalDevicePushDescriptorPropertiesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -23310,7 +23314,7 @@ impl<'a> PhysicalDevicePushDescriptorPropertiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkConformanceVersion.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkConformanceVersion.html>"]
 pub struct ConformanceVersion {
     pub major: u8,
     pub minor: u8,
@@ -23367,7 +23371,7 @@ impl<'a> ConformanceVersionBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDriverProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceDriverProperties.html>"]
 pub struct PhysicalDeviceDriverProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -23465,7 +23469,7 @@ impl<'a> PhysicalDeviceDriverPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPresentRegionsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentRegionsKHR.html>"]
 pub struct PresentRegionsKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -23523,7 +23527,7 @@ impl<'a> PresentRegionsKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPresentRegionKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentRegionKHR.html>"]
 pub struct PresentRegionKHR {
     pub rectangle_count: u32,
     pub p_rectangles: *const RectLayerKHR,
@@ -23575,7 +23579,7 @@ impl<'a> PresentRegionKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRectLayerKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRectLayerKHR.html>"]
 pub struct RectLayerKHR {
     pub offset: Offset2D,
     pub extent: Extent2D,
@@ -23627,7 +23631,7 @@ impl<'a> RectLayerKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVariablePointersFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceVariablePointersFeatures.html>"]
 pub struct PhysicalDeviceVariablePointersFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -23694,7 +23698,7 @@ impl<'a> PhysicalDeviceVariablePointersFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalMemoryProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryProperties.html>"]
 pub struct ExternalMemoryProperties {
     pub external_memory_features: ExternalMemoryFeatureFlags,
     pub export_from_imported_handle_types: ExternalMemoryHandleTypeFlags,
@@ -23755,7 +23759,7 @@ impl<'a> ExternalMemoryPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceExternalImageFormatInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceExternalImageFormatInfo.html>"]
 pub struct PhysicalDeviceExternalImageFormatInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -23816,7 +23820,7 @@ impl<'a> PhysicalDeviceExternalImageFormatInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalImageFormatProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalImageFormatProperties.html>"]
 pub struct ExternalImageFormatProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -23874,7 +23878,7 @@ impl<'a> ExternalImageFormatPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceExternalBufferInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceExternalBufferInfo.html>"]
 pub struct PhysicalDeviceExternalBufferInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -23963,7 +23967,7 @@ impl<'a> PhysicalDeviceExternalBufferInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalBufferProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalBufferProperties.html>"]
 pub struct ExternalBufferProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -24037,7 +24041,7 @@ impl<'a> ExternalBufferPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceIDProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceIDProperties.html>"]
 pub struct PhysicalDeviceIDProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -24131,7 +24135,7 @@ impl<'a> PhysicalDeviceIDPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalMemoryImageCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryImageCreateInfo.html>"]
 pub struct ExternalMemoryImageCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24189,7 +24193,7 @@ impl<'a> ExternalMemoryImageCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalMemoryBufferCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryBufferCreateInfo.html>"]
 pub struct ExternalMemoryBufferCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24247,7 +24251,7 @@ impl<'a> ExternalMemoryBufferCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExportMemoryAllocateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExportMemoryAllocateInfo.html>"]
 pub struct ExportMemoryAllocateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24305,7 +24309,7 @@ impl<'a> ExportMemoryAllocateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImportMemoryWin32HandleInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImportMemoryWin32HandleInfoKHR.html>"]
 pub struct ImportMemoryWin32HandleInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24375,7 +24379,7 @@ impl<'a> ImportMemoryWin32HandleInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExportMemoryWin32HandleInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExportMemoryWin32HandleInfoKHR.html>"]
 pub struct ExportMemoryWin32HandleInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24445,7 +24449,7 @@ impl<'a> ExportMemoryWin32HandleInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryWin32HandlePropertiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryWin32HandlePropertiesKHR.html>"]
 pub struct MemoryWin32HandlePropertiesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -24519,7 +24523,7 @@ impl<'a> MemoryWin32HandlePropertiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryGetWin32HandleInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryGetWin32HandleInfoKHR.html>"]
 pub struct MemoryGetWin32HandleInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24599,7 +24603,7 @@ impl<'a> MemoryGetWin32HandleInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImportMemoryFdInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImportMemoryFdInfoKHR.html>"]
 pub struct ImportMemoryFdInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24663,7 +24667,7 @@ impl<'a> ImportMemoryFdInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryFdPropertiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryFdPropertiesKHR.html>"]
 pub struct MemoryFdPropertiesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -24734,7 +24738,7 @@ impl<'a> MemoryFdPropertiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryGetFdInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryGetFdInfoKHR.html>"]
 pub struct MemoryGetFdInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24814,7 +24818,7 @@ impl<'a> MemoryGetFdInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkWin32KeyedMutexAcquireReleaseInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWin32KeyedMutexAcquireReleaseInfoKHR.html>"]
 pub struct Win32KeyedMutexAcquireReleaseInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24917,7 +24921,7 @@ impl<'a> Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceExternalSemaphoreInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceExternalSemaphoreInfo.html>"]
 pub struct PhysicalDeviceExternalSemaphoreInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -24991,7 +24995,7 @@ impl<'a> PhysicalDeviceExternalSemaphoreInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalSemaphoreProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalSemaphoreProperties.html>"]
 pub struct ExternalSemaphoreProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -25083,7 +25087,7 @@ impl<'a> ExternalSemaphorePropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExportSemaphoreCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExportSemaphoreCreateInfo.html>"]
 pub struct ExportSemaphoreCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25141,7 +25145,7 @@ impl<'a> ExportSemaphoreCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImportSemaphoreWin32HandleInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImportSemaphoreWin32HandleInfoKHR.html>"]
 pub struct ImportSemaphoreWin32HandleInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25245,7 +25249,7 @@ impl<'a> ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExportSemaphoreWin32HandleInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExportSemaphoreWin32HandleInfoKHR.html>"]
 pub struct ExportSemaphoreWin32HandleInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25315,7 +25319,7 @@ impl<'a> ExportSemaphoreWin32HandleInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkD3D12FenceSubmitInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkD3D12FenceSubmitInfoKHR.html>"]
 pub struct D3D12FenceSubmitInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25388,7 +25392,7 @@ impl<'a> D3D12FenceSubmitInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreGetWin32HandleInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreGetWin32HandleInfoKHR.html>"]
 pub struct SemaphoreGetWin32HandleInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25468,7 +25472,7 @@ impl<'a> SemaphoreGetWin32HandleInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImportSemaphoreFdInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImportSemaphoreFdInfoKHR.html>"]
 pub struct ImportSemaphoreFdInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25560,7 +25564,7 @@ impl<'a> ImportSemaphoreFdInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreGetFdInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreGetFdInfoKHR.html>"]
 pub struct SemaphoreGetFdInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25640,7 +25644,7 @@ impl<'a> SemaphoreGetFdInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceExternalFenceInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceExternalFenceInfo.html>"]
 pub struct PhysicalDeviceExternalFenceInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25714,7 +25718,7 @@ impl<'a> PhysicalDeviceExternalFenceInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalFenceProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalFenceProperties.html>"]
 pub struct ExternalFenceProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -25806,7 +25810,7 @@ impl<'a> ExternalFencePropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExportFenceCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExportFenceCreateInfo.html>"]
 pub struct ExportFenceCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25864,7 +25868,7 @@ impl<'a> ExportFenceCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImportFenceWin32HandleInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImportFenceWin32HandleInfoKHR.html>"]
 pub struct ImportFenceWin32HandleInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -25962,7 +25966,7 @@ impl<'a> ImportFenceWin32HandleInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExportFenceWin32HandleInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExportFenceWin32HandleInfoKHR.html>"]
 pub struct ExportFenceWin32HandleInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -26032,7 +26036,7 @@ impl<'a> ExportFenceWin32HandleInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFenceGetWin32HandleInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFenceGetWin32HandleInfoKHR.html>"]
 pub struct FenceGetWin32HandleInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -26112,7 +26116,7 @@ impl<'a> FenceGetWin32HandleInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImportFenceFdInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImportFenceFdInfoKHR.html>"]
 pub struct ImportFenceFdInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -26204,7 +26208,7 @@ impl<'a> ImportFenceFdInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFenceGetFdInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFenceGetFdInfoKHR.html>"]
 pub struct FenceGetFdInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -26284,7 +26288,7 @@ impl<'a> FenceGetFdInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMultiviewFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMultiviewFeatures.html>"]
 pub struct PhysicalDeviceMultiviewFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -26357,7 +26361,7 @@ impl<'a> PhysicalDeviceMultiviewFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMultiviewProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMultiviewProperties.html>"]
 pub struct PhysicalDeviceMultiviewProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -26424,7 +26428,7 @@ impl<'a> PhysicalDeviceMultiviewPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassMultiviewCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassMultiviewCreateInfo.html>"]
 pub struct RenderPassMultiviewCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -26506,7 +26510,7 @@ impl<'a> RenderPassMultiviewCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceCapabilities2EXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceCapabilities2EXT.html>"]
 pub struct SurfaceCapabilities2EXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -26664,7 +26668,7 @@ impl<'a> SurfaceCapabilities2EXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPowerInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPowerInfoEXT.html>"]
 pub struct DisplayPowerInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -26738,7 +26742,7 @@ impl<'a> DisplayPowerInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceEventInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceEventInfoEXT.html>"]
 pub struct DeviceEventInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -26812,7 +26816,7 @@ impl<'a> DeviceEventInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayEventInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayEventInfoEXT.html>"]
 pub struct DisplayEventInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -26886,7 +26890,7 @@ impl<'a> DisplayEventInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSwapchainCounterCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSwapchainCounterCreateInfoEXT.html>"]
 pub struct SwapchainCounterCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -26944,7 +26948,7 @@ impl<'a> SwapchainCounterCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceGroupProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceGroupProperties.html>"]
 pub struct PhysicalDeviceGroupProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -27036,7 +27040,7 @@ impl<'a> PhysicalDeviceGroupPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryAllocateFlagsInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryAllocateFlagsInfo.html>"]
 pub struct MemoryAllocateFlagsInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27097,7 +27101,7 @@ impl<'a> MemoryAllocateFlagsInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBindBufferMemoryInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBindBufferMemoryInfo.html>"]
 pub struct BindBufferMemoryInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27180,7 +27184,7 @@ impl<'a> BindBufferMemoryInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBindBufferMemoryDeviceGroupInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBindBufferMemoryDeviceGroupInfo.html>"]
 pub struct BindBufferMemoryDeviceGroupInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27241,7 +27245,7 @@ impl<'a> BindBufferMemoryDeviceGroupInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBindImageMemoryInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBindImageMemoryInfo.html>"]
 pub struct BindImageMemoryInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27324,7 +27328,7 @@ impl<'a> BindImageMemoryInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBindImageMemoryDeviceGroupInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBindImageMemoryDeviceGroupInfo.html>"]
 pub struct BindImageMemoryDeviceGroupInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27397,7 +27401,7 @@ impl<'a> BindImageMemoryDeviceGroupInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGroupRenderPassBeginInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupRenderPassBeginInfo.html>"]
 pub struct DeviceGroupRenderPassBeginInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27464,7 +27468,7 @@ impl<'a> DeviceGroupRenderPassBeginInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGroupCommandBufferBeginInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupCommandBufferBeginInfo.html>"]
 pub struct DeviceGroupCommandBufferBeginInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27519,7 +27523,7 @@ impl<'a> DeviceGroupCommandBufferBeginInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGroupSubmitInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupSubmitInfo.html>"]
 pub struct DeviceGroupSubmitInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27604,7 +27608,7 @@ impl<'a> DeviceGroupSubmitInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGroupBindSparseInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupBindSparseInfo.html>"]
 pub struct DeviceGroupBindSparseInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27671,7 +27675,7 @@ impl<'a> DeviceGroupBindSparseInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGroupPresentCapabilitiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupPresentCapabilitiesKHR.html>"]
 pub struct DeviceGroupPresentCapabilitiesKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27754,7 +27758,7 @@ impl<'a> DeviceGroupPresentCapabilitiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageSwapchainCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageSwapchainCreateInfoKHR.html>"]
 pub struct ImageSwapchainCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27809,7 +27813,7 @@ impl<'a> ImageSwapchainCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBindImageMemorySwapchainInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBindImageMemorySwapchainInfoKHR.html>"]
 pub struct BindImageMemorySwapchainInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27873,7 +27877,7 @@ impl<'a> BindImageMemorySwapchainInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAcquireNextImageInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAcquireNextImageInfoKHR.html>"]
 pub struct AcquireNextImageInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -27968,7 +27972,7 @@ impl<'a> AcquireNextImageInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGroupPresentInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupPresentInfoKHR.html>"]
 pub struct DeviceGroupPresentInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -28035,7 +28039,7 @@ impl<'a> DeviceGroupPresentInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGroupDeviceCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupDeviceCreateInfo.html>"]
 pub struct DeviceGroupDeviceCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -28096,7 +28100,7 @@ impl<'a> DeviceGroupDeviceCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGroupSwapchainCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupSwapchainCreateInfoKHR.html>"]
 pub struct DeviceGroupSwapchainCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -28154,7 +28158,7 @@ impl<'a> DeviceGroupSwapchainCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorUpdateTemplateEntry.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorUpdateTemplateEntry.html>"]
 pub struct DescriptorUpdateTemplateEntry {
     pub dst_binding: u32,
     pub dst_array_element: u32,
@@ -28230,7 +28234,7 @@ impl<'a> DescriptorUpdateTemplateEntryBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorUpdateTemplateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorUpdateTemplateCreateInfo.html>"]
 pub struct DescriptorUpdateTemplateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -28358,7 +28362,7 @@ impl<'a> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkXYColorEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkXYColorEXT.html>"]
 pub struct XYColorEXT {
     pub x: f32,
     pub y: f32,
@@ -28405,7 +28409,7 @@ impl<'a> XYColorEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkHdrMetadataEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkHdrMetadataEXT.html>"]
 pub struct HdrMetadataEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -28533,7 +28537,7 @@ impl<'a> HdrMetadataEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayNativeHdrSurfaceCapabilitiesAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayNativeHdrSurfaceCapabilitiesAMD.html>"]
 pub struct DisplayNativeHdrSurfaceCapabilitiesAMD {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -28591,7 +28595,7 @@ impl<'a> DisplayNativeHdrSurfaceCapabilitiesAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSwapchainDisplayNativeHdrCreateInfoAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSwapchainDisplayNativeHdrCreateInfoAMD.html>"]
 pub struct SwapchainDisplayNativeHdrCreateInfoAMD {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -28649,7 +28653,7 @@ impl<'a> SwapchainDisplayNativeHdrCreateInfoAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRefreshCycleDurationGOOGLE.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRefreshCycleDurationGOOGLE.html>"]
 pub struct RefreshCycleDurationGOOGLE {
     pub refresh_duration: u64,
 }
@@ -28694,7 +28698,7 @@ impl<'a> RefreshCycleDurationGOOGLEBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPastPresentationTimingGOOGLE.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPastPresentationTimingGOOGLE.html>"]
 pub struct PastPresentationTimingGOOGLE {
     pub present_id: u32,
     pub desired_present_time: u64,
@@ -28768,7 +28772,7 @@ impl<'a> PastPresentationTimingGOOGLEBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPresentTimesInfoGOOGLE.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentTimesInfoGOOGLE.html>"]
 pub struct PresentTimesInfoGOOGLE {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -28826,7 +28830,7 @@ impl<'a> PresentTimesInfoGOOGLEBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPresentTimeGOOGLE.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentTimeGOOGLE.html>"]
 pub struct PresentTimeGOOGLE {
     pub present_id: u32,
     pub desired_present_time: u64,
@@ -28876,7 +28880,7 @@ impl<'a> PresentTimeGOOGLEBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkIOSSurfaceCreateInfoMVK.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIOSSurfaceCreateInfoMVK.html>"]
 pub struct IOSSurfaceCreateInfoMVK {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -28953,7 +28957,7 @@ impl<'a> IOSSurfaceCreateInfoMVKBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMacOSSurfaceCreateInfoMVK.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMacOSSurfaceCreateInfoMVK.html>"]
 pub struct MacOSSurfaceCreateInfoMVK {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -29033,7 +29037,7 @@ impl<'a> MacOSSurfaceCreateInfoMVKBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMetalSurfaceCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMetalSurfaceCreateInfoEXT.html>"]
 pub struct MetalSurfaceCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -29113,7 +29117,7 @@ impl<'a> MetalSurfaceCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkViewportWScalingNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkViewportWScalingNV.html>"]
 pub struct ViewportWScalingNV {
     pub xcoeff: f32,
     pub ycoeff: f32,
@@ -29160,7 +29164,7 @@ impl<'a> ViewportWScalingNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineViewportWScalingStateCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportWScalingStateCreateInfoNV.html>"]
 pub struct PipelineViewportWScalingStateCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -29233,7 +29237,7 @@ impl<'a> PipelineViewportWScalingStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkViewportSwizzleNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkViewportSwizzleNV.html>"]
 pub struct ViewportSwizzleNV {
     pub x: ViewportCoordinateSwizzleNV,
     pub y: ViewportCoordinateSwizzleNV,
@@ -29290,7 +29294,7 @@ impl<'a> ViewportSwizzleNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineViewportSwizzleStateCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportSwizzleStateCreateInfoNV.html>"]
 pub struct PipelineViewportSwizzleStateCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -29363,7 +29367,7 @@ impl<'a> PipelineViewportSwizzleStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDiscardRectanglePropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceDiscardRectanglePropertiesEXT.html>"]
 pub struct PhysicalDeviceDiscardRectanglePropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -29424,7 +29428,7 @@ impl<'a> PhysicalDeviceDiscardRectanglePropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineDiscardRectangleStateCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDiscardRectangleStateCreateInfoEXT.html>"]
 pub struct PipelineDiscardRectangleStateCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -29506,7 +29510,7 @@ impl<'a> PipelineDiscardRectangleStateCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX.html>"]
 pub struct PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -29570,7 +29574,7 @@ impl<'a> PhysicalDeviceMultiviewPerViewAttributesPropertiesNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkInputAttachmentAspectReference.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkInputAttachmentAspectReference.html>"]
 pub struct InputAttachmentAspectReference {
     pub subpass: u32,
     pub input_attachment_index: u32,
@@ -29628,7 +29632,7 @@ impl<'a> InputAttachmentAspectReferenceBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassInputAttachmentAspectCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassInputAttachmentAspectCreateInfo.html>"]
 pub struct RenderPassInputAttachmentAspectCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -29689,7 +29693,7 @@ impl<'a> RenderPassInputAttachmentAspectCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSurfaceInfo2KHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSurfaceInfo2KHR.html>"]
 pub struct PhysicalDeviceSurfaceInfo2KHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -29760,7 +29764,7 @@ impl<'a> PhysicalDeviceSurfaceInfo2KHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceCapabilities2KHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceCapabilities2KHR.html>"]
 pub struct SurfaceCapabilities2KHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -29834,7 +29838,7 @@ impl<'a> SurfaceCapabilities2KHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceFormat2KHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceFormat2KHR.html>"]
 pub struct SurfaceFormat2KHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -29908,7 +29912,7 @@ impl<'a> SurfaceFormat2KHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayProperties2KHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayProperties2KHR.html>"]
 pub struct DisplayProperties2KHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -29982,7 +29986,7 @@ impl<'a> DisplayProperties2KHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPlaneProperties2KHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPlaneProperties2KHR.html>"]
 pub struct DisplayPlaneProperties2KHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30056,7 +30060,7 @@ impl<'a> DisplayPlaneProperties2KHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayModeProperties2KHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayModeProperties2KHR.html>"]
 pub struct DisplayModeProperties2KHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30130,7 +30134,7 @@ impl<'a> DisplayModeProperties2KHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPlaneInfo2KHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPlaneInfo2KHR.html>"]
 pub struct DisplayPlaneInfo2KHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -30207,7 +30211,7 @@ impl<'a> DisplayPlaneInfo2KHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPlaneCapabilities2KHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPlaneCapabilities2KHR.html>"]
 pub struct DisplayPlaneCapabilities2KHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30281,7 +30285,7 @@ impl<'a> DisplayPlaneCapabilities2KHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSharedPresentSurfaceCapabilitiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSharedPresentSurfaceCapabilitiesKHR.html>"]
 pub struct SharedPresentSurfaceCapabilitiesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30339,7 +30343,7 @@ impl<'a> SharedPresentSurfaceCapabilitiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevice16BitStorageFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevice16BitStorageFeatures.html>"]
 pub struct PhysicalDevice16BitStorageFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30425,7 +30429,7 @@ impl<'a> PhysicalDevice16BitStorageFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSubgroupProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSubgroupProperties.html>"]
 pub struct PhysicalDeviceSubgroupProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30510,7 +30514,7 @@ impl<'a> PhysicalDeviceSubgroupPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures.html>"]
 pub struct PhysicalDeviceShaderSubgroupExtendedTypesFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30571,7 +30575,7 @@ impl<'a> PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferMemoryRequirementsInfo2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferMemoryRequirementsInfo2.html>"]
 pub struct BufferMemoryRequirementsInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -30642,7 +30646,7 @@ impl<'a> BufferMemoryRequirementsInfo2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageMemoryRequirementsInfo2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageMemoryRequirementsInfo2.html>"]
 pub struct ImageMemoryRequirementsInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -30713,7 +30717,7 @@ impl<'a> ImageMemoryRequirementsInfo2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageSparseMemoryRequirementsInfo2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageSparseMemoryRequirementsInfo2.html>"]
 pub struct ImageSparseMemoryRequirementsInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -30784,7 +30788,7 @@ impl<'a> ImageSparseMemoryRequirementsInfo2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryRequirements2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryRequirements2.html>"]
 pub struct MemoryRequirements2 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30858,7 +30862,7 @@ impl<'a> MemoryRequirements2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseImageMemoryRequirements2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseImageMemoryRequirements2.html>"]
 pub struct SparseImageMemoryRequirements2 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30932,7 +30936,7 @@ impl<'a> SparseImageMemoryRequirements2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePointClippingProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevicePointClippingProperties.html>"]
 pub struct PhysicalDevicePointClippingProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -30990,7 +30994,7 @@ impl<'a> PhysicalDevicePointClippingPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryDedicatedRequirements.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryDedicatedRequirements.html>"]
 pub struct MemoryDedicatedRequirements {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -31057,7 +31061,7 @@ impl<'a> MemoryDedicatedRequirementsBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryDedicatedAllocateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryDedicatedAllocateInfo.html>"]
 pub struct MemoryDedicatedAllocateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -31118,7 +31122,7 @@ impl<'a> MemoryDedicatedAllocateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageViewUsageCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageViewUsageCreateInfo.html>"]
 pub struct ImageViewUsageCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -31173,7 +31177,7 @@ impl<'a> ImageViewUsageCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineTessellationDomainOriginStateCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineTessellationDomainOriginStateCreateInfo.html>"]
 pub struct PipelineTessellationDomainOriginStateCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -31237,7 +31241,7 @@ impl<'a> PipelineTessellationDomainOriginStateCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerYcbcrConversionInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerYcbcrConversionInfo.html>"]
 pub struct SamplerYcbcrConversionInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -31297,7 +31301,7 @@ impl<'a> SamplerYcbcrConversionInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerYcbcrConversionCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerYcbcrConversionCreateInfo.html>"]
 pub struct SamplerYcbcrConversionCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -31431,7 +31435,7 @@ impl<'a> SamplerYcbcrConversionCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBindImagePlaneMemoryInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBindImagePlaneMemoryInfo.html>"]
 pub struct BindImagePlaneMemoryInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -31489,7 +31493,7 @@ impl<'a> BindImagePlaneMemoryInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImagePlaneMemoryRequirementsInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImagePlaneMemoryRequirementsInfo.html>"]
 pub struct ImagePlaneMemoryRequirementsInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -31547,7 +31551,7 @@ impl<'a> ImagePlaneMemoryRequirementsInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSamplerYcbcrConversionFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSamplerYcbcrConversionFeatures.html>"]
 pub struct PhysicalDeviceSamplerYcbcrConversionFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -31605,7 +31609,7 @@ impl<'a> PhysicalDeviceSamplerYcbcrConversionFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerYcbcrConversionImageFormatProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerYcbcrConversionImageFormatProperties.html>"]
 pub struct SamplerYcbcrConversionImageFormatProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -31667,7 +31671,7 @@ impl<'a> SamplerYcbcrConversionImageFormatPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkTextureLODGatherFormatPropertiesAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkTextureLODGatherFormatPropertiesAMD.html>"]
 pub struct TextureLODGatherFormatPropertiesAMD {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -31726,7 +31730,7 @@ impl<'a> TextureLODGatherFormatPropertiesAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkConditionalRenderingBeginInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkConditionalRenderingBeginInfoEXT.html>"]
 pub struct ConditionalRenderingBeginInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -31812,7 +31816,7 @@ impl<'a> ConditionalRenderingBeginInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkProtectedSubmitInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkProtectedSubmitInfo.html>"]
 pub struct ProtectedSubmitInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -31867,7 +31871,7 @@ impl<'a> ProtectedSubmitInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceProtectedMemoryFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceProtectedMemoryFeatures.html>"]
 pub struct PhysicalDeviceProtectedMemoryFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -31925,7 +31929,7 @@ impl<'a> PhysicalDeviceProtectedMemoryFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceProtectedMemoryProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceProtectedMemoryProperties.html>"]
 pub struct PhysicalDeviceProtectedMemoryProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -31986,7 +31990,7 @@ impl<'a> PhysicalDeviceProtectedMemoryPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceQueueInfo2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceQueueInfo2.html>"]
 pub struct DeviceQueueInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -32069,7 +32073,7 @@ impl<'a> DeviceQueueInfo2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCoverageToColorStateCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCoverageToColorStateCreateInfoNV.html>"]
 pub struct PipelineCoverageToColorStateCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -32148,7 +32152,7 @@ impl<'a> PipelineCoverageToColorStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSamplerFilterMinmaxProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSamplerFilterMinmaxProperties.html>"]
 pub struct PhysicalDeviceSamplerFilterMinmaxProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -32220,7 +32224,7 @@ impl<'a> PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSampleLocationEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSampleLocationEXT.html>"]
 pub struct SampleLocationEXT {
     pub x: f32,
     pub y: f32,
@@ -32267,7 +32271,7 @@ impl<'a> SampleLocationEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSampleLocationsInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSampleLocationsInfoEXT.html>"]
 pub struct SampleLocationsInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -32346,7 +32350,7 @@ impl<'a> SampleLocationsInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentSampleLocationsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentSampleLocationsEXT.html>"]
 pub struct AttachmentSampleLocationsEXT {
     pub attachment_index: u32,
     pub sample_locations_info: SampleLocationsInfoEXT,
@@ -32399,7 +32403,7 @@ impl<'a> AttachmentSampleLocationsEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassSampleLocationsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassSampleLocationsEXT.html>"]
 pub struct SubpassSampleLocationsEXT {
     pub subpass_index: u32,
     pub sample_locations_info: SampleLocationsInfoEXT,
@@ -32449,7 +32453,7 @@ impl<'a> SubpassSampleLocationsEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassSampleLocationsBeginInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassSampleLocationsBeginInfoEXT.html>"]
 pub struct RenderPassSampleLocationsBeginInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -32524,7 +32528,7 @@ impl<'a> RenderPassSampleLocationsBeginInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineSampleLocationsStateCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineSampleLocationsStateCreateInfoEXT.html>"]
 pub struct PipelineSampleLocationsStateCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -32597,7 +32601,7 @@ impl<'a> PipelineSampleLocationsStateCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSampleLocationsPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSampleLocationsPropertiesEXT.html>"]
 pub struct PhysicalDeviceSampleLocationsPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -32694,7 +32698,7 @@ impl<'a> PhysicalDeviceSampleLocationsPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMultisamplePropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMultisamplePropertiesEXT.html>"]
 pub struct MultisamplePropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -32768,7 +32772,7 @@ impl<'a> MultisamplePropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerReductionModeCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerReductionModeCreateInfo.html>"]
 pub struct SamplerReductionModeCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -32826,7 +32830,7 @@ impl<'a> SamplerReductionModeCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT.html>"]
 pub struct PhysicalDeviceBlendOperationAdvancedFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -32884,7 +32888,7 @@ impl<'a> PhysicalDeviceBlendOperationAdvancedFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT.html>"]
 pub struct PhysicalDeviceBlendOperationAdvancedPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -32992,7 +32996,7 @@ impl<'a> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineColorBlendAdvancedStateCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineColorBlendAdvancedStateCreateInfoEXT.html>"]
 pub struct PipelineColorBlendAdvancedStateCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -33074,7 +33078,7 @@ impl<'a> PipelineColorBlendAdvancedStateCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceInlineUniformBlockFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceInlineUniformBlockFeaturesEXT.html>"]
 pub struct PhysicalDeviceInlineUniformBlockFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -33143,7 +33147,7 @@ impl<'a> PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceInlineUniformBlockPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceInlineUniformBlockPropertiesEXT.html>"]
 pub struct PhysicalDeviceInlineUniformBlockPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -33246,7 +33250,7 @@ impl<'a> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkWriteDescriptorSetInlineUniformBlockEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWriteDescriptorSetInlineUniformBlockEXT.html>"]
 pub struct WriteDescriptorSetInlineUniformBlockEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -33304,7 +33308,7 @@ impl<'a> WriteDescriptorSetInlineUniformBlockEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorPoolInlineUniformBlockCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorPoolInlineUniformBlockCreateInfoEXT.html>"]
 pub struct DescriptorPoolInlineUniformBlockCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -33365,7 +33369,7 @@ impl<'a> DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCoverageModulationStateCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCoverageModulationStateCreateInfoNV.html>"]
 pub struct PipelineCoverageModulationStateCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -33459,7 +33463,7 @@ impl<'a> PipelineCoverageModulationStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageFormatListCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageFormatListCreateInfo.html>"]
 pub struct ImageFormatListCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -33524,7 +33528,7 @@ impl<'a> ImageFormatListCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkValidationCacheCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationCacheCreateInfoEXT.html>"]
 pub struct ValidationCacheCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -33610,7 +33614,7 @@ impl<'a> ValidationCacheCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderModuleValidationCacheCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderModuleValidationCacheCreateInfoEXT.html>"]
 pub struct ShaderModuleValidationCacheCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -33668,7 +33672,7 @@ impl<'a> ShaderModuleValidationCacheCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMaintenance3Properties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMaintenance3Properties.html>"]
 pub struct PhysicalDeviceMaintenance3Properties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -33735,7 +33739,7 @@ impl<'a> PhysicalDeviceMaintenance3PropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetLayoutSupport.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetLayoutSupport.html>"]
 pub struct DescriptorSetLayoutSupport {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -33806,7 +33810,7 @@ impl<'a> DescriptorSetLayoutSupportBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderDrawParametersFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderDrawParametersFeatures.html>"]
 pub struct PhysicalDeviceShaderDrawParametersFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -33864,7 +33868,7 @@ impl<'a> PhysicalDeviceShaderDrawParametersFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderFloat16Int8Features.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderFloat16Int8Features.html>"]
 pub struct PhysicalDeviceShaderFloat16Int8Features {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -33931,7 +33935,7 @@ impl<'a> PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceFloatControlsProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceFloatControlsProperties.html>"]
 pub struct PhysicalDeviceFloatControlsProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -34136,7 +34140,7 @@ impl<'a> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceHostQueryResetFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceHostQueryResetFeatures.html>"]
 pub struct PhysicalDeviceHostQueryResetFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -34194,7 +34198,7 @@ impl<'a> PhysicalDeviceHostQueryResetFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkNativeBufferUsage2ANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkNativeBufferUsage2ANDROID.html>"]
 pub struct NativeBufferUsage2ANDROID {
     pub consumer: u64,
     pub producer: u64,
@@ -34241,7 +34245,7 @@ impl<'a> NativeBufferUsage2ANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkNativeBufferANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkNativeBufferANDROID.html>"]
 pub struct NativeBufferANDROID {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -34336,7 +34340,7 @@ impl<'a> NativeBufferANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSwapchainImageCreateInfoANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSwapchainImageCreateInfoANDROID.html>"]
 pub struct SwapchainImageCreateInfoANDROID {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -34410,7 +34414,7 @@ impl<'a> SwapchainImageCreateInfoANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePresentationPropertiesANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevicePresentationPropertiesANDROID.html>"]
 pub struct PhysicalDevicePresentationPropertiesANDROID {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -34484,7 +34488,7 @@ impl<'a> PhysicalDevicePresentationPropertiesANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderResourceUsageAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderResourceUsageAMD.html>"]
 pub struct ShaderResourceUsageAMD {
     pub num_used_vgprs: u32,
     pub num_used_sgprs: u32,
@@ -34555,7 +34559,7 @@ impl<'a> ShaderResourceUsageAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderStatisticsInfoAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderStatisticsInfoAMD.html>"]
 pub struct ShaderStatisticsInfoAMD {
     pub shader_stage_mask: ShaderStageFlags,
     pub resource_usage: ShaderResourceUsageAMD,
@@ -34661,7 +34665,7 @@ impl<'a> ShaderStatisticsInfoAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceQueueGlobalPriorityCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceQueueGlobalPriorityCreateInfoEXT.html>"]
 pub struct DeviceQueueGlobalPriorityCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -34719,7 +34723,7 @@ impl<'a> DeviceQueueGlobalPriorityCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsObjectNameInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsObjectNameInfoEXT.html>"]
 pub struct DebugUtilsObjectNameInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -34808,7 +34812,7 @@ impl<'a> DebugUtilsObjectNameInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsObjectTagInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsObjectTagInfoEXT.html>"]
 pub struct DebugUtilsObjectTagInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -34900,7 +34904,7 @@ impl<'a> DebugUtilsObjectTagInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsLabelEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsLabelEXT.html>"]
 pub struct DebugUtilsLabelEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -34977,7 +34981,7 @@ impl<'a> DebugUtilsLabelEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsMessengerCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessengerCreateInfoEXT.html>"]
 pub struct DebugUtilsMessengerCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -35087,7 +35091,7 @@ impl<'a> DebugUtilsMessengerCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsMessengerCallbackDataEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessengerCallbackDataEXT.html>"]
 pub struct DebugUtilsMessengerCallbackDataEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -35224,7 +35228,7 @@ impl<'a> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImportMemoryHostPointerInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImportMemoryHostPointerInfoEXT.html>"]
 pub struct ImportMemoryHostPointerInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -35291,7 +35295,7 @@ impl<'a> ImportMemoryHostPointerInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryHostPointerPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryHostPointerPropertiesEXT.html>"]
 pub struct MemoryHostPointerPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -35365,7 +35369,7 @@ impl<'a> MemoryHostPointerPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceExternalMemoryHostPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceExternalMemoryHostPropertiesEXT.html>"]
 pub struct PhysicalDeviceExternalMemoryHostPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -35426,7 +35430,7 @@ impl<'a> PhysicalDeviceExternalMemoryHostPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceConservativeRasterizationPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceConservativeRasterizationPropertiesEXT.html>"]
 pub struct PhysicalDeviceConservativeRasterizationPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -35567,7 +35571,7 @@ impl<'a> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCalibratedTimestampInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCalibratedTimestampInfoEXT.html>"]
 pub struct CalibratedTimestampInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -35641,7 +35645,7 @@ impl<'a> CalibratedTimestampInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderCorePropertiesAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderCorePropertiesAMD.html>"]
 pub struct PhysicalDeviceShaderCorePropertiesAMD {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -35816,7 +35820,7 @@ impl<'a> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderCoreProperties2AMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderCoreProperties2AMD.html>"]
 pub struct PhysicalDeviceShaderCoreProperties2AMD {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -35883,7 +35887,7 @@ impl<'a> PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationConservativeStateCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationConservativeStateCreateInfoEXT.html>"]
 pub struct PipelineRasterizationConservativeStateCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -35965,7 +35969,7 @@ impl<'a> PipelineRasterizationConservativeStateCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDescriptorIndexingFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceDescriptorIndexingFeatures.html>"]
 pub struct PhysicalDeviceDescriptorIndexingFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -36223,7 +36227,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDescriptorIndexingProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceDescriptorIndexingProperties.html>"]
 pub struct PhysicalDeviceDescriptorIndexingProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -36522,7 +36526,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetLayoutBindingFlagsCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetLayoutBindingFlagsCreateInfo.html>"]
 pub struct DescriptorSetLayoutBindingFlagsCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -36586,7 +36590,7 @@ impl<'a> DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetVariableDescriptorCountAllocateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetVariableDescriptorCountAllocateInfo.html>"]
 pub struct DescriptorSetVariableDescriptorCountAllocateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -36650,7 +36654,7 @@ impl<'a> DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetVariableDescriptorCountLayoutSupport.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetVariableDescriptorCountLayoutSupport.html>"]
 pub struct DescriptorSetVariableDescriptorCountLayoutSupport {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -36714,7 +36718,7 @@ impl<'a> DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentDescription2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentDescription2.html>"]
 pub struct AttachmentDescription2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -36842,7 +36846,7 @@ impl<'a> AttachmentDescription2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentReference2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentReference2.html>"]
 pub struct AttachmentReference2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -36925,7 +36929,7 @@ impl<'a> AttachmentReference2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDescription2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassDescription2.html>"]
 pub struct SubpassDescription2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37066,7 +37070,7 @@ impl<'a> SubpassDescription2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDependency2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassDependency2.html>"]
 pub struct SubpassDependency2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37194,7 +37198,7 @@ impl<'a> SubpassDependency2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassCreateInfo2.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassCreateInfo2.html>"]
 pub struct RenderPassCreateInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37313,7 +37317,7 @@ impl<'a> RenderPassCreateInfo2Builder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassBeginInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassBeginInfo.html>"]
 pub struct SubpassBeginInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37384,7 +37388,7 @@ impl<'a> SubpassBeginInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassEndInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassEndInfo.html>"]
 pub struct SubpassEndInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37449,7 +37453,7 @@ impl<'a> SubpassEndInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTimelineSemaphoreFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceTimelineSemaphoreFeatures.html>"]
 pub struct PhysicalDeviceTimelineSemaphoreFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -37507,7 +37511,7 @@ impl<'a> PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTimelineSemaphoreProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceTimelineSemaphoreProperties.html>"]
 pub struct PhysicalDeviceTimelineSemaphoreProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -37569,7 +37573,7 @@ impl<'a> PhysicalDeviceTimelineSemaphorePropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreTypeCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreTypeCreateInfo.html>"]
 pub struct SemaphoreTypeCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37635,7 +37639,7 @@ impl<'a> SemaphoreTypeCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkTimelineSemaphoreSubmitInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkTimelineSemaphoreSubmitInfo.html>"]
 pub struct TimelineSemaphoreSubmitInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37710,7 +37714,7 @@ impl<'a> TimelineSemaphoreSubmitInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreWaitInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreWaitInfo.html>"]
 pub struct SemaphoreWaitInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37797,7 +37801,7 @@ impl<'a> SemaphoreWaitInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreSignalInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreSignalInfo.html>"]
 pub struct SemaphoreSignalInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37874,7 +37878,7 @@ impl<'a> SemaphoreSignalInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkVertexInputBindingDivisorDescriptionEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVertexInputBindingDivisorDescriptionEXT.html>"]
 pub struct VertexInputBindingDivisorDescriptionEXT {
     pub binding: u32,
     pub divisor: u32,
@@ -37921,7 +37925,7 @@ impl<'a> VertexInputBindingDivisorDescriptionEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineVertexInputDivisorStateCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineVertexInputDivisorStateCreateInfoEXT.html>"]
 pub struct PipelineVertexInputDivisorStateCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -37988,7 +37992,7 @@ impl<'a> PipelineVertexInputDivisorStateCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT.html>"]
 pub struct PhysicalDeviceVertexAttributeDivisorPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38049,7 +38053,7 @@ impl<'a> PhysicalDeviceVertexAttributeDivisorPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePCIBusInfoPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevicePCIBusInfoPropertiesEXT.html>"]
 pub struct PhysicalDevicePCIBusInfoPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38131,7 +38135,7 @@ impl<'a> PhysicalDevicePCIBusInfoPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImportAndroidHardwareBufferInfoANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImportAndroidHardwareBufferInfoANDROID.html>"]
 pub struct ImportAndroidHardwareBufferInfoANDROID {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -38189,7 +38193,7 @@ impl<'a> ImportAndroidHardwareBufferInfoANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAndroidHardwareBufferUsageANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAndroidHardwareBufferUsageANDROID.html>"]
 pub struct AndroidHardwareBufferUsageANDROID {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38247,7 +38251,7 @@ impl<'a> AndroidHardwareBufferUsageANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAndroidHardwareBufferPropertiesANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAndroidHardwareBufferPropertiesANDROID.html>"]
 pub struct AndroidHardwareBufferPropertiesANDROID {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38330,7 +38334,7 @@ impl<'a> AndroidHardwareBufferPropertiesANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryGetAndroidHardwareBufferInfoANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryGetAndroidHardwareBufferInfoANDROID.html>"]
 pub struct MemoryGetAndroidHardwareBufferInfoANDROID {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -38404,7 +38408,7 @@ impl<'a> MemoryGetAndroidHardwareBufferInfoANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAndroidHardwareBufferFormatPropertiesANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAndroidHardwareBufferFormatPropertiesANDROID.html>"]
 pub struct AndroidHardwareBufferFormatPropertiesANDROID {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38531,7 +38535,7 @@ impl<'a> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandBufferInheritanceConditionalRenderingInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferInheritanceConditionalRenderingInfoEXT.html>"]
 pub struct CommandBufferInheritanceConditionalRenderingInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -38595,7 +38599,7 @@ impl<'a> CommandBufferInheritanceConditionalRenderingInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalFormatANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalFormatANDROID.html>"]
 pub struct ExternalFormatANDROID {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38652,7 +38656,7 @@ impl<'a> ExternalFormatANDROIDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevice8BitStorageFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevice8BitStorageFeatures.html>"]
 pub struct PhysicalDevice8BitStorageFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38729,7 +38733,7 @@ impl<'a> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceConditionalRenderingFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceConditionalRenderingFeaturesEXT.html>"]
 pub struct PhysicalDeviceConditionalRenderingFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38796,7 +38800,7 @@ impl<'a> PhysicalDeviceConditionalRenderingFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkanMemoryModelFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceVulkanMemoryModelFeatures.html>"]
 pub struct PhysicalDeviceVulkanMemoryModelFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38874,7 +38878,7 @@ impl<'a> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderAtomicInt64Features.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderAtomicInt64Features.html>"]
 pub struct PhysicalDeviceShaderAtomicInt64Features {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -38941,7 +38945,7 @@ impl<'a> PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT.html>"]
 pub struct PhysicalDeviceVertexAttributeDivisorFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -39010,7 +39014,7 @@ impl<'a> PhysicalDeviceVertexAttributeDivisorFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueueFamilyCheckpointPropertiesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueueFamilyCheckpointPropertiesNV.html>"]
 pub struct QueueFamilyCheckpointPropertiesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -39068,7 +39072,7 @@ impl<'a> QueueFamilyCheckpointPropertiesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCheckpointDataNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCheckpointDataNV.html>"]
 pub struct CheckpointDataNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -39148,7 +39152,7 @@ impl<'a> CheckpointDataNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDepthStencilResolveProperties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceDepthStencilResolveProperties.html>"]
 pub struct PhysicalDeviceDepthStencilResolveProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -39236,7 +39240,7 @@ impl<'a> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDescriptionDepthStencilResolve.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassDescriptionDepthStencilResolve.html>"]
 pub struct SubpassDescriptionDepthStencilResolve {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -39312,7 +39316,7 @@ impl<'a> SubpassDescriptionDepthStencilResolveBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageViewASTCDecodeModeEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageViewASTCDecodeModeEXT.html>"]
 pub struct ImageViewASTCDecodeModeEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -39367,7 +39371,7 @@ impl<'a> ImageViewASTCDecodeModeEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceASTCDecodeFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceASTCDecodeFeaturesEXT.html>"]
 pub struct PhysicalDeviceASTCDecodeFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -39425,7 +39429,7 @@ impl<'a> PhysicalDeviceASTCDecodeFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTransformFeedbackFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceTransformFeedbackFeaturesEXT.html>"]
 pub struct PhysicalDeviceTransformFeedbackFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -39492,7 +39496,7 @@ impl<'a> PhysicalDeviceTransformFeedbackFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTransformFeedbackPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceTransformFeedbackPropertiesEXT.html>"]
 pub struct PhysicalDeviceTransformFeedbackPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -39639,7 +39643,7 @@ impl<'a> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationStateStreamCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationStateStreamCreateInfoEXT.html>"]
 pub struct PipelineRasterizationStateStreamCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -39712,7 +39716,7 @@ impl<'a> PipelineRasterizationStateStreamCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV.html>"]
 pub struct PhysicalDeviceRepresentativeFragmentTestFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -39773,7 +39777,7 @@ impl<'a> PhysicalDeviceRepresentativeFragmentTestFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRepresentativeFragmentTestStateCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRepresentativeFragmentTestStateCreateInfoNV.html>"]
 pub struct PipelineRepresentativeFragmentTestStateCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -39837,7 +39841,7 @@ impl<'a> PipelineRepresentativeFragmentTestStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceExclusiveScissorFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceExclusiveScissorFeaturesNV.html>"]
 pub struct PhysicalDeviceExclusiveScissorFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -39895,7 +39899,7 @@ impl<'a> PhysicalDeviceExclusiveScissorFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineViewportExclusiveScissorStateCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportExclusiveScissorStateCreateInfoNV.html>"]
 pub struct PipelineViewportExclusiveScissorStateCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -39962,7 +39966,7 @@ impl<'a> PipelineViewportExclusiveScissorStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceCornerSampledImageFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceCornerSampledImageFeaturesNV.html>"]
 pub struct PhysicalDeviceCornerSampledImageFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -40020,7 +40024,7 @@ impl<'a> PhysicalDeviceCornerSampledImageFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceComputeShaderDerivativesFeaturesNV.html>"]
 pub struct PhysicalDeviceComputeShaderDerivativesFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -40090,7 +40094,7 @@ impl<'a> PhysicalDeviceComputeShaderDerivativesFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV.html>"]
 pub struct PhysicalDeviceFragmentShaderBarycentricFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -40151,7 +40155,7 @@ impl<'a> PhysicalDeviceFragmentShaderBarycentricFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderImageFootprintFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderImageFootprintFeaturesNV.html>"]
 pub struct PhysicalDeviceShaderImageFootprintFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -40209,7 +40213,7 @@ impl<'a> PhysicalDeviceShaderImageFootprintFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV.html>"]
 pub struct PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -40272,7 +40276,7 @@ impl<'a> PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShadingRatePaletteNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShadingRatePaletteNV.html>"]
 pub struct ShadingRatePaletteNV {
     pub shading_rate_palette_entry_count: u32,
     pub p_shading_rate_palette_entries: *const ShadingRatePaletteEntryNV,
@@ -40327,7 +40331,7 @@ impl<'a> ShadingRatePaletteNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineViewportShadingRateImageStateCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportShadingRateImageStateCreateInfoNV.html>"]
 pub struct PipelineViewportShadingRateImageStateCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -40403,7 +40407,7 @@ impl<'a> PipelineViewportShadingRateImageStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShadingRateImageFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShadingRateImageFeaturesNV.html>"]
 pub struct PhysicalDeviceShadingRateImageFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -40470,7 +40474,7 @@ impl<'a> PhysicalDeviceShadingRateImageFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShadingRateImagePropertiesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShadingRateImagePropertiesNV.html>"]
 pub struct PhysicalDeviceShadingRateImagePropertiesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -40549,7 +40553,7 @@ impl<'a> PhysicalDeviceShadingRateImagePropertiesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCoarseSampleLocationNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCoarseSampleLocationNV.html>"]
 pub struct CoarseSampleLocationNV {
     pub pixel_x: u32,
     pub pixel_y: u32,
@@ -40601,7 +40605,7 @@ impl<'a> CoarseSampleLocationNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCoarseSampleOrderCustomNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCoarseSampleOrderCustomNV.html>"]
 pub struct CoarseSampleOrderCustomNV {
     pub shading_rate: ShadingRatePaletteEntryNV,
     pub sample_count: u32,
@@ -40671,7 +40675,7 @@ impl<'a> CoarseSampleOrderCustomNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineViewportCoarseSampleOrderStateCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportCoarseSampleOrderStateCreateInfoNV.html>"]
 pub struct PipelineViewportCoarseSampleOrderStateCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -40747,7 +40751,7 @@ impl<'a> PipelineViewportCoarseSampleOrderStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMeshShaderFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMeshShaderFeaturesNV.html>"]
 pub struct PhysicalDeviceMeshShaderFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -40814,7 +40818,7 @@ impl<'a> PhysicalDeviceMeshShaderFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMeshShaderPropertiesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMeshShaderPropertiesNV.html>"]
 pub struct PhysicalDeviceMeshShaderPropertiesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -40980,7 +40984,7 @@ impl<'a> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDrawMeshTasksIndirectCommandNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDrawMeshTasksIndirectCommandNV.html>"]
 pub struct DrawMeshTasksIndirectCommandNV {
     pub task_count: u32,
     pub first_task: u32,
@@ -41027,7 +41031,7 @@ impl<'a> DrawMeshTasksIndirectCommandNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRayTracingShaderGroupCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRayTracingShaderGroupCreateInfoNV.html>"]
 pub struct RayTracingShaderGroupCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -41137,7 +41141,7 @@ impl<'a> RayTracingShaderGroupCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRayTracingPipelineCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRayTracingPipelineCreateInfoNV.html>"]
 pub struct RayTracingPipelineCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -41268,7 +41272,7 @@ impl<'a> RayTracingPipelineCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkGeometryTrianglesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryTrianglesNV.html>"]
 pub struct GeometryTrianglesNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -41402,7 +41406,7 @@ impl<'a> GeometryTrianglesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkGeometryAABBNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryAABBNV.html>"]
 pub struct GeometryAABBNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -41491,7 +41495,7 @@ impl<'a> GeometryAABBNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkGeometryDataNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryDataNV.html>"]
 pub struct GeometryDataNV {
     pub triangles: GeometryTrianglesNV,
     pub aabbs: GeometryAABBNV,
@@ -41538,7 +41542,7 @@ impl<'a> GeometryDataNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkGeometryNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryNV.html>"]
 pub struct GeometryNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -41618,7 +41622,7 @@ impl<'a> GeometryNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAccelerationStructureInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureInfoNV.html>"]
 pub struct AccelerationStructureInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -41716,7 +41720,7 @@ impl<'a> AccelerationStructureInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAccelerationStructureCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureCreateInfoNV.html>"]
 pub struct AccelerationStructureCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -41799,7 +41803,7 @@ impl<'a> AccelerationStructureCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBindAccelerationStructureMemoryInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBindAccelerationStructureMemoryInfoNV.html>"]
 pub struct BindAccelerationStructureMemoryInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -41903,7 +41907,7 @@ impl<'a> BindAccelerationStructureMemoryInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkWriteDescriptorSetAccelerationStructureNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWriteDescriptorSetAccelerationStructureNV.html>"]
 pub struct WriteDescriptorSetAccelerationStructureNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -41964,7 +41968,7 @@ impl<'a> WriteDescriptorSetAccelerationStructureNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAccelerationStructureMemoryRequirementsInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureMemoryRequirementsInfoNV.html>"]
 pub struct AccelerationStructureMemoryRequirementsInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -42047,7 +42051,7 @@ impl<'a> AccelerationStructureMemoryRequirementsInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceRayTracingPropertiesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceRayTracingPropertiesNV.html>"]
 pub struct PhysicalDeviceRayTracingPropertiesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -42169,7 +42173,7 @@ impl<'a> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDrmFormatModifierPropertiesListEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDrmFormatModifierPropertiesListEXT.html>"]
 pub struct DrmFormatModifierPropertiesListEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -42230,7 +42234,7 @@ impl<'a> DrmFormatModifierPropertiesListEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDrmFormatModifierPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDrmFormatModifierPropertiesEXT.html>"]
 pub struct DrmFormatModifierPropertiesEXT {
     pub drm_format_modifier: u64,
     pub drm_format_modifier_plane_count: u32,
@@ -42291,7 +42295,7 @@ impl<'a> DrmFormatModifierPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceImageDrmFormatModifierInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceImageDrmFormatModifierInfoEXT.html>"]
 pub struct PhysicalDeviceImageDrmFormatModifierInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -42373,7 +42377,7 @@ impl<'a> PhysicalDeviceImageDrmFormatModifierInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageDrmFormatModifierListCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageDrmFormatModifierListCreateInfoEXT.html>"]
 pub struct ImageDrmFormatModifierListCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -42434,7 +42438,7 @@ impl<'a> ImageDrmFormatModifierListCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageDrmFormatModifierExplicitCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageDrmFormatModifierExplicitCreateInfoEXT.html>"]
 pub struct ImageDrmFormatModifierExplicitCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -42504,7 +42508,7 @@ impl<'a> ImageDrmFormatModifierExplicitCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageDrmFormatModifierPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageDrmFormatModifierPropertiesEXT.html>"]
 pub struct ImageDrmFormatModifierPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -42578,7 +42582,7 @@ impl<'a> ImageDrmFormatModifierPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageStencilUsageCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageStencilUsageCreateInfo.html>"]
 pub struct ImageStencilUsageCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -42638,7 +42642,7 @@ impl<'a> ImageStencilUsageCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceMemoryOverallocationCreateInfoAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceMemoryOverallocationCreateInfoAMD.html>"]
 pub struct DeviceMemoryOverallocationCreateInfoAMD {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -42696,7 +42700,7 @@ impl<'a> DeviceMemoryOverallocationCreateInfoAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceFragmentDensityMapFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceFragmentDensityMapFeaturesEXT.html>"]
 pub struct PhysicalDeviceFragmentDensityMapFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -42773,7 +42777,7 @@ impl<'a> PhysicalDeviceFragmentDensityMapFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceFragmentDensityMapPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceFragmentDensityMapPropertiesEXT.html>"]
 pub struct PhysicalDeviceFragmentDensityMapPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -42852,7 +42856,7 @@ impl<'a> PhysicalDeviceFragmentDensityMapPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassFragmentDensityMapCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassFragmentDensityMapCreateInfoEXT.html>"]
 pub struct RenderPassFragmentDensityMapCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -42912,7 +42916,7 @@ impl<'a> RenderPassFragmentDensityMapCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceScalarBlockLayoutFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceScalarBlockLayoutFeatures.html>"]
 pub struct PhysicalDeviceScalarBlockLayoutFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -42970,7 +42974,7 @@ impl<'a> PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceProtectedCapabilitiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceProtectedCapabilitiesKHR.html>"]
 pub struct SurfaceProtectedCapabilitiesKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -43028,7 +43032,7 @@ impl<'a> SurfaceProtectedCapabilitiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceUniformBufferStandardLayoutFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceUniformBufferStandardLayoutFeatures.html>"]
 pub struct PhysicalDeviceUniformBufferStandardLayoutFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -43089,7 +43093,7 @@ impl<'a> PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceDepthClipEnableFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceDepthClipEnableFeaturesEXT.html>"]
 pub struct PhysicalDeviceDepthClipEnableFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -43147,7 +43151,7 @@ impl<'a> PhysicalDeviceDepthClipEnableFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationDepthClipStateCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationDepthClipStateCreateInfoEXT.html>"]
 pub struct PipelineRasterizationDepthClipStateCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -43220,7 +43224,7 @@ impl<'a> PipelineRasterizationDepthClipStateCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMemoryBudgetPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMemoryBudgetPropertiesEXT.html>"]
 pub struct PhysicalDeviceMemoryBudgetPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -43290,7 +43294,7 @@ impl<'a> PhysicalDeviceMemoryBudgetPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceMemoryPriorityFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceMemoryPriorityFeaturesEXT.html>"]
 pub struct PhysicalDeviceMemoryPriorityFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -43348,7 +43352,7 @@ impl<'a> PhysicalDeviceMemoryPriorityFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryPriorityAllocateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryPriorityAllocateInfoEXT.html>"]
 pub struct MemoryPriorityAllocateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -43403,7 +43407,7 @@ impl<'a> MemoryPriorityAllocateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceBufferDeviceAddressFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceBufferDeviceAddressFeatures.html>"]
 pub struct PhysicalDeviceBufferDeviceAddressFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -43480,7 +43484,7 @@ impl<'a> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceBufferDeviceAddressFeaturesEXT.html>"]
 pub struct PhysicalDeviceBufferDeviceAddressFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -43557,7 +43561,7 @@ impl<'a> PhysicalDeviceBufferDeviceAddressFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferDeviceAddressInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferDeviceAddressInfo.html>"]
 pub struct BufferDeviceAddressInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -43628,7 +43632,7 @@ impl<'a> BufferDeviceAddressInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferOpaqueCaptureAddressCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferOpaqueCaptureAddressCreateInfo.html>"]
 pub struct BufferOpaqueCaptureAddressCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -43686,7 +43690,7 @@ impl<'a> BufferOpaqueCaptureAddressCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferDeviceAddressCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferDeviceAddressCreateInfoEXT.html>"]
 pub struct BufferDeviceAddressCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -43744,7 +43748,7 @@ impl<'a> BufferDeviceAddressCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceImageViewImageFormatInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceImageViewImageFormatInfoEXT.html>"]
 pub struct PhysicalDeviceImageViewImageFormatInfoEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -43805,7 +43809,7 @@ impl<'a> PhysicalDeviceImageViewImageFormatInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFilterCubicImageViewImageFormatPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFilterCubicImageViewImageFormatPropertiesEXT.html>"]
 pub struct FilterCubicImageViewImageFormatPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -43875,7 +43879,7 @@ impl<'a> FilterCubicImageViewImageFormatPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceImagelessFramebufferFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceImagelessFramebufferFeatures.html>"]
 pub struct PhysicalDeviceImagelessFramebufferFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -43933,7 +43937,7 @@ impl<'a> PhysicalDeviceImagelessFramebufferFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebufferAttachmentsCreateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFramebufferAttachmentsCreateInfo.html>"]
 pub struct FramebufferAttachmentsCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -43994,7 +43998,7 @@ impl<'a> FramebufferAttachmentsCreateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebufferAttachmentImageInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFramebufferAttachmentImageInfo.html>"]
 pub struct FramebufferAttachmentImageInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -44101,7 +44105,7 @@ impl<'a> FramebufferAttachmentImageInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassAttachmentBeginInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassAttachmentBeginInfo.html>"]
 pub struct RenderPassAttachmentBeginInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -44162,7 +44166,7 @@ impl<'a> RenderPassAttachmentBeginInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT.html>"]
 pub struct PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -44223,7 +44227,7 @@ impl<'a> PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceCooperativeMatrixFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceCooperativeMatrixFeaturesNV.html>"]
 pub struct PhysicalDeviceCooperativeMatrixFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -44291,7 +44295,7 @@ impl<'a> PhysicalDeviceCooperativeMatrixFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceCooperativeMatrixPropertiesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceCooperativeMatrixPropertiesNV.html>"]
 pub struct PhysicalDeviceCooperativeMatrixPropertiesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -44352,7 +44356,7 @@ impl<'a> PhysicalDeviceCooperativeMatrixPropertiesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCooperativeMatrixPropertiesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCooperativeMatrixPropertiesNV.html>"]
 pub struct CooperativeMatrixPropertiesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -44465,7 +44469,7 @@ impl<'a> CooperativeMatrixPropertiesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceYcbcrImageArraysFeaturesEXT.html>"]
 pub struct PhysicalDeviceYcbcrImageArraysFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -44523,7 +44527,7 @@ impl<'a> PhysicalDeviceYcbcrImageArraysFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageViewHandleInfoNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageViewHandleInfoNVX.html>"]
 pub struct ImageViewHandleInfoNVX {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -44609,7 +44613,7 @@ impl<'a> ImageViewHandleInfoNVXBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPresentFrameTokenGGP.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentFrameTokenGGP.html>"]
 pub struct PresentFrameTokenGGP {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -44664,7 +44668,7 @@ impl<'a> PresentFrameTokenGGPBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCreationFeedbackEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCreationFeedbackEXT.html>"]
 pub struct PipelineCreationFeedbackEXT {
     pub flags: PipelineCreationFeedbackFlagsEXT,
     pub duration: u64,
@@ -44714,7 +44718,7 @@ impl<'a> PipelineCreationFeedbackEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCreationFeedbackCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCreationFeedbackCreateInfoEXT.html>"]
 pub struct PipelineCreationFeedbackCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -44793,7 +44797,7 @@ impl<'a> PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceFullScreenExclusiveInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceFullScreenExclusiveInfoEXT.html>"]
 pub struct SurfaceFullScreenExclusiveInfoEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -44853,7 +44857,7 @@ impl<'a> SurfaceFullScreenExclusiveInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceFullScreenExclusiveWin32InfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceFullScreenExclusiveWin32InfoEXT.html>"]
 pub struct SurfaceFullScreenExclusiveWin32InfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -44916,7 +44920,7 @@ impl<'a> SurfaceFullScreenExclusiveWin32InfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceCapabilitiesFullScreenExclusiveEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceCapabilitiesFullScreenExclusiveEXT.html>"]
 pub struct SurfaceCapabilitiesFullScreenExclusiveEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -44977,7 +44981,7 @@ impl<'a> SurfaceCapabilitiesFullScreenExclusiveEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePerformanceQueryFeaturesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevicePerformanceQueryFeaturesKHR.html>"]
 pub struct PhysicalDevicePerformanceQueryFeaturesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -45045,7 +45049,7 @@ impl<'a> PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePerformanceQueryPropertiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevicePerformanceQueryPropertiesKHR.html>"]
 pub struct PhysicalDevicePerformanceQueryPropertiesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -45106,7 +45110,7 @@ impl<'a> PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterKHR.html>"]
 pub struct PerformanceCounterKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -45198,7 +45202,7 @@ impl<'a> PerformanceCounterKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterDescriptionKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterDescriptionKHR.html>"]
 pub struct PerformanceCounterDescriptionKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -45317,7 +45321,7 @@ impl<'a> PerformanceCounterDescriptionKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryPoolPerformanceCreateInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPoolPerformanceCreateInfoKHR.html>"]
 pub struct QueryPoolPerformanceCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -45387,7 +45391,7 @@ impl<'a> QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterResultKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterResultKHR.html>"]
 pub union PerformanceCounterResultKHR {
     pub int32: i32,
     pub int64: i64,
@@ -45403,7 +45407,7 @@ impl ::std::default::Default for PerformanceCounterResultKHR {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAcquireProfilingLockInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAcquireProfilingLockInfoKHR.html>"]
 pub struct AcquireProfilingLockInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -45483,7 +45487,7 @@ impl<'a> AcquireProfilingLockInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceQuerySubmitInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceQuerySubmitInfoKHR.html>"]
 pub struct PerformanceQuerySubmitInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -45541,7 +45545,7 @@ impl<'a> PerformanceQuerySubmitInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkHeadlessSurfaceCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkHeadlessSurfaceCreateInfoEXT.html>"]
 pub struct HeadlessSurfaceCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -45615,7 +45619,7 @@ impl<'a> HeadlessSurfaceCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceCoverageReductionModeFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceCoverageReductionModeFeaturesNV.html>"]
 pub struct PhysicalDeviceCoverageReductionModeFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -45673,7 +45677,7 @@ impl<'a> PhysicalDeviceCoverageReductionModeFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCoverageReductionStateCreateInfoNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCoverageReductionStateCreateInfoNV.html>"]
 pub struct PipelineCoverageReductionStateCreateInfoNV {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -45746,7 +45750,7 @@ impl<'a> PipelineCoverageReductionStateCreateInfoNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebufferMixedSamplesCombinationNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFramebufferMixedSamplesCombinationNV.html>"]
 pub struct FramebufferMixedSamplesCombinationNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -45847,7 +45851,7 @@ impl<'a> FramebufferMixedSamplesCombinationNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL.html>"]
 pub struct PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -45908,7 +45912,7 @@ impl<'a> PhysicalDeviceShaderIntegerFunctions2FeaturesINTELBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceValueDataINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceValueDataINTEL.html>"]
 pub union PerformanceValueDataINTEL {
     pub value32: u32,
     pub value64: u64,
@@ -45923,7 +45927,7 @@ impl ::std::default::Default for PerformanceValueDataINTEL {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Default)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceValueINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceValueINTEL.html>"]
 pub struct PerformanceValueINTEL {
     pub ty: PerformanceValueTypeINTEL,
     pub data: PerformanceValueDataINTEL,
@@ -45978,7 +45982,7 @@ impl<'a> PerformanceValueINTELBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkInitializePerformanceApiInfoINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkInitializePerformanceApiInfoINTEL.html>"]
 pub struct InitializePerformanceApiInfoINTEL {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -46052,7 +46056,7 @@ impl<'a> InitializePerformanceApiInfoINTELBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryPoolCreateInfoINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPoolCreateInfoINTEL.html>"]
 pub struct QueryPoolCreateInfoINTEL {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -46126,7 +46130,7 @@ impl<'a> QueryPoolCreateInfoINTELBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceMarkerInfoINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceMarkerInfoINTEL.html>"]
 pub struct PerformanceMarkerInfoINTEL {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -46197,7 +46201,7 @@ impl<'a> PerformanceMarkerInfoINTELBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceStreamMarkerInfoINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceStreamMarkerInfoINTEL.html>"]
 pub struct PerformanceStreamMarkerInfoINTEL {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -46268,7 +46272,7 @@ impl<'a> PerformanceStreamMarkerInfoINTELBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceOverrideInfoINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceOverrideInfoINTEL.html>"]
 pub struct PerformanceOverrideInfoINTEL {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -46354,7 +46358,7 @@ impl<'a> PerformanceOverrideInfoINTELBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceConfigurationAcquireInfoINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceConfigurationAcquireInfoINTEL.html>"]
 pub struct PerformanceConfigurationAcquireInfoINTEL {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -46428,7 +46432,7 @@ impl<'a> PerformanceConfigurationAcquireInfoINTELBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderClockFeaturesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderClockFeaturesKHR.html>"]
 pub struct PhysicalDeviceShaderClockFeaturesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -46495,7 +46499,7 @@ impl<'a> PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceIndexTypeUint8FeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceIndexTypeUint8FeaturesEXT.html>"]
 pub struct PhysicalDeviceIndexTypeUint8FeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -46553,7 +46557,7 @@ impl<'a> PhysicalDeviceIndexTypeUint8FeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderSMBuiltinsPropertiesNV.html>"]
 pub struct PhysicalDeviceShaderSMBuiltinsPropertiesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -46623,7 +46627,7 @@ impl<'a> PhysicalDeviceShaderSMBuiltinsPropertiesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderSMBuiltinsFeaturesNV.html>"]
 pub struct PhysicalDeviceShaderSMBuiltinsFeaturesNV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -46681,7 +46685,7 @@ impl<'a> PhysicalDeviceShaderSMBuiltinsFeaturesNVBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT.html>"]
 pub struct PhysicalDeviceFragmentShaderInterlockFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -46761,7 +46765,7 @@ impl<'a> PhysicalDeviceFragmentShaderInterlockFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures.html>"]
 pub struct PhysicalDeviceSeparateDepthStencilLayoutsFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -46822,7 +46826,7 @@ impl<'a> PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentReferenceStencilLayout.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentReferenceStencilLayout.html>"]
 pub struct AttachmentReferenceStencilLayout {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -46880,7 +46884,7 @@ impl<'a> AttachmentReferenceStencilLayoutBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentDescriptionStencilLayout.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentDescriptionStencilLayout.html>"]
 pub struct AttachmentDescriptionStencilLayout {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -46947,7 +46951,7 @@ impl<'a> AttachmentDescriptionStencilLayoutBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR.html>"]
 pub struct PhysicalDevicePipelineExecutablePropertiesFeaturesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47008,7 +47012,7 @@ impl<'a> PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineInfoKHR.html>"]
 pub struct PipelineInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -47079,7 +47083,7 @@ impl<'a> PipelineInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutablePropertiesKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineExecutablePropertiesKHR.html>"]
 pub struct PipelineExecutablePropertiesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47196,7 +47200,7 @@ impl<'a> PipelineExecutablePropertiesKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableInfoKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineExecutableInfoKHR.html>"]
 pub struct PipelineExecutableInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -47276,7 +47280,7 @@ impl<'a> PipelineExecutableInfoKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableStatisticValueKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineExecutableStatisticValueKHR.html>"]
 pub union PipelineExecutableStatisticValueKHR {
     pub b32: Bool32,
     pub i64: i64,
@@ -47290,7 +47294,7 @@ impl ::std::default::Default for PipelineExecutableStatisticValueKHR {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableStatisticKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineExecutableStatisticKHR.html>"]
 pub struct PipelineExecutableStatisticKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47407,7 +47411,7 @@ impl<'a> PipelineExecutableStatisticKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableInternalRepresentationKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineExecutableInternalRepresentationKHR.html>"]
 pub struct PipelineExecutableInternalRepresentationKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47528,7 +47532,7 @@ impl<'a> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT.html>"]
 pub struct PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47591,7 +47595,7 @@ impl<'a> PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT.html>"]
 pub struct PhysicalDeviceTexelBufferAlignmentFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47649,7 +47653,7 @@ impl<'a> PhysicalDeviceTexelBufferAlignmentFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT.html>"]
 pub struct PhysicalDeviceTexelBufferAlignmentPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47743,7 +47747,7 @@ impl<'a> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT.html>"]
 pub struct PhysicalDeviceSubgroupSizeControlFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47810,7 +47814,7 @@ impl<'a> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT.html>"]
 pub struct PhysicalDeviceSubgroupSizeControlPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47898,7 +47902,7 @@ impl<'a> PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT.html>"]
 pub struct PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -47962,7 +47966,7 @@ impl<'a> PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryOpaqueCaptureAddressAllocateInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryOpaqueCaptureAddressAllocateInfo.html>"]
 pub struct MemoryOpaqueCaptureAddressAllocateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -48020,7 +48024,7 @@ impl<'a> MemoryOpaqueCaptureAddressAllocateInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceMemoryOpaqueCaptureAddressInfo.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceMemoryOpaqueCaptureAddressInfo.html>"]
 pub struct DeviceMemoryOpaqueCaptureAddressInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -48094,7 +48098,7 @@ impl<'a> DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceLineRasterizationFeaturesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceLineRasterizationFeaturesEXT.html>"]
 pub struct PhysicalDeviceLineRasterizationFeaturesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -48197,7 +48201,7 @@ impl<'a> PhysicalDeviceLineRasterizationFeaturesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceLineRasterizationPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceLineRasterizationPropertiesEXT.html>"]
 pub struct PhysicalDeviceLineRasterizationPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -48258,7 +48262,7 @@ impl<'a> PhysicalDeviceLineRasterizationPropertiesEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineRasterizationLineStateCreateInfoEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationLineStateCreateInfoEXT.html>"]
 pub struct PipelineRasterizationLineStateCreateInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -48349,7 +48353,7 @@ impl<'a> PipelineRasterizationLineStateCreateInfoEXTBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkan11Features.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceVulkan11Features.html>"]
 pub struct PhysicalDeviceVulkan11Features {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -48504,7 +48508,7 @@ impl<'a> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkan11Properties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceVulkan11Properties.html>"]
 pub struct PhysicalDeviceVulkan11Properties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -48689,7 +48693,7 @@ impl<'a> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkan12Features.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceVulkan12Features.html>"]
 pub struct PhysicalDeviceVulkan12Features {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -49191,7 +49195,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceVulkan12Properties.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceVulkan12Properties.html>"]
 pub struct PhysicalDeviceVulkan12Properties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -49954,7 +49958,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCompilerControlCreateInfoAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCompilerControlCreateInfoAMD.html>"]
 pub struct PipelineCompilerControlCreateInfoAMD {
     pub s_type: StructureType,
     pub p_next: *const c_void,
@@ -50014,7 +50018,7 @@ impl<'a> PipelineCompilerControlCreateInfoAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceCoherentMemoryFeaturesAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceCoherentMemoryFeaturesAMD.html>"]
 pub struct PhysicalDeviceCoherentMemoryFeaturesAMD {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -50072,7 +50076,7 @@ impl<'a> PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceToolPropertiesEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceToolPropertiesEXT.html>"]
 pub struct PhysicalDeviceToolPropertiesEXT {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
@@ -50203,7 +50207,7 @@ impl<'a> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageLayout.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageLayout.html>"]
 pub struct ImageLayout(pub(crate) i32);
 impl ImageLayout {
     pub fn from_raw(x: i32) -> Self {
@@ -50235,7 +50239,7 @@ impl ImageLayout {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentLoadOp.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentLoadOp.html>"]
 pub struct AttachmentLoadOp(pub(crate) i32);
 impl AttachmentLoadOp {
     pub fn from_raw(x: i32) -> Self {
@@ -50252,7 +50256,7 @@ impl AttachmentLoadOp {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentStoreOp.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentStoreOp.html>"]
 pub struct AttachmentStoreOp(pub(crate) i32);
 impl AttachmentStoreOp {
     pub fn from_raw(x: i32) -> Self {
@@ -50268,7 +50272,7 @@ impl AttachmentStoreOp {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageType.html>"]
 pub struct ImageType(pub(crate) i32);
 impl ImageType {
     pub fn from_raw(x: i32) -> Self {
@@ -50285,7 +50289,7 @@ impl ImageType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageTiling.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageTiling.html>"]
 pub struct ImageTiling(pub(crate) i32);
 impl ImageTiling {
     pub fn from_raw(x: i32) -> Self {
@@ -50301,7 +50305,7 @@ impl ImageTiling {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageViewType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageViewType.html>"]
 pub struct ImageViewType(pub(crate) i32);
 impl ImageViewType {
     pub fn from_raw(x: i32) -> Self {
@@ -50322,7 +50326,7 @@ impl ImageViewType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandBufferLevel.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferLevel.html>"]
 pub struct CommandBufferLevel(pub(crate) i32);
 impl CommandBufferLevel {
     pub fn from_raw(x: i32) -> Self {
@@ -50338,7 +50342,7 @@ impl CommandBufferLevel {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkComponentSwizzle.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkComponentSwizzle.html>"]
 pub struct ComponentSwizzle(pub(crate) i32);
 impl ComponentSwizzle {
     pub fn from_raw(x: i32) -> Self {
@@ -50359,7 +50363,7 @@ impl ComponentSwizzle {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorType.html>"]
 pub struct DescriptorType(pub(crate) i32);
 impl DescriptorType {
     pub fn from_raw(x: i32) -> Self {
@@ -50384,7 +50388,7 @@ impl DescriptorType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryType.html>"]
 pub struct QueryType(pub(crate) i32);
 impl QueryType {
     pub fn from_raw(x: i32) -> Self {
@@ -50402,7 +50406,7 @@ impl QueryType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBorderColor.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBorderColor.html>"]
 pub struct BorderColor(pub(crate) i32);
 impl BorderColor {
     pub fn from_raw(x: i32) -> Self {
@@ -50422,7 +50426,7 @@ impl BorderColor {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineBindPoint.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineBindPoint.html>"]
 pub struct PipelineBindPoint(pub(crate) i32);
 impl PipelineBindPoint {
     pub fn from_raw(x: i32) -> Self {
@@ -50438,7 +50442,7 @@ impl PipelineBindPoint {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCacheHeaderVersion.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCacheHeaderVersion.html>"]
 pub struct PipelineCacheHeaderVersion(pub(crate) i32);
 impl PipelineCacheHeaderVersion {
     pub fn from_raw(x: i32) -> Self {
@@ -50453,7 +50457,7 @@ impl PipelineCacheHeaderVersion {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPrimitiveTopology.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPrimitiveTopology.html>"]
 pub struct PrimitiveTopology(pub(crate) i32);
 impl PrimitiveTopology {
     pub fn from_raw(x: i32) -> Self {
@@ -50478,7 +50482,7 @@ impl PrimitiveTopology {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSharingMode.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSharingMode.html>"]
 pub struct SharingMode(pub(crate) i32);
 impl SharingMode {
     pub fn from_raw(x: i32) -> Self {
@@ -50494,7 +50498,7 @@ impl SharingMode {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkIndexType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndexType.html>"]
 pub struct IndexType(pub(crate) i32);
 impl IndexType {
     pub fn from_raw(x: i32) -> Self {
@@ -50510,7 +50514,7 @@ impl IndexType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFilter.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFilter.html>"]
 pub struct Filter(pub(crate) i32);
 impl Filter {
     pub fn from_raw(x: i32) -> Self {
@@ -50526,7 +50530,7 @@ impl Filter {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerMipmapMode.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerMipmapMode.html>"]
 pub struct SamplerMipmapMode(pub(crate) i32);
 impl SamplerMipmapMode {
     pub fn from_raw(x: i32) -> Self {
@@ -50544,7 +50548,7 @@ impl SamplerMipmapMode {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerAddressMode.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerAddressMode.html>"]
 pub struct SamplerAddressMode(pub(crate) i32);
 impl SamplerAddressMode {
     pub fn from_raw(x: i32) -> Self {
@@ -50562,7 +50566,7 @@ impl SamplerAddressMode {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCompareOp.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCompareOp.html>"]
 pub struct CompareOp(pub(crate) i32);
 impl CompareOp {
     pub fn from_raw(x: i32) -> Self {
@@ -50584,7 +50588,7 @@ impl CompareOp {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPolygonMode.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPolygonMode.html>"]
 pub struct PolygonMode(pub(crate) i32);
 impl PolygonMode {
     pub fn from_raw(x: i32) -> Self {
@@ -50601,7 +50605,7 @@ impl PolygonMode {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFrontFace.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFrontFace.html>"]
 pub struct FrontFace(pub(crate) i32);
 impl FrontFace {
     pub fn from_raw(x: i32) -> Self {
@@ -50617,7 +50621,7 @@ impl FrontFace {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBlendFactor.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBlendFactor.html>"]
 pub struct BlendFactor(pub(crate) i32);
 impl BlendFactor {
     pub fn from_raw(x: i32) -> Self {
@@ -50650,7 +50654,7 @@ impl BlendFactor {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBlendOp.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBlendOp.html>"]
 pub struct BlendOp(pub(crate) i32);
 impl BlendOp {
     pub fn from_raw(x: i32) -> Self {
@@ -50669,7 +50673,7 @@ impl BlendOp {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkStencilOp.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStencilOp.html>"]
 pub struct StencilOp(pub(crate) i32);
 impl StencilOp {
     pub fn from_raw(x: i32) -> Self {
@@ -50691,7 +50695,7 @@ impl StencilOp {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkLogicOp.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkLogicOp.html>"]
 pub struct LogicOp(pub(crate) i32);
 impl LogicOp {
     pub fn from_raw(x: i32) -> Self {
@@ -50721,7 +50725,7 @@ impl LogicOp {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkInternalAllocationType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkInternalAllocationType.html>"]
 pub struct InternalAllocationType(pub(crate) i32);
 impl InternalAllocationType {
     pub fn from_raw(x: i32) -> Self {
@@ -50736,7 +50740,7 @@ impl InternalAllocationType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSystemAllocationScope.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSystemAllocationScope.html>"]
 pub struct SystemAllocationScope(pub(crate) i32);
 impl SystemAllocationScope {
     pub fn from_raw(x: i32) -> Self {
@@ -50755,7 +50759,7 @@ impl SystemAllocationScope {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceType.html>"]
 pub struct PhysicalDeviceType(pub(crate) i32);
 impl PhysicalDeviceType {
     pub fn from_raw(x: i32) -> Self {
@@ -50774,7 +50778,7 @@ impl PhysicalDeviceType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkVertexInputRate.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVertexInputRate.html>"]
 pub struct VertexInputRate(pub(crate) i32);
 impl VertexInputRate {
     pub fn from_raw(x: i32) -> Self {
@@ -50790,7 +50794,7 @@ impl VertexInputRate {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFormat.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFormat.html>"]
 pub struct Format(pub(crate) i32);
 impl Format {
     pub fn from_raw(x: i32) -> Self {
@@ -50989,7 +50993,7 @@ impl Format {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkStructureType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStructureType.html>"]
 pub struct StructureType(pub(crate) i32);
 impl StructureType {
     pub fn from_raw(x: i32) -> Self {
@@ -51054,7 +51058,7 @@ impl StructureType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassContents.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassContents.html>"]
 pub struct SubpassContents(pub(crate) i32);
 impl SubpassContents {
     pub fn from_raw(x: i32) -> Self {
@@ -51070,7 +51074,7 @@ impl SubpassContents {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkResult.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkResult.html>"]
 pub struct Result(pub(crate) i32);
 impl Result {
     pub fn from_raw(x: i32) -> Self {
@@ -51204,7 +51208,7 @@ impl fmt::Display for Result {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDynamicState.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDynamicState.html>"]
 pub struct DynamicState(pub(crate) i32);
 impl DynamicState {
     pub fn from_raw(x: i32) -> Self {
@@ -51227,7 +51231,7 @@ impl DynamicState {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorUpdateTemplateType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorUpdateTemplateType.html>"]
 pub struct DescriptorUpdateTemplateType(pub(crate) i32);
 impl DescriptorUpdateTemplateType {
     pub fn from_raw(x: i32) -> Self {
@@ -51243,7 +51247,7 @@ impl DescriptorUpdateTemplateType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectType.html>"]
 pub struct ObjectType(pub(crate) i32);
 impl ObjectType {
     pub fn from_raw(x: i32) -> Self {
@@ -51308,7 +51312,7 @@ impl ObjectType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreType.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreType.html>"]
 pub struct SemaphoreType(pub(crate) i32);
 impl SemaphoreType {
     pub fn from_raw(x: i32) -> Self {
@@ -51324,7 +51328,7 @@ impl SemaphoreType {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPresentModeKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentModeKHR.html>"]
 pub struct PresentModeKHR(pub(crate) i32);
 impl PresentModeKHR {
     pub fn from_raw(x: i32) -> Self {
@@ -51342,7 +51346,7 @@ impl PresentModeKHR {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkColorSpaceKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkColorSpaceKHR.html>"]
 pub struct ColorSpaceKHR(pub(crate) i32);
 impl ColorSpaceKHR {
     pub fn from_raw(x: i32) -> Self {
@@ -51357,7 +51361,7 @@ impl ColorSpaceKHR {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkTimeDomainEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkTimeDomainEXT.html>"]
 pub struct TimeDomainEXT(pub(crate) i32);
 impl TimeDomainEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51375,7 +51379,7 @@ impl TimeDomainEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugReportObjectTypeEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugReportObjectTypeEXT.html>"]
 pub struct DebugReportObjectTypeEXT(pub(crate) i32);
 impl DebugReportObjectTypeEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51423,7 +51427,7 @@ impl DebugReportObjectTypeEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRasterizationOrderAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRasterizationOrderAMD.html>"]
 pub struct RasterizationOrderAMD(pub(crate) i32);
 impl RasterizationOrderAMD {
     pub fn from_raw(x: i32) -> Self {
@@ -51439,7 +51443,7 @@ impl RasterizationOrderAMD {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkValidationCheckEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationCheckEXT.html>"]
 pub struct ValidationCheckEXT(pub(crate) i32);
 impl ValidationCheckEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51455,7 +51459,7 @@ impl ValidationCheckEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkValidationFeatureEnableEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationFeatureEnableEXT.html>"]
 pub struct ValidationFeatureEnableEXT(pub(crate) i32);
 impl ValidationFeatureEnableEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51472,7 +51476,7 @@ impl ValidationFeatureEnableEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkValidationFeatureDisableEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationFeatureDisableEXT.html>"]
 pub struct ValidationFeatureDisableEXT(pub(crate) i32);
 impl ValidationFeatureDisableEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51493,7 +51497,7 @@ impl ValidationFeatureDisableEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkIndirectCommandsTokenTypeNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndirectCommandsTokenTypeNVX.html>"]
 pub struct IndirectCommandsTokenTypeNVX(pub(crate) i32);
 impl IndirectCommandsTokenTypeNVX {
     pub fn from_raw(x: i32) -> Self {
@@ -51515,7 +51519,7 @@ impl IndirectCommandsTokenTypeNVX {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectEntryTypeNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectEntryTypeNVX.html>"]
 pub struct ObjectEntryTypeNVX(pub(crate) i32);
 impl ObjectEntryTypeNVX {
     pub fn from_raw(x: i32) -> Self {
@@ -51534,7 +51538,7 @@ impl ObjectEntryTypeNVX {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPowerStateEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPowerStateEXT.html>"]
 pub struct DisplayPowerStateEXT(pub(crate) i32);
 impl DisplayPowerStateEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51551,7 +51555,7 @@ impl DisplayPowerStateEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceEventTypeEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceEventTypeEXT.html>"]
 pub struct DeviceEventTypeEXT(pub(crate) i32);
 impl DeviceEventTypeEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51566,7 +51570,7 @@ impl DeviceEventTypeEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayEventTypeEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayEventTypeEXT.html>"]
 pub struct DisplayEventTypeEXT(pub(crate) i32);
 impl DisplayEventTypeEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51581,7 +51585,7 @@ impl DisplayEventTypeEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkViewportCoordinateSwizzleNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkViewportCoordinateSwizzleNV.html>"]
 pub struct ViewportCoordinateSwizzleNV(pub(crate) i32);
 impl ViewportCoordinateSwizzleNV {
     pub fn from_raw(x: i32) -> Self {
@@ -51603,7 +51607,7 @@ impl ViewportCoordinateSwizzleNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDiscardRectangleModeEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDiscardRectangleModeEXT.html>"]
 pub struct DiscardRectangleModeEXT(pub(crate) i32);
 impl DiscardRectangleModeEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51619,7 +51623,7 @@ impl DiscardRectangleModeEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPointClippingBehavior.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPointClippingBehavior.html>"]
 pub struct PointClippingBehavior(pub(crate) i32);
 impl PointClippingBehavior {
     pub fn from_raw(x: i32) -> Self {
@@ -51635,7 +51639,7 @@ impl PointClippingBehavior {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerReductionMode.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerReductionMode.html>"]
 pub struct SamplerReductionMode(pub(crate) i32);
 impl SamplerReductionMode {
     pub fn from_raw(x: i32) -> Self {
@@ -51652,7 +51656,7 @@ impl SamplerReductionMode {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkTessellationDomainOrigin.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkTessellationDomainOrigin.html>"]
 pub struct TessellationDomainOrigin(pub(crate) i32);
 impl TessellationDomainOrigin {
     pub fn from_raw(x: i32) -> Self {
@@ -51668,7 +51672,7 @@ impl TessellationDomainOrigin {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerYcbcrModelConversion.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerYcbcrModelConversion.html>"]
 pub struct SamplerYcbcrModelConversion(pub(crate) i32);
 impl SamplerYcbcrModelConversion {
     pub fn from_raw(x: i32) -> Self {
@@ -51691,7 +51695,7 @@ impl SamplerYcbcrModelConversion {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerYcbcrRange.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerYcbcrRange.html>"]
 pub struct SamplerYcbcrRange(pub(crate) i32);
 impl SamplerYcbcrRange {
     pub fn from_raw(x: i32) -> Self {
@@ -51709,7 +51713,7 @@ impl SamplerYcbcrRange {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkChromaLocation.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkChromaLocation.html>"]
 pub struct ChromaLocation(pub(crate) i32);
 impl ChromaLocation {
     pub fn from_raw(x: i32) -> Self {
@@ -51725,7 +51729,7 @@ impl ChromaLocation {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBlendOverlapEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBlendOverlapEXT.html>"]
 pub struct BlendOverlapEXT(pub(crate) i32);
 impl BlendOverlapEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51742,7 +51746,7 @@ impl BlendOverlapEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCoverageModulationModeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCoverageModulationModeNV.html>"]
 pub struct CoverageModulationModeNV(pub(crate) i32);
 impl CoverageModulationModeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -51760,7 +51764,7 @@ impl CoverageModulationModeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCoverageReductionModeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCoverageReductionModeNV.html>"]
 pub struct CoverageReductionModeNV(pub(crate) i32);
 impl CoverageReductionModeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -51776,7 +51780,7 @@ impl CoverageReductionModeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkValidationCacheHeaderVersionEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationCacheHeaderVersionEXT.html>"]
 pub struct ValidationCacheHeaderVersionEXT(pub(crate) i32);
 impl ValidationCacheHeaderVersionEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51791,7 +51795,7 @@ impl ValidationCacheHeaderVersionEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderInfoTypeAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderInfoTypeAMD.html>"]
 pub struct ShaderInfoTypeAMD(pub(crate) i32);
 impl ShaderInfoTypeAMD {
     pub fn from_raw(x: i32) -> Self {
@@ -51808,7 +51812,7 @@ impl ShaderInfoTypeAMD {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueueGlobalPriorityEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueueGlobalPriorityEXT.html>"]
 pub struct QueueGlobalPriorityEXT(pub(crate) i32);
 impl QueueGlobalPriorityEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51826,7 +51830,7 @@ impl QueueGlobalPriorityEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkConservativeRasterizationModeEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkConservativeRasterizationModeEXT.html>"]
 pub struct ConservativeRasterizationModeEXT(pub(crate) i32);
 impl ConservativeRasterizationModeEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -51843,7 +51847,7 @@ impl ConservativeRasterizationModeEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkVendorId.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVendorId.html>"]
 pub struct VendorId(pub(crate) i32);
 impl VendorId {
     pub fn from_raw(x: i32) -> Self {
@@ -51863,7 +51867,7 @@ impl VendorId {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDriverId.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDriverId.html>"]
 pub struct DriverId(pub(crate) i32);
 impl DriverId {
     pub fn from_raw(x: i32) -> Self {
@@ -51901,7 +51905,7 @@ impl DriverId {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShadingRatePaletteEntryNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShadingRatePaletteEntryNV.html>"]
 pub struct ShadingRatePaletteEntryNV(pub(crate) i32);
 impl ShadingRatePaletteEntryNV {
     pub fn from_raw(x: i32) -> Self {
@@ -51927,7 +51931,7 @@ impl ShadingRatePaletteEntryNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCoarseSampleOrderTypeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCoarseSampleOrderTypeNV.html>"]
 pub struct CoarseSampleOrderTypeNV(pub(crate) i32);
 impl CoarseSampleOrderTypeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -51945,7 +51949,7 @@ impl CoarseSampleOrderTypeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCopyAccelerationStructureModeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCopyAccelerationStructureModeNV.html>"]
 pub struct CopyAccelerationStructureModeNV(pub(crate) i32);
 impl CopyAccelerationStructureModeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -51961,7 +51965,7 @@ impl CopyAccelerationStructureModeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAccelerationStructureTypeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureTypeNV.html>"]
 pub struct AccelerationStructureTypeNV(pub(crate) i32);
 impl AccelerationStructureTypeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -51977,7 +51981,7 @@ impl AccelerationStructureTypeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkGeometryTypeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryTypeNV.html>"]
 pub struct GeometryTypeNV(pub(crate) i32);
 impl GeometryTypeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -51993,7 +51997,7 @@ impl GeometryTypeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAccelerationStructureMemoryRequirementsTypeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureMemoryRequirementsTypeNV.html>"]
 pub struct AccelerationStructureMemoryRequirementsTypeNV(pub(crate) i32);
 impl AccelerationStructureMemoryRequirementsTypeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -52010,7 +52014,7 @@ impl AccelerationStructureMemoryRequirementsTypeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRayTracingShaderGroupTypeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRayTracingShaderGroupTypeNV.html>"]
 pub struct RayTracingShaderGroupTypeNV(pub(crate) i32);
 impl RayTracingShaderGroupTypeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -52027,7 +52031,7 @@ impl RayTracingShaderGroupTypeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryOverallocationBehaviorAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryOverallocationBehaviorAMD.html>"]
 pub struct MemoryOverallocationBehaviorAMD(pub(crate) i32);
 impl MemoryOverallocationBehaviorAMD {
     pub fn from_raw(x: i32) -> Self {
@@ -52044,7 +52048,7 @@ impl MemoryOverallocationBehaviorAMD {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkScopeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkScopeNV.html>"]
 pub struct ScopeNV(pub(crate) i32);
 impl ScopeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -52062,7 +52066,7 @@ impl ScopeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkComponentTypeNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkComponentTypeNV.html>"]
 pub struct ComponentTypeNV(pub(crate) i32);
 impl ComponentTypeNV {
     pub fn from_raw(x: i32) -> Self {
@@ -52087,7 +52091,7 @@ impl ComponentTypeNV {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFullScreenExclusiveEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFullScreenExclusiveEXT.html>"]
 pub struct FullScreenExclusiveEXT(pub(crate) i32);
 impl FullScreenExclusiveEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -52105,7 +52109,7 @@ impl FullScreenExclusiveEXT {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterScopeKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterScopeKHR.html>"]
 pub struct PerformanceCounterScopeKHR(pub(crate) i32);
 impl PerformanceCounterScopeKHR {
     pub fn from_raw(x: i32) -> Self {
@@ -52122,7 +52126,7 @@ impl PerformanceCounterScopeKHR {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterUnitKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterUnitKHR.html>"]
 pub struct PerformanceCounterUnitKHR(pub(crate) i32);
 impl PerformanceCounterUnitKHR {
     pub fn from_raw(x: i32) -> Self {
@@ -52147,7 +52151,7 @@ impl PerformanceCounterUnitKHR {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterStorageKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterStorageKHR.html>"]
 pub struct PerformanceCounterStorageKHR(pub(crate) i32);
 impl PerformanceCounterStorageKHR {
     pub fn from_raw(x: i32) -> Self {
@@ -52167,7 +52171,7 @@ impl PerformanceCounterStorageKHR {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceConfigurationTypeINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceConfigurationTypeINTEL.html>"]
 pub struct PerformanceConfigurationTypeINTEL(pub(crate) i32);
 impl PerformanceConfigurationTypeINTEL {
     pub fn from_raw(x: i32) -> Self {
@@ -52183,7 +52187,7 @@ impl PerformanceConfigurationTypeINTEL {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryPoolSamplingModeINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPoolSamplingModeINTEL.html>"]
 pub struct QueryPoolSamplingModeINTEL(pub(crate) i32);
 impl QueryPoolSamplingModeINTEL {
     pub fn from_raw(x: i32) -> Self {
@@ -52198,7 +52202,7 @@ impl QueryPoolSamplingModeINTEL {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceOverrideTypeINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceOverrideTypeINTEL.html>"]
 pub struct PerformanceOverrideTypeINTEL(pub(crate) i32);
 impl PerformanceOverrideTypeINTEL {
     pub fn from_raw(x: i32) -> Self {
@@ -52215,7 +52219,7 @@ impl PerformanceOverrideTypeINTEL {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceParameterTypeINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceParameterTypeINTEL.html>"]
 pub struct PerformanceParameterTypeINTEL(pub(crate) i32);
 impl PerformanceParameterTypeINTEL {
     pub fn from_raw(x: i32) -> Self {
@@ -52233,7 +52237,7 @@ impl PerformanceParameterTypeINTEL {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceValueTypeINTEL.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceValueTypeINTEL.html>"]
 pub struct PerformanceValueTypeINTEL(pub(crate) i32);
 impl PerformanceValueTypeINTEL {
     pub fn from_raw(x: i32) -> Self {
@@ -52252,7 +52256,7 @@ impl PerformanceValueTypeINTEL {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderFloatControlsIndependence.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderFloatControlsIndependence.html>"]
 pub struct ShaderFloatControlsIndependence(pub(crate) i32);
 impl ShaderFloatControlsIndependence {
     pub fn from_raw(x: i32) -> Self {
@@ -52269,7 +52273,7 @@ impl ShaderFloatControlsIndependence {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableStatisticFormatKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineExecutableStatisticFormatKHR.html>"]
 pub struct PipelineExecutableStatisticFormatKHR(pub(crate) i32);
 impl PipelineExecutableStatisticFormatKHR {
     pub fn from_raw(x: i32) -> Self {
@@ -52287,7 +52291,7 @@ impl PipelineExecutableStatisticFormatKHR {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkLineRasterizationModeEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkLineRasterizationModeEXT.html>"]
 pub struct LineRasterizationModeEXT(pub(crate) i32);
 impl LineRasterizationModeEXT {
     pub fn from_raw(x: i32) -> Self {
@@ -52305,7 +52309,7 @@ impl LineRasterizationModeEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCullModeFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCullModeFlagBits.html>"]
 pub struct CullModeFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(CullModeFlags, 0b11, Flags);
 impl CullModeFlags {
@@ -52316,7 +52320,7 @@ impl CullModeFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueueFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueueFlagBits.html>"]
 pub struct QueueFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(QueueFlags, 0b1111, Flags);
 impl QueueFlags {
@@ -52331,19 +52335,19 @@ impl QueueFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkRenderPassCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassCreateFlagBits.html>"]
 pub struct RenderPassCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(RenderPassCreateFlags, 0b0, Flags);
 impl RenderPassCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceQueueCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceQueueCreateFlagBits.html>"]
 pub struct DeviceQueueCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(DeviceQueueCreateFlags, 0b0, Flags);
 impl DeviceQueueCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryPropertyFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryPropertyFlagBits.html>"]
 pub struct MemoryPropertyFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(MemoryPropertyFlags, 0b1_1111, Flags);
 impl MemoryPropertyFlags {
@@ -52360,7 +52364,7 @@ impl MemoryPropertyFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryHeapFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryHeapFlagBits.html>"]
 pub struct MemoryHeapFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(MemoryHeapFlags, 0b1, Flags);
 impl MemoryHeapFlags {
@@ -52369,7 +52373,7 @@ impl MemoryHeapFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAccessFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccessFlagBits.html>"]
 pub struct AccessFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(AccessFlags, 0b1_1111_1111_1111_1111, Flags);
 impl AccessFlags {
@@ -52410,7 +52414,7 @@ impl AccessFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferUsageFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferUsageFlagBits.html>"]
 pub struct BufferUsageFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(BufferUsageFlags, 0b1_1111_1111, Flags);
 impl BufferUsageFlags {
@@ -52435,7 +52439,7 @@ impl BufferUsageFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferCreateFlagBits.html>"]
 pub struct BufferCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(BufferCreateFlags, 0b111, Flags);
 impl BufferCreateFlags {
@@ -52448,7 +52452,7 @@ impl BufferCreateFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderStageFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderStageFlagBits.html>"]
 pub struct ShaderStageFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(
     ShaderStageFlags,
@@ -52467,7 +52471,7 @@ impl ShaderStageFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageUsageFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageUsageFlagBits.html>"]
 pub struct ImageUsageFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ImageUsageFlags, 0b1111_1111, Flags);
 impl ImageUsageFlags {
@@ -52490,7 +52494,7 @@ impl ImageUsageFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageCreateFlagBits.html>"]
 pub struct ImageCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ImageCreateFlags, 0b1_1111, Flags);
 impl ImageCreateFlags {
@@ -52507,19 +52511,19 @@ impl ImageCreateFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageViewCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageViewCreateFlagBits.html>"]
 pub struct ImageViewCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ImageViewCreateFlags, 0b0, Flags);
 impl ImageViewCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSamplerCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerCreateFlagBits.html>"]
 pub struct SamplerCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(SamplerCreateFlags, 0b0, Flags);
 impl SamplerCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCreateFlagBits.html>"]
 pub struct PipelineCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(PipelineCreateFlags, 0b111, Flags);
 impl PipelineCreateFlags {
@@ -52529,13 +52533,13 @@ impl PipelineCreateFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineShaderStageCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineShaderStageCreateFlagBits.html>"]
 pub struct PipelineShaderStageCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(PipelineShaderStageCreateFlags, 0b0, Flags);
 impl PipelineShaderStageCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkColorComponentFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkColorComponentFlagBits.html>"]
 pub struct ColorComponentFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ColorComponentFlags, 0b1111, Flags);
 impl ColorComponentFlags {
@@ -52546,7 +52550,7 @@ impl ColorComponentFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFenceCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFenceCreateFlagBits.html>"]
 pub struct FenceCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(FenceCreateFlags, 0b1, Flags);
 impl FenceCreateFlags {
@@ -52554,13 +52558,13 @@ impl FenceCreateFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreCreateFlagBits.html>"]
 pub struct SemaphoreCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(SemaphoreCreateFlags, 0b0, Flags);
 impl SemaphoreCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFormatFeatureFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFormatFeatureFlagBits.html>"]
 pub struct FormatFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(FormatFeatureFlags, 0b1_1111_1111_1111, Flags);
 impl FormatFeatureFlags {
@@ -52593,7 +52597,7 @@ impl FormatFeatureFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryControlFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryControlFlagBits.html>"]
 pub struct QueryControlFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(QueryControlFlags, 0b1, Flags);
 impl QueryControlFlags {
@@ -52602,7 +52606,7 @@ impl QueryControlFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryResultFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryResultFlagBits.html>"]
 pub struct QueryResultFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(QueryResultFlags, 0b1111, Flags);
 impl QueryResultFlags {
@@ -52617,7 +52621,7 @@ impl QueryResultFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandBufferUsageFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferUsageFlagBits.html>"]
 pub struct CommandBufferUsageFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(CommandBufferUsageFlags, 0b111, Flags);
 impl CommandBufferUsageFlags {
@@ -52628,7 +52632,7 @@ impl CommandBufferUsageFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkQueryPipelineStatisticFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPipelineStatisticFlagBits.html>"]
 pub struct QueryPipelineStatisticFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(QueryPipelineStatisticFlags, 0b111_1111_1111, Flags);
 impl QueryPipelineStatisticFlags {
@@ -52659,7 +52663,7 @@ impl QueryPipelineStatisticFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkImageAspectFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageAspectFlagBits.html>"]
 pub struct ImageAspectFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ImageAspectFlags, 0b1111, Flags);
 impl ImageAspectFlags {
@@ -52670,7 +52674,7 @@ impl ImageAspectFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseImageFormatFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseImageFormatFlagBits.html>"]
 pub struct SparseImageFormatFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(SparseImageFormatFlags, 0b111, Flags);
 impl SparseImageFormatFlags {
@@ -52683,7 +52687,7 @@ impl SparseImageFormatFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSparseMemoryBindFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseMemoryBindFlagBits.html>"]
 pub struct SparseMemoryBindFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(SparseMemoryBindFlags, 0b1, Flags);
 impl SparseMemoryBindFlags {
@@ -52692,7 +52696,7 @@ impl SparseMemoryBindFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineStageFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineStageFlagBits.html>"]
 pub struct PipelineStageFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(PipelineStageFlags, 0b1_1111_1111_1111_1111, Flags);
 impl PipelineStageFlags {
@@ -52733,7 +52737,7 @@ impl PipelineStageFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandPoolCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandPoolCreateFlagBits.html>"]
 pub struct CommandPoolCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(CommandPoolCreateFlags, 0b11, Flags);
 impl CommandPoolCreateFlags {
@@ -52744,7 +52748,7 @@ impl CommandPoolCreateFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandPoolResetFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandPoolResetFlagBits.html>"]
 pub struct CommandPoolResetFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(CommandPoolResetFlags, 0b1, Flags);
 impl CommandPoolResetFlags {
@@ -52753,7 +52757,7 @@ impl CommandPoolResetFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCommandBufferResetFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferResetFlagBits.html>"]
 pub struct CommandBufferResetFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(CommandBufferResetFlags, 0b1, Flags);
 impl CommandBufferResetFlags {
@@ -52762,7 +52766,7 @@ impl CommandBufferResetFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSampleCountFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSampleCountFlagBits.html>"]
 pub struct SampleCountFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(SampleCountFlags, 0b111_1111, Flags);
 impl SampleCountFlags {
@@ -52783,7 +52787,7 @@ impl SampleCountFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAttachmentDescriptionFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentDescriptionFlagBits.html>"]
 pub struct AttachmentDescriptionFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(AttachmentDescriptionFlags, 0b1, Flags);
 impl AttachmentDescriptionFlags {
@@ -52792,7 +52796,7 @@ impl AttachmentDescriptionFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkStencilFaceFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStencilFaceFlagBits.html>"]
 pub struct StencilFaceFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(StencilFaceFlags, 0b11, Flags);
 impl StencilFaceFlags {
@@ -52805,7 +52809,7 @@ impl StencilFaceFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorPoolCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorPoolCreateFlagBits.html>"]
 pub struct DescriptorPoolCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(DescriptorPoolCreateFlags, 0b1, Flags);
 impl DescriptorPoolCreateFlags {
@@ -52814,7 +52818,7 @@ impl DescriptorPoolCreateFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDependencyFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDependencyFlagBits.html>"]
 pub struct DependencyFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(DependencyFlags, 0b1, Flags);
 impl DependencyFlags {
@@ -52823,7 +52827,7 @@ impl DependencyFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreWaitFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreWaitFlagBits.html>"]
 pub struct SemaphoreWaitFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(SemaphoreWaitFlags, 0b1, Flags);
 impl SemaphoreWaitFlags {
@@ -52831,7 +52835,7 @@ impl SemaphoreWaitFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDisplayPlaneAlphaFlagBitsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPlaneAlphaFlagBitsKHR.html>"]
 pub struct DisplayPlaneAlphaFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(DisplayPlaneAlphaFlagsKHR, 0b1111, Flags);
 impl DisplayPlaneAlphaFlagsKHR {
@@ -52842,7 +52846,7 @@ impl DisplayPlaneAlphaFlagsKHR {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkCompositeAlphaFlagBitsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCompositeAlphaFlagBitsKHR.html>"]
 pub struct CompositeAlphaFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(CompositeAlphaFlagsKHR, 0b1111, Flags);
 impl CompositeAlphaFlagsKHR {
@@ -52853,7 +52857,7 @@ impl CompositeAlphaFlagsKHR {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceTransformFlagBitsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceTransformFlagBitsKHR.html>"]
 pub struct SurfaceTransformFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(SurfaceTransformFlagsKHR, 0b1_1111_1111, Flags);
 impl SurfaceTransformFlagsKHR {
@@ -52869,7 +52873,7 @@ impl SurfaceTransformFlagsKHR {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSwapchainImageUsageFlagBitsANDROID.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSwapchainImageUsageFlagBitsANDROID.html>"]
 pub struct SwapchainImageUsageFlagsANDROID(pub(crate) Flags);
 vk_bitflags_wrapped!(SwapchainImageUsageFlagsANDROID, 0b1, Flags);
 impl SwapchainImageUsageFlagsANDROID {
@@ -52877,7 +52881,7 @@ impl SwapchainImageUsageFlagsANDROID {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugReportFlagBitsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugReportFlagBitsEXT.html>"]
 pub struct DebugReportFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(DebugReportFlagsEXT, 0b1_1111, Flags);
 impl DebugReportFlagsEXT {
@@ -52889,7 +52893,7 @@ impl DebugReportFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalMemoryHandleTypeFlagBitsNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryHandleTypeFlagBitsNV.html>"]
 pub struct ExternalMemoryHandleTypeFlagsNV(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalMemoryHandleTypeFlagsNV, 0b1111, Flags);
 impl ExternalMemoryHandleTypeFlagsNV {
@@ -52904,7 +52908,7 @@ impl ExternalMemoryHandleTypeFlagsNV {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalMemoryFeatureFlagBitsNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryFeatureFlagBitsNV.html>"]
 pub struct ExternalMemoryFeatureFlagsNV(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalMemoryFeatureFlagsNV, 0b111, Flags);
 impl ExternalMemoryFeatureFlagsNV {
@@ -52914,7 +52918,7 @@ impl ExternalMemoryFeatureFlagsNV {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubgroupFeatureFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubgroupFeatureFlagBits.html>"]
 pub struct SubgroupFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(SubgroupFeatureFlags, 0b1111_1111, Flags);
 impl SubgroupFeatureFlags {
@@ -52937,7 +52941,7 @@ impl SubgroupFeatureFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkIndirectCommandsLayoutUsageFlagBitsNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndirectCommandsLayoutUsageFlagBitsNVX.html>"]
 pub struct IndirectCommandsLayoutUsageFlagsNVX(pub(crate) Flags);
 vk_bitflags_wrapped!(IndirectCommandsLayoutUsageFlagsNVX, 0b1111, Flags);
 impl IndirectCommandsLayoutUsageFlagsNVX {
@@ -52948,7 +52952,7 @@ impl IndirectCommandsLayoutUsageFlagsNVX {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkObjectEntryUsageFlagBitsNVX.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectEntryUsageFlagBitsNVX.html>"]
 pub struct ObjectEntryUsageFlagsNVX(pub(crate) Flags);
 vk_bitflags_wrapped!(ObjectEntryUsageFlagsNVX, 0b11, Flags);
 impl ObjectEntryUsageFlagsNVX {
@@ -52957,13 +52961,13 @@ impl ObjectEntryUsageFlagsNVX {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorSetLayoutCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetLayoutCreateFlagBits.html>"]
 pub struct DescriptorSetLayoutCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(DescriptorSetLayoutCreateFlags, 0b0, Flags);
 impl DescriptorSetLayoutCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalMemoryHandleTypeFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryHandleTypeFlagBits.html>"]
 pub struct ExternalMemoryHandleTypeFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalMemoryHandleTypeFlags, 0b111_1111, Flags);
 impl ExternalMemoryHandleTypeFlags {
@@ -52982,7 +52986,7 @@ impl ExternalMemoryHandleTypeFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalMemoryFeatureFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryFeatureFlagBits.html>"]
 pub struct ExternalMemoryFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalMemoryFeatureFlags, 0b111, Flags);
 impl ExternalMemoryFeatureFlags {
@@ -52992,7 +52996,7 @@ impl ExternalMemoryFeatureFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalSemaphoreHandleTypeFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalSemaphoreHandleTypeFlagBits.html>"]
 pub struct ExternalSemaphoreHandleTypeFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalSemaphoreHandleTypeFlags, 0b1_1111, Flags);
 impl ExternalSemaphoreHandleTypeFlags {
@@ -53009,7 +53013,7 @@ impl ExternalSemaphoreHandleTypeFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalSemaphoreFeatureFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalSemaphoreFeatureFlagBits.html>"]
 pub struct ExternalSemaphoreFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalSemaphoreFeatureFlags, 0b11, Flags);
 impl ExternalSemaphoreFeatureFlags {
@@ -53018,7 +53022,7 @@ impl ExternalSemaphoreFeatureFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSemaphoreImportFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreImportFlagBits.html>"]
 pub struct SemaphoreImportFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(SemaphoreImportFlags, 0b1, Flags);
 impl SemaphoreImportFlags {
@@ -53026,7 +53030,7 @@ impl SemaphoreImportFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalFenceHandleTypeFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalFenceHandleTypeFlagBits.html>"]
 pub struct ExternalFenceHandleTypeFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalFenceHandleTypeFlags, 0b1111, Flags);
 impl ExternalFenceHandleTypeFlags {
@@ -53038,7 +53042,7 @@ impl ExternalFenceHandleTypeFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkExternalFenceFeatureFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalFenceFeatureFlagBits.html>"]
 pub struct ExternalFenceFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalFenceFeatureFlags, 0b11, Flags);
 impl ExternalFenceFeatureFlags {
@@ -53047,7 +53051,7 @@ impl ExternalFenceFeatureFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFenceImportFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFenceImportFlagBits.html>"]
 pub struct FenceImportFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(FenceImportFlags, 0b1, Flags);
 impl FenceImportFlags {
@@ -53055,7 +53059,7 @@ impl FenceImportFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSurfaceCounterFlagBitsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceCounterFlagBitsEXT.html>"]
 pub struct SurfaceCounterFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(SurfaceCounterFlagsEXT, 0b1, Flags);
 impl SurfaceCounterFlagsEXT {
@@ -53063,7 +53067,7 @@ impl SurfaceCounterFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPeerMemoryFeatureFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPeerMemoryFeatureFlagBits.html>"]
 pub struct PeerMemoryFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(PeerMemoryFeatureFlags, 0b1111, Flags);
 impl PeerMemoryFeatureFlags {
@@ -53078,7 +53082,7 @@ impl PeerMemoryFeatureFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkMemoryAllocateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryAllocateFlagBits.html>"]
 pub struct MemoryAllocateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(MemoryAllocateFlags, 0b1, Flags);
 impl MemoryAllocateFlags {
@@ -53087,7 +53091,7 @@ impl MemoryAllocateFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDeviceGroupPresentModeFlagBitsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupPresentModeFlagBitsKHR.html>"]
 pub struct DeviceGroupPresentModeFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(DeviceGroupPresentModeFlagsKHR, 0b1111, Flags);
 impl DeviceGroupPresentModeFlagsKHR {
@@ -53102,19 +53106,19 @@ impl DeviceGroupPresentModeFlagsKHR {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSwapchainCreateFlagBitsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSwapchainCreateFlagBitsKHR.html>"]
 pub struct SwapchainCreateFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(SwapchainCreateFlagsKHR, 0b0, Flags);
 impl SwapchainCreateFlagsKHR {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkSubpassDescriptionFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassDescriptionFlagBits.html>"]
 pub struct SubpassDescriptionFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(SubpassDescriptionFlags, 0b0, Flags);
 impl SubpassDescriptionFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsMessageSeverityFlagBitsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessageSeverityFlagBitsEXT.html>"]
 pub struct DebugUtilsMessageSeverityFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(DebugUtilsMessageSeverityFlagsEXT, 0b1_0001_0001_0001, Flags);
 impl DebugUtilsMessageSeverityFlagsEXT {
@@ -53125,7 +53129,7 @@ impl DebugUtilsMessageSeverityFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugUtilsMessageTypeFlagBitsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessageTypeFlagBitsEXT.html>"]
 pub struct DebugUtilsMessageTypeFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(DebugUtilsMessageTypeFlagsEXT, 0b111, Flags);
 impl DebugUtilsMessageTypeFlagsEXT {
@@ -53135,7 +53139,7 @@ impl DebugUtilsMessageTypeFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDescriptorBindingFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorBindingFlagBits.html>"]
 pub struct DescriptorBindingFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(DescriptorBindingFlags, 0b1111, Flags);
 impl DescriptorBindingFlags {
@@ -53146,7 +53150,7 @@ impl DescriptorBindingFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkConditionalRenderingFlagBitsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkConditionalRenderingFlagBitsEXT.html>"]
 pub struct ConditionalRenderingFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(ConditionalRenderingFlagsEXT, 0b1, Flags);
 impl ConditionalRenderingFlagsEXT {
@@ -53154,7 +53158,7 @@ impl ConditionalRenderingFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkResolveModeFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkResolveModeFlagBits.html>"]
 pub struct ResolveModeFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ResolveModeFlags, 0b1111, Flags);
 impl ResolveModeFlags {
@@ -53166,7 +53170,7 @@ impl ResolveModeFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkGeometryInstanceFlagBitsNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryInstanceFlagBitsNV.html>"]
 pub struct GeometryInstanceFlagsNV(pub(crate) Flags);
 vk_bitflags_wrapped!(GeometryInstanceFlagsNV, 0b1111, Flags);
 impl GeometryInstanceFlagsNV {
@@ -53177,7 +53181,7 @@ impl GeometryInstanceFlagsNV {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkGeometryFlagBitsNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryFlagBitsNV.html>"]
 pub struct GeometryFlagsNV(pub(crate) Flags);
 vk_bitflags_wrapped!(GeometryFlagsNV, 0b11, Flags);
 impl GeometryFlagsNV {
@@ -53186,7 +53190,7 @@ impl GeometryFlagsNV {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBuildAccelerationStructureFlagBitsNV.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBuildAccelerationStructureFlagBitsNV.html>"]
 pub struct BuildAccelerationStructureFlagsNV(pub(crate) Flags);
 vk_bitflags_wrapped!(BuildAccelerationStructureFlagsNV, 0b1_1111, Flags);
 impl BuildAccelerationStructureFlagsNV {
@@ -53198,13 +53202,13 @@ impl BuildAccelerationStructureFlagsNV {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkFramebufferCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFramebufferCreateFlagBits.html>"]
 pub struct FramebufferCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(FramebufferCreateFlags, 0b0, Flags);
 impl FramebufferCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCreationFeedbackFlagBitsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCreationFeedbackFlagBitsEXT.html>"]
 pub struct PipelineCreationFeedbackFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(PipelineCreationFeedbackFlagsEXT, 0b111, Flags);
 impl PipelineCreationFeedbackFlagsEXT {
@@ -53214,7 +53218,7 @@ impl PipelineCreationFeedbackFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPerformanceCounterDescriptionFlagBitsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterDescriptionFlagBitsKHR.html>"]
 pub struct PerformanceCounterDescriptionFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(PerformanceCounterDescriptionFlagsKHR, 0b11, Flags);
 impl PerformanceCounterDescriptionFlagsKHR {
@@ -53223,31 +53227,31 @@ impl PerformanceCounterDescriptionFlagsKHR {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkAcquireProfilingLockFlagBitsKHR.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAcquireProfilingLockFlagBitsKHR.html>"]
 pub struct AcquireProfilingLockFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(AcquireProfilingLockFlagsKHR, 0b0, Flags);
 impl AcquireProfilingLockFlagsKHR {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderCorePropertiesFlagBitsAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderCorePropertiesFlagBitsAMD.html>"]
 pub struct ShaderCorePropertiesFlagsAMD(pub(crate) Flags);
 vk_bitflags_wrapped!(ShaderCorePropertiesFlagsAMD, 0b0, Flags);
 impl ShaderCorePropertiesFlagsAMD {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkShaderModuleCreateFlagBits.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderModuleCreateFlagBits.html>"]
 pub struct ShaderModuleCreateFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ShaderModuleCreateFlags, 0b0, Flags);
 impl ShaderModuleCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineCompilerControlFlagBitsAMD.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCompilerControlFlagBitsAMD.html>"]
 pub struct PipelineCompilerControlFlagsAMD(pub(crate) Flags);
 vk_bitflags_wrapped!(PipelineCompilerControlFlagsAMD, 0b0, Flags);
 impl PipelineCompilerControlFlagsAMD {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkToolPurposeFlagBitsEXT.html>"]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkToolPurposeFlagBitsEXT.html>"]
 pub struct ToolPurposeFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(ToolPurposeFlagsEXT, 0b1_1111, Flags);
 impl ToolPurposeFlagsEXT {
@@ -53470,7 +53474,7 @@ impl KhrSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroySurfaceKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroySurfaceKHR.html>"]
     pub unsafe fn destroy_surface_khr(
         &self,
         instance: Instance,
@@ -53479,7 +53483,7 @@ impl KhrSurfaceFn {
     ) -> c_void {
         (self.destroy_surface_khr)(instance, surface, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfaceSupportKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceSupportKHR.html>"]
     pub unsafe fn get_physical_device_surface_support_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -53494,7 +53498,7 @@ impl KhrSurfaceFn {
             p_supported,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfaceCapabilitiesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceCapabilitiesKHR.html>"]
     pub unsafe fn get_physical_device_surface_capabilities_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -53507,7 +53511,7 @@ impl KhrSurfaceFn {
             p_surface_capabilities,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html>"]
     pub unsafe fn get_physical_device_surface_formats_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -53522,7 +53526,7 @@ impl KhrSurfaceFn {
             p_surface_formats,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModesKHR.html>"]
     pub unsafe fn get_physical_device_surface_present_modes_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -53867,7 +53871,7 @@ impl KhrSwapchainFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateSwapchainKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateSwapchainKHR.html>"]
     pub unsafe fn create_swapchain_khr(
         &self,
         device: Device,
@@ -53877,7 +53881,7 @@ impl KhrSwapchainFn {
     ) -> Result {
         (self.create_swapchain_khr)(device, p_create_info, p_allocator, p_swapchain)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroySwapchainKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroySwapchainKHR.html>"]
     pub unsafe fn destroy_swapchain_khr(
         &self,
         device: Device,
@@ -53886,7 +53890,7 @@ impl KhrSwapchainFn {
     ) -> c_void {
         (self.destroy_swapchain_khr)(device, swapchain, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetSwapchainImagesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSwapchainImagesKHR.html>"]
     pub unsafe fn get_swapchain_images_khr(
         &self,
         device: Device,
@@ -53901,7 +53905,7 @@ impl KhrSwapchainFn {
             p_swapchain_images,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAcquireNextImageKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAcquireNextImageKHR.html>"]
     pub unsafe fn acquire_next_image_khr(
         &self,
         device: Device,
@@ -53913,7 +53917,7 @@ impl KhrSwapchainFn {
     ) -> Result {
         (self.acquire_next_image_khr)(device, swapchain, timeout, semaphore, fence, p_image_index)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkQueuePresentKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueuePresentKHR.html>"]
     pub unsafe fn queue_present_khr(
         &self,
         queue: Queue,
@@ -53921,7 +53925,7 @@ impl KhrSwapchainFn {
     ) -> Result {
         (self.queue_present_khr)(queue, p_present_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceGroupPresentCapabilitiesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceGroupPresentCapabilitiesKHR.html>"]
     pub unsafe fn get_device_group_present_capabilities_khr(
         &self,
         device: Device,
@@ -53932,7 +53936,7 @@ impl KhrSwapchainFn {
             p_device_group_present_capabilities,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceGroupSurfacePresentModesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceGroupSurfacePresentModesKHR.html>"]
     pub unsafe fn get_device_group_surface_present_modes_khr(
         &self,
         device: Device,
@@ -53941,7 +53945,7 @@ impl KhrSwapchainFn {
     ) -> Result {
         (self.get_device_group_surface_present_modes_khr)(device, surface, p_modes)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDevicePresentRectanglesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDevicePresentRectanglesKHR.html>"]
     pub unsafe fn get_physical_device_present_rectangles_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -53956,7 +53960,7 @@ impl KhrSwapchainFn {
             p_rects,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAcquireNextImage2KHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAcquireNextImage2KHR.html>"]
     pub unsafe fn acquire_next_image2_khr(
         &self,
         device: Device,
@@ -54289,7 +54293,7 @@ impl KhrDisplayFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceDisplayPropertiesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceDisplayPropertiesKHR.html>"]
     pub unsafe fn get_physical_device_display_properties_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -54302,7 +54306,7 @@ impl KhrDisplayFn {
             p_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceDisplayPlanePropertiesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceDisplayPlanePropertiesKHR.html>"]
     pub unsafe fn get_physical_device_display_plane_properties_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -54315,7 +54319,7 @@ impl KhrDisplayFn {
             p_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDisplayPlaneSupportedDisplaysKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDisplayPlaneSupportedDisplaysKHR.html>"]
     pub unsafe fn get_display_plane_supported_displays_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -54330,7 +54334,7 @@ impl KhrDisplayFn {
             p_displays,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDisplayModePropertiesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDisplayModePropertiesKHR.html>"]
     pub unsafe fn get_display_mode_properties_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -54345,7 +54349,7 @@ impl KhrDisplayFn {
             p_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDisplayModeKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDisplayModeKHR.html>"]
     pub unsafe fn create_display_mode_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -54356,7 +54360,7 @@ impl KhrDisplayFn {
     ) -> Result {
         (self.create_display_mode_khr)(physical_device, display, p_create_info, p_allocator, p_mode)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDisplayPlaneCapabilitiesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDisplayPlaneCapabilitiesKHR.html>"]
     pub unsafe fn get_display_plane_capabilities_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -54371,7 +54375,7 @@ impl KhrDisplayFn {
             p_capabilities,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDisplayPlaneSurfaceKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDisplayPlaneSurfaceKHR.html>"]
     pub unsafe fn create_display_plane_surface_khr(
         &self,
         instance: Instance,
@@ -54460,7 +54464,7 @@ impl KhrDisplaySwapchainFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateSharedSwapchainsKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateSharedSwapchainsKHR.html>"]
     pub unsafe fn create_shared_swapchains_khr(
         &self,
         device: Device,
@@ -54581,7 +54585,7 @@ impl KhrXlibSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateXlibSurfaceKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateXlibSurfaceKHR.html>"]
     pub unsafe fn create_xlib_surface_khr(
         &self,
         instance: Instance,
@@ -54591,7 +54595,7 @@ impl KhrXlibSurfaceFn {
     ) -> Result {
         (self.create_xlib_surface_khr)(instance, p_create_info, p_allocator, p_surface)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceXlibPresentationSupportKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceXlibPresentationSupportKHR.html>"]
     pub unsafe fn get_physical_device_xlib_presentation_support_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -54706,7 +54710,7 @@ impl KhrXcbSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateXcbSurfaceKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateXcbSurfaceKHR.html>"]
     pub unsafe fn create_xcb_surface_khr(
         &self,
         instance: Instance,
@@ -54716,7 +54720,7 @@ impl KhrXcbSurfaceFn {
     ) -> Result {
         (self.create_xcb_surface_khr)(instance, p_create_info, p_allocator, p_surface)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceXcbPresentationSupportKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceXcbPresentationSupportKHR.html>"]
     pub unsafe fn get_physical_device_xcb_presentation_support_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -54828,7 +54832,7 @@ impl KhrWaylandSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateWaylandSurfaceKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateWaylandSurfaceKHR.html>"]
     pub unsafe fn create_wayland_surface_khr(
         &self,
         instance: Instance,
@@ -54838,7 +54842,7 @@ impl KhrWaylandSurfaceFn {
     ) -> Result {
         (self.create_wayland_surface_khr)(instance, p_create_info, p_allocator, p_surface)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceWaylandPresentationSupportKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceWaylandPresentationSupportKHR.html>"]
     pub unsafe fn get_physical_device_wayland_presentation_support_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -54937,7 +54941,7 @@ impl KhrAndroidSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateAndroidSurfaceKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateAndroidSurfaceKHR.html>"]
     pub unsafe fn create_android_surface_khr(
         &self,
         instance: Instance,
@@ -55037,7 +55041,7 @@ impl KhrWin32SurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateWin32SurfaceKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateWin32SurfaceKHR.html>"]
     pub unsafe fn create_win32_surface_khr(
         &self,
         instance: Instance,
@@ -55047,7 +55051,7 @@ impl KhrWin32SurfaceFn {
     ) -> Result {
         (self.create_win32_surface_khr)(instance, p_create_info, p_allocator, p_surface)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceWin32PresentationSupportKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceWin32PresentationSupportKHR.html>"]
     pub unsafe fn get_physical_device_win32_presentation_support_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -55239,7 +55243,7 @@ impl AndroidNativeBufferFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetSwapchainGrallocUsageANDROID.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSwapchainGrallocUsageANDROID.html>"]
     pub unsafe fn get_swapchain_gralloc_usage_android(
         &self,
         device: Device,
@@ -55249,7 +55253,7 @@ impl AndroidNativeBufferFn {
     ) -> Result {
         (self.get_swapchain_gralloc_usage_android)(device, format, image_usage, gralloc_usage)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAcquireImageANDROID.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAcquireImageANDROID.html>"]
     pub unsafe fn acquire_image_android(
         &self,
         device: Device,
@@ -55260,7 +55264,7 @@ impl AndroidNativeBufferFn {
     ) -> Result {
         (self.acquire_image_android)(device, image, native_fence_fd, semaphore, fence)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkQueueSignalReleaseImageANDROID.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueSignalReleaseImageANDROID.html>"]
     pub unsafe fn queue_signal_release_image_android(
         &self,
         queue: Queue,
@@ -55277,7 +55281,7 @@ impl AndroidNativeBufferFn {
             p_native_fence_fd,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetSwapchainGrallocUsage2ANDROID.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSwapchainGrallocUsage2ANDROID.html>"]
     pub unsafe fn get_swapchain_gralloc_usage2_android(
         &self,
         device: Device,
@@ -55447,7 +55451,7 @@ impl ExtDebugReportFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDebugReportCallbackEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDebugReportCallbackEXT.html>"]
     pub unsafe fn create_debug_report_callback_ext(
         &self,
         instance: Instance,
@@ -55457,7 +55461,7 @@ impl ExtDebugReportFn {
     ) -> Result {
         (self.create_debug_report_callback_ext)(instance, p_create_info, p_allocator, p_callback)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyDebugReportCallbackEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDebugReportCallbackEXT.html>"]
     pub unsafe fn destroy_debug_report_callback_ext(
         &self,
         instance: Instance,
@@ -55466,7 +55470,7 @@ impl ExtDebugReportFn {
     ) -> c_void {
         (self.destroy_debug_report_callback_ext)(instance, callback, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDebugReportMessageEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDebugReportMessageEXT.html>"]
     pub unsafe fn debug_report_message_ext(
         &self,
         instance: Instance,
@@ -55909,7 +55913,7 @@ impl ExtDebugMarkerFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDebugMarkerSetObjectTagEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDebugMarkerSetObjectTagEXT.html>"]
     pub unsafe fn debug_marker_set_object_tag_ext(
         &self,
         device: Device,
@@ -55917,7 +55921,7 @@ impl ExtDebugMarkerFn {
     ) -> Result {
         (self.debug_marker_set_object_tag_ext)(device, p_tag_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDebugMarkerSetObjectNameEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDebugMarkerSetObjectNameEXT.html>"]
     pub unsafe fn debug_marker_set_object_name_ext(
         &self,
         device: Device,
@@ -55925,7 +55929,7 @@ impl ExtDebugMarkerFn {
     ) -> Result {
         (self.debug_marker_set_object_name_ext)(device, p_name_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDebugMarkerBeginEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDebugMarkerBeginEXT.html>"]
     pub unsafe fn cmd_debug_marker_begin_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -55933,11 +55937,11 @@ impl ExtDebugMarkerFn {
     ) -> c_void {
         (self.cmd_debug_marker_begin_ext)(command_buffer, p_marker_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDebugMarkerEndEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDebugMarkerEndEXT.html>"]
     pub unsafe fn cmd_debug_marker_end_ext(&self, command_buffer: CommandBuffer) -> c_void {
         (self.cmd_debug_marker_end_ext)(command_buffer)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDebugMarkerInsertEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDebugMarkerInsertEXT.html>"]
     pub unsafe fn cmd_debug_marker_insert_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -56434,7 +56438,7 @@ impl ExtTransformFeedbackFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBindTransformFeedbackBuffersEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBindTransformFeedbackBuffersEXT.html>"]
     pub unsafe fn cmd_bind_transform_feedback_buffers_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -56453,7 +56457,7 @@ impl ExtTransformFeedbackFn {
             p_sizes,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBeginTransformFeedbackEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginTransformFeedbackEXT.html>"]
     pub unsafe fn cmd_begin_transform_feedback_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -56470,7 +56474,7 @@ impl ExtTransformFeedbackFn {
             p_counter_buffer_offsets,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdEndTransformFeedbackEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndTransformFeedbackEXT.html>"]
     pub unsafe fn cmd_end_transform_feedback_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -56487,7 +56491,7 @@ impl ExtTransformFeedbackFn {
             p_counter_buffer_offsets,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBeginQueryIndexedEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginQueryIndexedEXT.html>"]
     pub unsafe fn cmd_begin_query_indexed_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -56498,7 +56502,7 @@ impl ExtTransformFeedbackFn {
     ) -> c_void {
         (self.cmd_begin_query_indexed_ext)(command_buffer, query_pool, query, flags, index)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdEndQueryIndexedEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndQueryIndexedEXT.html>"]
     pub unsafe fn cmd_end_query_indexed_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -56508,7 +56512,7 @@ impl ExtTransformFeedbackFn {
     ) -> c_void {
         (self.cmd_end_query_indexed_ext)(command_buffer, query_pool, query, index)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndirectByteCountEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawIndirectByteCountEXT.html>"]
     pub unsafe fn cmd_draw_indirect_byte_count_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -56645,7 +56649,7 @@ impl NvxImageViewHandleFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetImageViewHandleNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageViewHandleNVX.html>"]
     pub unsafe fn get_image_view_handle_nvx(
         &self,
         device: Device,
@@ -56966,7 +56970,7 @@ impl AmdShaderInfoFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetShaderInfoAMD.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetShaderInfoAMD.html>"]
     pub unsafe fn get_shader_info_amd(
         &self,
         device: Device,
@@ -57177,7 +57181,7 @@ impl GgpStreamDescriptorSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateStreamDescriptorSurfaceGGP.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateStreamDescriptorSurfaceGGP.html>"]
     pub unsafe fn create_stream_descriptor_surface_ggp(
         &self,
         instance: Instance,
@@ -57422,7 +57426,7 @@ impl NvExternalMemoryCapabilitiesFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceExternalImageFormatPropertiesNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceExternalImageFormatPropertiesNV.html>"]
     pub unsafe fn get_physical_device_external_image_format_properties_nv(
         &self,
         physical_device: PhysicalDevice,
@@ -57535,7 +57539,7 @@ impl NvExternalMemoryWin32Fn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetMemoryWin32HandleNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryWin32HandleNV.html>"]
     pub unsafe fn get_memory_win32_handle_nv(
         &self,
         device: Device,
@@ -57706,7 +57710,7 @@ impl NnViSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateViSurfaceNN.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateViSurfaceNN.html>"]
     pub unsafe fn create_vi_surface_nn(
         &self,
         instance: Instance,
@@ -58101,7 +58105,7 @@ impl KhrExternalMemoryWin32Fn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetMemoryWin32HandleKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryWin32HandleKHR.html>"]
     pub unsafe fn get_memory_win32_handle_khr(
         &self,
         device: Device,
@@ -58110,7 +58114,7 @@ impl KhrExternalMemoryWin32Fn {
     ) -> Result {
         (self.get_memory_win32_handle_khr)(device, p_get_win32_handle_info, p_handle)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetMemoryWin32HandlePropertiesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryWin32HandlePropertiesKHR.html>"]
     pub unsafe fn get_memory_win32_handle_properties_khr(
         &self,
         device: Device,
@@ -58230,7 +58234,7 @@ impl KhrExternalMemoryFdFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetMemoryFdKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryFdKHR.html>"]
     pub unsafe fn get_memory_fd_khr(
         &self,
         device: Device,
@@ -58239,7 +58243,7 @@ impl KhrExternalMemoryFdFn {
     ) -> Result {
         (self.get_memory_fd_khr)(device, p_get_fd_info, p_fd)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetMemoryFdPropertiesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryFdPropertiesKHR.html>"]
     pub unsafe fn get_memory_fd_properties_khr(
         &self,
         device: Device,
@@ -58417,7 +58421,7 @@ impl KhrExternalSemaphoreWin32Fn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkImportSemaphoreWin32HandleKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkImportSemaphoreWin32HandleKHR.html>"]
     pub unsafe fn import_semaphore_win32_handle_khr(
         &self,
         device: Device,
@@ -58425,7 +58429,7 @@ impl KhrExternalSemaphoreWin32Fn {
     ) -> Result {
         (self.import_semaphore_win32_handle_khr)(device, p_import_semaphore_win32_handle_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetSemaphoreWin32HandleKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSemaphoreWin32HandleKHR.html>"]
     pub unsafe fn get_semaphore_win32_handle_khr(
         &self,
         device: Device,
@@ -58533,7 +58537,7 @@ impl KhrExternalSemaphoreFdFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkImportSemaphoreFdKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkImportSemaphoreFdKHR.html>"]
     pub unsafe fn import_semaphore_fd_khr(
         &self,
         device: Device,
@@ -58541,7 +58545,7 @@ impl KhrExternalSemaphoreFdFn {
     ) -> Result {
         (self.import_semaphore_fd_khr)(device, p_import_semaphore_fd_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetSemaphoreFdKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSemaphoreFdKHR.html>"]
     pub unsafe fn get_semaphore_fd_khr(
         &self,
         device: Device,
@@ -58663,7 +58667,7 @@ impl KhrPushDescriptorFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdPushDescriptorSetKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdPushDescriptorSetKHR.html>"]
     pub unsafe fn cmd_push_descriptor_set_khr(
         &self,
         command_buffer: CommandBuffer,
@@ -58682,7 +58686,7 @@ impl KhrPushDescriptorFn {
             p_descriptor_writes,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdPushDescriptorSetWithTemplateKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdPushDescriptorSetWithTemplateKHR.html>"]
     pub unsafe fn cmd_push_descriptor_set_with_template_khr(
         &self,
         command_buffer: CommandBuffer,
@@ -58789,7 +58793,7 @@ impl ExtConditionalRenderingFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBeginConditionalRenderingEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginConditionalRenderingEXT.html>"]
     pub unsafe fn cmd_begin_conditional_rendering_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -58797,7 +58801,7 @@ impl ExtConditionalRenderingFn {
     ) -> c_void {
         (self.cmd_begin_conditional_rendering_ext)(command_buffer, p_conditional_rendering_begin)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdEndConditionalRenderingEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndConditionalRenderingEXT.html>"]
     pub unsafe fn cmd_end_conditional_rendering_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -59245,7 +59249,7 @@ impl NvxDeviceGeneratedCommandsFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdProcessCommandsNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdProcessCommandsNVX.html>"]
     pub unsafe fn cmd_process_commands_nvx(
         &self,
         command_buffer: CommandBuffer,
@@ -59253,7 +59257,7 @@ impl NvxDeviceGeneratedCommandsFn {
     ) -> c_void {
         (self.cmd_process_commands_nvx)(command_buffer, p_process_commands_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdReserveSpaceForCommandsNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdReserveSpaceForCommandsNVX.html>"]
     pub unsafe fn cmd_reserve_space_for_commands_nvx(
         &self,
         command_buffer: CommandBuffer,
@@ -59261,7 +59265,7 @@ impl NvxDeviceGeneratedCommandsFn {
     ) -> c_void {
         (self.cmd_reserve_space_for_commands_nvx)(command_buffer, p_reserve_space_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateIndirectCommandsLayoutNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateIndirectCommandsLayoutNVX.html>"]
     pub unsafe fn create_indirect_commands_layout_nvx(
         &self,
         device: Device,
@@ -59276,7 +59280,7 @@ impl NvxDeviceGeneratedCommandsFn {
             p_indirect_commands_layout,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyIndirectCommandsLayoutNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyIndirectCommandsLayoutNVX.html>"]
     pub unsafe fn destroy_indirect_commands_layout_nvx(
         &self,
         device: Device,
@@ -59285,7 +59289,7 @@ impl NvxDeviceGeneratedCommandsFn {
     ) -> c_void {
         (self.destroy_indirect_commands_layout_nvx)(device, indirect_commands_layout, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateObjectTableNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateObjectTableNVX.html>"]
     pub unsafe fn create_object_table_nvx(
         &self,
         device: Device,
@@ -59295,7 +59299,7 @@ impl NvxDeviceGeneratedCommandsFn {
     ) -> Result {
         (self.create_object_table_nvx)(device, p_create_info, p_allocator, p_object_table)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyObjectTableNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyObjectTableNVX.html>"]
     pub unsafe fn destroy_object_table_nvx(
         &self,
         device: Device,
@@ -59304,7 +59308,7 @@ impl NvxDeviceGeneratedCommandsFn {
     ) -> c_void {
         (self.destroy_object_table_nvx)(device, object_table, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkRegisterObjectsNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkRegisterObjectsNVX.html>"]
     pub unsafe fn register_objects_nvx(
         &self,
         device: Device,
@@ -59321,7 +59325,7 @@ impl NvxDeviceGeneratedCommandsFn {
             p_object_indices,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkUnregisterObjectsNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkUnregisterObjectsNVX.html>"]
     pub unsafe fn unregister_objects_nvx(
         &self,
         device: Device,
@@ -59338,7 +59342,7 @@ impl NvxDeviceGeneratedCommandsFn {
             p_object_indices,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX.html>"]
     pub unsafe fn get_physical_device_generated_commands_properties_nvx(
         &self,
         physical_device: PhysicalDevice,
@@ -59455,7 +59459,7 @@ impl NvClipSpaceWScalingFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetViewportWScalingNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetViewportWScalingNV.html>"]
     pub unsafe fn cmd_set_viewport_w_scaling_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -59525,7 +59529,7 @@ impl ExtDirectModeDisplayFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkReleaseDisplayEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkReleaseDisplayEXT.html>"]
     pub unsafe fn release_display_ext(
         &self,
         physical_device: PhysicalDevice,
@@ -59625,7 +59629,7 @@ impl ExtAcquireXlibDisplayFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAcquireXlibDisplayEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAcquireXlibDisplayEXT.html>"]
     pub unsafe fn acquire_xlib_display_ext(
         &self,
         physical_device: PhysicalDevice,
@@ -59634,7 +59638,7 @@ impl ExtAcquireXlibDisplayFn {
     ) -> Result {
         (self.acquire_xlib_display_ext)(physical_device, dpy, display)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetRandROutputDisplayEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetRandROutputDisplayEXT.html>"]
     pub unsafe fn get_rand_r_output_display_ext(
         &self,
         physical_device: PhysicalDevice,
@@ -59702,7 +59706,7 @@ impl ExtDisplaySurfaceCounterFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfaceCapabilities2EXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceCapabilities2EXT.html>"]
     pub unsafe fn get_physical_device_surface_capabilities2_ext(
         &self,
         physical_device: PhysicalDevice,
@@ -59884,7 +59888,7 @@ impl ExtDisplayControlFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDisplayPowerControlEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDisplayPowerControlEXT.html>"]
     pub unsafe fn display_power_control_ext(
         &self,
         device: Device,
@@ -59893,7 +59897,7 @@ impl ExtDisplayControlFn {
     ) -> Result {
         (self.display_power_control_ext)(device, display, p_display_power_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkRegisterDeviceEventEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkRegisterDeviceEventEXT.html>"]
     pub unsafe fn register_device_event_ext(
         &self,
         device: Device,
@@ -59903,7 +59907,7 @@ impl ExtDisplayControlFn {
     ) -> Result {
         (self.register_device_event_ext)(device, p_device_event_info, p_allocator, p_fence)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkRegisterDisplayEventEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkRegisterDisplayEventEXT.html>"]
     pub unsafe fn register_display_event_ext(
         &self,
         device: Device,
@@ -59920,7 +59924,7 @@ impl ExtDisplayControlFn {
             p_fence,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetSwapchainCounterEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSwapchainCounterEXT.html>"]
     pub unsafe fn get_swapchain_counter_ext(
         &self,
         device: Device,
@@ -60038,7 +60042,7 @@ impl GoogleDisplayTimingFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetRefreshCycleDurationGOOGLE.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetRefreshCycleDurationGOOGLE.html>"]
     pub unsafe fn get_refresh_cycle_duration_google(
         &self,
         device: Device,
@@ -60047,7 +60051,7 @@ impl GoogleDisplayTimingFn {
     ) -> Result {
         (self.get_refresh_cycle_duration_google)(device, swapchain, p_display_timing_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPastPresentationTimingGOOGLE.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPastPresentationTimingGOOGLE.html>"]
     pub unsafe fn get_past_presentation_timing_google(
         &self,
         device: Device,
@@ -60253,7 +60257,7 @@ impl ExtDiscardRectanglesFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetDiscardRectangleEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetDiscardRectangleEXT.html>"]
     pub unsafe fn cmd_set_discard_rectangle_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -60522,7 +60526,7 @@ impl ExtHdrMetadataFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkSetHdrMetadataEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSetHdrMetadataEXT.html>"]
     pub unsafe fn set_hdr_metadata_ext(
         &self,
         device: Device,
@@ -60696,7 +60700,7 @@ impl KhrSharedPresentableImageFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetSwapchainStatusKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSwapchainStatusKHR.html>"]
     pub unsafe fn get_swapchain_status_khr(
         &self,
         device: Device,
@@ -60850,7 +60854,7 @@ impl KhrExternalFenceWin32Fn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkImportFenceWin32HandleKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkImportFenceWin32HandleKHR.html>"]
     pub unsafe fn import_fence_win32_handle_khr(
         &self,
         device: Device,
@@ -60858,7 +60862,7 @@ impl KhrExternalFenceWin32Fn {
     ) -> Result {
         (self.import_fence_win32_handle_khr)(device, p_import_fence_win32_handle_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetFenceWin32HandleKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetFenceWin32HandleKHR.html>"]
     pub unsafe fn get_fence_win32_handle_khr(
         &self,
         device: Device,
@@ -60959,7 +60963,7 @@ impl KhrExternalFenceFdFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkImportFenceFdKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkImportFenceFdKHR.html>"]
     pub unsafe fn import_fence_fd_khr(
         &self,
         device: Device,
@@ -60967,7 +60971,7 @@ impl KhrExternalFenceFdFn {
     ) -> Result {
         (self.import_fence_fd_khr)(device, p_import_fence_fd_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetFenceFdKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetFenceFdKHR.html>"]
     pub unsafe fn get_fence_fd_khr(
         &self,
         device: Device,
@@ -61133,7 +61137,7 @@ impl KhrPerformanceQueryFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR.html>"]
     pub unsafe fn enumerate_physical_device_queue_family_performance_query_counters_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -61150,7 +61154,7 @@ impl KhrPerformanceQueryFn {
             p_counter_descriptions,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR.html>"]
     pub unsafe fn get_physical_device_queue_family_performance_query_passes_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -61163,7 +61167,7 @@ impl KhrPerformanceQueryFn {
             p_num_passes,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAcquireProfilingLockKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAcquireProfilingLockKHR.html>"]
     pub unsafe fn acquire_profiling_lock_khr(
         &self,
         device: Device,
@@ -61171,7 +61175,7 @@ impl KhrPerformanceQueryFn {
     ) -> Result {
         (self.acquire_profiling_lock_khr)(device, p_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkReleaseProfilingLockKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkReleaseProfilingLockKHR.html>"]
     pub unsafe fn release_profiling_lock_khr(&self, device: Device) -> c_void {
         (self.release_profiling_lock_khr)(device)
     }
@@ -61344,7 +61348,7 @@ impl KhrGetSurfaceCapabilities2Fn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfaceCapabilities2KHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceCapabilities2KHR.html>"]
     pub unsafe fn get_physical_device_surface_capabilities2_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -61357,7 +61361,7 @@ impl KhrGetSurfaceCapabilities2Fn {
             p_surface_capabilities,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfaceFormats2KHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceFormats2KHR.html>"]
     pub unsafe fn get_physical_device_surface_formats2_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -61564,7 +61568,7 @@ impl KhrGetDisplayProperties2Fn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceDisplayProperties2KHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceDisplayProperties2KHR.html>"]
     pub unsafe fn get_physical_device_display_properties2_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -61577,7 +61581,7 @@ impl KhrGetDisplayProperties2Fn {
             p_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceDisplayPlaneProperties2KHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceDisplayPlaneProperties2KHR.html>"]
     pub unsafe fn get_physical_device_display_plane_properties2_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -61590,7 +61594,7 @@ impl KhrGetDisplayProperties2Fn {
             p_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDisplayModeProperties2KHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDisplayModeProperties2KHR.html>"]
     pub unsafe fn get_display_mode_properties2_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -61605,7 +61609,7 @@ impl KhrGetDisplayProperties2Fn {
             p_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDisplayPlaneCapabilities2KHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDisplayPlaneCapabilities2KHR.html>"]
     pub unsafe fn get_display_plane_capabilities2_khr(
         &self,
         physical_device: PhysicalDevice,
@@ -61698,7 +61702,7 @@ impl MvkIosSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateIOSSurfaceMVK.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateIOSSurfaceMVK.html>"]
     pub unsafe fn create_ios_surface_mvk(
         &self,
         instance: Instance,
@@ -61772,7 +61776,7 @@ impl MvkMacosSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateMacOSSurfaceMVK.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateMacOSSurfaceMVK.html>"]
     pub unsafe fn create_mac_os_surface_mvk(
         &self,
         instance: Instance,
@@ -62208,7 +62212,7 @@ impl ExtDebugUtilsFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html>"]
     pub unsafe fn set_debug_utils_object_name_ext(
         &self,
         device: Device,
@@ -62216,7 +62220,7 @@ impl ExtDebugUtilsFn {
     ) -> Result {
         (self.set_debug_utils_object_name_ext)(device, p_name_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html>"]
     pub unsafe fn set_debug_utils_object_tag_ext(
         &self,
         device: Device,
@@ -62224,7 +62228,7 @@ impl ExtDebugUtilsFn {
     ) -> Result {
         (self.set_debug_utils_object_tag_ext)(device, p_tag_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkQueueBeginDebugUtilsLabelEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueBeginDebugUtilsLabelEXT.html>"]
     pub unsafe fn queue_begin_debug_utils_label_ext(
         &self,
         queue: Queue,
@@ -62232,11 +62236,11 @@ impl ExtDebugUtilsFn {
     ) -> c_void {
         (self.queue_begin_debug_utils_label_ext)(queue, p_label_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkQueueEndDebugUtilsLabelEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueEndDebugUtilsLabelEXT.html>"]
     pub unsafe fn queue_end_debug_utils_label_ext(&self, queue: Queue) -> c_void {
         (self.queue_end_debug_utils_label_ext)(queue)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkQueueInsertDebugUtilsLabelEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueInsertDebugUtilsLabelEXT.html>"]
     pub unsafe fn queue_insert_debug_utils_label_ext(
         &self,
         queue: Queue,
@@ -62244,7 +62248,7 @@ impl ExtDebugUtilsFn {
     ) -> c_void {
         (self.queue_insert_debug_utils_label_ext)(queue, p_label_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBeginDebugUtilsLabelEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginDebugUtilsLabelEXT.html>"]
     pub unsafe fn cmd_begin_debug_utils_label_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -62252,11 +62256,11 @@ impl ExtDebugUtilsFn {
     ) -> c_void {
         (self.cmd_begin_debug_utils_label_ext)(command_buffer, p_label_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdEndDebugUtilsLabelEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndDebugUtilsLabelEXT.html>"]
     pub unsafe fn cmd_end_debug_utils_label_ext(&self, command_buffer: CommandBuffer) -> c_void {
         (self.cmd_end_debug_utils_label_ext)(command_buffer)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdInsertDebugUtilsLabelEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdInsertDebugUtilsLabelEXT.html>"]
     pub unsafe fn cmd_insert_debug_utils_label_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -62264,7 +62268,7 @@ impl ExtDebugUtilsFn {
     ) -> c_void {
         (self.cmd_insert_debug_utils_label_ext)(command_buffer, p_label_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDebugUtilsMessengerEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDebugUtilsMessengerEXT.html>"]
     pub unsafe fn create_debug_utils_messenger_ext(
         &self,
         instance: Instance,
@@ -62274,7 +62278,7 @@ impl ExtDebugUtilsFn {
     ) -> Result {
         (self.create_debug_utils_messenger_ext)(instance, p_create_info, p_allocator, p_messenger)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyDebugUtilsMessengerEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDebugUtilsMessengerEXT.html>"]
     pub unsafe fn destroy_debug_utils_messenger_ext(
         &self,
         instance: Instance,
@@ -62283,7 +62287,7 @@ impl ExtDebugUtilsFn {
     ) -> c_void {
         (self.destroy_debug_utils_messenger_ext)(instance, messenger, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkSubmitDebugUtilsMessageEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSubmitDebugUtilsMessageEXT.html>"]
     pub unsafe fn submit_debug_utils_message_ext(
         &self,
         instance: Instance,
@@ -62415,7 +62419,7 @@ impl AndroidExternalMemoryAndroidHardwareBufferFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetAndroidHardwareBufferPropertiesANDROID.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetAndroidHardwareBufferPropertiesANDROID.html>"]
     pub unsafe fn get_android_hardware_buffer_properties_android(
         &self,
         device: Device,
@@ -62424,7 +62428,7 @@ impl AndroidExternalMemoryAndroidHardwareBufferFn {
     ) -> Result {
         (self.get_android_hardware_buffer_properties_android)(device, buffer, p_properties)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetMemoryAndroidHardwareBufferANDROID.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryAndroidHardwareBufferANDROID.html>"]
     pub unsafe fn get_memory_android_hardware_buffer_android(
         &self,
         device: Device,
@@ -62859,7 +62863,7 @@ impl ExtSampleLocationsFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetSampleLocationsEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetSampleLocationsEXT.html>"]
     pub unsafe fn cmd_set_sample_locations_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -62867,7 +62871,7 @@ impl ExtSampleLocationsFn {
     ) -> c_void {
         (self.cmd_set_sample_locations_ext)(command_buffer, p_sample_locations_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceMultisamplePropertiesEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceMultisamplePropertiesEXT.html>"]
     pub unsafe fn get_physical_device_multisample_properties_ext(
         &self,
         physical_device: PhysicalDevice,
@@ -63500,7 +63504,7 @@ impl ExtImageDrmFormatModifierFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetImageDrmFormatModifierPropertiesEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageDrmFormatModifierPropertiesEXT.html>"]
     pub unsafe fn get_image_drm_format_modifier_properties_ext(
         &self,
         device: Device,
@@ -63743,7 +63747,7 @@ impl ExtValidationCacheFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateValidationCacheEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateValidationCacheEXT.html>"]
     pub unsafe fn create_validation_cache_ext(
         &self,
         device: Device,
@@ -63753,7 +63757,7 @@ impl ExtValidationCacheFn {
     ) -> Result {
         (self.create_validation_cache_ext)(device, p_create_info, p_allocator, p_validation_cache)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyValidationCacheEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyValidationCacheEXT.html>"]
     pub unsafe fn destroy_validation_cache_ext(
         &self,
         device: Device,
@@ -63762,7 +63766,7 @@ impl ExtValidationCacheFn {
     ) -> c_void {
         (self.destroy_validation_cache_ext)(device, validation_cache, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkMergeValidationCachesEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkMergeValidationCachesEXT.html>"]
     pub unsafe fn merge_validation_caches_ext(
         &self,
         device: Device,
@@ -63772,7 +63776,7 @@ impl ExtValidationCacheFn {
     ) -> Result {
         (self.merge_validation_caches_ext)(device, dst_cache, src_cache_count, p_src_caches)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetValidationCacheDataEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetValidationCacheDataEXT.html>"]
     pub unsafe fn get_validation_cache_data_ext(
         &self,
         device: Device,
@@ -63987,7 +63991,7 @@ impl NvShadingRateImageFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBindShadingRateImageNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBindShadingRateImageNV.html>"]
     pub unsafe fn cmd_bind_shading_rate_image_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -63996,7 +64000,7 @@ impl NvShadingRateImageFn {
     ) -> c_void {
         (self.cmd_bind_shading_rate_image_nv)(command_buffer, image_view, image_layout)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetViewportShadingRatePaletteNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetViewportShadingRatePaletteNV.html>"]
     pub unsafe fn cmd_set_viewport_shading_rate_palette_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -64011,7 +64015,7 @@ impl NvShadingRateImageFn {
             p_shading_rate_palettes,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetCoarseSampleOrderNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetCoarseSampleOrderNV.html>"]
     pub unsafe fn cmd_set_coarse_sample_order_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -64557,7 +64561,7 @@ impl NvRayTracingFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateAccelerationStructureNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateAccelerationStructureNV.html>"]
     pub unsafe fn create_acceleration_structure_nv(
         &self,
         device: Device,
@@ -64572,7 +64576,7 @@ impl NvRayTracingFn {
             p_acceleration_structure,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkDestroyAccelerationStructureNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyAccelerationStructureNV.html>"]
     pub unsafe fn destroy_acceleration_structure_nv(
         &self,
         device: Device,
@@ -64581,7 +64585,7 @@ impl NvRayTracingFn {
     ) -> c_void {
         (self.destroy_acceleration_structure_nv)(device, acceleration_structure, p_allocator)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetAccelerationStructureMemoryRequirementsNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetAccelerationStructureMemoryRequirementsNV.html>"]
     pub unsafe fn get_acceleration_structure_memory_requirements_nv(
         &self,
         device: Device,
@@ -64594,7 +64598,7 @@ impl NvRayTracingFn {
             p_memory_requirements,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkBindAccelerationStructureMemoryNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBindAccelerationStructureMemoryNV.html>"]
     pub unsafe fn bind_acceleration_structure_memory_nv(
         &self,
         device: Device,
@@ -64603,7 +64607,7 @@ impl NvRayTracingFn {
     ) -> Result {
         (self.bind_acceleration_structure_memory_nv)(device, bind_info_count, p_bind_infos)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdBuildAccelerationStructureNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBuildAccelerationStructureNV.html>"]
     pub unsafe fn cmd_build_acceleration_structure_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -64628,7 +64632,7 @@ impl NvRayTracingFn {
             scratch_offset,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdCopyAccelerationStructureNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdCopyAccelerationStructureNV.html>"]
     pub unsafe fn cmd_copy_acceleration_structure_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -64638,7 +64642,7 @@ impl NvRayTracingFn {
     ) -> c_void {
         (self.cmd_copy_acceleration_structure_nv)(command_buffer, dst, src, mode)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdTraceRaysNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdTraceRaysNV.html>"]
     pub unsafe fn cmd_trace_rays_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -64675,7 +64679,7 @@ impl NvRayTracingFn {
             depth,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateRayTracingPipelinesNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateRayTracingPipelinesNV.html>"]
     pub unsafe fn create_ray_tracing_pipelines_nv(
         &self,
         device: Device,
@@ -64694,7 +64698,7 @@ impl NvRayTracingFn {
             p_pipelines,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetRayTracingShaderGroupHandlesNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetRayTracingShaderGroupHandlesNV.html>"]
     pub unsafe fn get_ray_tracing_shader_group_handles_nv(
         &self,
         device: Device,
@@ -64713,7 +64717,7 @@ impl NvRayTracingFn {
             p_data,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetAccelerationStructureHandleNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetAccelerationStructureHandleNV.html>"]
     pub unsafe fn get_acceleration_structure_handle_nv(
         &self,
         device: Device,
@@ -64728,7 +64732,7 @@ impl NvRayTracingFn {
             p_data,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdWriteAccelerationStructuresPropertiesNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdWriteAccelerationStructuresPropertiesNV.html>"]
     pub unsafe fn cmd_write_acceleration_structures_properties_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -64747,7 +64751,7 @@ impl NvRayTracingFn {
             first_query,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCompileDeferredNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCompileDeferredNV.html>"]
     pub unsafe fn compile_deferred_nv(
         &self,
         device: Device,
@@ -65245,7 +65249,7 @@ impl ExtExternalMemoryHostFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetMemoryHostPointerPropertiesEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryHostPointerPropertiesEXT.html>"]
     pub unsafe fn get_memory_host_pointer_properties_ext(
         &self,
         device: Device,
@@ -65346,7 +65350,7 @@ impl AmdBufferMarkerFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdWriteBufferMarkerAMD.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdWriteBufferMarkerAMD.html>"]
     pub unsafe fn cmd_write_buffer_marker_amd(
         &self,
         command_buffer: CommandBuffer,
@@ -65555,7 +65559,7 @@ impl ExtCalibratedTimestampsFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceCalibrateableTimeDomainsEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceCalibrateableTimeDomainsEXT.html>"]
     pub unsafe fn get_physical_device_calibrateable_time_domains_ext(
         &self,
         physical_device: PhysicalDevice,
@@ -65568,7 +65572,7 @@ impl ExtCalibratedTimestampsFn {
             p_time_domains,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetCalibratedTimestampsEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetCalibratedTimestampsEXT.html>"]
     pub unsafe fn get_calibrated_timestamps_ext(
         &self,
         device: Device,
@@ -66143,7 +66147,7 @@ impl NvMeshShaderFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawMeshTasksNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawMeshTasksNV.html>"]
     pub unsafe fn cmd_draw_mesh_tasks_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -66152,7 +66156,7 @@ impl NvMeshShaderFn {
     ) -> c_void {
         (self.cmd_draw_mesh_tasks_nv)(command_buffer, task_count, first_task)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawMeshTasksIndirectNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawMeshTasksIndirectNV.html>"]
     pub unsafe fn cmd_draw_mesh_tasks_indirect_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -66163,7 +66167,7 @@ impl NvMeshShaderFn {
     ) -> c_void {
         (self.cmd_draw_mesh_tasks_indirect_nv)(command_buffer, buffer, offset, draw_count, stride)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawMeshTasksIndirectCountNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawMeshTasksIndirectCountNV.html>"]
     pub unsafe fn cmd_draw_mesh_tasks_indirect_count_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -66322,7 +66326,7 @@ impl NvScissorExclusiveFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetExclusiveScissorNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetExclusiveScissorNV.html>"]
     pub unsafe fn cmd_set_exclusive_scissor_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -66434,7 +66438,7 @@ impl NvDeviceDiagnosticCheckpointsFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetCheckpointNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetCheckpointNV.html>"]
     pub unsafe fn cmd_set_checkpoint_nv(
         &self,
         command_buffer: CommandBuffer,
@@ -66442,7 +66446,7 @@ impl NvDeviceDiagnosticCheckpointsFn {
     ) -> c_void {
         (self.cmd_set_checkpoint_nv)(command_buffer, p_checkpoint_marker)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetQueueCheckpointDataNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetQueueCheckpointDataNV.html>"]
     pub unsafe fn get_queue_checkpoint_data_nv(
         &self,
         queue: Queue,
@@ -66806,7 +66810,7 @@ impl IntelPerformanceQueryFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkInitializePerformanceApiINTEL.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkInitializePerformanceApiINTEL.html>"]
     pub unsafe fn initialize_performance_api_intel(
         &self,
         device: Device,
@@ -66814,11 +66818,11 @@ impl IntelPerformanceQueryFn {
     ) -> Result {
         (self.initialize_performance_api_intel)(device, p_initialize_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkUninitializePerformanceApiINTEL.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkUninitializePerformanceApiINTEL.html>"]
     pub unsafe fn uninitialize_performance_api_intel(&self, device: Device) -> c_void {
         (self.uninitialize_performance_api_intel)(device)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetPerformanceMarkerINTEL.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetPerformanceMarkerINTEL.html>"]
     pub unsafe fn cmd_set_performance_marker_intel(
         &self,
         command_buffer: CommandBuffer,
@@ -66826,7 +66830,7 @@ impl IntelPerformanceQueryFn {
     ) -> Result {
         (self.cmd_set_performance_marker_intel)(command_buffer, p_marker_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetPerformanceStreamMarkerINTEL.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetPerformanceStreamMarkerINTEL.html>"]
     pub unsafe fn cmd_set_performance_stream_marker_intel(
         &self,
         command_buffer: CommandBuffer,
@@ -66834,7 +66838,7 @@ impl IntelPerformanceQueryFn {
     ) -> Result {
         (self.cmd_set_performance_stream_marker_intel)(command_buffer, p_marker_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetPerformanceOverrideINTEL.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetPerformanceOverrideINTEL.html>"]
     pub unsafe fn cmd_set_performance_override_intel(
         &self,
         command_buffer: CommandBuffer,
@@ -66842,7 +66846,7 @@ impl IntelPerformanceQueryFn {
     ) -> Result {
         (self.cmd_set_performance_override_intel)(command_buffer, p_override_info)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAcquirePerformanceConfigurationINTEL.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAcquirePerformanceConfigurationINTEL.html>"]
     pub unsafe fn acquire_performance_configuration_intel(
         &self,
         device: Device,
@@ -66851,7 +66855,7 @@ impl IntelPerformanceQueryFn {
     ) -> Result {
         (self.acquire_performance_configuration_intel)(device, p_acquire_info, p_configuration)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkReleasePerformanceConfigurationINTEL.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkReleasePerformanceConfigurationINTEL.html>"]
     pub unsafe fn release_performance_configuration_intel(
         &self,
         device: Device,
@@ -66859,7 +66863,7 @@ impl IntelPerformanceQueryFn {
     ) -> Result {
         (self.release_performance_configuration_intel)(device, configuration)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkQueueSetPerformanceConfigurationINTEL.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueSetPerformanceConfigurationINTEL.html>"]
     pub unsafe fn queue_set_performance_configuration_intel(
         &self,
         queue: Queue,
@@ -66867,7 +66871,7 @@ impl IntelPerformanceQueryFn {
     ) -> Result {
         (self.queue_set_performance_configuration_intel)(queue, configuration)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPerformanceParameterINTEL.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPerformanceParameterINTEL.html>"]
     pub unsafe fn get_performance_parameter_intel(
         &self,
         device: Device,
@@ -67013,7 +67017,7 @@ impl AmdDisplayNativeHdrFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkSetLocalDimmingAMD.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSetLocalDimmingAMD.html>"]
     pub unsafe fn set_local_dimming_amd(
         &self,
         device: Device,
@@ -67094,7 +67098,7 @@ impl FuchsiaImagepipeSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateImagePipeSurfaceFUCHSIA.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateImagePipeSurfaceFUCHSIA.html>"]
     pub unsafe fn create_image_pipe_surface_fuchsia(
         &self,
         instance: Instance,
@@ -67212,7 +67216,7 @@ impl ExtMetalSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateMetalSurfaceEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateMetalSurfaceEXT.html>"]
     pub unsafe fn create_metal_surface_ext(
         &self,
         instance: Instance,
@@ -68002,7 +68006,7 @@ impl ExtToolingInfoFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceToolPropertiesEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceToolPropertiesEXT.html>"]
     pub unsafe fn get_physical_device_tool_properties_ext(
         &self,
         physical_device: PhysicalDevice,
@@ -68155,7 +68159,7 @@ impl NvCooperativeMatrixFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceCooperativeMatrixPropertiesNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceCooperativeMatrixPropertiesNV.html>"]
     pub unsafe fn get_physical_device_cooperative_matrix_properties_nv(
         &self,
         physical_device: PhysicalDevice,
@@ -68243,7 +68247,7 @@ impl NvCoverageReductionModeFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV.html>"]
     pub unsafe fn get_physical_device_supported_framebuffer_mixed_samples_combinations_nv(
         &self,
         physical_device: PhysicalDevice,
@@ -68510,7 +68514,7 @@ impl ExtFullScreenExclusiveFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModes2EXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModes2EXT.html>"]
     pub unsafe fn get_physical_device_surface_present_modes2_ext(
         &self,
         physical_device: PhysicalDevice,
@@ -68525,7 +68529,7 @@ impl ExtFullScreenExclusiveFn {
             p_present_modes,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkAcquireFullScreenExclusiveModeEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAcquireFullScreenExclusiveModeEXT.html>"]
     pub unsafe fn acquire_full_screen_exclusive_mode_ext(
         &self,
         device: Device,
@@ -68533,7 +68537,7 @@ impl ExtFullScreenExclusiveFn {
     ) -> Result {
         (self.acquire_full_screen_exclusive_mode_ext)(device, swapchain)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkReleaseFullScreenExclusiveModeEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkReleaseFullScreenExclusiveModeEXT.html>"]
     pub unsafe fn release_full_screen_exclusive_mode_ext(
         &self,
         device: Device,
@@ -68541,7 +68545,7 @@ impl ExtFullScreenExclusiveFn {
     ) -> Result {
         (self.release_full_screen_exclusive_mode_ext)(device, swapchain)
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetDeviceGroupSurfacePresentModes2EXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceGroupSurfacePresentModes2EXT.html>"]
     pub unsafe fn get_device_group_surface_present_modes2_ext(
         &self,
         device: Device,
@@ -68626,7 +68630,7 @@ impl ExtHeadlessSurfaceFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateHeadlessSurfaceEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateHeadlessSurfaceEXT.html>"]
     pub unsafe fn create_headless_surface_ext(
         &self,
         instance: Instance,
@@ -68741,7 +68745,7 @@ impl ExtLineRasterizationFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdSetLineStippleEXT.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetLineStippleEXT.html>"]
     pub unsafe fn cmd_set_line_stipple_ext(
         &self,
         command_buffer: CommandBuffer,
@@ -69105,7 +69109,7 @@ impl KhrPipelineExecutablePropertiesFn {
             },
         }
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPipelineExecutablePropertiesKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineExecutablePropertiesKHR.html>"]
     pub unsafe fn get_pipeline_executable_properties_khr(
         &self,
         device: Device,
@@ -69120,7 +69124,7 @@ impl KhrPipelineExecutablePropertiesFn {
             p_properties,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPipelineExecutableStatisticsKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineExecutableStatisticsKHR.html>"]
     pub unsafe fn get_pipeline_executable_statistics_khr(
         &self,
         device: Device,
@@ -69135,7 +69139,7 @@ impl KhrPipelineExecutablePropertiesFn {
             p_statistics,
         )
     }
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkGetPipelineExecutableInternalRepresentationsKHR.html>"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineExecutableInternalRepresentationsKHR.html>"]
     pub unsafe fn get_pipeline_executable_internal_representations_khr(
         &self,
         device: Device,

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -47406,6 +47406,127 @@ impl<'a> PipelineExecutableStatisticKHRBuilder<'a> {
     }
 }
 #[repr(C)]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPipelineExecutableInternalRepresentationKHR.html>"]
+pub struct PipelineExecutableInternalRepresentationKHR {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub name: [c_char; MAX_DESCRIPTION_SIZE],
+    pub description: [c_char; MAX_DESCRIPTION_SIZE],
+    pub is_text: Bool32,
+    pub data_size: usize,
+    pub p_data: *const c_void,
+}
+impl fmt::Debug for PipelineExecutableInternalRepresentationKHR {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("PipelineExecutableInternalRepresentationKHR")
+            .field("s_type", &self.s_type)
+            .field("p_next", &self.p_next)
+            .field("name", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.name.as_ptr() as *const c_char)
+            })
+            .field("description", &unsafe {
+                ::std::ffi::CStr::from_ptr(self.description.as_ptr() as *const c_char)
+            })
+            .field("is_text", &self.is_text)
+            .field("data_size", &self.data_size)
+            .field("p_data", &self.p_data)
+            .finish()
+    }
+}
+impl ::std::default::Default for PipelineExecutableInternalRepresentationKHR {
+    fn default() -> PipelineExecutableInternalRepresentationKHR {
+        PipelineExecutableInternalRepresentationKHR {
+            s_type: StructureType::PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR,
+            p_next: ::std::ptr::null_mut(),
+            name: unsafe { ::std::mem::zeroed() },
+            description: unsafe { ::std::mem::zeroed() },
+            is_text: Bool32::default(),
+            data_size: usize::default(),
+            p_data: ::std::ptr::null(),
+        }
+    }
+}
+impl PipelineExecutableInternalRepresentationKHR {
+    pub fn builder<'a>() -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+        PipelineExecutableInternalRepresentationKHRBuilder {
+            inner: PipelineExecutableInternalRepresentationKHR::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+    inner: PipelineExecutableInternalRepresentationKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+pub unsafe trait ExtendsPipelineExecutableInternalRepresentationKHR {}
+impl<'a> ::std::ops::Deref for PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+    type Target = PipelineExecutableInternalRepresentationKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+    pub fn name(
+        mut self,
+        name: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+        self.inner.name = name;
+        self
+    }
+    pub fn description(
+        mut self,
+        description: [c_char; MAX_DESCRIPTION_SIZE],
+    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+        self.inner.description = description;
+        self
+    }
+    pub fn is_text(
+        mut self,
+        is_text: bool,
+    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+        self.inner.is_text = is_text.into();
+        self
+    }
+    pub fn data(
+        mut self,
+        data: &'a [u8],
+    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+        self.inner.data_size = data.len() as _;
+        self.inner.p_data = data.as_ptr() as *const c_void;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsPipelineExecutableInternalRepresentationKHR>(
+        mut self,
+        next: &'a mut T,
+    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+        unsafe {
+            let next_ptr = next as *mut T as *mut BaseOutStructure;
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr as _;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PipelineExecutableInternalRepresentationKHR {
+        self.inner
+    }
+}
+#[repr(C)]
 #[derive(Copy, Clone, Debug)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT.html>"]
 pub struct PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT {
@@ -55459,6 +55580,10 @@ impl KhrSamplerMirrorClampToEdgeFn {
         KhrSamplerMirrorClampToEdgeFn {}
     }
 }
+#[doc = "Generated from \'VK_KHR_sampler_mirror_clamp_to_edge\'"]
+impl SamplerAddressMode {
+    pub const MIRROR_CLAMP_TO_EDGE: Self = SamplerAddressMode(4);
+}
 impl ImgFilterCubicFn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_IMG_filter_cubic\0")
@@ -58582,6 +58707,10 @@ impl StructureType {
 #[doc = "Generated from \'VK_KHR_push_descriptor\'"]
 impl DescriptorSetLayoutCreateFlags {
     pub const PUSH_DESCRIPTOR_KHR: Self = DescriptorSetLayoutCreateFlags(0b1);
+}
+#[doc = "Generated from \'VK_KHR_push_descriptor\'"]
+impl DescriptorUpdateTemplateType {
+    pub const PUSH_DESCRIPTORS_KHR: Self = DescriptorUpdateTemplateType(1);
 }
 impl ExtConditionalRenderingFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -70508,6 +70637,22 @@ impl StructureType {
 }
 #[doc = "Generated from \'VK_VERSION_1_2\'"]
 impl StructureType {
+    pub const PHYSICAL_DEVICE_VULKAN_1_1_FEATURES: Self = StructureType(49);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES: Self = StructureType(50);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_VULKAN_1_2_FEATURES: Self = StructureType(51);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES: Self = StructureType(52);
+}
+#[doc = "Generated from \'VK_VERSION_1_2\'"]
+impl StructureType {
     pub const IMAGE_FORMAT_LIST_CREATE_INFO: Self = StructureType(1_000_147_000);
 }
 #[doc = "Generated from \'VK_VERSION_1_2\'"]
@@ -71650,6 +71795,7 @@ impl fmt::Debug for DescriptorUpdateTemplateType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
             Self::DESCRIPTOR_SET => Some("DESCRIPTOR_SET"),
+            Self::PUSH_DESCRIPTORS_KHR => Some("PUSH_DESCRIPTORS_KHR"),
             _ => None,
         };
         if let Some(x) = name {
@@ -73685,6 +73831,7 @@ impl fmt::Debug for SamplerAddressMode {
             Self::MIRRORED_REPEAT => Some("MIRRORED_REPEAT"),
             Self::CLAMP_TO_EDGE => Some("CLAMP_TO_EDGE"),
             Self::CLAMP_TO_BORDER => Some("CLAMP_TO_BORDER"),
+            Self::MIRROR_CLAMP_TO_EDGE => Some("MIRROR_CLAMP_TO_EDGE"),
             _ => None,
         };
         if let Some(x) = name {
@@ -74709,6 +74856,18 @@ impl fmt::Debug for StructureType {
             Self::DESCRIPTOR_SET_LAYOUT_SUPPORT => Some("DESCRIPTOR_SET_LAYOUT_SUPPORT"),
             Self::PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES => {
                 Some("PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_VULKAN_1_1_FEATURES => {
+                Some("PHYSICAL_DEVICE_VULKAN_1_1_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES")
+            }
+            Self::PHYSICAL_DEVICE_VULKAN_1_2_FEATURES => {
+                Some("PHYSICAL_DEVICE_VULKAN_1_2_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES")
             }
             Self::IMAGE_FORMAT_LIST_CREATE_INFO => Some("IMAGE_FORMAT_LIST_CREATE_INFO"),
             Self::ATTACHMENT_DESCRIPTION_2 => Some("ATTACHMENT_DESCRIPTION_2"),

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -45394,7 +45394,7 @@ pub union PerformanceCounterResultKHR {
     pub uint32: u32,
     pub uint64: u64,
     pub float32: f32,
-    pub float64: double,
+    pub float64: f64,
 }
 impl ::std::default::Default for PerformanceCounterResultKHR {
     fn default() -> PerformanceCounterResultKHR {
@@ -47281,7 +47281,7 @@ pub union PipelineExecutableStatisticValueKHR {
     pub b32: Bool32,
     pub i64: i64,
     pub u64: u64,
-    pub f64: double,
+    pub f64: f64,
 }
 impl ::std::default::Default for PipelineExecutableStatisticValueKHR {
     fn default() -> PipelineExecutableStatisticValueKHR {

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Maik Klein <maikklein@googlemail.com>"]
 edition = "2018"
 
 [dependencies]
-vk-parse = "0.2"
+vk-parse = "0.3.0"
 vkxml = "0.3"
 nom = "4.0"
 heck = "0.3"
@@ -18,4 +18,3 @@ version = "0.4.2"
 [dependencies.syn]
 version = "0.12.14"
 features = ["full", "extra-traits"]
-

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -946,7 +946,16 @@ pub fn generate_extension_constants<'a>(
                     let value = if *positive { value } else { -value };
                     Some((Constant::Number(value as i32), Some(extends.clone())))
                 }
-                _ => None,
+                EnumSpec::Value { value, extends } => {
+                    if let (Some(extends), Ok(value)) = (extends, value.parse::<i32>()) {
+                        Some((Constant::Number(value), Some(extends.clone())))
+                    } else {
+                        None
+                    }
+                }
+                _ => {
+                    None
+                },
             }?;
             let extends = extends?;
             let ext_constant = ExtensionConstant {
@@ -2176,6 +2185,7 @@ pub fn write_source_code(path: &Path) {
         })
         .flat_map(|definitions| definitions.elements.iter())
         .collect();
+    // println!("{:#?}", definitions);
 
     let enums: Vec<&vkxml::Enumeration> = spec
         .elements
@@ -2201,6 +2211,7 @@ pub fn write_source_code(path: &Path) {
         })
         .flat_map(|constants| constants.elements.iter())
         .collect();
+    // println!("{:#?}", constants);
 
     let mut fn_cache = HashSet::new();
     let mut bitflags_cache = HashSet::new();
@@ -2218,6 +2229,7 @@ pub fn write_source_code(path: &Path) {
             };
             acc
         });
+    // println!("{:#?}", const_values);
 
     let constants_code: Vec<_> = constants
         .iter()

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -89,7 +89,7 @@ named!(cfloat<&str, f32>,
 
 fn khronos_link<S: Display>(name: &S) -> Literal {
     Literal::string(&format!(
-        "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/{name}.html>",
+        "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/{name}.html>",
         name = name
     ))
 }
@@ -185,22 +185,22 @@ pub fn handle_nondispatchable_macro() -> Tokens {
 }
 pub fn vk_version_macros() -> Tokens {
     quote! {
-        #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_MAKE_VERSION.html>"]
+        #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_MAKE_VERSION.html>"]
         pub const fn make_version(major: u32, minor: u32, patch: u32) -> u32 {
             (major << 22) | (minor << 12) | patch
         }
 
-        #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_VERSION_MAJOR.html>"]
+        #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_VERSION_MAJOR.html>"]
         pub const fn version_major(version: u32) -> u32 {
             version >> 22
         }
 
-        #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_VERSION_MINOR.html>"]
+        #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_VERSION_MINOR.html>"]
         pub const fn version_minor(version: u32) -> u32 {
             (version >> 12) & 0x3ff
         }
 
-        #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VK_VERSION_PATCH.html>"]
+        #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_VERSION_PATCH.html>"]
         pub const fn version_patch(version: u32) -> u32 {
             version & 0xfff
         }

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -953,9 +953,7 @@ pub fn generate_extension_constants<'a>(
                         None
                     }
                 }
-                _ => {
-                    None
-                },
+                _ => None,
             }?;
             let extends = extends?;
             let ext_constant = ExtensionConstant {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -2281,7 +2281,7 @@ pub fn write_source_code(path: &Path) {
     let version_macros = vk_version_macros();
     let platform_specific_types = platform_specific_types();
     let source_code = quote! {
-        #![allow(clippy::too_many_arguments, clippy::cognitive_complexity)]
+        #![allow(clippy::too_many_arguments, clippy::cognitive_complexity, clippy::wrong_self_convention)]
         use std::fmt;
         use std::os::raw::*;
         /// Iterates through the pointer chain. Includes the item that is passed into the function.

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1597,7 +1597,7 @@ pub fn derive_setters(
                             // *mut
                             let slice_type = &param_ty_string[5..];
                             if slice_type == "c_void" {
-                                slice_param_ty_tokens = "&mut 'a [u8]".to_string();
+                                slice_param_ty_tokens = "&'a mut [u8]".to_string();
                                 ptr = ".as_mut_ptr() as *mut c_void";
                             } else {
                                 slice_param_ty_tokens = "&'a mut [".to_string() + slice_type + "]";

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -648,6 +648,7 @@ fn name_to_tokens(type_name: &str) -> Ident {
         "void" => "c_void",
         "char" => "c_char",
         "float" => "f32",
+        "double" => "f64",
         "long" => "c_ulong",
         _ => {
             if type_name.starts_with("Vk") {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -2185,7 +2185,6 @@ pub fn write_source_code(path: &Path) {
         })
         .flat_map(|definitions| definitions.elements.iter())
         .collect();
-    // println!("{:#?}", definitions);
 
     let enums: Vec<&vkxml::Enumeration> = spec
         .elements
@@ -2211,7 +2210,6 @@ pub fn write_source_code(path: &Path) {
         })
         .flat_map(|constants| constants.elements.iter())
         .collect();
-    // println!("{:#?}", constants);
 
     let mut fn_cache = HashSet::new();
     let mut bitflags_cache = HashSet::new();
@@ -2229,7 +2227,6 @@ pub fn write_source_code(path: &Path) {
             };
             acc
         });
-    // println!("{:#?}", const_values);
 
     let constants_code: Vec<_> = constants
         .iter()


### PR DESCRIPTION
Remaining work:
- [x] Include `VkPipelineExecutableInternalRepresentationKHR`(currently excluded as it generates invalid Rust code)
- [x] Passes `cargo check`
    ```
    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES = 49,
    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES = 50,
    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES = 51,
    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES = 52,
    ```

    The above associated types are not generated.
- [x] ~~Decide what to do about breaking API changes making pre-1.2 types unreachable.~~ *type aliases generated**
- [ ] Update non-generated code
- [x] Test new features against a Vulkan 1.2 Driver
- [ ] Test dependent crates(`gfx-hal`, `vk-mem`) [full list](https://crates.io/crates/ash/reverse_dependencies)

Fixes #263