### PR TITLE
Add a Safety section to the documentation of create_instance and create_device

### DIFF
--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -77,7 +77,12 @@ pub trait EntryV1_0 {
     type Instance;
     fn fp_v1_0(&self) -> &vk::EntryFnV1_0;
     fn static_fn(&self) -> &vk::StaticFn;
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>"]
+    /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>
+    ///
+    /// # Safety
+    /// In order for the created `Instance` to be valid for the duration of its
+    /// usage, the `Entry` this was called on must be dropped later than the
+    /// resulting `Instance`.
     unsafe fn create_instance(
         &self,
         create_info: &vk::InstanceCreateInfo,
@@ -138,7 +143,12 @@ pub trait EntryV1_0 {
 
 impl<L> EntryV1_0 for EntryCustom<L> {
     type Instance = Instance;
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>"]
+    /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>
+    ///
+    /// # Safety
+    /// In order for the created `Instance` to be valid for the duration of its
+    /// usage, the `Entry` this was called on must be dropped later than the
+    /// resulting `Instance`.
     unsafe fn create_instance(
         &self,
         create_info: &vk::InstanceCreateInfo,

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -77,12 +77,11 @@ pub trait EntryV1_0 {
     type Instance;
     fn fp_v1_0(&self) -> &vk::EntryFnV1_0;
     fn static_fn(&self) -> &vk::StaticFn;
-    /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>
-    ///
     /// # Safety
     /// In order for the created `Instance` to be valid for the duration of its
     /// usage, the `Entry` this was called on must be dropped later than the
     /// resulting `Instance`.
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>"]
     unsafe fn create_instance(
         &self,
         create_info: &vk::InstanceCreateInfo,
@@ -143,12 +142,11 @@ pub trait EntryV1_0 {
 
 impl<L> EntryV1_0 for EntryCustom<L> {
     type Instance = Instance;
-    /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>
-    ///
     /// # Safety
     /// In order for the created `Instance` to be valid for the duration of its
     /// usage, the `Entry` this was called on must be dropped later than the
     /// resulting `Instance`.
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>"]
     unsafe fn create_instance(
         &self,
         create_info: &vk::InstanceCreateInfo,

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -38,12 +38,11 @@ impl Instance {
 
 impl InstanceV1_0 for Instance {
     type Device = Device;
-    /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>
-    ///
     /// # Safety
     /// In order for the created `Device` to be valid for the duration of its
     /// usage, the `Instance` this was called on must be dropped later than the
     /// resulting `Device`.
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>"]
     unsafe fn create_device(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -293,12 +292,11 @@ pub trait InstanceV1_0 {
     type Device;
     fn handle(&self) -> vk::Instance;
     fn fp_v1_0(&self) -> &vk::InstanceFnV1_0;
-    /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>
-    ///
     /// # Safety
     /// In order for the created `Device` to be valid for the duration of its
     /// usage, the `Instance` this was called on must be dropped later than the
     /// resulting `Device`.
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>"]
     unsafe fn create_device(
         &self,
         physical_device: vk::PhysicalDevice,

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -38,7 +38,12 @@ impl Instance {
 
 impl InstanceV1_0 for Instance {
     type Device = Device;
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>"]
+    /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>
+    ///
+    /// # Safety
+    /// In order for the created `Device` to be valid for the duration of its
+    /// usage, the `Instance` this was called on must be dropped later than the
+    /// resulting `Device`.
     unsafe fn create_device(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -288,7 +293,12 @@ pub trait InstanceV1_0 {
     type Device;
     fn handle(&self) -> vk::Instance;
     fn fp_v1_0(&self) -> &vk::InstanceFnV1_0;
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>"]
+    /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>
+    ///
+    /// # Safety
+    /// In order for the created `Device` to be valid for the duration of its
+    /// usage, the `Instance` this was called on must be dropped later than the
+    /// resulting `Device`.
     unsafe fn create_device(
         &self,
         physical_device: vk::PhysicalDevice,


### PR DESCRIPTION
This PR is the result of the fact that as a new user of this library, it caught me off guard that I wasn't able to drop `Entry` after successfully creating an `Instance`.
It adds documentation to specify these invariants which the caller must uphold when creating `Device`s and `Instance`s.

Closes #271

One caveat to this, I am currently under the impression that the entry, instance, and device traits are maintained by hand, and are not auto-generated. If that is incorrect, then likely this PR only includes edits to auto-generated code, which likely isn't desirable, and I'll happily close the PR without it merging, since this interaction *is* documented in the README.