### PR TITLE
Add `VK_KHR_external_memory_fd` extension support

### DIFF
--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -1,0 +1,66 @@
+use crate::prelude::*;
+use crate::version::{DeviceV1_0, InstanceV1_0};
+use crate::vk;
+use std::ffi::CStr;
+use std::mem;
+
+#[derive(Clone)]
+pub struct ExternalMemoryFd {
+    handle: vk::Device,
+    external_memory_fd_fn: vk::KhrExternalMemoryFdFn,
+}
+
+impl ExternalMemoryFd {
+    pub fn new<I: InstanceV1_0, D: DeviceV1_0>(instance: &I, device: &D) -> Self {
+        let external_memory_fd_fn = vk::KhrExternalMemoryFdFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        });
+        Self {
+            handle: device.handle(),
+            external_memory_fd_fn,
+        }
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrExternalMemoryFdFn::name()
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryFdKHR.html>"]
+    pub unsafe fn get_memory_fd(&self, create_info: &vk::MemoryGetFdInfoKHR) -> VkResult<i32> {
+        let mut fd = -1;
+        let err_code =
+            self.external_memory_fd_fn
+                .get_memory_fd_khr(self.handle, create_info, &mut fd);
+        match err_code {
+            vk::Result::SUCCESS => Ok(fd),
+            _ => Err(err_code),
+        }
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryFdPropertiesKHR.html>"]
+    pub unsafe fn get_memory_fd_properties_khr(
+        &self,
+        handle_type: vk::ExternalMemoryHandleTypeFlags,
+        fd: i32,
+    ) -> VkResult<vk::MemoryFdPropertiesKHR> {
+        let mut memory_fd_properties = mem::zeroed();
+        let err_code = self.external_memory_fd_fn.get_memory_fd_properties_khr(
+            self.handle,
+            handle_type,
+            fd,
+            &mut memory_fd_properties,
+        );
+        match err_code {
+            vk::Result::SUCCESS => Ok(memory_fd_properties),
+            _ => Err(err_code),
+        }
+    }
+
+    pub fn fp(&self) -> &vk::KhrExternalMemoryFdFn {
+        &self.external_memory_fd_fn
+    }
+
+    pub fn device(&self) -> vk::Device {
+        self.handle
+    }
+}

--- a/ash/src/extensions/khr/mod.rs
+++ b/ash/src/extensions/khr/mod.rs
@@ -1,6 +1,7 @@
 pub use self::android_surface::AndroidSurface;
 pub use self::display::Display;
 pub use self::display_swapchain::DisplaySwapchain;
+pub use self::external_memory_fd::ExternalMemoryFd;
 pub use self::push_descriptor::PushDescriptor;
 pub use self::surface::Surface;
 pub use self::swapchain::Swapchain;
@@ -12,6 +13,7 @@ pub use self::xlib_surface::XlibSurface;
 mod android_surface;
 mod display;
 mod display_swapchain;
+mod external_memory_fd;
 mod push_descriptor;
 mod surface;
 mod swapchain;


### PR DESCRIPTION
This is my go at adding support for the `VK_KHR_external_memory_fd` extension. There are a couple things I'm unsure about though:

 1. That this is a necessary addition. Is the end goal of ash to have all possible extensions supported this way?
 2. The storing of the device handle in the extension struct. I suppose this is because it's a device specific extension, so it's only guaranteed to work with with the device it was created with.
 3. The specificity of this extension to unix. As far as I know, file descriptors are unique to unix alone, so it makes sense to put this extension behind a unix feature flag.