### PR TITLE
Pass raw pointers in FFI, generalize generator type handling

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -1448,22 +1448,16 @@ impl Device {
         &self,
         query_pool: vk::QueryPool,
         first_query: u32,
-        query_count: u32,
         data: &mut [T],
         flags: vk::QueryResultFlags,
     ) -> VkResult<()> {
-        let data_length = query_count as usize;
-        assert!(
-            data_length <= data.len(),
-            "query_count was higher than the length of the slice"
-        );
-        let data_size = mem::size_of::<T>() * data_length;
+        let data_size = mem::size_of::<T>() * data.len();
         self.device_fn_1_0
             .get_query_pool_results(
                 self.handle(),
                 query_pool,
                 first_query,
-                query_count,
+                data.len() as u32,
                 data_size,
                 data.as_mut_ptr() as *mut _,
                 mem::size_of::<T>() as _,

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -42501,7 +42501,7 @@ impl<'a> AccelerationStructureDeviceAddressInfoKHRBuilder<'a> {
 pub struct AccelerationStructureVersionInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub p_version_data: *const u8,
+    pub p_version_data: *const [u8; 2 * UUID_SIZE],
 }
 impl ::std::default::Default for AccelerationStructureVersionInfoKHR {
     fn default() -> AccelerationStructureVersionInfoKHR {
@@ -42538,8 +42538,8 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureVersionInfoKHRBuilder<'a>
     }
 }
 impl<'a> AccelerationStructureVersionInfoKHRBuilder<'a> {
-    pub fn version_data(mut self, version_data: &'a [u8; 2 * UUID_SIZE]) -> Self {
-        self.inner.p_version_data = version_data.as_ptr();
+    pub fn version_data(mut self, version_data: *const [u8; 2 * UUID_SIZE]) -> Self {
+        self.inner.p_version_data = version_data;
         self
     }
     #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -42538,8 +42538,8 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureVersionInfoKHRBuilder<'a>
     }
 }
 impl<'a> AccelerationStructureVersionInfoKHRBuilder<'a> {
-    pub fn version_data(mut self, version_data: *const [u8; 2 * UUID_SIZE]) -> Self {
-        self.inner.p_version_data = version_data;
+    pub fn version_data(mut self, version_data: &'a [u8; 2 * UUID_SIZE]) -> Self {
+        self.inner.p_version_data = version_data as *const _;
         self
     }
     #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -862,14 +862,14 @@ impl FieldExt for vkxml::Field {
     fn type_tokens(&self, is_ffi_param: bool) -> TokenStream {
         let (ty, reference) = self.inner_type_tokens();
 
-        let ty = match self.array {
+        let reference = match self.array {
             Some(vkxml::ArrayType::Static) if is_ffi_param => {
-                // Unused and untested, disallow this for now.
+                // Needs `increment_indirection`:
                 assert!(reference.is_none());
                 // arrays in c are always passed as a pointer
-                quote!(*const #ty)
+                Some(vkxml::ReferenceType::Pointer)
             }
-            _ => ty,
+            _ => reference,
         };
 
         let pointer = reference.as_ref().map(|r| r.to_tokens(self.is_const));

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -604,7 +604,7 @@ pub trait CommandExt {
 
 impl CommandExt for vkxml::Command {
     fn command_ident(&self) -> Ident {
-        format_ident!("{}", &self.name[2..].to_snake_case())
+        format_ident!("{}", self.name.strip_prefix("vk").unwrap().to_snake_case())
     }
 
     fn function_type(&self) -> FunctionType {
@@ -856,8 +856,11 @@ fn generate_function_pointers<'a>(
         }
     };
     let function_name = |name: &str| -> Ident {
-        let fn_name = function_name_raw(&name);
-        format_ident!("{}", fn_name[2..].to_snake_case().as_str())
+        let fn_name = function_name_raw(name);
+        format_ident!(
+            "{}",
+            fn_name.strip_prefix("vk").unwrap().to_snake_case().as_str()
+        )
     };
     let names: Vec<_> = commands
         .iter()
@@ -1117,8 +1120,10 @@ pub fn generate_extension_commands<'a>(
             }
         });
 
-    let name = format!("{}Fn", extension_name.to_camel_case());
-    let ident = format_ident!("{}", &name[2..]);
+    let ident = format_ident!(
+        "{}Fn",
+        extension_name.to_camel_case().strip_prefix("Vk").unwrap()
+    );
     let fp = generate_function_pointers(ident.clone(), &commands, &aliases, fn_cache);
     let byte_name = format!("{}\0", extension_name);
 
@@ -1244,7 +1249,7 @@ pub fn generate_bitmask(
         return None;
     }
 
-    let name = &bitmask.name[2..];
+    let name = bitmask.name.strip_prefix("Vk").unwrap();
     let ident = format_ident!("{}", name);
     if !bitflags_cache.insert(ident.clone()) {
         return None;
@@ -2091,7 +2096,7 @@ pub fn generate_handle(handle: &vkxml::Handle) -> Option<TokenStream> {
     let khronos_link = khronos_link(&handle.name);
     let tokens = match handle.ty {
         vkxml::HandleType::Dispatch => {
-            let name = &handle.name[2..];
+            let name = handle.name.strip_prefix("Vk").unwrap();
             let ty = format_ident!("{}", name.to_shouty_snake_case());
             let name = format_ident!("{}", name);
             quote! {
@@ -2099,7 +2104,7 @@ pub fn generate_handle(handle: &vkxml::Handle) -> Option<TokenStream> {
             }
         }
         vkxml::HandleType::NoDispatch => {
-            let name = &handle.name[2..];
+            let name = handle.name.strip_prefix("Vk").unwrap();
             let ty = format_ident!("{}", name.to_shouty_snake_case());
             let name = format_ident!("{}", name);
             quote! {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -920,7 +920,7 @@ fn generate_function_pointers<'a>(
         .iter()
         .map(|inner_params| {
             let inner_params_iter = inner_params.iter().map(|&(ref param_name, ref param_ty)| {
-                let unused_name = format_ident!("{}", format!("_{}", param_name).as_str());
+                let unused_name = format_ident!("_{}", param_name);
                 quote! {#unused_name: #param_ty}
             });
             quote! {
@@ -932,7 +932,7 @@ fn generate_function_pointers<'a>(
 
     let pfn_names: Vec<_> = commands_pfn
         .iter()
-        .map(|cmd| format_ident!("{}", format!("PFN_{}", cmd.name.as_str())))
+        .map(|cmd| format_ident!("PFN_{}", cmd.name))
         .collect();
     let pfn_names_ref = &pfn_names;
 
@@ -1331,7 +1331,7 @@ pub fn variant_ident(enum_name: &str, variant_name: &str) -> Ident {
         .map(|c| c.is_digit(10))
         .unwrap_or(false);
     if is_digit {
-        format_ident!("{}", format!("TYPE_{}", new_variant_name).as_str())
+        format_ident!("TYPE_{}", new_variant_name)
     } else {
         format_ident!("{}", new_variant_name)
     }
@@ -2257,19 +2257,19 @@ pub fn generate_feature<'a>(
         quote! {}
     };
     let entry = generate_function_pointers(
-        format_ident!("{}", format!("EntryFnV{}", version).as_str()),
+        format_ident!("EntryFnV{}", version),
         &entry_commands,
         &HashMap::new(),
         fn_cache,
     );
     let instance = generate_function_pointers(
-        format_ident!("{}", format!("InstanceFnV{}", version).as_str()),
+        format_ident!("InstanceFnV{}", version),
         &instance_commands,
         &HashMap::new(),
         fn_cache,
     );
     let device = generate_function_pointers(
-        format_ident!("{}", format!("DeviceFnV{}", version).as_str()),
+        format_ident!("DeviceFnV{}", version),
         &device_commands,
         &HashMap::new(),
         fn_cache,


### PR DESCRIPTION
Similar to #351 this change was already well in the works when a shift to a second generator was announced. Submitting a PR here just to not loose the concepts, even if it might end up not getting reviewed/merged.

The main goal of this PR is to unify handling of types between unsafe (FFI) types and their "safe" counterpart (builder functions), and remove some case-specific broken code introduced in previous PRs again. Vkxml arrays versus references are pretty troublesome to deal with, here's hoping that can be dealt with in the pure vk_parse implementation of the new generator :)

Finally, FFI signatures are adjusted to use `*const` instead of `&` which represents a "fat" pointer in certain scenarios (16-bytes).