### PR TITLE
[CI] Test/check/lint all targets, fixup leftover clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --workspace --all-targets
 
   test:
     name: Test Suite
@@ -30,6 +31,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --workspace --all-targets
 
   fmt:
     name: Rustfmt
@@ -61,4 +63,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --workspace --all-targets -- -D warnings

--- a/ash-window/examples/winit.rs
+++ b/ash-window/examples/winit.rs
@@ -35,12 +35,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         let mut running = true;
         while running {
-            events_loop.poll_events(|event| match event {
-                winit::Event::WindowEvent {
+            events_loop.poll_events(|event| {
+                if let winit::Event::WindowEvent {
                     event: winit::WindowEvent::CloseRequested,
                     ..
-                } => running = false,
-                _ => (),
+                } = event
+                {
+                    running = false;
+                }
             });
         }
 

--- a/ash/tests/constant_size_arrays.rs
+++ b/ash/tests/constant_size_arrays.rs
@@ -1,5 +1,3 @@
-use ash;
-
 use ash::vk::{PhysicalDeviceProperties, PipelineColorBlendStateCreateInfo};
 
 #[test]

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1,11 +1,7 @@
 #![recursion_limit = "256"]
 
-#[macro_use]
-extern crate nom;
-#[macro_use]
-extern crate quote;
-pub use vk_parse;
-pub use vkxml;
+use nom::{alt, char, do_parse, map, named, opt, tag, take_while1, terminated};
+use quote::*;
 
 use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
 use itertools::Itertools;


### PR DESCRIPTION
This allows me to use my beloved `clippy --workspace --all-targets` without noise from leftover issues :slightly_smiling_face: 