### PR TITLE
Remove device argument from acceleration structure and RT pipeline fns

### DIFF
--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -125,7 +125,6 @@ impl AccelerationStructure {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBuildAccelerationStructuresKHR.html>"]
     pub unsafe fn build_acceleration_structures(
         &self,
-        device: vk::Device,
         deferred_operation: vk::DeferredOperationKHR,
         infos: &[vk::AccelerationStructureBuildGeometryInfoKHR],
         build_range_infos: &[&[vk::AccelerationStructureBuildRangeInfoKHR]],
@@ -139,7 +138,7 @@ impl AccelerationStructure {
 
         self.acceleration_structure_fn
             .build_acceleration_structures_khr(
-                device,
+                self.handle,
                 deferred_operation,
                 infos.len() as _,
                 infos.as_ptr(),
@@ -151,43 +150,47 @@ impl AccelerationStructure {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCopyAccelerationStructureKHR.html>"]
     pub unsafe fn copy_acceleration_structure(
         &self,
-        device: vk::Device,
         deferred_operation: vk::DeferredOperationKHR,
         info: &vk::CopyAccelerationStructureInfoKHR,
     ) -> VkResult<()> {
         self.acceleration_structure_fn
-            .copy_acceleration_structure_khr(device, deferred_operation, info as *const _)
+            .copy_acceleration_structure_khr(self.handle, deferred_operation, info as *const _)
             .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCopyAccelerationStructureToMemoryKHR.html>"]
     pub unsafe fn copy_acceleration_structure_to_memory(
         &self,
-        device: vk::Device,
         deferred_operation: vk::DeferredOperationKHR,
         info: &vk::CopyAccelerationStructureToMemoryInfoKHR,
     ) -> VkResult<()> {
         self.acceleration_structure_fn
-            .copy_acceleration_structure_to_memory_khr(device, deferred_operation, info as *const _)
+            .copy_acceleration_structure_to_memory_khr(
+                self.handle,
+                deferred_operation,
+                info as *const _,
+            )
             .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCopyMemoryToAccelerationStructureKHR.html>"]
     pub unsafe fn copy_memory_to_acceleration_structure(
         &self,
-        device: vk::Device,
         deferred_operation: vk::DeferredOperationKHR,
         info: &vk::CopyMemoryToAccelerationStructureInfoKHR,
     ) -> VkResult<()> {
         self.acceleration_structure_fn
-            .copy_memory_to_acceleration_structure_khr(device, deferred_operation, info as *const _)
+            .copy_memory_to_acceleration_structure_khr(
+                self.handle,
+                deferred_operation,
+                info as *const _,
+            )
             .into()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkWriteAccelerationStructuresPropertiesKHR.html>"]
     pub unsafe fn write_acceleration_structures_properties(
         &self,
-        device: vk::Device,
         acceleration_structures: &[vk::AccelerationStructureKHR],
         query_type: vk::QueryType,
         data: &mut [u8],
@@ -195,7 +198,7 @@ impl AccelerationStructure {
     ) -> VkResult<()> {
         self.acceleration_structure_fn
             .write_acceleration_structures_properties_khr(
-                device,
+                self.handle,
                 acceleration_structures.len() as _,
                 acceleration_structures.as_ptr(),
                 query_type,
@@ -239,11 +242,10 @@ impl AccelerationStructure {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetAccelerationStructureHandleKHR.html>"]
     pub unsafe fn get_acceleration_structure_device_address(
         &self,
-        device: vk::Device,
         info: &vk::AccelerationStructureDeviceAddressInfoKHR,
     ) -> vk::DeviceAddress {
         self.acceleration_structure_fn
-            .get_acceleration_structure_device_address_khr(device, info as *const _)
+            .get_acceleration_structure_device_address_khr(self.handle, info as *const _)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdWriteAccelerationStructuresPropertiesKHR.html>"]
@@ -269,14 +271,13 @@ impl AccelerationStructure {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceAccelerationStructureCompatibilityKHR.html>"]
     pub unsafe fn get_device_acceleration_structure_compatibility(
         &self,
-        device: vk::Device,
         version: &vk::AccelerationStructureVersionInfoKHR,
     ) -> vk::AccelerationStructureCompatibilityKHR {
         let mut compatibility = vk::AccelerationStructureCompatibilityKHR::default();
 
         self.acceleration_structure_fn
             .get_device_acceleration_structure_compatibility_khr(
-                device,
+                self.handle,
                 version,
                 &mut compatibility as *mut _,
             );
@@ -287,7 +288,6 @@ impl AccelerationStructure {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetAccelerationStructureBuildSizesKHR.html>"]
     pub unsafe fn get_acceleration_structure_build_sizes(
         &self,
-        device: vk::Device,
         build_type: vk::AccelerationStructureBuildTypeKHR,
         build_info: &vk::AccelerationStructureBuildGeometryInfoKHR,
         max_primitive_counts: &[u32],
@@ -298,7 +298,7 @@ impl AccelerationStructure {
 
         self.acceleration_structure_fn
             .get_acceleration_structure_build_sizes_khr(
-                device,
+                self.handle,
                 build_type,
                 build_info as *const _,
                 max_primitive_counts.as_ptr(),

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -107,7 +107,6 @@ impl RayTracingPipeline {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetRayTracingCaptureReplayShaderGroupHandlesKHR.html>"]
     pub unsafe fn get_ray_tracing_capture_replay_shader_group_handles(
         &self,
-        device: vk::Device,
         pipeline: vk::Pipeline,
         first_group: u32,
         group_count: u32,
@@ -117,7 +116,7 @@ impl RayTracingPipeline {
 
         self.ray_tracing_fn
             .get_ray_tracing_capture_replay_shader_group_handles_khr(
-                device,
+                self.handle,
                 pipeline,
                 first_group,
                 group_count,
@@ -150,13 +149,12 @@ impl RayTracingPipeline {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetRayTracingShaderGroupStackSizeKHR.html>"]
     pub unsafe fn get_ray_tracing_shader_group_stack_size(
         &self,
-        device: vk::Device,
         pipeline: vk::Pipeline,
         group: u32,
         group_shader: vk::ShaderGroupShaderKHR,
     ) -> vk::DeviceSize {
         self.ray_tracing_fn
-            .get_ray_tracing_shader_group_stack_size_khr(device, pipeline, group, group_shader)
+            .get_ray_tracing_shader_group_stack_size_khr(self.handle, pipeline, group, group_shader)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetRayTracingPipelineStackSizeKHR.html>"]


### PR DESCRIPTION
This handle is already held onto when creating the safe wrapper object, but is inconsistently required again in some but not all functions.  Remove it from every function and use the internal handle instead.

Closes: #377
Fixes: 05747b2 ("Update Vulkan-Headers to 1.2.162 with stable ray-tracing spec (#341)")

---

_Yet another_ porting artifact of the stable KHR RT bindings...
