### PR TITLE
Use raw pointers to static-sized arrays in FFI signatures

### DIFF
--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -18507,7 +18507,7 @@ pub type PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR = extern "system" fn(
 pub type PFN_vkCmdSetFragmentShadingRateKHR = extern "system" fn(
     command_buffer: CommandBuffer,
     p_fragment_size: *const Extent2D,
-    combiner_ops: &[FragmentShadingRateCombinerOpKHR; 2],
+    combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
 ) -> c_void;
 pub struct KhrFragmentShadingRateFn {
     pub get_physical_device_fragment_shading_rates_khr: extern "system" fn(
@@ -18518,7 +18518,7 @@ pub struct KhrFragmentShadingRateFn {
     pub cmd_set_fragment_shading_rate_khr: extern "system" fn(
         command_buffer: CommandBuffer,
         p_fragment_size: *const Extent2D,
-        combiner_ops: &[FragmentShadingRateCombinerOpKHR; 2],
+        combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
     ) -> c_void,
 }
 unsafe impl Send for KhrFragmentShadingRateFn {}
@@ -18562,7 +18562,7 @@ impl KhrFragmentShadingRateFn {
                 extern "system" fn cmd_set_fragment_shading_rate_khr(
                     _command_buffer: CommandBuffer,
                     _p_fragment_size: *const Extent2D,
-                    _combiner_ops: &[FragmentShadingRateCombinerOpKHR; 2],
+                    _combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
                 ) -> c_void {
                     panic!(concat!(
                         "Unable to load ",
@@ -18598,7 +18598,7 @@ impl KhrFragmentShadingRateFn {
         &self,
         command_buffer: CommandBuffer,
         p_fragment_size: *const Extent2D,
-        combiner_ops: &[FragmentShadingRateCombinerOpKHR; 2],
+        combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
     ) -> c_void {
         (self.cmd_set_fragment_shading_rate_khr)(command_buffer, p_fragment_size, combiner_ops)
     }
@@ -23477,13 +23477,13 @@ impl NvFragmentShadingRateEnumsFn {
 pub type PFN_vkCmdSetFragmentShadingRateEnumNV = extern "system" fn(
     command_buffer: CommandBuffer,
     shading_rate: FragmentShadingRateNV,
-    combiner_ops: &[FragmentShadingRateCombinerOpKHR; 2],
+    combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
 ) -> c_void;
 pub struct NvFragmentShadingRateEnumsFn {
     pub cmd_set_fragment_shading_rate_enum_nv: extern "system" fn(
         command_buffer: CommandBuffer,
         shading_rate: FragmentShadingRateNV,
-        combiner_ops: &[FragmentShadingRateCombinerOpKHR; 2],
+        combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
     ) -> c_void,
 }
 unsafe impl Send for NvFragmentShadingRateEnumsFn {}
@@ -23505,7 +23505,7 @@ impl NvFragmentShadingRateEnumsFn {
                 extern "system" fn cmd_set_fragment_shading_rate_enum_nv(
                     _command_buffer: CommandBuffer,
                     _shading_rate: FragmentShadingRateNV,
-                    _combiner_ops: &[FragmentShadingRateCombinerOpKHR; 2],
+                    _combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
                 ) -> c_void {
                     panic!(concat!(
                         "Unable to load ",
@@ -23528,7 +23528,7 @@ impl NvFragmentShadingRateEnumsFn {
         &self,
         command_buffer: CommandBuffer,
         shading_rate: FragmentShadingRateNV,
-        combiner_ops: &[FragmentShadingRateCombinerOpKHR; 2],
+        combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
     ) -> c_void {
         (self.cmd_set_fragment_shading_rate_enum_nv)(command_buffer, shading_rate, combiner_ops)
     }

--- a/ash/src/vk/features.rs
+++ b/ash/src/vk/features.rs
@@ -1268,7 +1268,7 @@ pub type PFN_vkCmdSetDepthBias = extern "system" fn(
 ) -> c_void;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetBlendConstants =
-    extern "system" fn(command_buffer: CommandBuffer, blend_constants: &[f32; 4]) -> c_void;
+    extern "system" fn(command_buffer: CommandBuffer, blend_constants: *const [f32; 4]) -> c_void;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetDepthBounds = extern "system" fn(
     command_buffer: CommandBuffer,
@@ -1972,8 +1972,10 @@ pub struct DeviceFnV1_0 {
         depth_bias_clamp: f32,
         depth_bias_slope_factor: f32,
     ) -> c_void,
-    pub cmd_set_blend_constants:
-        extern "system" fn(command_buffer: CommandBuffer, blend_constants: &[f32; 4]) -> c_void,
+    pub cmd_set_blend_constants: extern "system" fn(
+        command_buffer: CommandBuffer,
+        blend_constants: *const [f32; 4],
+    ) -> c_void,
     pub cmd_set_depth_bounds: extern "system" fn(
         command_buffer: CommandBuffer,
         min_depth_bounds: f32,
@@ -3841,7 +3843,7 @@ impl DeviceFnV1_0 {
             cmd_set_blend_constants: unsafe {
                 extern "system" fn cmd_set_blend_constants(
                     _command_buffer: CommandBuffer,
-                    _blend_constants: &[f32; 4],
+                    _blend_constants: *const [f32; 4],
                 ) -> c_void {
                     panic!(concat!(
                         "Unable to load ",
@@ -5410,7 +5412,7 @@ impl DeviceFnV1_0 {
     pub unsafe fn cmd_set_blend_constants(
         &self,
         command_buffer: CommandBuffer,
-        blend_constants: &[f32; 4],
+        blend_constants: *const [f32; 4],
     ) -> c_void {
         (self.cmd_set_blend_constants)(command_buffer, blend_constants)
     }

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -773,7 +773,7 @@ impl FieldExt for vkxml::Field {
                 let size: TokenStream = constant_name(size).parse().unwrap();
                 // arrays in c are always passed as a pointer
                 if is_ffi_param {
-                    quote!(&[#ty; #size])
+                    quote!(*const [#ty; #size])
                 } else {
                     quote!([#ty; #size])
                 }


### PR DESCRIPTION
In rust references to DSTs (Dynamically Sized Types) like slices and
trait objects are 16-bytes instead of 8 (leaking into the next parameter
of a function call). The static-sized array generated here has its size
known beforehand and will not suffer from this issue [1], but might be
confusing for future readers/authors: convert it to a raw pointer just
to be safe.

[1]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=88acb9736455f7262ecf4af2077f3a59

---

See https://github.com/MaikKlein/ash/pull/352#issuecomment-753475214 as well :)
