### PR TITLE
Add missing doc link in AccelerationStructure

### DIFF
--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -266,6 +266,7 @@ impl AccelerationStructure {
             );
     }
 
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceAccelerationStructureCompatibilityKHR.html>"]
     pub unsafe fn get_device_acceleration_structure_compatibility(
         &self,
         device: vk::Device,


### PR DESCRIPTION
I was working with `ash::extensions::khr::AccelerationStructure` and noticed one method was missing the docs link!

Cheers!