### PR TITLE
ash: Update libloading from 0.6 to 0.7

### DIFF
--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/ash"
 edition = "2018"
 
 [dependencies]
-libloading = { version = "0.6.1", optional = true }
+libloading = { version = "0.7", optional = true }
 
 [features]
 default = ["libloading"]

--- a/ash/src/entry_libloading.rs
+++ b/ash/src/entry_libloading.rs
@@ -42,6 +42,10 @@ impl Error for LoadingError {
 impl EntryCustom<Arc<Library>> {
     /// Load default Vulkan library for the current platform
     ///
+    /// # Safety
+    /// `dlopen`ing native libraries is inherently unsafe. The safety guidelines
+    /// for [`Library::new`] and [`Library::get`] apply here.
+    ///
     /// ```rust,no_run
     /// use ash::{vk, Entry, version::EntryV1_0};
     /// # fn main() -> Result<(), Box<std::error::Error>> {
@@ -57,15 +61,19 @@ impl EntryCustom<Arc<Library>> {
     /// let instance = unsafe { entry.create_instance(&create_info, None)? };
     /// # Ok(()) }
     /// ```
-    pub fn new() -> Result<Entry, LoadingError> {
+    pub unsafe fn new() -> Result<Entry, LoadingError> {
         Self::with_library(&LIB_PATH)
     }
 
     /// Load Vulkan library at `path`
-    pub fn with_library<P: AsRef<OsStr>>(path: &P) -> Result<Entry, LoadingError> {
+    ///
+    /// # Safety
+    /// `dlopen`ing native libraries is inherently unsafe. The safety guidelines
+    /// for [`Library::new`] and [`Library::get`] apply here.
+    pub unsafe fn with_library(path: &impl AsRef<OsStr>) -> Result<Entry, LoadingError> {
         let lib = Library::new(path).map_err(LoadingError).map(Arc::new)?;
 
-        Ok(Self::new_custom(lib, |vk_lib, name| unsafe {
+        Ok(Self::new_custom(lib, |vk_lib, name| {
             vk_lib
                 .get(name.to_bytes_with_nul())
                 .map(|symbol| *symbol)


### PR DESCRIPTION
This new version marks `Library::new` as unsafe, because loading a library invokes the libraries' entrypoint which may or may not have certain preconditions and perform unsafe/undefined operations, just like any other native function loaded through `libloading`.

---

Not sure if we should wrap this in `unsafe` or mark the entire `fn with_library` as unsafe, just like all other Vulkan functions?
