### PR TITLE
Only scan memory_type_count memory types in examples

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -122,8 +122,7 @@ pub fn find_memorytype_index(
     memory_prop: &vk::PhysicalDeviceMemoryProperties,
     flags: vk::MemoryPropertyFlags,
 ) -> Option<u32> {
-    memory_prop
-        .memory_types
+    memory_prop.memory_types[..memory_prop.memory_type_count as _]
         .iter()
         .enumerate()
         .find(|(index, memory_type)| {


### PR DESCRIPTION
The example code originally checked all 32 memory types even if the instance returned fewer memory types.