### PR TITLE
Simplify example memory selection

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -122,34 +122,15 @@ pub fn find_memorytype_index(
     memory_prop: &vk::PhysicalDeviceMemoryProperties,
     flags: vk::MemoryPropertyFlags,
 ) -> Option<u32> {
-    // Try to find an exactly matching memory flag
-    let best_suitable_index =
-        find_memorytype_index_f(memory_req, memory_prop, flags, |property_flags, flags| {
-            property_flags == flags
-        });
-    if best_suitable_index.is_some() {
-        return best_suitable_index;
-    }
-    // Otherwise find a memory flag that works
-    find_memorytype_index_f(memory_req, memory_prop, flags, |property_flags, flags| {
-        property_flags & flags == flags
-    })
-}
-
-pub fn find_memorytype_index_f<F: Fn(vk::MemoryPropertyFlags, vk::MemoryPropertyFlags) -> bool>(
-    memory_req: &vk::MemoryRequirements,
-    memory_prop: &vk::PhysicalDeviceMemoryProperties,
-    flags: vk::MemoryPropertyFlags,
-    f: F,
-) -> Option<u32> {
-    let mut memory_type_bits = memory_req.memory_type_bits;
-    for (index, ref memory_type) in memory_prop.memory_types.iter().enumerate() {
-        if memory_type_bits & 1 == 1 && f(memory_type.property_flags, flags) {
-            return Some(index as u32);
-        }
-        memory_type_bits >>= 1;
-    }
-    None
+    memory_prop
+        .memory_types
+        .iter()
+        .enumerate()
+        .find(|(index, memory_type)| {
+            (1 << index) & memory_req.memory_type_bits != 0
+                && memory_type.property_flags & flags == flags
+        })
+        .map(|(index, _memory_type)| index as _)
 }
 
 pub struct ExampleBase {


### PR DESCRIPTION
Hopefully this will make it easier to understand `find_memorytype_index()`:

* I find it harder to reason about loops that write to variables they read from, so this avoids repeatedly updating `memory_type_bits` in favor of making the relationship between `index` and `memory_req.memory_type_bits` more explicit.
* This has merged `find_memorytype_index_f()` into `find_memorytype_index()` to reduce the amount of jumping around needed to understand what's going on.

~Unfortunately, this _does_ come with a behavior change: If an exactly matching memory type cannot be found, this now returns the last acceptable memory type, whereas it previously returned the first.~