### PR TITLE
Add `VK_KHR_deferred_host_operations` extension support.

### DIFF
--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -1,0 +1,82 @@
+#![allow(dead_code)]
+use crate::prelude::*;
+use crate::version::{DeviceV1_0, InstanceV1_0};
+use crate::vk;
+use crate::RawPtr;
+use std::mem;
+
+#[derive(Clone)]
+pub struct DeferredHostOperations {
+    handle: vk::Device,
+    deferred_host_operations_fn: vk::KhrDeferredHostOperationsFn,
+}
+
+impl DeferredHostOperations {
+    pub fn new<I: InstanceV1_0, D: DeviceV1_0>(instance: &I, device: &D) -> Self {
+        let deferred_host_operations_fn = vk::KhrDeferredHostOperationsFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        });
+        Self {
+            handle: device.handle(),
+            deferred_host_operations_fn,
+        }
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDeferredOperationKHR.html>"]
+    pub unsafe fn create_deferred_operation(
+        &self,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+    ) -> VkResult<vk::DeferredOperationKHR> {
+        let mut operation = mem::zeroed();
+        self.deferred_host_operations_fn
+            .create_deferred_operation_khr(
+                self.handle,
+                allocation_callbacks.as_raw_ptr(),
+                &mut operation,
+            )
+            .result_with_success(operation)
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDeferredOperationJoinKHR.html>"]
+    pub unsafe fn deferred_operation_join(
+        &self,
+        operation: vk::DeferredOperationKHR,
+    ) -> VkResult<()> {
+        self.deferred_host_operations_fn
+            .deferred_operation_join_khr(self.handle, operation)
+            .result()
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDeferredOperationKHR.html>"]
+    pub unsafe fn destroy_deferred_operation(
+        &self,
+        operation: vk::DeferredOperationKHR,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+    ) {
+        self.deferred_host_operations_fn
+            .destroy_deferred_operation_khr(
+                self.handle,
+                operation,
+                allocation_callbacks.as_raw_ptr(),
+            );
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeferredOperationMaxConcurrencyKHR.html>"]
+    pub unsafe fn get_deferred_operation_max_concurrency(
+        &self,
+        operation: vk::DeferredOperationKHR,
+    ) -> u32 {
+        self.deferred_host_operations_fn
+            .get_deferred_operation_max_concurrency_khr(self.handle, operation)
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeferredOperationResultKHR.html>"]
+    pub unsafe fn get_deferred_operation_result(
+        &self,
+        operation: vk::DeferredOperationKHR,
+    ) -> VkResult<()> {
+        self.deferred_host_operations_fn
+            .get_deferred_operation_result_khr(self.handle, operation)
+            .result()
+    }
+}

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -79,4 +79,16 @@ impl DeferredHostOperations {
             .get_deferred_operation_result_khr(self.handle, operation)
             .result()
     }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrDeferredHostOperationsFn::name()
+    }
+
+    pub fn fp(&self) -> &vk::KhrDeferredHostOperationsFn {
+        &self.deferred_host_operations_fn
+    }
+
+    pub fn device(&self) -> vk::Device {
+        self.handle
+    }
 }

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -3,6 +3,7 @@ use crate::prelude::*;
 use crate::version::{DeviceV1_0, InstanceV1_0};
 use crate::vk;
 use crate::RawPtr;
+use std::ffi::CStr;
 use std::mem;
 
 #[derive(Clone)]

--- a/ash/src/extensions/khr/mod.rs
+++ b/ash/src/extensions/khr/mod.rs
@@ -1,5 +1,6 @@
 pub use self::acceleration_structure::AccelerationStructure;
 pub use self::android_surface::AndroidSurface;
+pub use self::deferred_host_operations::DeferredHostOperations;
 pub use self::display::Display;
 pub use self::display_swapchain::DisplaySwapchain;
 pub use self::draw_indirect_count::DrawIndirectCount;
@@ -18,6 +19,7 @@ pub use self::xlib_surface::XlibSurface;
 
 mod acceleration_structure;
 mod android_surface;
+mod deferred_host_operations;
 mod display;
 mod display_swapchain;
 mod draw_indirect_count;


### PR DESCRIPTION
The [`VK_KHR_deferred_host_operations` extension](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_deferred_host_operations.html) is used by `VK_KHR_acceleration_structure` to request deferral for host operations and thus can be useful for optimizing ray tracing programs.

I tried to match the style of other extensions, but please let me know if I should make any changes!