### PR TITLE
Update `libloading` to `0.6.1`

### DIFF
--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/ash"
 edition = "2018"
 
 [dependencies]
-libloading = "0.5.2"
+libloading = "0.6.1"
 
 [features]
 default = []

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -5,7 +5,6 @@ use crate::RawPtr;
 use libloading::Library;
 use std::error::Error;
 use std::fmt;
-use std::io;
 use std::mem;
 use std::os::raw::c_char;
 use std::os::raw::c_void;
@@ -42,7 +41,7 @@ pub struct EntryCustom<L> {
 
 #[derive(Debug)]
 pub enum LoadingError {
-    LibraryLoadError(io::Error),
+    LibraryLoadError(libloading::Error),
 }
 
 impl fmt::Display for LoadingError {


### PR DESCRIPTION
This improves the build time because `libloading` doesn't depend on `cc` anymore. See: https://github.com/nagisa/rust_libloading/issues/61