### PR TITLE
Deprecate the DebugMarker and DebugReport extension modules

### DIFF
--- a/ash/src/extensions/ext/mod.rs
+++ b/ash/src/extensions/ext/mod.rs
@@ -4,7 +4,9 @@ pub use self::debug_utils::DebugUtils;
 pub use self::metal_surface::MetalSurface;
 pub use self::tooling_info::ToolingInfo;
 
+#[deprecated(note = "Please use the [DebugUtils](struct.DebugUtils.html) extension instead.")]
 mod debug_marker;
+#[deprecated(note = "Please use the [DebugUtils](struct.DebugUtils.html) extension instead.")]
 mod debug_report;
 mod debug_utils;
 mod metal_surface;

--- a/ash/src/extensions/ext/mod.rs
+++ b/ash/src/extensions/ext/mod.rs
@@ -1,4 +1,6 @@
+#[allow(deprecated)]
 pub use self::debug_marker::DebugMarker;
+#[allow(deprecated)]
 pub use self::debug_report::DebugReport;
 pub use self::debug_utils::DebugUtils;
 pub use self::metal_surface::MetalSurface;


### PR DESCRIPTION
The [DebugMarker](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_EXT_debug_marker.html#_deprecation_state) and [DebugReport](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_EXT_debug_report.html#_deprecation_state) extensions in Vulkan have been deprecated and replaced by the unified DebugUtils extension, as announced in this [LunarG document [PDF]](https://www.lunarg.com/wp-content/uploads/2018/05/Vulkan-Debug-Utils_05_18_v1.pdf).

I used the DebugMarker module and experienced a crash on Ubuntu 20.04 on an Ice Lake CPU + GPU.

This PR adds this deprecation to the crate documentation, and points users to the documentation for the replacement DebugUtils extension.