### PR TITLE
Adjust doc link rendering with safety sections

### DIFF
--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -77,11 +77,12 @@ pub trait EntryV1_0 {
     type Instance;
     fn fp_v1_0(&self) -> &vk::EntryFnV1_0;
     fn static_fn(&self) -> &vk::StaticFn;
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>"]
+    ///
     /// # Safety
     /// In order for the created `Instance` to be valid for the duration of its
     /// usage, the `Entry` this was called on must be dropped later than the
     /// resulting `Instance`.
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>"]
     unsafe fn create_instance(
         &self,
         create_info: &vk::InstanceCreateInfo,
@@ -142,11 +143,12 @@ pub trait EntryV1_0 {
 
 impl<L> EntryV1_0 for EntryCustom<L> {
     type Instance = Instance;
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>"]
+    ///
     /// # Safety
     /// In order for the created `Instance` to be valid for the duration of its
     /// usage, the `Entry` this was called on must be dropped later than the
     /// resulting `Instance`.
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateInstance.html>"]
     unsafe fn create_instance(
         &self,
         create_info: &vk::InstanceCreateInfo,

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -38,11 +38,12 @@ impl Instance {
 
 impl InstanceV1_0 for Instance {
     type Device = Device;
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>"]
+    ///
     /// # Safety
     /// In order for the created `Device` to be valid for the duration of its
     /// usage, the `Instance` this was called on must be dropped later than the
     /// resulting `Device`.
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>"]
     unsafe fn create_device(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -292,11 +293,12 @@ pub trait InstanceV1_0 {
     type Device;
     fn handle(&self) -> vk::Instance;
     fn fp_v1_0(&self) -> &vk::InstanceFnV1_0;
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>"]
+    ///
     /// # Safety
     /// In order for the created `Device` to be valid for the duration of its
     /// usage, the `Instance` this was called on must be dropped later than the
     /// resulting `Device`.
-    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDevice.html>"]
     unsafe fn create_device(
         &self,
         physical_device: vk::PhysicalDevice,


### PR DESCRIPTION
Minor adjustment to how the doc links are rendered with the new safety sections.

See here for example:

https://github.com/MaikKlein/ash/pull/272#discussion_r386053611