### PR TITLE
Optimized example fences. Waited immediately. Now waits before reuse (next frame)

### DIFF
--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -355,6 +355,7 @@ fn main() {
         record_submit_commandbuffer(
             &base.device,
             base.setup_command_buffer,
+            base.setup_commands_reuse_fence,
             base.present_queue,
             &[],
             &[],
@@ -736,6 +737,7 @@ fn main() {
             record_submit_commandbuffer(
                 &base.device,
                 base.draw_command_buffer,
+                base.draw_commands_reuse_fence,
                 base.present_queue,
                 &[vk::PipelineStageFlags::BOTTOM_OF_PIPE],
                 &[base.present_complete_semaphore],

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -394,6 +394,7 @@ fn main() {
             record_submit_commandbuffer(
                 &base.device,
                 base.draw_command_buffer,
+                base.draw_commands_reuse_fence,
                 base.present_queue,
                 &[vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT],
                 &[base.present_complete_semaphore],

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -25,7 +25,9 @@ macro_rules! offset_of {
         }
     }};
 }
-
+/// Helper function for submitting command buffers. Immediately waits for the fence before the command buffer
+/// is executed. That way we can delay the waiting for the fences by 1 frame which is good for performance.
+/// Make sure to create the fence in a signaled state on the first use.
 #[allow(clippy::too_many_arguments)]
 pub fn record_submit_commandbuffer<D: DeviceV1_0, F: FnOnce(&D, vk::CommandBuffer)>(
     device: &D,

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -26,6 +26,7 @@ macro_rules! offset_of {
     }};
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn record_submit_commandbuffer<D: DeviceV1_0, F: FnOnce(&D, vk::CommandBuffer)>(
     device: &D,
     command_buffer: vk::CommandBuffer,
@@ -72,7 +73,11 @@ pub fn record_submit_commandbuffer<D: DeviceV1_0, F: FnOnce(&D, vk::CommandBuffe
             .signal_semaphores(signal_semaphores);
 
         device
-            .queue_submit(submit_queue, &[submit_info.build()], command_buffer_reuse_fence)
+            .queue_submit(
+                submit_queue,
+                &[submit_info.build()],
+                command_buffer_reuse_fence,
+            )
             .expect("queue submit failed.");
     }
 }
@@ -463,8 +468,8 @@ impl ExampleBase {
                 .bind_image_memory(depth_image, depth_image_memory, 0)
                 .expect("Unable to bind depth image memory");
 
-            let fence_create_info = vk::FenceCreateInfo::builder()
-                .flags(vk::FenceCreateFlags::SIGNALED);
+            let fence_create_info =
+                vk::FenceCreateInfo::builder().flags(vk::FenceCreateFlags::SIGNALED);
 
             let draw_commands_reuse_fence = device
                 .create_fence(&fence_create_info, None)
@@ -577,7 +582,7 @@ impl Drop for ExampleBase {
             self.device
                 .destroy_semaphore(self.present_complete_semaphore, None);
             self.device
-                .destroy_semaphore(self.rendering_complete_semaphore, None);           
+                .destroy_semaphore(self.rendering_complete_semaphore, None);
             self.device
                 .destroy_fence(self.draw_commands_reuse_fence, None);
             self.device


### PR DESCRIPTION
The examples (triangle and texture) wait for a fence immediately after submitting a command buffer. This is not a good practice for performance. I moved the wait until the command buffer is reused (one frame later).

Measured average frame times on Intel i7-1065g7 (4K display, 200% scaling).

**Triangle sample:**
Old = 3.5ms
New = 2.4ms

**Texture sample:**
Old = 4.2ms
New = 3.0ms
