### PR TITLE
Initialize MemoryRequirements2 with `Default`

### DIFF
--- a/ash/src/extensions/khr/ray_tracing.rs
+++ b/ash/src/extensions/khr/ray_tracing.rs
@@ -72,7 +72,7 @@ impl RayTracing {
         &self,
         info: &vk::AccelerationStructureMemoryRequirementsInfoKHR,
     ) -> vk::MemoryRequirements2KHR {
-        let mut requirements = mem::zeroed();
+        let mut requirements = Default::default();
         self.ray_tracing_fn
             .get_acceleration_structure_memory_requirements_khr(
                 self.handle,


### PR DESCRIPTION
[`MemoryRequirements2`](https://docs.rs/ash/0.30.0/ash/vk/struct.MemoryRequirements2.html) has a `sType` field, which should not be zero-initialized because it results in a invalid instance. I looked through some more usages of `mem::zeroed` and this seems like the only wrong one.

Fixes #293 (I don't have hardware that supports this extension but this should fix it)