### PR TITLE
Preliminary cleanup pass

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -61,16 +61,14 @@ pub trait DeviceV1_2: DeviceV1_1 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::zeroed();
-        let err_code = self.fp_v1_2().create_render_pass2(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut renderpass,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(renderpass),
-            _ => Err(err_code),
-        }
+        self.fp_v1_2()
+            .create_render_pass2(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut renderpass,
+            )
+            .result_with_success(renderpass)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginRenderPass2.html>"]
@@ -122,13 +120,9 @@ pub trait DeviceV1_2: DeviceV1_1 {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSemaphoreCounterValue.html>"]
     unsafe fn get_semaphore_counter_value(&self, semaphore: vk::Semaphore) -> VkResult<u64> {
         let mut value = 0;
-        let err_code =
-            self.fp_v1_2()
-                .get_semaphore_counter_value(self.handle(), semaphore, &mut value);
-        match err_code {
-            vk::Result::SUCCESS => Ok(value),
-            _ => Err(err_code),
-        }
+        self.fp_v1_2()
+            .get_semaphore_counter_value(self.handle(), semaphore, &mut value)
+            .result_with_success(value)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkWaitSemaphores.html>"]
@@ -304,16 +298,14 @@ pub trait DeviceV1_1: DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SamplerYcbcrConversion> {
         let mut ycbcr_conversion = mem::zeroed();
-        let err_code = self.fp_v1_1().create_sampler_ycbcr_conversion(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut ycbcr_conversion,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(ycbcr_conversion),
-            _ => Err(err_code),
-        }
+        self.fp_v1_1()
+            .create_sampler_ycbcr_conversion(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut ycbcr_conversion,
+            )
+            .result_with_success(ycbcr_conversion)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroySamplerYcbcrConversion.html>"]
@@ -336,16 +328,14 @@ pub trait DeviceV1_1: DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DescriptorUpdateTemplate> {
         let mut descriptor_update_template = mem::zeroed();
-        let err_code = self.fp_v1_1().create_descriptor_update_template(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut descriptor_update_template,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(descriptor_update_template),
-            _ => Err(err_code),
-        }
+        self.fp_v1_1()
+            .create_descriptor_update_template(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut descriptor_update_template,
+            )
+            .result_with_success(descriptor_update_template)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDescriptorUpdateTemplate.html>"]
@@ -438,16 +428,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Event> {
         let mut event = mem::zeroed();
-        let err_code = self.fp_v1_0().create_event(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut event,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(event),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_event(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut event,
+            )
+            .result_with_success(event)
     }
 
     /// Returns true if the event was set, and false if the event was reset, otherwise it will
@@ -743,16 +731,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Sampler> {
         let mut sampler = mem::zeroed();
-        let err_code = self.fp_v1_0().create_sampler(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut sampler,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(sampler),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_sampler(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut sampler,
+            )
+            .result_with_success(sampler)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBlitImage.html>"]
@@ -931,16 +917,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DescriptorSetLayout> {
         let mut layout = mem::zeroed();
-        let err_code = self.fp_v1_0().create_descriptor_set_layout(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut layout,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(layout),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_descriptor_set_layout(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut layout,
+            )
+            .result_with_success(layout)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDeviceWaitIdle.html>"]
@@ -955,16 +939,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DescriptorPool> {
         let mut pool = mem::zeroed();
-        let err_code = self.fp_v1_0().create_descriptor_pool(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut pool,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(pool),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_descriptor_pool(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut pool,
+            )
+            .result_with_success(pool)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetDescriptorPool.html>"]
@@ -1486,16 +1468,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Semaphore> {
         let mut semaphore = mem::zeroed();
-        let err_code = self.fp_v1_0().create_semaphore(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut semaphore,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(semaphore),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_semaphore(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut semaphore,
+            )
+            .result_with_success(semaphore)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateGraphicsPipelines.html>"]
@@ -1551,16 +1531,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Buffer> {
         let mut buffer = mem::zeroed();
-        let err_code = self.fp_v1_0().create_buffer(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut buffer,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(buffer),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_buffer(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut buffer,
+            )
+            .result_with_success(buffer)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreatePipelineLayout.html>"]
@@ -1570,16 +1548,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::PipelineLayout> {
         let mut pipeline_layout = mem::zeroed();
-        let err_code = self.fp_v1_0().create_pipeline_layout(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut pipeline_layout,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(pipeline_layout),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_pipeline_layout(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut pipeline_layout,
+            )
+            .result_with_success(pipeline_layout)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreatePipelineCache.html>"]
@@ -1589,17 +1565,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::PipelineCache> {
         let mut pipeline_cache = mem::zeroed();
-        let err_code = self.fp_v1_0().create_pipeline_cache(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut pipeline_cache,
-        );
-
-        match err_code {
-            vk::Result::SUCCESS => Ok(pipeline_cache),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_pipeline_cache(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut pipeline_cache,
+            )
+            .result_with_success(pipeline_cache)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineCacheData.html>"]
@@ -1640,13 +1613,9 @@ pub trait DeviceV1_0 {
         flags: vk::MemoryMapFlags,
     ) -> VkResult<*mut c_void> {
         let mut data: *mut c_void = ptr::null_mut();
-        let err_code =
-            self.fp_v1_0()
-                .map_memory(self.handle(), memory, offset, size, flags, &mut data);
-        match err_code {
-            vk::Result::SUCCESS => Ok(data),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .map_memory(self.handle(), memory, offset, size, flags, &mut data)
+            .result_with_success(data)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkUnmapMemory.html>"]
@@ -1678,16 +1647,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Framebuffer> {
         let mut framebuffer = mem::zeroed();
-        let err_code = self.fp_v1_0().create_framebuffer(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut framebuffer,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(framebuffer),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_framebuffer(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut framebuffer,
+            )
+            .result_with_success(framebuffer)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceQueue.html>"]
@@ -1730,16 +1697,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::zeroed();
-        let err_code = self.fp_v1_0().create_render_pass(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut renderpass,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(renderpass),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_render_pass(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut renderpass,
+            )
+            .result_with_success(renderpass)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBeginCommandBuffer.html>"]
@@ -1810,16 +1775,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::BufferView> {
         let mut buffer_view = mem::zeroed();
-        let err_code = self.fp_v1_0().create_buffer_view(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut buffer_view,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(buffer_view),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_buffer_view(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut buffer_view,
+            )
+            .result_with_success(buffer_view)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyBufferView.html>"]
@@ -1842,16 +1805,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::ImageView> {
         let mut image_view = mem::zeroed();
-        let err_code = self.fp_v1_0().create_image_view(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut image_view,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(image_view),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_image_view(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut image_view,
+            )
+            .result_with_success(image_view)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAllocateCommandBuffers.html>"]
@@ -1879,16 +1840,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::CommandPool> {
         let mut pool = mem::zeroed();
-        let err_code = self.fp_v1_0().create_command_pool(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut pool,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(pool),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_command_pool(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut pool,
+            )
+            .result_with_success(pool)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateQueryPool.html>"]
@@ -1898,16 +1857,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::QueryPool> {
         let mut pool = mem::zeroed();
-        let err_code = self.fp_v1_0().create_query_pool(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut pool,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(pool),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_query_pool(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut pool,
+            )
+            .result_with_success(pool)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateImage.html>"]
@@ -1917,16 +1874,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Image> {
         let mut image = mem::zeroed();
-        let err_code = self.fp_v1_0().create_image(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut image,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(image),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_image(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut image,
+            )
+            .result_with_success(image)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageSubresourceLayout.html>"]
@@ -1968,16 +1923,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DeviceMemory> {
         let mut memory = mem::zeroed();
-        let err_code = self.fp_v1_0().allocate_memory(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut memory,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(memory),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .allocate_memory(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut memory,
+            )
+            .result_with_success(memory)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateShaderModule.html>"]
@@ -1987,16 +1940,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::ShaderModule> {
         let mut shader = mem::zeroed();
-        let err_code = self.fp_v1_0().create_shader_module(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut shader,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(shader),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_shader_module(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut shader,
+            )
+            .result_with_success(shader)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateFence.html>"]
@@ -2006,16 +1957,14 @@ pub trait DeviceV1_0 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::Fence> {
         let mut fence = mem::zeroed();
-        let err_code = self.fp_v1_0().create_fence(
-            self.handle(),
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut fence,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(fence),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .create_fence(
+                self.handle(),
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut fence,
+            )
+            .result_with_success(fence)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBindBufferMemory.html>"]

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -904,10 +904,7 @@ pub trait DeviceV1_0 {
         );
 
         desc_set.set_len(create_info.descriptor_set_count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(desc_set),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(desc_set)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDescriptorSetLayout.html>"]
@@ -1597,10 +1594,7 @@ pub trait DeviceV1_0 {
             data.as_mut_ptr() as _,
         );
         data.set_len(data_size);
-        match err_code {
-            vk::Result::SUCCESS => Ok(data),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(data)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkMapMemory.html>"]
@@ -1826,10 +1820,7 @@ pub trait DeviceV1_0 {
             buffers.as_mut_ptr(),
         );
         buffers.set_len(create_info.command_buffer_count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(buffers),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(buffers)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateCommandPool.html>"]

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -137,22 +137,16 @@ pub trait DeviceV1_2: DeviceV1_1 {
         wait_info: &vk::SemaphoreWaitInfo,
         timeout: u64,
     ) -> VkResult<()> {
-        let err_code = self
-            .fp_v1_2()
-            .wait_semaphores(self.handle(), wait_info, timeout);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_2()
+            .wait_semaphores(self.handle(), wait_info, timeout)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSignalSemaphore.html>"]
     unsafe fn signal_semaphore(&self, signal_info: &vk::SemaphoreSignalInfo) -> VkResult<()> {
-        let err_code = self.fp_v1_2().signal_semaphore(self.handle(), signal_info);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_2()
+            .signal_semaphore(self.handle(), signal_info)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferDeviceAddress.html>"]
@@ -186,28 +180,16 @@ pub trait DeviceV1_1: DeviceV1_0 {
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBindBufferMemory2.html>"]
     unsafe fn bind_buffer_memory2(&self, bind_infos: &[vk::BindBufferMemoryInfo]) -> VkResult<()> {
-        let err_code = self.fp_v1_1().bind_buffer_memory2(
-            self.handle(),
-            bind_infos.len() as _,
-            bind_infos.as_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_1()
+            .bind_buffer_memory2(self.handle(), bind_infos.len() as _, bind_infos.as_ptr())
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBindImageMemory2.html>"]
     unsafe fn bind_image_memory2(&self, bind_infos: &[vk::BindImageMemoryInfo]) -> VkResult<()> {
-        let err_code = self.fp_v1_1().bind_image_memory2(
-            self.handle(),
-            bind_infos.len() as _,
-            bind_infos.as_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_1()
+            .bind_image_memory2(self.handle(), bind_infos.len() as _, bind_infos.as_ptr())
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceGroupPeerMemoryFeatures.html>"]
@@ -482,20 +464,12 @@ pub trait DeviceV1_0 {
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSetEvent.html>"]
     unsafe fn set_event(&self, event: vk::Event) -> VkResult<()> {
-        let err_code = self.fp_v1_0().set_event(self.handle(), event);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0().set_event(self.handle(), event).into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetEvent.html>"]
     unsafe fn reset_event(&self, event: vk::Event) -> VkResult<()> {
-        let err_code = self.fp_v1_0().reset_event(self.handle(), event);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0().reset_event(self.handle(), event).into()
     }
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetEvent.html>"]
     unsafe fn cmd_set_event(
@@ -969,11 +943,7 @@ pub trait DeviceV1_0 {
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDeviceWaitIdle.html>"]
     unsafe fn device_wait_idle(&self) -> VkResult<()> {
-        let err_code = self.fp_v1_0().device_wait_idle(self.handle());
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0().device_wait_idle(self.handle()).into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDescriptorPool.html>"]
@@ -1001,13 +971,9 @@ pub trait DeviceV1_0 {
         pool: vk::DescriptorPool,
         flags: vk::DescriptorPoolResetFlags,
     ) -> VkResult<()> {
-        let err_code = self
-            .fp_v1_0()
-            .reset_descriptor_pool(self.handle(), pool, flags);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .reset_descriptor_pool(self.handle(), pool, flags)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetCommandPool.html>"]
@@ -1016,13 +982,9 @@ pub trait DeviceV1_0 {
         command_pool: vk::CommandPool,
         flags: vk::CommandPoolResetFlags,
     ) -> VkResult<()> {
-        let err_code = self
-            .fp_v1_0()
-            .reset_command_pool(self.handle(), command_pool, flags);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .reset_command_pool(self.handle(), command_pool, flags)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetCommandBuffer.html>"]
@@ -1031,22 +993,16 @@ pub trait DeviceV1_0 {
         command_buffer: vk::CommandBuffer,
         flags: vk::CommandBufferResetFlags,
     ) -> VkResult<()> {
-        let err_code = self.fp_v1_0().reset_command_buffer(command_buffer, flags);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .reset_command_buffer(command_buffer, flags)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkResetFences.html>"]
     unsafe fn reset_fences(&self, fences: &[vk::Fence]) -> VkResult<()> {
-        let err_code =
-            self.fp_v1_0()
-                .reset_fences(self.handle(), fences.len() as u32, fences.as_ptr());
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .reset_fences(self.handle(), fences.len() as u32, fences.as_ptr())
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBindIndexBuffer.html>"]
@@ -1460,21 +1416,18 @@ pub trait DeviceV1_0 {
             "query_count was higher than the length of the slice"
         );
         let data_size = mem::size_of::<T>() * data_length;
-        let err_code = self.fp_v1_0().get_query_pool_results(
-            self.handle(),
-            query_pool,
-            first_query,
-            query_count,
-            data_size,
-            data.as_mut_ptr() as *mut _,
-            mem::size_of::<T>() as _,
-            flags,
-        );
-
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .get_query_pool_results(
+                self.handle(),
+                query_pool,
+                first_query,
+                query_count,
+                data_size,
+                data.as_mut_ptr() as *mut _,
+                mem::size_of::<T>() as _,
+                flags,
+            )
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginQuery.html>"]
@@ -1661,7 +1614,7 @@ pub trait DeviceV1_0 {
         );
         if err_code != vk::Result::SUCCESS {
             return Err(err_code);
-        };
+        }
         let mut data: Vec<u8> = Vec::with_capacity(data_size);
         let err_code = self.fp_v1_0().get_pipeline_cache_data(
             self.handle(),
@@ -1704,28 +1657,16 @@ pub trait DeviceV1_0 {
         &self,
         ranges: &[vk::MappedMemoryRange],
     ) -> VkResult<()> {
-        let err_code = self.fp_v1_0().invalidate_mapped_memory_ranges(
-            self.handle(),
-            ranges.len() as u32,
-            ranges.as_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .invalidate_mapped_memory_ranges(self.handle(), ranges.len() as u32, ranges.as_ptr())
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkFlushMappedMemoryRanges.html>"]
     unsafe fn flush_mapped_memory_ranges(&self, ranges: &[vk::MappedMemoryRange]) -> VkResult<()> {
-        let err_code = self.fp_v1_0().flush_mapped_memory_ranges(
-            self.handle(),
-            ranges.len() as u32,
-            ranges.as_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .flush_mapped_memory_ranges(self.handle(), ranges.len() as u32, ranges.as_ptr())
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateFramebuffer.html>"]
@@ -1805,22 +1746,14 @@ pub trait DeviceV1_0 {
         command_buffer: vk::CommandBuffer,
         begin_info: &vk::CommandBufferBeginInfo,
     ) -> VkResult<()> {
-        let err_code = self
-            .fp_v1_0()
-            .begin_command_buffer(command_buffer, begin_info);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .begin_command_buffer(command_buffer, begin_info)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEndCommandBuffer.html>"]
     unsafe fn end_command_buffer(&self, command_buffer: vk::CommandBuffer) -> VkResult<()> {
-        let err_code = self.fp_v1_0().end_command_buffer(command_buffer);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0().end_command_buffer(command_buffer).into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkWaitForFences.html>"]
@@ -1830,17 +1763,15 @@ pub trait DeviceV1_0 {
         wait_all: bool,
         timeout: u64,
     ) -> VkResult<()> {
-        let err_code = self.fp_v1_0().wait_for_fences(
-            self.handle(),
-            fences.len() as u32,
-            fences.as_ptr(),
-            wait_all as u32,
-            timeout,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .wait_for_fences(
+                self.handle(),
+                fences.len() as u32,
+                fences.as_ptr(),
+                wait_all as u32,
+                timeout,
+            )
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetFenceStatus.html>"]
@@ -1855,11 +1786,7 @@ pub trait DeviceV1_0 {
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueWaitIdle.html>"]
     unsafe fn queue_wait_idle(&self, queue: vk::Queue) -> VkResult<()> {
-        let err_code = self.fp_v1_0().queue_wait_idle(queue);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0().queue_wait_idle(queue).into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueSubmit.html>"]
@@ -1869,13 +1796,9 @@ pub trait DeviceV1_0 {
         submits: &[vk::SubmitInfo],
         fence: vk::Fence,
     ) -> VkResult<()> {
-        let err_code =
-            self.fp_v1_0()
-                .queue_submit(queue, submits.len() as u32, submits.as_ptr(), fence);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .queue_submit(queue, submits.len() as u32, submits.as_ptr(), fence)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateBufferView.html>"]
@@ -2100,13 +2023,9 @@ pub trait DeviceV1_0 {
         device_memory: vk::DeviceMemory,
         offset: vk::DeviceSize,
     ) -> VkResult<()> {
-        let err_code =
-            self.fp_v1_0()
-                .bind_buffer_memory(self.handle(), buffer, device_memory, offset);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .bind_buffer_memory(self.handle(), buffer, device_memory, offset)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBindImageMemory.html>"]
@@ -2116,13 +2035,9 @@ pub trait DeviceV1_0 {
         device_memory: vk::DeviceMemory,
         offset: vk::DeviceSize,
     ) -> VkResult<()> {
-        let err_code =
-            self.fp_v1_0()
-                .bind_image_memory(self.handle(), image, device_memory, offset);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.fp_v1_0()
+            .bind_image_memory(self.handle(), image, device_memory, offset)
+            .into()
     }
 }
 

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -1581,15 +1581,14 @@ pub trait DeviceV1_0 {
         pipeline_cache: vk::PipelineCache,
     ) -> VkResult<Vec<u8>> {
         let mut data_size: usize = 0;
-        let err_code = self.fp_v1_0().get_pipeline_cache_data(
-            self.handle(),
-            pipeline_cache,
-            &mut data_size,
-            ptr::null_mut(),
-        );
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.fp_v1_0()
+            .get_pipeline_cache_data(
+                self.handle(),
+                pipeline_cache,
+                &mut data_size,
+                ptr::null_mut(),
+            )
+            .result()?;
         let mut data: Vec<u8> = Vec::with_capacity(data_size);
         let err_code = self.fp_v1_0().get_pipeline_cache_data(
             self.handle(),

--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -710,13 +710,15 @@ pub trait DeviceV1_0 {
         &self,
         pool: vk::DescriptorPool,
         descriptor_sets: &[vk::DescriptorSet],
-    ) {
-        self.fp_v1_0().free_descriptor_sets(
-            self.handle(),
-            pool,
-            descriptor_sets.len() as u32,
-            descriptor_sets.as_ptr(),
-        );
+    ) -> VkResult<()> {
+        self.fp_v1_0()
+            .free_descriptor_sets(
+                self.handle(),
+                pool,
+                descriptor_sets.len() as u32,
+                descriptor_sets.as_ptr(),
+            )
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkUpdateDescriptorSets.html>"]

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -152,11 +152,9 @@ pub trait EntryV1_1: EntryV1_0 {
     fn enumerate_instance_version(&self) -> VkResult<u32> {
         unsafe {
             let mut api_version = 0;
-            let err_code = self.fp_v1_1().enumerate_instance_version(&mut api_version);
-            match err_code {
-                vk::Result::SUCCESS => Ok(api_version),
-                _ => Err(err_code),
-            }
+            self.fp_v1_1()
+                .enumerate_instance_version(&mut api_version)
+                .result_with_success(api_version)
         }
     }
 }

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -57,9 +57,12 @@ pub trait EntryV1_0 {
     fn enumerate_instance_layer_properties(&self) -> VkResult<Vec<vk::LayerProperties>> {
         unsafe {
             let mut num = 0;
-            self.fp_v1_0()
+            let err_code = self
+                .fp_v1_0()
                 .enumerate_instance_layer_properties(&mut num, ptr::null_mut());
-
+            if err_code != vk::Result::SUCCESS {
+                return Err(err_code);
+            }
             let mut v = Vec::with_capacity(num as usize);
             let err_code = self
                 .fp_v1_0()
@@ -76,11 +79,14 @@ pub trait EntryV1_0 {
     fn enumerate_instance_extension_properties(&self) -> VkResult<Vec<vk::ExtensionProperties>> {
         unsafe {
             let mut num = 0;
-            self.fp_v1_0().enumerate_instance_extension_properties(
+            let err_code = self.fp_v1_0().enumerate_instance_extension_properties(
                 ptr::null(),
                 &mut num,
                 ptr::null_mut(),
             );
+            if err_code != vk::Result::SUCCESS {
+                return Err(err_code);
+            }
             let mut data = Vec::with_capacity(num as usize);
             let err_code = self.fp_v1_0().enumerate_instance_extension_properties(
                 ptr::null(),

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -79,14 +79,9 @@ pub trait EntryV1_0 {
     fn enumerate_instance_extension_properties(&self) -> VkResult<Vec<vk::ExtensionProperties>> {
         unsafe {
             let mut num = 0;
-            let err_code = self.fp_v1_0().enumerate_instance_extension_properties(
-                ptr::null(),
-                &mut num,
-                ptr::null_mut(),
-            );
-            if err_code != vk::Result::SUCCESS {
-                return Err(err_code);
-            }
+            self.fp_v1_0()
+                .enumerate_instance_extension_properties(ptr::null(), &mut num, ptr::null_mut())
+                .result()?;
             let mut data = Vec::with_capacity(num as usize);
             let err_code = self.fp_v1_0().enumerate_instance_extension_properties(
                 ptr::null(),

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -234,11 +234,8 @@ impl<L> EntryCustom<L> {
                 )
             };
             if let Some(enumerate_instance_version) = enumerate_instance_version {
-                let err_code = (enumerate_instance_version)(&mut api_version);
-                match err_code {
-                    vk::Result::SUCCESS => Ok(Some(api_version)),
-                    _ => Err(err_code),
-                }
+                (enumerate_instance_version)(&mut api_version)
+                    .result_with_success(Some(api_version))
             } else {
                 Ok(None)
             }

--- a/ash/src/extensions/ext/debug_marker.rs
+++ b/ash/src/extensions/ext/debug_marker.rs
@@ -28,13 +28,9 @@ impl DebugMarker {
         device: vk::Device,
         name_info: &vk::DebugMarkerObjectNameInfoEXT,
     ) -> VkResult<()> {
-        let err_code = self
-            .debug_marker_fn
-            .debug_marker_set_object_name_ext(device, name_info);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.debug_marker_fn
+            .debug_marker_set_object_name_ext(device, name_info)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDebugMarkerBeginEXT.html>"]

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -47,16 +47,14 @@ impl DebugReport {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DebugReportCallbackEXT> {
         let mut debug_cb = mem::zeroed();
-        let err_code = self.debug_report_fn.create_debug_report_callback_ext(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut debug_cb,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(debug_cb),
-            _ => Err(err_code),
-        }
+        self.debug_report_fn
+            .create_debug_report_callback_ext(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut debug_cb,
+            )
+            .result_with_success(debug_cb)
     }
 
     pub fn fp(&self) -> &vk::ExtDebugReportFn {

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -106,16 +106,14 @@ impl DebugUtils {
         allocator: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DebugUtilsMessengerEXT> {
         let mut messenger = mem::zeroed();
-        let err_code = self.debug_utils_fn.create_debug_utils_messenger_ext(
-            self.handle,
-            create_info,
-            allocator.as_raw_ptr(),
-            &mut messenger,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(messenger),
-            _ => Err(err_code),
-        }
+        self.debug_utils_fn
+            .create_debug_utils_messenger_ext(
+                self.handle,
+                create_info,
+                allocator.as_raw_ptr(),
+                &mut messenger,
+            )
+            .result_with_success(messenger)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDebugUtilsMessengerEXT.html>"]

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -32,13 +32,9 @@ impl DebugUtils {
         device: vk::Device,
         name_info: &vk::DebugUtilsObjectNameInfoEXT,
     ) -> VkResult<()> {
-        let err_code = self
-            .debug_utils_fn
-            .set_debug_utils_object_name_ext(device, name_info);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.debug_utils_fn
+            .set_debug_utils_object_name_ext(device, name_info)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html>"]
@@ -47,13 +43,9 @@ impl DebugUtils {
         device: vk::Device,
         tag_info: &vk::DebugUtilsObjectTagInfoEXT,
     ) -> VkResult<()> {
-        let err_code = self
-            .debug_utils_fn
-            .set_debug_utils_object_tag_ext(device, tag_info);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.debug_utils_fn
+            .set_debug_utils_object_tag_ext(device, tag_info)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginDebugUtilsLabelEXT.html>"]

--- a/ash/src/extensions/ext/metal_surface.rs
+++ b/ash/src/extensions/ext/metal_surface.rs
@@ -34,16 +34,14 @@ impl MetalSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        let err_code = self.metal_surface_fn.create_metal_surface_ext(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut surface,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface),
-            _ => Err(err_code),
-        }
+        self.metal_surface_fn
+            .create_metal_surface_ext(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut surface,
+            )
+            .result_with_success(surface)
     }
 
     pub fn fp(&self) -> &vk::ExtMetalSurfaceFn {

--- a/ash/src/extensions/ext/tooling_info.rs
+++ b/ash/src/extensions/ext/tooling_info.rs
@@ -33,21 +33,15 @@ impl ToolingInfo {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::PhysicalDeviceToolPropertiesEXT>> {
         let mut count = 0;
-        let err_code = self
-            .tooling_info_fn
-            .get_physical_device_tool_properties_ext(physical_device, &mut count, ptr::null_mut());
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.tooling_info_fn
+            .get_physical_device_tool_properties_ext(physical_device, &mut count, ptr::null_mut())
+            .result()?;
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self
             .tooling_info_fn
             .get_physical_device_tool_properties_ext(physical_device, &mut count, v.as_mut_ptr());
         v.set_len(count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(v)
     }
 
     pub fn fp(&self) -> &vk::ExtToolingInfoFn {

--- a/ash/src/extensions/ext/tooling_info.rs
+++ b/ash/src/extensions/ext/tooling_info.rs
@@ -33,8 +33,12 @@ impl ToolingInfo {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::PhysicalDeviceToolPropertiesEXT>> {
         let mut count = 0;
-        self.tooling_info_fn
+        let err_code = self
+            .tooling_info_fn
             .get_physical_device_tool_properties_ext(physical_device, &mut count, ptr::null_mut());
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self
             .tooling_info_fn

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -34,16 +34,14 @@ impl AndroidSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        let err_code = self.android_surface_fn.create_android_surface_khr(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut surface,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface),
-            _ => Err(err_code),
-        }
+        self.android_surface_fn
+            .create_android_surface_khr(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut surface,
+            )
+            .result_with_success(surface)
     }
 
     pub fn fp(&self) -> &vk::KhrAndroidSurfaceFn {

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -33,11 +33,14 @@ impl Display {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::DisplayPropertiesKHR>> {
         let mut count = 0;
-        self.display_fn.get_physical_device_display_properties_khr(
+        let err_code = self.display_fn.get_physical_device_display_properties_khr(
             physical_device,
             &mut count,
             ptr::null_mut(),
         );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.display_fn.get_physical_device_display_properties_khr(
             physical_device,
@@ -57,12 +60,16 @@ impl Display {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::DisplayPlanePropertiesKHR>> {
         let mut count = 0;
-        self.display_fn
+        let err_code = self
+            .display_fn
             .get_physical_device_display_plane_properties_khr(
                 physical_device,
                 &mut count,
                 ptr::null_mut(),
             );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self
             .display_fn
@@ -85,12 +92,15 @@ impl Display {
         plane_index: u32,
     ) -> VkResult<Vec<vk::DisplayKHR>> {
         let mut count = 0;
-        self.display_fn.get_display_plane_supported_displays_khr(
+        let err_code = self.display_fn.get_display_plane_supported_displays_khr(
             physical_device,
             plane_index,
             &mut count,
             ptr::null_mut(),
         );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.display_fn.get_display_plane_supported_displays_khr(
             physical_device,
@@ -112,12 +122,15 @@ impl Display {
         display: vk::DisplayKHR,
     ) -> VkResult<Vec<vk::DisplayModePropertiesKHR>> {
         let mut count = 0;
-        self.display_fn.get_display_mode_properties_khr(
+        let err_code = self.display_fn.get_display_mode_properties_khr(
             physical_device,
             display,
             &mut count,
             ptr::null_mut(),
         );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.display_fn.get_display_mode_properties_khr(
             physical_device,

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -47,10 +47,7 @@ impl Display {
             v.as_mut_ptr(),
         );
         v.set_len(count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(v)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceDisplayPlanePropertiesKHR.html>"]
@@ -78,10 +75,7 @@ impl Display {
                 v.as_mut_ptr(),
             );
         v.set_len(count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(v)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDisplayPlaneSupportedDisplaysKHR.html>"]
@@ -107,10 +101,7 @@ impl Display {
             v.as_mut_ptr(),
         );
         v.set_len(count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(v)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDisplayModePropertiesKHR.html>"]
@@ -131,10 +122,7 @@ impl Display {
             v.as_mut_ptr(),
         );
         v.set_len(count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(v)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDisplayModeKHR.html>"]

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -154,17 +154,15 @@ impl Display {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DisplayModeKHR> {
         let mut display_mode = mem::MaybeUninit::zeroed();
-        let err_code = self.display_fn.create_display_mode_khr(
-            physical_device,
-            display,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            display_mode.as_mut_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(display_mode.assume_init()),
-            _ => Err(err_code),
-        }
+        self.display_fn
+            .create_display_mode_khr(
+                physical_device,
+                display,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                display_mode.as_mut_ptr(),
+            )
+            .result_with_success(display_mode.assume_init())
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDisplayPlaneCapabilitiesKHR.html>"]
@@ -175,16 +173,14 @@ impl Display {
         plane_index: u32,
     ) -> VkResult<vk::DisplayPlaneCapabilitiesKHR> {
         let mut display_plane_capabilities = mem::MaybeUninit::zeroed();
-        let err_code = self.display_fn.get_display_plane_capabilities_khr(
-            physical_device,
-            mode,
-            plane_index,
-            display_plane_capabilities.as_mut_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(display_plane_capabilities.assume_init()),
-            _ => Err(err_code),
-        }
+        self.display_fn
+            .get_display_plane_capabilities_khr(
+                physical_device,
+                mode,
+                plane_index,
+                display_plane_capabilities.as_mut_ptr(),
+            )
+            .result_with_success(display_plane_capabilities.assume_init())
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDisplayPlaneSurfaceKHR.html>"]
@@ -194,16 +190,14 @@ impl Display {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::zeroed();
-        let err_code = self.display_fn.create_display_plane_surface_khr(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            surface.as_mut_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface.assume_init()),
-            _ => Err(err_code),
-        }
+        self.display_fn
+            .create_display_plane_surface_khr(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                surface.as_mut_ptr(),
+            )
+            .result_with_success(surface.assume_init())
     }
 
     pub fn fp(&self) -> &vk::KhrDisplayFn {

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -33,14 +33,13 @@ impl Display {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::DisplayPropertiesKHR>> {
         let mut count = 0;
-        let err_code = self.display_fn.get_physical_device_display_properties_khr(
-            physical_device,
-            &mut count,
-            ptr::null_mut(),
-        );
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.display_fn
+            .get_physical_device_display_properties_khr(
+                physical_device,
+                &mut count,
+                ptr::null_mut(),
+            )
+            .result()?;
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.display_fn.get_physical_device_display_properties_khr(
             physical_device,
@@ -92,15 +91,14 @@ impl Display {
         plane_index: u32,
     ) -> VkResult<Vec<vk::DisplayKHR>> {
         let mut count = 0;
-        let err_code = self.display_fn.get_display_plane_supported_displays_khr(
-            physical_device,
-            plane_index,
-            &mut count,
-            ptr::null_mut(),
-        );
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.display_fn
+            .get_display_plane_supported_displays_khr(
+                physical_device,
+                plane_index,
+                &mut count,
+                ptr::null_mut(),
+            )
+            .result()?;
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.display_fn.get_display_plane_supported_displays_khr(
             physical_device,
@@ -122,15 +120,9 @@ impl Display {
         display: vk::DisplayKHR,
     ) -> VkResult<Vec<vk::DisplayModePropertiesKHR>> {
         let mut count = 0;
-        let err_code = self.display_fn.get_display_mode_properties_khr(
-            physical_device,
-            display,
-            &mut count,
-            ptr::null_mut(),
-        );
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.display_fn
+            .get_display_mode_properties_khr(physical_device, display, &mut count, ptr::null_mut())
+            .result()?;
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.display_fn.get_display_mode_properties_khr(
             physical_device,

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -42,10 +42,7 @@ impl DisplaySwapchain {
             swapchains.as_mut_ptr(),
         );
         swapchains.set_len(create_infos.len());
-        match err_code {
-            vk::Result::SUCCESS => Ok(swapchains),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(swapchains)
     }
 
     pub fn fp(&self) -> &vk::KhrDisplaySwapchainFn {

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -44,16 +44,9 @@ impl ExternalMemoryFd {
         fd: i32,
     ) -> VkResult<vk::MemoryFdPropertiesKHR> {
         let mut memory_fd_properties = mem::zeroed();
-        let err_code = self.external_memory_fd_fn.get_memory_fd_properties_khr(
-            self.handle,
-            handle_type,
-            fd,
-            &mut memory_fd_properties,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(memory_fd_properties),
-            _ => Err(err_code),
-        }
+        self.external_memory_fd_fn
+            .get_memory_fd_properties_khr(self.handle, handle_type, fd, &mut memory_fd_properties)
+            .result_with_success(memory_fd_properties)
     }
 
     pub fn fp(&self) -> &vk::KhrExternalMemoryFdFn {

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -28,13 +28,10 @@ impl ExternalMemoryFd {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryFdKHR.html>"]
     pub unsafe fn get_memory_fd(&self, create_info: &vk::MemoryGetFdInfoKHR) -> VkResult<i32> {
         let mut fd = -1;
-        let err_code =
-            self.external_memory_fd_fn
-                .get_memory_fd_khr(self.handle, create_info, &mut fd);
-        match err_code {
-            vk::Result::SUCCESS => Ok(fd),
-            _ => Err(err_code),
-        }
+
+        self.external_memory_fd_fn
+            .get_memory_fd_khr(self.handle, create_info, &mut fd)
+            .result_with_success(fd)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryFdPropertiesKHR.html>"]

--- a/ash/src/extensions/khr/pipeline_executable_properties.rs
+++ b/ash/src/extensions/khr/pipeline_executable_properties.rs
@@ -51,18 +51,14 @@ impl PipelineExecutableProperties {
             return Err(err_code);
         }
         let mut v: Vec<_> = vec![Default::default(); count as usize];
-        let err_code = self
-            .pipeline_executable_properties_fn
+        self.pipeline_executable_properties_fn
             .get_pipeline_executable_internal_representations_khr(
                 device,
                 executable_info,
                 &mut count,
                 v.as_mut_ptr(),
-            );
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+            )
+            .result_with_success(v)
     }
 
     #[doc = "https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineExecutablePropertiesKHR.html"]
@@ -84,18 +80,14 @@ impl PipelineExecutableProperties {
             return Err(err_code);
         }
         let mut v: Vec<_> = vec![Default::default(); count as usize];
-        let err_code = self
-            .pipeline_executable_properties_fn
+        self.pipeline_executable_properties_fn
             .get_pipeline_executable_properties_khr(
                 device,
                 pipeline_info,
                 &mut count,
                 v.as_mut_ptr(),
-            );
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+            )
+            .result_with_success(v)
     }
 
     #[doc = "https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineExecutableStatisticsKHR.html"]
@@ -117,18 +109,14 @@ impl PipelineExecutableProperties {
             return Err(err_code);
         }
         let mut v: Vec<_> = vec![Default::default(); count as usize];
-        let err_code = self
-            .pipeline_executable_properties_fn
+        self.pipeline_executable_properties_fn
             .get_pipeline_executable_statistics_khr(
                 device,
                 executable_info,
                 &mut count,
                 v.as_mut_ptr(),
-            );
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+            )
+            .result_with_success(v)
     }
 
     pub fn fp(&self) -> &vk::KhrPipelineExecutablePropertiesFn {

--- a/ash/src/extensions/khr/pipeline_executable_properties.rs
+++ b/ash/src/extensions/khr/pipeline_executable_properties.rs
@@ -39,13 +39,17 @@ impl PipelineExecutableProperties {
         executable_info: &vk::PipelineExecutableInfoKHR,
     ) -> VkResult<Vec<vk::PipelineExecutableInternalRepresentationKHR>> {
         let mut count = 0;
-        self.pipeline_executable_properties_fn
+        let err_code = self
+            .pipeline_executable_properties_fn
             .get_pipeline_executable_internal_representations_khr(
                 device,
                 executable_info,
                 &mut count,
                 ptr::null_mut(),
             );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v: Vec<_> = vec![Default::default(); count as usize];
         let err_code = self
             .pipeline_executable_properties_fn
@@ -68,13 +72,17 @@ impl PipelineExecutableProperties {
         pipeline_info: &vk::PipelineInfoKHR,
     ) -> VkResult<Vec<vk::PipelineExecutablePropertiesKHR>> {
         let mut count = 0;
-        self.pipeline_executable_properties_fn
+        let err_code = self
+            .pipeline_executable_properties_fn
             .get_pipeline_executable_properties_khr(
                 device,
                 pipeline_info,
                 &mut count,
                 ptr::null_mut(),
             );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v: Vec<_> = vec![Default::default(); count as usize];
         let err_code = self
             .pipeline_executable_properties_fn
@@ -97,13 +105,17 @@ impl PipelineExecutableProperties {
         executable_info: &vk::PipelineExecutableInfoKHR,
     ) -> VkResult<Vec<vk::PipelineExecutableStatisticKHR>> {
         let mut count = 0;
-        self.pipeline_executable_properties_fn
+        let err_code = self
+            .pipeline_executable_properties_fn
             .get_pipeline_executable_statistics_khr(
                 device,
                 executable_info,
                 &mut count,
                 ptr::null_mut(),
             );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v: Vec<_> = vec![Default::default(); count as usize];
         let err_code = self
             .pipeline_executable_properties_fn

--- a/ash/src/extensions/khr/ray_tracing.rs
+++ b/ash/src/extensions/khr/ray_tracing.rs
@@ -42,16 +42,14 @@ impl RayTracing {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::AccelerationStructureKHR> {
         let mut accel_struct = mem::zeroed();
-        let err_code = self.ray_tracing_fn.create_acceleration_structure_khr(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut accel_struct,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(accel_struct),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .create_acceleration_structure_khr(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut accel_struct,
+            )
+            .result_with_success(accel_struct)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyAccelerationStructureKHR.html>"]
@@ -158,18 +156,16 @@ impl RayTracing {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Vec<vk::Pipeline>> {
         let mut pipelines = vec![mem::zeroed(); create_info.len()];
-        let err_code = self.ray_tracing_fn.create_ray_tracing_pipelines_khr(
-            self.handle,
-            pipeline_cache,
-            create_info.len() as u32,
-            create_info.as_ptr(),
-            allocation_callbacks.as_raw_ptr(),
-            pipelines.as_mut_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(pipelines),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .create_ray_tracing_pipelines_khr(
+                self.handle,
+                pipeline_cache,
+                create_info.len() as u32,
+                create_info.as_ptr(),
+                allocation_callbacks.as_raw_ptr(),
+                pipelines.as_mut_ptr(),
+            )
+            .result_with_success(pipelines)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetRayTracingShaderGroupHandlesKHR.html>"]

--- a/ash/src/extensions/khr/ray_tracing.rs
+++ b/ash/src/extensions/khr/ray_tracing.rs
@@ -87,15 +87,13 @@ impl RayTracing {
         &self,
         bind_info: &[vk::BindAccelerationStructureMemoryInfoKHR],
     ) -> VkResult<()> {
-        let err_code = self.ray_tracing_fn.bind_acceleration_structure_memory_khr(
-            self.handle,
-            bind_info.len() as u32,
-            bind_info.as_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .bind_acceleration_structure_memory_khr(
+                self.handle,
+                bind_info.len() as u32,
+                bind_info.as_ptr(),
+            )
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBuildAccelerationStructureKHR.html>"]
@@ -182,8 +180,7 @@ impl RayTracing {
         group_count: u32,
         data: &mut [u8],
     ) -> VkResult<()> {
-        let err_code = self
-            .ray_tracing_fn
+        self.ray_tracing_fn
             .get_ray_tracing_shader_group_handles_khr(
                 self.handle,
                 pipeline,
@@ -191,11 +188,8 @@ impl RayTracing {
                 group_count,
                 data.len(),
                 data.as_mut_ptr() as *mut std::ffi::c_void,
-            );
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+            )
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetAccelerationStructureHandleKHR.html>"]
@@ -250,13 +244,9 @@ impl RayTracing {
         device: vk::Device,
         info: &vk::CopyAccelerationStructureToMemoryInfoKHR,
     ) -> VkResult<()> {
-        let err_code = self
-            .ray_tracing_fn
-            .copy_acceleration_structure_to_memory_khr(device, info);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .copy_acceleration_structure_to_memory_khr(device, info)
+            .into()
     }
 
     pub unsafe fn copy_memory_to_acceleration_structure(
@@ -264,14 +254,9 @@ impl RayTracing {
         device: vk::Device,
         info: &vk::CopyMemoryToAccelerationStructureInfoKHR,
     ) -> VkResult<()> {
-        let err_code = self
-            .ray_tracing_fn
-            .copy_memory_to_acceleration_structure_khr(device, info);
-
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .copy_memory_to_acceleration_structure_khr(device, info)
+            .into()
     }
 
     pub unsafe fn cmd_copy_acceleration_structure_to_memory(
@@ -345,14 +330,9 @@ impl RayTracing {
         device: vk::Device,
         version: &vk::AccelerationStructureVersionKHR,
     ) -> VkResult<()> {
-        let err_code = self
-            .ray_tracing_fn
-            .get_device_acceleration_structure_compatibility_khr(device, version);
-
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .get_device_acceleration_structure_compatibility_khr(device, version)
+            .into()
     }
 
     pub fn name() -> &'static CStr {

--- a/ash/src/extensions/khr/ray_tracing.rs
+++ b/ash/src/extensions/khr/ray_tracing.rs
@@ -174,18 +174,21 @@ impl RayTracing {
         pipeline: vk::Pipeline,
         first_group: u32,
         group_count: u32,
-        data: &mut [u8],
-    ) -> VkResult<()> {
-        self.ray_tracing_fn
+        data_size: usize,
+    ) -> VkResult<Vec<u8>> {
+        let mut data = Vec::<u8>::with_capacity(data_size);
+        let err_code = self
+            .ray_tracing_fn
             .get_ray_tracing_shader_group_handles_khr(
                 self.handle,
                 pipeline,
                 first_group,
                 group_count,
-                data.len(),
+                data_size,
                 data.as_mut_ptr() as *mut std::ffi::c_void,
-            )
-            .into()
+            );
+        data.set_len(data_size);
+        err_code.result_with_success(data)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetAccelerationStructureHandleKHR.html>"]

--- a/ash/src/extensions/khr/ray_tracing.rs
+++ b/ash/src/extensions/khr/ray_tracing.rs
@@ -283,8 +283,7 @@ impl RayTracing {
     ) -> VkResult<Vec<u8>> {
         let mut data: Vec<u8> = Vec::with_capacity(data_size);
 
-        let err_code = self
-            .ray_tracing_fn
+        self.ray_tracing_fn
             .get_ray_tracing_capture_replay_shader_group_handles_khr(
                 device,
                 pipeline,
@@ -292,12 +291,8 @@ impl RayTracing {
                 group_count,
                 data_size,
                 data.as_mut_ptr() as *mut _,
-            );
-
-        match err_code {
-            vk::Result::SUCCESS => Ok(data),
-            _ => Err(err_code),
-        }
+            )
+            .result_with_success(data)
     }
 
     pub unsafe fn cmd_trace_rays_indirect(

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -56,13 +56,17 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
         let mut count = 0;
-        self.surface_fn
+        let err_code = self
+            .surface_fn
             .get_physical_device_surface_present_modes_khr(
                 physical_device,
                 surface,
                 &mut count,
                 ptr::null_mut(),
             );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self
             .surface_fn
@@ -106,12 +110,15 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::SurfaceFormatKHR>> {
         let mut count = 0;
-        self.surface_fn.get_physical_device_surface_formats_khr(
+        let err_code = self.surface_fn.get_physical_device_surface_formats_khr(
             physical_device,
             surface,
             &mut count,
             ptr::null_mut(),
         );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.surface_fn.get_physical_device_surface_formats_khr(
             physical_device,

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -48,17 +48,14 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
         let mut count = 0;
-        let err_code = self
-            .surface_fn
+        self.surface_fn
             .get_physical_device_surface_present_modes_khr(
                 physical_device,
                 surface,
                 &mut count,
                 ptr::null_mut(),
-            );
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+            )
+            .result()?;
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self
             .surface_fn
@@ -69,10 +66,7 @@ impl Surface {
                 v.as_mut_ptr(),
             );
         v.set_len(count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(v)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceCapabilitiesKHR.html>"]
@@ -82,17 +76,13 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<vk::SurfaceCapabilitiesKHR> {
         let mut surface_capabilities = mem::zeroed();
-        let err_code = self
-            .surface_fn
+        self.surface_fn
             .get_physical_device_surface_capabilities_khr(
                 physical_device,
                 surface,
                 &mut surface_capabilities,
-            );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface_capabilities),
-            _ => Err(err_code),
-        }
+            )
+            .result_with_success(surface_capabilities)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html>"]
@@ -118,10 +108,7 @@ impl Surface {
             v.as_mut_ptr(),
         );
         v.set_len(count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(v)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroySurfaceKHR.html>"]

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -102,15 +102,14 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::SurfaceFormatKHR>> {
         let mut count = 0;
-        let err_code = self.surface_fn.get_physical_device_surface_formats_khr(
-            physical_device,
-            surface,
-            &mut count,
-            ptr::null_mut(),
-        );
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.surface_fn
+            .get_physical_device_surface_formats_khr(
+                physical_device,
+                surface,
+                &mut count,
+                ptr::null_mut(),
+            )
+            .result()?;
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.surface_fn.get_physical_device_surface_formats_khr(
             physical_device,

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -36,17 +36,9 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<bool> {
         let mut b = mem::zeroed();
-        let err_code = self.surface_fn.get_physical_device_surface_support_khr(
-            physical_device,
-            queue_index,
-            surface,
-            &mut b,
-        );
-
-        match err_code {
-            vk::Result::SUCCESS => Ok(b > 0),
-            _ => Err(err_code),
-        }
+        self.surface_fn
+            .get_physical_device_surface_support_khr(physical_device, queue_index, surface, &mut b)
+            .result_with_success(b > 0)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfacePresentModesKHR.html>"]

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -116,10 +116,7 @@ impl Swapchain {
             v.as_mut_ptr(),
         );
         v.set_len(count as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(v),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(v)
     }
 
     pub fn fp(&self) -> &vk::KhrSwapchainFn {

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -73,16 +73,14 @@ impl Swapchain {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SwapchainKHR> {
         let mut swapchain = mem::zeroed();
-        let err_code = self.swapchain_fn.create_swapchain_khr(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut swapchain,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(swapchain),
-            _ => Err(err_code),
-        }
+        self.swapchain_fn
+            .create_swapchain_khr(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut swapchain,
+            )
+            .result_with_success(swapchain)
     }
 
     /// On success, returns whether the swapchain is suboptimal for the surface.

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -106,12 +106,15 @@ impl Swapchain {
         swapchain: vk::SwapchainKHR,
     ) -> VkResult<Vec<vk::Image>> {
         let mut count = 0;
-        self.swapchain_fn.get_swapchain_images_khr(
+        let err_code = self.swapchain_fn.get_swapchain_images_khr(
             self.handle,
             swapchain,
             &mut count,
             ptr::null_mut(),
         );
+        if err_code != vk::Result::SUCCESS {
+            return Err(err_code);
+        }
 
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.swapchain_fn.get_swapchain_images_khr(

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -104,15 +104,9 @@ impl Swapchain {
         swapchain: vk::SwapchainKHR,
     ) -> VkResult<Vec<vk::Image>> {
         let mut count = 0;
-        let err_code = self.swapchain_fn.get_swapchain_images_khr(
-            self.handle,
-            swapchain,
-            &mut count,
-            ptr::null_mut(),
-        );
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.swapchain_fn
+            .get_swapchain_images_khr(self.handle, swapchain, &mut count, ptr::null_mut())
+            .result()?;
 
         let mut v = Vec::with_capacity(count as usize);
         let err_code = self.swapchain_fn.get_swapchain_images_khr(

--- a/ash/src/extensions/khr/timeline_semaphore.rs
+++ b/ash/src/extensions/khr/timeline_semaphore.rs
@@ -34,14 +34,9 @@ impl TimelineSemaphore {
         semaphore: vk::Semaphore,
     ) -> VkResult<u64> {
         let mut value = 0;
-        let err_code = self
-            .timeline_semaphore_fn
-            .get_semaphore_counter_value_khr(device, semaphore, &mut value);
-
-        match err_code {
-            vk::Result::SUCCESS => Ok(value),
-            _ => Err(err_code),
-        }
+        self.timeline_semaphore_fn
+            .get_semaphore_counter_value_khr(device, semaphore, &mut value)
+            .result_with_success(value)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkWaitSemaphores.html>"]

--- a/ash/src/extensions/khr/timeline_semaphore.rs
+++ b/ash/src/extensions/khr/timeline_semaphore.rs
@@ -51,14 +51,9 @@ impl TimelineSemaphore {
         wait_info: &vk::SemaphoreWaitInfo,
         timeout: u64,
     ) -> VkResult<()> {
-        let err_code = self
-            .timeline_semaphore_fn
-            .wait_semaphores_khr(device, wait_info, timeout);
-
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.timeline_semaphore_fn
+            .wait_semaphores_khr(device, wait_info, timeout)
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSignalSemaphore.html>"]
@@ -67,14 +62,9 @@ impl TimelineSemaphore {
         device: vk::Device,
         signal_info: &vk::SemaphoreSignalInfo,
     ) -> VkResult<()> {
-        let err_code = self
-            .timeline_semaphore_fn
-            .signal_semaphore_khr(device, signal_info);
-
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.timeline_semaphore_fn
+            .signal_semaphore_khr(device, signal_info)
+            .into()
     }
 
     pub fn fp(&self) -> &vk::KhrTimelineSemaphoreFn {

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -34,16 +34,14 @@ impl WaylandSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        let err_code = self.wayland_surface_fn.create_wayland_surface_khr(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut surface,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface),
-            _ => Err(err_code),
-        }
+        self.wayland_surface_fn
+            .create_wayland_surface_khr(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut surface,
+            )
+            .result_with_success(surface)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceWaylandPresentationSupportKHR.html"]

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -34,16 +34,14 @@ impl Win32Surface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        let err_code = self.win32_surface_fn.create_win32_surface_khr(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut surface,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface),
-            _ => Err(err_code),
-        }
+        self.win32_surface_fn
+            .create_win32_surface_khr(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut surface,
+            )
+            .result_with_success(surface)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceWin32PresentationSupportKHR.html"]

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -34,16 +34,14 @@ impl XcbSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        let err_code = self.xcb_surface_fn.create_xcb_surface_khr(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut surface,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface),
-            _ => Err(err_code),
-        }
+        self.xcb_surface_fn
+            .create_xcb_surface_khr(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut surface,
+            )
+            .result_with_success(surface)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceXcbPresentationSupportKHR.html"]

--- a/ash/src/extensions/khr/xlib_surface.rs
+++ b/ash/src/extensions/khr/xlib_surface.rs
@@ -34,16 +34,14 @@ impl XlibSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        let err_code = self.xlib_surface_fn.create_xlib_surface_khr(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut surface,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface),
-            _ => Err(err_code),
-        }
+        self.xlib_surface_fn
+            .create_xlib_surface_khr(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut surface,
+            )
+            .result_with_success(surface)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceXlibPresentationSupportKHR.html"]

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -34,16 +34,14 @@ impl IOSSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        let err_code = self.ios_surface_fn.create_ios_surface_mvk(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut surface,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface),
-            _ => Err(err_code),
-        }
+        self.ios_surface_fn
+            .create_ios_surface_mvk(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut surface,
+            )
+            .result_with_success(surface)
     }
 
     pub fn fp(&self) -> &vk::MvkIosSurfaceFn {

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -34,16 +34,14 @@ impl MacOSSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        let err_code = self.macos_surface_fn.create_mac_os_surface_mvk(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut surface,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(surface),
-            _ => Err(err_code),
-        }
+        self.macos_surface_fn
+            .create_mac_os_surface_mvk(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut surface,
+            )
+            .result_with_success(surface)
     }
 
     pub fn fp(&self) -> &vk::MvkMacosSurfaceFn {

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -42,16 +42,14 @@ impl RayTracing {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::AccelerationStructureNV> {
         let mut accel_struct = mem::zeroed();
-        let err_code = self.ray_tracing_fn.create_acceleration_structure_nv(
-            self.handle,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut accel_struct,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(accel_struct),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .create_acceleration_structure_nv(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut accel_struct,
+            )
+            .result_with_success(accel_struct)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyAccelerationStructureNV.html>"]
@@ -180,18 +178,16 @@ impl RayTracing {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Vec<vk::Pipeline>> {
         let mut pipelines = vec![mem::zeroed(); create_info.len()];
-        let err_code = self.ray_tracing_fn.create_ray_tracing_pipelines_nv(
-            self.handle,
-            pipeline_cache,
-            create_info.len() as u32,
-            create_info.as_ptr(),
-            allocation_callbacks.as_raw_ptr(),
-            pipelines.as_mut_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(pipelines),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .create_ray_tracing_pipelines_nv(
+                self.handle,
+                pipeline_cache,
+                create_info.len() as u32,
+                create_info.as_ptr(),
+                allocation_callbacks.as_raw_ptr(),
+                pipelines.as_mut_ptr(),
+            )
+            .result_with_success(pipelines)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetRayTracingShaderGroupHandlesNV.html>"]
@@ -221,16 +217,14 @@ impl RayTracing {
     ) -> VkResult<u64> {
         let mut handle: u64 = 0;
         let handle_ptr: *mut u64 = &mut handle;
-        let err_code = self.ray_tracing_fn.get_acceleration_structure_handle_nv(
-            self.handle,
-            accel_struct,
-            std::mem::size_of::<u64>(),
-            handle_ptr as *mut std::ffi::c_void,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(handle),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .get_acceleration_structure_handle_nv(
+                self.handle,
+                accel_struct,
+                std::mem::size_of::<u64>(),
+                handle_ptr as *mut std::ffi::c_void,
+            )
+            .result_with_success(handle)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdWriteAccelerationStructuresPropertiesNV.html>"]

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -87,15 +87,13 @@ impl RayTracing {
         &self,
         bind_info: &[vk::BindAccelerationStructureMemoryInfoNV],
     ) -> VkResult<()> {
-        let err_code = self.ray_tracing_fn.bind_acceleration_structure_memory_nv(
-            self.handle,
-            bind_info.len() as u32,
-            bind_info.as_ptr(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .bind_acceleration_structure_memory_nv(
+                self.handle,
+                bind_info.len() as u32,
+                bind_info.as_ptr(),
+            )
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBuildAccelerationStructureNV.html>"]
@@ -204,18 +202,16 @@ impl RayTracing {
         group_count: u32,
         data: &mut [u8],
     ) -> VkResult<()> {
-        let err_code = self.ray_tracing_fn.get_ray_tracing_shader_group_handles_nv(
-            self.handle,
-            pipeline,
-            first_group,
-            group_count,
-            data.len(),
-            data.as_mut_ptr() as *mut std::ffi::c_void,
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .get_ray_tracing_shader_group_handles_nv(
+                self.handle,
+                pipeline,
+                first_group,
+                group_count,
+                data.len(),
+                data.as_mut_ptr() as *mut std::ffi::c_void,
+            )
+            .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetAccelerationStructureHandleNV.html>"]
@@ -259,13 +255,9 @@ impl RayTracing {
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCompileDeferredNV.html>"]
     pub unsafe fn compile_deferred(&self, pipeline: vk::Pipeline, shader: u32) -> VkResult<()> {
-        let err_code = self
-            .ray_tracing_fn
-            .compile_deferred_nv(self.handle, pipeline, shader);
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
-        }
+        self.ray_tracing_fn
+            .compile_deferred_nv(self.handle, pipeline, shader)
+            .into()
     }
 
     pub fn name() -> &'static CStr {

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -94,15 +94,9 @@ pub trait InstanceV1_1: InstanceV1_0 {
 
     unsafe fn enumerate_physical_device_groups_len(&self) -> VkResult<usize> {
         let mut group_count = mem::zeroed();
-        let err_code = self.fp_v1_1().enumerate_physical_device_groups(
-            self.handle(),
-            &mut group_count,
-            ptr::null_mut(),
-        );
-        match err_code {
-            vk::Result::SUCCESS => Ok(group_count as usize),
-            _ => Err(err_code),
-        }
+        self.fp_v1_1()
+            .enumerate_physical_device_groups(self.handle(), &mut group_count, ptr::null_mut())
+            .result_with_success(group_count as usize)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumeratePhysicalDeviceGroups.html>"]

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -51,15 +51,14 @@ impl InstanceV1_0 for Instance {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Self::Device> {
         let mut device: vk::Device = mem::zeroed();
-        let err_code = self.fp_v1_0().create_device(
-            physical_device,
-            create_info,
-            allocation_callbacks.as_raw_ptr(),
-            &mut device,
-        );
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.fp_v1_0()
+            .create_device(
+                physical_device,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut device,
+            )
+            .result()?;
         Ok(Device::load(&self.instance_fn_1_0, device))
     }
     fn handle(&self) -> vk::Instance {
@@ -407,12 +406,9 @@ pub trait InstanceV1_0 {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumeratePhysicalDevices.html>"]
     unsafe fn enumerate_physical_devices(&self) -> VkResult<Vec<vk::PhysicalDevice>> {
         let mut num = mem::zeroed();
-        let err_code =
-            self.fp_v1_0()
-                .enumerate_physical_devices(self.handle(), &mut num, ptr::null_mut());
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.fp_v1_0()
+            .enumerate_physical_devices(self.handle(), &mut num, ptr::null_mut())
+            .result()?;
         let mut physical_devices = Vec::<vk::PhysicalDevice>::with_capacity(num as usize);
         let err_code = self.fp_v1_0().enumerate_physical_devices(
             self.handle(),
@@ -432,15 +428,9 @@ pub trait InstanceV1_0 {
         device: vk::PhysicalDevice,
     ) -> Result<Vec<vk::ExtensionProperties>, vk::Result> {
         let mut num = 0;
-        let err_code = self.fp_v1_0().enumerate_device_extension_properties(
-            device,
-            ptr::null(),
-            &mut num,
-            ptr::null_mut(),
-        );
-        if err_code != vk::Result::SUCCESS {
-            return Err(err_code);
-        }
+        self.fp_v1_0()
+            .enumerate_device_extension_properties(device, ptr::null(), &mut num, ptr::null_mut())
+            .result()?;
         let mut data = Vec::with_capacity(num as usize);
         let err_code = self.fp_v1_0().enumerate_device_extension_properties(
             device,

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -49,7 +49,7 @@ impl InstanceV1_0 for Instance {
         physical_device: vk::PhysicalDevice,
         create_info: &vk::DeviceCreateInfo,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
-    ) -> Result<Self::Device, vk::Result> {
+    ) -> VkResult<Self::Device> {
         let mut device: vk::Device = mem::zeroed();
         let err_code = self.fp_v1_0().create_device(
             physical_device,
@@ -109,16 +109,9 @@ pub trait InstanceV1_1: InstanceV1_0 {
     ) -> VkResult<()> {
         unsafe {
             let mut group_count = out.len() as u32;
-            let err_code = self.fp_v1_1().enumerate_physical_device_groups(
-                self.handle(),
-                &mut group_count,
-                out.as_mut_ptr(),
-            );
-            if err_code == vk::Result::SUCCESS {
-                Ok(())
-            } else {
-                Err(err_code)
-            }
+            self.fp_v1_1()
+                .enumerate_physical_device_groups(self.handle(), &mut group_count, out.as_mut_ptr())
+                .into()
         }
     }
 
@@ -160,16 +153,13 @@ pub trait InstanceV1_1: InstanceV1_0 {
         format_info: &vk::PhysicalDeviceImageFormatInfo2,
         image_format_prop: &mut vk::ImageFormatProperties2,
     ) -> VkResult<()> {
-        let err_code = self.fp_v1_1().get_physical_device_image_format_properties2(
-            physical_device,
-            format_info,
-            image_format_prop,
-        );
-        if err_code == vk::Result::SUCCESS {
-            Ok(())
-        } else {
-            Err(err_code)
-        }
+        self.fp_v1_1()
+            .get_physical_device_image_format_properties2(
+                physical_device,
+                format_info,
+                image_format_prop,
+            )
+            .into()
     }
 
     unsafe fn get_physical_device_queue_family_properties2_len(

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -290,7 +290,7 @@ pub trait InstanceV1_0 {
         physical_device: vk::PhysicalDevice,
         create_info: &vk::DeviceCreateInfo,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
-    ) -> Result<Self::Device, vk::Result>;
+    ) -> VkResult<Self::Device>;
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceProcAddr.html>"]
     unsafe fn get_device_proc_addr(
@@ -333,20 +333,17 @@ pub trait InstanceV1_0 {
         flags: vk::ImageCreateFlags,
     ) -> VkResult<vk::ImageFormatProperties> {
         let mut image_format_prop = mem::zeroed();
-        let err_code = self.fp_v1_0().get_physical_device_image_format_properties(
-            physical_device,
-            format,
-            typ,
-            tiling,
-            usage,
-            flags,
-            &mut image_format_prop,
-        );
-        if err_code == vk::Result::SUCCESS {
-            Ok(image_format_prop)
-        } else {
-            Err(err_code)
-        }
+        self.fp_v1_0()
+            .get_physical_device_image_format_properties(
+                physical_device,
+                format,
+                typ,
+                tiling,
+                usage,
+                flags,
+                &mut image_format_prop,
+            )
+            .result_with_success(image_format_prop)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceMemoryProperties.html>"]
@@ -416,17 +413,14 @@ pub trait InstanceV1_0 {
             physical_devices.as_mut_ptr(),
         );
         physical_devices.set_len(num as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(physical_devices),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(physical_devices)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateDeviceExtensionProperties.html>"]
     unsafe fn enumerate_device_extension_properties(
         &self,
         device: vk::PhysicalDevice,
-    ) -> Result<Vec<vk::ExtensionProperties>, vk::Result> {
+    ) -> VkResult<Vec<vk::ExtensionProperties>> {
         let mut num = 0;
         self.fp_v1_0()
             .enumerate_device_extension_properties(device, ptr::null(), &mut num, ptr::null_mut())
@@ -439,9 +433,6 @@ pub trait InstanceV1_0 {
             data.as_mut_ptr(),
         );
         data.set_len(num as usize);
-        match err_code {
-            vk::Result::SUCCESS => Ok(data),
-            _ => Err(err_code),
-        }
+        err_code.result_with_success(data)
     }
 }

--- a/ash/src/prelude.rs
+++ b/ash/src/prelude.rs
@@ -1,2 +1,11 @@
 use crate::vk;
 pub type VkResult<T> = Result<T, vk::Result>;
+
+impl From<vk::Result> for VkResult<()> {
+    fn from(err_code: vk::Result) -> Self {
+        match err_code {
+            vk::Result::SUCCESS => Ok(()),
+            _ => Err(err_code),
+        }
+    }
+}

--- a/ash/src/prelude.rs
+++ b/ash/src/prelude.rs
@@ -3,9 +3,19 @@ pub type VkResult<T> = Result<T, vk::Result>;
 
 impl From<vk::Result> for VkResult<()> {
     fn from(err_code: vk::Result) -> Self {
-        match err_code {
-            vk::Result::SUCCESS => Ok(()),
-            _ => Err(err_code),
+        err_code.result()
+    }
+}
+
+impl vk::Result {
+    pub fn result(self) -> VkResult<()> {
+        self.result_with_success(())
+    }
+
+    pub fn result_with_success<T>(self, v: T) -> VkResult<T> {
+        match self {
+            vk::Result::SUCCESS => Ok(v),
+            _ => Err(self),
         }
     }
 }

--- a/ash/src/vk.rs
+++ b/ash/src/vk.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::too_many_arguments, clippy::cognitive_complexity, clippy::wrong_self_convention)]
+#![allow(
+    clippy::too_many_arguments,
+    clippy::cognitive_complexity,
+    clippy::wrong_self_convention
+)]
 #[macro_use]
 mod macros;
 pub use macros::*;

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -1543,16 +1543,16 @@ impl<'a> DeviceCreateInfoBuilder<'a> {
         mut self,
         enabled_layer_names: &'a [*const c_char],
     ) -> DeviceCreateInfoBuilder<'a> {
-        self.inner.pp_enabled_layer_names = enabled_layer_names.as_ptr();
         self.inner.enabled_layer_count = enabled_layer_names.len() as _;
+        self.inner.pp_enabled_layer_names = enabled_layer_names.as_ptr();
         self
     }
     pub fn enabled_extension_names(
         mut self,
         enabled_extension_names: &'a [*const c_char],
     ) -> DeviceCreateInfoBuilder<'a> {
-        self.inner.pp_enabled_extension_names = enabled_extension_names.as_ptr();
         self.inner.enabled_extension_count = enabled_extension_names.len() as _;
+        self.inner.pp_enabled_extension_names = enabled_extension_names.as_ptr();
         self
     }
     pub fn enabled_features(
@@ -1654,16 +1654,16 @@ impl<'a> InstanceCreateInfoBuilder<'a> {
         mut self,
         enabled_layer_names: &'a [*const c_char],
     ) -> InstanceCreateInfoBuilder<'a> {
-        self.inner.pp_enabled_layer_names = enabled_layer_names.as_ptr();
         self.inner.enabled_layer_count = enabled_layer_names.len() as _;
+        self.inner.pp_enabled_layer_names = enabled_layer_names.as_ptr();
         self
     }
     pub fn enabled_extension_names(
         mut self,
         enabled_extension_names: &'a [*const c_char],
     ) -> InstanceCreateInfoBuilder<'a> {
-        self.inner.pp_enabled_extension_names = enabled_extension_names.as_ptr();
         self.inner.enabled_extension_count = enabled_extension_names.len() as _;
+        self.inner.pp_enabled_extension_names = enabled_extension_names.as_ptr();
         self
     }
     #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -20906,7 +20906,7 @@ impl<'a> IOSSurfaceCreateInfoMVKBuilder<'a> {
         self.inner.flags = flags;
         self
     }
-    pub fn view(mut self, view: &'a c_void) -> IOSSurfaceCreateInfoMVKBuilder<'a> {
+    pub fn view(mut self, view: *const c_void) -> IOSSurfaceCreateInfoMVKBuilder<'a> {
         self.inner.p_view = view;
         self
     }
@@ -20986,7 +20986,7 @@ impl<'a> MacOSSurfaceCreateInfoMVKBuilder<'a> {
         self.inner.flags = flags;
         self
     }
-    pub fn view(mut self, view: &'a c_void) -> MacOSSurfaceCreateInfoMVKBuilder<'a> {
+    pub fn view(mut self, view: *const c_void) -> MacOSSurfaceCreateInfoMVKBuilder<'a> {
         self.inner.p_view = view;
         self
     }
@@ -21066,7 +21066,7 @@ impl<'a> MetalSurfaceCreateInfoEXTBuilder<'a> {
         self.inner.flags = flags;
         self
     }
-    pub fn layer(mut self, layer: &'a CAMetalLayer) -> MetalSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn layer(mut self, layer: *const CAMetalLayer) -> MetalSurfaceCreateInfoEXTBuilder<'a> {
         self.inner.p_layer = layer;
         self
     }
@@ -26273,7 +26273,7 @@ impl<'a> ::std::ops::DerefMut for NativeBufferANDROIDBuilder<'a> {
     }
 }
 impl<'a> NativeBufferANDROIDBuilder<'a> {
-    pub fn handle(mut self, handle: &'a c_void) -> NativeBufferANDROIDBuilder<'a> {
+    pub fn handle(mut self, handle: *const c_void) -> NativeBufferANDROIDBuilder<'a> {
         self.inner.handle = handle;
         self
     }
@@ -33208,7 +33208,7 @@ impl<'a> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
     }
     pub fn shader_group_capture_replay_handle(
         mut self,
-        shader_group_capture_replay_handle: &'a c_void,
+        shader_group_capture_replay_handle: *const c_void,
     ) -> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
         self.inner.p_shader_group_capture_replay_handle = shader_group_capture_replay_handle;
         self
@@ -37491,7 +37491,7 @@ impl<'a> ::std::ops::DerefMut for PipelineCreationFeedbackCreateInfoEXTBuilder<'
 impl<'a> PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
     pub fn pipeline_creation_feedback(
         mut self,
-        pipeline_creation_feedback: *mut PipelineCreationFeedbackEXT,
+        pipeline_creation_feedback: &'a mut PipelineCreationFeedbackEXT,
     ) -> PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
         self.inner.p_pipeline_creation_feedback = pipeline_creation_feedback;
         self

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -10527,8 +10527,11 @@ impl<'a> DisplayPropertiesKHRBuilder<'a> {
         self.inner.display = display;
         self
     }
-    pub fn display_name(mut self, display_name: *const c_char) -> DisplayPropertiesKHRBuilder<'a> {
-        self.inner.display_name = display_name;
+    pub fn display_name(
+        mut self,
+        display_name: &'a ::std::ffi::CStr,
+    ) -> DisplayPropertiesKHRBuilder<'a> {
+        self.inner.display_name = display_name.as_ptr();
         self
     }
     pub fn physical_dimensions(
@@ -26270,7 +26273,7 @@ impl<'a> ::std::ops::DerefMut for NativeBufferANDROIDBuilder<'a> {
     }
 }
 impl<'a> NativeBufferANDROIDBuilder<'a> {
-    pub fn handle(mut self, handle: *const c_void) -> NativeBufferANDROIDBuilder<'a> {
+    pub fn handle(mut self, handle: &'a c_void) -> NativeBufferANDROIDBuilder<'a> {
         self.inner.handle = handle;
         self
     }
@@ -44090,9 +44093,9 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureVersionKHRBuilder<'a> {
 impl<'a> AccelerationStructureVersionKHRBuilder<'a> {
     pub fn version_data(
         mut self,
-        version_data: *const u8,
+        version_data: &'a [u8; 2 * UUID_SIZE],
     ) -> AccelerationStructureVersionKHRBuilder<'a> {
-        self.inner.version_data = version_data;
+        self.inner.version_data = version_data.as_ptr();
         self
     }
     #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]

--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -869,6 +869,7 @@ impl SubpassContents {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkResult.html>"]
+#[must_use]
 pub struct Result(pub(crate) i32);
 impl Result {
     pub const fn from_raw(x: i32) -> Self {

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 vk-parse = { version = "0.5.0", features = ["vkxml-convert"] }
 vkxml = "0.3"
-nom = "4.0"
+nom = "6.0"
 heck = "0.3"
 proc-macro2 = "0.2"
 itertools = "0.9"

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -619,26 +619,15 @@ pub trait ToTokens {
 }
 impl ToTokens for vkxml::ReferenceType {
     fn to_tokens(&self, is_const: bool) -> Tokens {
-        let ptr_name = match self {
-            vkxml::ReferenceType::Pointer => {
-                if is_const {
-                    "*const"
-                } else {
-                    "*mut"
-                }
-            }
-            vkxml::ReferenceType::PointerToPointer => "*mut *mut",
-            vkxml::ReferenceType::PointerToConstPointer => {
-                if is_const {
-                    "*const *const"
-                } else {
-                    "*mut *const"
-                }
-            }
+        let r = if is_const {
+            quote!(*const)
+        } else {
+            quote!(*mut)
         };
-        let ident = Term::intern(ptr_name);
-        quote! {
-            #ident
+        match self {
+            vkxml::ReferenceType::Pointer => quote!(#r),
+            vkxml::ReferenceType::PointerToPointer => quote!(#r *mut),
+            vkxml::ReferenceType::PointerToConstPointer => quote!(#r *const),
         }
     }
 }

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -2278,8 +2278,8 @@ pub fn generate_const_debugs(const_values: &BTreeMap<Ident, Vec<ConstantMatchInf
         #(#impls)*
     }
 }
-pub fn generate_aliases_of_types<'a>(
-    types: &'a vk_parse::Types,
+pub fn generate_aliases_of_types(
+    types: &vk_parse::Types,
     ty_cache: &mut HashSet<Ident, impl BuildHasher>,
 ) -> Tokens {
     let aliases = types

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1780,9 +1780,11 @@ pub fn derive_setters(
 
                         let mutable = if field.is_const { quote!() } else { quote!(mut) };
 
-                        let set_size_stmt = if array_size.contains("ename:") {
-                            // Should contain the same minus `ename:`-prefixed identifiers
-                            let array_size = field.c_size.as_ref().unwrap();
+                        // Apply some heuristics to determine whether the size is an expression.
+                        // If so, this is a pointer to a piece of memory with statically known size.
+                        let set_size_stmt = if array_size.contains("ename:") || array_size.contains('*') {
+                            // c_size should contain the same minus `ename:`-prefixed identifiers
+                            let array_size = field.c_size.as_ref().unwrap_or(array_size);
                             let c_size = convert_c_expression(array_size);
                             let inner_type = field.inner_type_tokens();
 

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1747,7 +1747,7 @@ pub fn derive_setters(
         }
 
         // TODO: Improve in future when https://github.com/rust-lang/rust/issues/53667 is merged id:6
-        if param_ident_string.starts_with("p_") || param_ident_string.starts_with("pp_") {
+        if field.reference.is_some() {
             if field.basetype == "char" && matches!(field.reference, Some(vkxml::ReferenceType::Pointer)) {
                 assert!(field.null_terminate);
                 assert_eq!(field.size, None);

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -359,7 +359,7 @@ pub fn platform_specific_types() -> Tokens {
         // typedefs are only here so that the code compiles for now
         #[allow(non_camel_case_types)]
         pub type SECURITY_ATTRIBUTES = ();
-        // Opage types
+        // Opaque types
         pub type ANativeWindow = c_void;
         pub type AHardwareBuffer = c_void;
         pub type CAMetalLayer = c_void;
@@ -603,7 +603,7 @@ impl CommandExt for vkxml::Command {
 }
 
 pub trait FieldExt {
-    /// Returns the name of the paramter that doesn't clash with Rusts resevered
+    /// Returns the name of the parameter that doesn't clash with Rusts reserved
     /// keywords
     fn param_ident(&self) -> Ident;
 
@@ -1438,9 +1438,9 @@ pub fn derive_default(_struct: &vkxml::Struct) -> Option<Tokens> {
     // also doesn't mark them as pointers
     let handles = ["LPCWSTR", "HANDLE", "HINSTANCE", "HWND", "HMONITOR"];
     let contains_ptr = members.clone().any(|field| field.reference.is_some());
-    let contains_strucutre_type = members.clone().any(is_structure_type);
+    let contains_structure_type = members.clone().any(is_structure_type);
     let contains_static_array = members.clone().any(is_static_array);
-    if !(contains_ptr || contains_strucutre_type || contains_static_array) {
+    if !(contains_ptr || contains_structure_type || contains_static_array) {
         return None;
     };
     let default_fields = members.clone().map(|field| {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1171,12 +1171,17 @@ pub fn generate_define(define: &vkxml::Define) -> Tokens {
     }
 }
 pub fn generate_typedef(typedef: &vkxml::Typedef) -> Tokens {
-    let typedef_name = to_type_tokens(&typedef.name, None);
-    let typedef_ty = to_type_tokens(&typedef.basetype, None);
-    let khronos_link = khronos_link(&typedef.name);
-    quote! {
-        #[doc = #khronos_link]
-        pub type #typedef_name = #typedef_ty;
+    if typedef.basetype.is_empty() {
+        // Ignore forward declarations
+        quote! {}
+    } else {
+        let typedef_name = to_type_tokens(&typedef.name, None);
+        let typedef_ty = to_type_tokens(&typedef.basetype, None);
+        let khronos_link = khronos_link(&typedef.name);
+        quote! {
+            #[doc = #khronos_link]
+            pub type #typedef_name = #typedef_ty;
+        }
     }
 }
 pub fn generate_bitmask(

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1346,24 +1346,24 @@ pub fn generate_enum<'a>(
             EnumType::Bitflags(q)
         }
     } else {
+        let (struct_attribute, special_quote) = match _name.as_str() {
+            //"StructureType" => generate_structure_type(&_name, _enum, create_info_constants),
+            "Result" => (quote!(#[must_use]), generate_result(ident, _enum)),
+            _ => (quote!(), quote!()),
+        };
+
         let impl_block = bitflags_impl_block(ident, &_enum.name, &constants);
         let enum_quote = quote! {
             #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
             #[repr(transparent)]
             #[doc = #khronos_link]
+            #struct_attribute
             pub struct #ident(pub(crate) i32);
             impl #ident {
                 pub const fn from_raw(x: i32) -> Self { #ident(x) }
                 pub const fn as_raw(self) -> i32 { self.0 }
             }
             #impl_block
-        };
-        let special_quote = match _name.as_str() {
-            //"StructureType" => generate_structure_type(&_name, _enum, create_info_constants),
-            "Result" => generate_result(ident, _enum),
-            _ => {
-                quote! {}
-            }
         };
         let q = quote! {
             #enum_quote

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -78,7 +78,7 @@ named!(inverse_number<&str, (CType, String)>,
 );
 
 named!(cfloat<&str, f32>,
-    terminated!(nom::float, char!('f'))
+    terminated!(nom::number::complete::float, char!('f'))
 );
 
 fn khronos_link<S: Display>(name: &S) -> Literal {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -673,7 +673,7 @@ fn to_type_tokens(type_name: &str, reference: Option<&vkxml::ReferenceType>) -> 
 fn map_identifier_to_rust(term: Term) -> Term {
     match term.as_str() {
         "VK_MAKE_VERSION" => Term::intern("crate::vk::make_version"),
-        s => Term::intern(&constant_name(&s)),
+        s => Term::intern(constant_name(s)),
     }
 }
 
@@ -761,8 +761,7 @@ impl FieldExt for vkxml::Field {
                     .expect("Should have size");
                 // Make sure we also rename the constant, that is
                 // used inside the static array
-                let size = constant_name(size);
-                let size = Term::intern(&size);
+                let size = Term::intern(constant_name(size));
                 // arrays in c are always passed as a pointer
                 if is_ffi_param {
                     quote!(&[#ty; #size])
@@ -1200,7 +1199,7 @@ pub fn generate_extension<'a>(
 }
 pub fn generate_define(define: &vkxml::Define) -> Tokens {
     let name = constant_name(&define.name);
-    let ident = Ident::from(name.as_str());
+    let ident = Ident::from(name);
     let deprecated = define
         .comment
         .as_ref()
@@ -2203,8 +2202,9 @@ pub fn generate_feature<'a>(
         #device
     }
 }
-pub fn constant_name(name: &str) -> String {
-    name.replace("VK_", "")
+
+pub fn constant_name(name: &str) -> &str {
+    name.strip_prefix("VK_").unwrap_or(name)
 }
 
 pub fn generate_constant<'a>(
@@ -2214,7 +2214,7 @@ pub fn generate_constant<'a>(
     cache.insert(constant.name.as_str());
     let c = Constant::from_constant(constant);
     let name = constant_name(&constant.name);
-    let ident = Ident::from(name.as_str());
+    let ident = Ident::from(name);
     let ty = if name == "TRUE" || name == "FALSE" {
         CType::Bool32
     } else {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -664,11 +664,6 @@ fn name_to_tokens(type_name: &str) -> Ident {
     let new_name = new_name.replace("FlagBits", "Flags");
     Ident::from(new_name.as_str())
 }
-fn to_type_tokens(type_name: &str, reference: Option<&vkxml::ReferenceType>) -> Tokens {
-    let new_name = name_to_tokens(type_name);
-    let ptr_name = reference.map(|r| r.to_tokens(false));
-    quote! {#ptr_name #new_name}
-}
 
 fn map_identifier_to_rust(term: Term) -> Term {
     match term.as_str() {
@@ -1226,8 +1221,8 @@ pub fn generate_typedef(typedef: &vkxml::Typedef) -> Tokens {
         // Ignore forward declarations
         quote! {}
     } else {
-        let typedef_name = to_type_tokens(&typedef.name, None);
-        let typedef_ty = to_type_tokens(&typedef.basetype, None);
+        let typedef_name = name_to_tokens(&typedef.name);
+        let typedef_ty = name_to_tokens(&typedef.basetype);
         let khronos_link = khronos_link(&typedef.name);
         quote! {
             #[doc = #khronos_link]
@@ -2059,7 +2054,7 @@ fn generate_funcptr(fnptr: &vkxml::FunctionPointer) -> Tokens {
 }
 
 fn generate_union(union: &vkxml::Union) -> Tokens {
-    let name = to_type_tokens(&union.name, None);
+    let name = name_to_tokens(&union.name);
     let fields = union.elements.iter().map(|field| {
         let name = field.param_ident();
         let ty = field.type_tokens(false);

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1689,6 +1689,8 @@ pub fn derive_setters(
         // TODO: Improve in future when https://github.com/rust-lang/rust/issues/53667 is merged id:6
         if param_ident_string.starts_with("p_") || param_ident_string.starts_with("pp_") {
             if param_ty_string == "*const c_char" {
+                assert!(field.null_terminate);
+                assert_eq!(field.size, None);
                 return Some(quote!{
                         pub fn #param_ident_short(mut self, #param_ident_short: &'a ::std::ffi::CStr) -> #name_builder<'a> {
                             self.inner.#param_ident = #param_ident_short.as_ptr();

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1974,7 +1974,7 @@ pub fn generate_struct(
 }
 
 pub fn generate_handle(handle: &vkxml::Handle) -> Option<Tokens> {
-    if handle.name == "" {
+    if handle.name.is_empty() {
         return None;
     }
     let khronos_link = khronos_link(&handle.name);

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -6,7 +6,6 @@ use quote::*;
 use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
 use itertools::Itertools;
 use proc_macro2::{Literal, Term, TokenNode, TokenStream, TokenTree};
-use quote::Tokens;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Display;
 use std::hash::BuildHasher;


### PR DESCRIPTION
Hi Maik,

Apologies for this massive PR. It's some upfront cleanup work that came up while working on `ash`, in particular around `Result` types and error handling.

I can only recommend to review the changes per commit to get around the bulk of it easily. While this aims to make the code ever so slightly better it results in lots of noise, let me know if any commit (hash) is not worth taking in and I'll gladly remove it again.

To highlight the changes:
- Make sure all results are checked with `#[must_use]` on `vk::Result`;
- Conversion helpers from `vk::Result` to `Result<T, vk::Result>`;
- Clippy fixes;
- Simplifications in the generator around array code handling;
- Parsing some C expressions into `TokenStream` and replacing identifiers with their Rust counterpart. This is going to be more relevant in the future;
- A breaking API change: 19552b241d34a483c9fdc03e04fef20788bf67b1. I don't think this one is worth taking in now that I look at it again.

Thanks!