### PR TITLE
Switch to `libloading`

### DIFF
--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/ash"
 edition = "2018"
 
 [dependencies]
-shared_library = "0.1.9"
+libloading = "0.5.2"
 
 [features]
 default = []


### PR DESCRIPTION
This switches the symbol loading from `shared_library` to `libloading` because `shared_library` is not *really* maintained (see https://github.com/tomaka/shared_library/issues/6#issuecomment-264773459 for example).

One noticeable benefit this brings is that it provides a fix for #251. Note that the examples currently require the `VK_EXT_debug_report` extension and therefore won't work on wine without changes.
So: fixes #251 