### PR TITLE
Fix safe CmdBuildAccelerationStructuresIndirect signature and add extra length validation

### DIFF
--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -82,7 +82,7 @@ impl AccelerationStructure {
         let build_range_infos = build_range_infos
             .iter()
             .map(|slice| slice.as_ptr())
-            .collect::<Vec<*const _>>();
+            .collect::<Vec<_>>();
 
         self.acceleration_structure_fn
             .cmd_build_acceleration_structures_khr(
@@ -100,7 +100,7 @@ impl AccelerationStructure {
         infos: &[vk::AccelerationStructureBuildGeometryInfoKHR],
         indirect_device_addresses: &[vk::DeviceAddress],
         indirect_strides: &[u32],
-        max_primitive_counts: &[&u32],
+        max_primitive_counts: &[&[u32]],
     ) {
         assert_eq!(infos.len(), indirect_device_addresses.len());
         assert_eq!(infos.len(), indirect_strides.len());
@@ -108,7 +108,7 @@ impl AccelerationStructure {
 
         let max_primitive_counts = max_primitive_counts
             .iter()
-            .map(|cnt| *cnt as *const _)
+            .map(|cnt| cnt.as_ptr())
             .collect::<Vec<_>>();
 
         self.acceleration_structure_fn
@@ -134,7 +134,7 @@ impl AccelerationStructure {
         let build_range_infos = build_range_infos
             .iter()
             .map(|slice| slice.as_ptr())
-            .collect::<Vec<*const _>>();
+            .collect::<Vec<_>>();
 
         self.acceleration_structure_fn
             .build_acceleration_structures_khr(

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -42,18 +42,14 @@ impl AccelerationStructure {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::AccelerationStructureKHR> {
         let mut accel_struct = mem::zeroed();
-        let err_code = self
-            .acceleration_structure_fn
+        self.acceleration_structure_fn
             .create_acceleration_structure_khr(
                 self.handle,
                 create_info,
                 allocation_callbacks.as_raw_ptr(),
                 &mut accel_struct,
-            );
-        match err_code {
-            vk::Result::SUCCESS => Ok(accel_struct),
-            _ => Err(err_code),
-        }
+            )
+            .result_with_success(accel_struct)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyAccelerationStructureKHR.html>"]
@@ -81,7 +77,11 @@ impl AccelerationStructure {
 
         let build_range_infos = build_range_infos
             .iter()
-            .map(|slice| slice.as_ptr())
+            .zip(infos.iter())
+            .map(|(range_info, info)| {
+                assert_eq!(range_info.len(), info.geometry_count as usize);
+                range_info.as_ptr()
+            })
             .collect::<Vec<_>>();
 
         self.acceleration_structure_fn
@@ -108,7 +108,11 @@ impl AccelerationStructure {
 
         let max_primitive_counts = max_primitive_counts
             .iter()
-            .map(|cnt| cnt.as_ptr())
+            .zip(infos.iter())
+            .map(|(cnt, info)| {
+                assert_eq!(cnt.len(), info.geometry_count as usize);
+                cnt.as_ptr()
+            })
             .collect::<Vec<_>>();
 
         self.acceleration_structure_fn
@@ -133,7 +137,11 @@ impl AccelerationStructure {
 
         let build_range_infos = build_range_infos
             .iter()
-            .map(|slice| slice.as_ptr())
+            .zip(infos.iter())
+            .map(|(range_info, info)| {
+                assert_eq!(range_info.len(), info.geometry_count as usize);
+                range_info.as_ptr()
+            })
             .collect::<Vec<_>>();
 
         self.acceleration_structure_fn


### PR DESCRIPTION
Came across the original PR introducing headers 1.2.162 with the official KHR RayTracing spec, and found a slightly related comment (https://github.com/MaikKlein/ash/pull/341#discussion_r541967759) about unfortunate casts that could have been safe transmutes because references to PODs have the same size as raw pointers. Turns out these shouldn't be normal pointers but slices (fat pointers) :anguished: 

In addition this PR introduces extra asserts: we're exposing a "safe" (still marked `unsafe` though, just type reinterpretation) layer that should at the very least validate the length of this and other nested arrays.