### PR TITLE
generator: Only expect vendor name at the end of constants

### DIFF
--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -587,10 +587,10 @@ impl DebugReportFlagsEXT {
 pub struct ExternalMemoryHandleTypeFlagsNV(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalMemoryHandleTypeFlagsNV, 0b1111, Flags);
 impl ExternalMemoryHandleTypeFlagsNV {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NV: Self = Self(0b1);
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_NV: Self = Self(0b10);
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_IMAGE_NV: Self = Self(0b100);
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_IMAGE_KMT_NV: Self = Self(0b1000);
+    pub const OPAQUE_WIN32: Self = Self(0b1);
+    pub const OPAQUE_WIN32_KMT: Self = Self(0b10);
+    pub const D3D11_IMAGE: Self = Self(0b100);
+    pub const D3D11_IMAGE_KMT: Self = Self(0b1000);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -598,9 +598,9 @@ impl ExternalMemoryHandleTypeFlagsNV {
 pub struct ExternalMemoryFeatureFlagsNV(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalMemoryFeatureFlagsNV, 0b111, Flags);
 impl ExternalMemoryFeatureFlagsNV {
-    pub const EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_NV: Self = Self(0b1);
-    pub const EXTERNAL_MEMORY_FEATURE_EXPORTABLE_NV: Self = Self(0b10);
-    pub const EXTERNAL_MEMORY_FEATURE_IMPORTABLE_NV: Self = Self(0b100);
+    pub const DEDICATED_ONLY: Self = Self(0b1);
+    pub const EXPORTABLE: Self = Self(0b10);
+    pub const IMPORTABLE: Self = Self(0b100);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -661,13 +661,13 @@ impl DescriptorSetLayoutCreateFlags {}
 pub struct ExternalMemoryHandleTypeFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalMemoryHandleTypeFlags, 0b111_1111, Flags);
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD: Self = Self(0b1);
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32: Self = Self(0b10);
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT: Self = Self(0b100);
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE: Self = Self(0b1000);
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT: Self = Self(0b1_0000);
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP: Self = Self(0b10_0000);
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE: Self = Self(0b100_0000);
+    pub const OPAQUE_FD: Self = Self(0b1);
+    pub const OPAQUE_WIN32: Self = Self(0b10);
+    pub const OPAQUE_WIN32_KMT: Self = Self(0b100);
+    pub const D3D11_TEXTURE: Self = Self(0b1000);
+    pub const D3D11_TEXTURE_KMT: Self = Self(0b1_0000);
+    pub const D3D12_HEAP: Self = Self(0b10_0000);
+    pub const D3D12_RESOURCE: Self = Self(0b100_0000);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -675,9 +675,9 @@ impl ExternalMemoryHandleTypeFlags {
 pub struct ExternalMemoryFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalMemoryFeatureFlags, 0b111, Flags);
 impl ExternalMemoryFeatureFlags {
-    pub const EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY: Self = Self(0b1);
-    pub const EXTERNAL_MEMORY_FEATURE_EXPORTABLE: Self = Self(0b10);
-    pub const EXTERNAL_MEMORY_FEATURE_IMPORTABLE: Self = Self(0b100);
+    pub const DEDICATED_ONLY: Self = Self(0b1);
+    pub const EXPORTABLE: Self = Self(0b10);
+    pub const IMPORTABLE: Self = Self(0b100);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -685,11 +685,11 @@ impl ExternalMemoryFeatureFlags {
 pub struct ExternalSemaphoreHandleTypeFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalSemaphoreHandleTypeFlags, 0b1_1111, Flags);
 impl ExternalSemaphoreHandleTypeFlags {
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD: Self = Self(0b1);
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32: Self = Self(0b10);
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT: Self = Self(0b100);
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE: Self = Self(0b1000);
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD: Self = Self(0b1_0000);
+    pub const OPAQUE_FD: Self = Self(0b1);
+    pub const OPAQUE_WIN32: Self = Self(0b10);
+    pub const OPAQUE_WIN32_KMT: Self = Self(0b100);
+    pub const D3D12_FENCE: Self = Self(0b1000);
+    pub const SYNC_FD: Self = Self(0b1_0000);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -697,8 +697,8 @@ impl ExternalSemaphoreHandleTypeFlags {
 pub struct ExternalSemaphoreFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalSemaphoreFeatureFlags, 0b11, Flags);
 impl ExternalSemaphoreFeatureFlags {
-    pub const EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE: Self = Self(0b1);
-    pub const EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE: Self = Self(0b10);
+    pub const EXPORTABLE: Self = Self(0b1);
+    pub const IMPORTABLE: Self = Self(0b10);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -714,10 +714,10 @@ impl SemaphoreImportFlags {
 pub struct ExternalFenceHandleTypeFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalFenceHandleTypeFlags, 0b1111, Flags);
 impl ExternalFenceHandleTypeFlags {
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD: Self = Self(0b1);
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32: Self = Self(0b10);
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT: Self = Self(0b100);
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD: Self = Self(0b1000);
+    pub const OPAQUE_FD: Self = Self(0b1);
+    pub const OPAQUE_WIN32: Self = Self(0b10);
+    pub const OPAQUE_WIN32_KMT: Self = Self(0b100);
+    pub const SYNC_FD: Self = Self(0b1000);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -725,8 +725,8 @@ impl ExternalFenceHandleTypeFlags {
 pub struct ExternalFenceFeatureFlags(pub(crate) Flags);
 vk_bitflags_wrapped!(ExternalFenceFeatureFlags, 0b11, Flags);
 impl ExternalFenceFeatureFlags {
-    pub const EXTERNAL_FENCE_FEATURE_EXPORTABLE: Self = Self(0b1);
-    pub const EXTERNAL_FENCE_FEATURE_IMPORTABLE: Self = Self(0b10);
+    pub const EXPORTABLE: Self = Self(0b1);
+    pub const IMPORTABLE: Self = Self(0b10);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -1234,14 +1234,8 @@ impl fmt::Debug for EventCreateFlags {
 impl fmt::Debug for ExternalFenceFeatureFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
-            (
-                ExternalFenceFeatureFlags::EXTERNAL_FENCE_FEATURE_EXPORTABLE.0,
-                "EXTERNAL_FENCE_FEATURE_EXPORTABLE",
-            ),
-            (
-                ExternalFenceFeatureFlags::EXTERNAL_FENCE_FEATURE_IMPORTABLE.0,
-                "EXTERNAL_FENCE_FEATURE_IMPORTABLE",
-            ),
+            (ExternalFenceFeatureFlags::EXPORTABLE.0, "EXPORTABLE"),
+            (ExternalFenceFeatureFlags::IMPORTABLE.0, "IMPORTABLE"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -1249,29 +1243,20 @@ impl fmt::Debug for ExternalFenceFeatureFlags {
 impl fmt::Debug for ExternalFenceHandleTypeFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
+            (ExternalFenceHandleTypeFlags::OPAQUE_FD.0, "OPAQUE_FD"),
+            (ExternalFenceHandleTypeFlags::OPAQUE_WIN32.0, "OPAQUE_WIN32"),
             (
-                ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD.0,
-                "EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD",
+                ExternalFenceHandleTypeFlags::OPAQUE_WIN32_KMT.0,
+                "OPAQUE_WIN32_KMT",
+            ),
+            (ExternalFenceHandleTypeFlags::SYNC_FD.0, "SYNC_FD"),
+            (
+                ExternalFenceHandleTypeFlags::RESERVED_4_NV.0,
+                "RESERVED_4_NV",
             ),
             (
-                ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32.0,
-                "EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32",
-            ),
-            (
-                ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT.0,
-                "EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT",
-            ),
-            (
-                ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD.0,
-                "EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD",
-            ),
-            (
-                ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_RESERVED_4_NV.0,
-                "EXTERNAL_FENCE_HANDLE_TYPE_RESERVED_4_NV",
-            ),
-            (
-                ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_RESERVED_5_NV.0,
-                "EXTERNAL_FENCE_HANDLE_TYPE_RESERVED_5_NV",
+                ExternalFenceHandleTypeFlags::RESERVED_5_NV.0,
+                "RESERVED_5_NV",
             ),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -1281,17 +1266,11 @@ impl fmt::Debug for ExternalMemoryFeatureFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
-                ExternalMemoryFeatureFlags::EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY.0,
-                "EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY",
+                ExternalMemoryFeatureFlags::DEDICATED_ONLY.0,
+                "DEDICATED_ONLY",
             ),
-            (
-                ExternalMemoryFeatureFlags::EXTERNAL_MEMORY_FEATURE_EXPORTABLE.0,
-                "EXTERNAL_MEMORY_FEATURE_EXPORTABLE",
-            ),
-            (
-                ExternalMemoryFeatureFlags::EXTERNAL_MEMORY_FEATURE_IMPORTABLE.0,
-                "EXTERNAL_MEMORY_FEATURE_IMPORTABLE",
-            ),
+            (ExternalMemoryFeatureFlags::EXPORTABLE.0, "EXPORTABLE"),
+            (ExternalMemoryFeatureFlags::IMPORTABLE.0, "IMPORTABLE"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -1300,24 +1279,54 @@ impl fmt::Debug for ExternalMemoryFeatureFlagsNV {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
-                ExternalMemoryFeatureFlagsNV::EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_NV.0,
-                "EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_NV",
+                ExternalMemoryFeatureFlagsNV::DEDICATED_ONLY.0,
+                "DEDICATED_ONLY",
             ),
-            (
-                ExternalMemoryFeatureFlagsNV::EXTERNAL_MEMORY_FEATURE_EXPORTABLE_NV.0,
-                "EXTERNAL_MEMORY_FEATURE_EXPORTABLE_NV",
-            ),
-            (
-                ExternalMemoryFeatureFlagsNV::EXTERNAL_MEMORY_FEATURE_IMPORTABLE_NV.0,
-                "EXTERNAL_MEMORY_FEATURE_IMPORTABLE_NV",
-            ),
+            (ExternalMemoryFeatureFlagsNV::EXPORTABLE.0, "EXPORTABLE"),
+            (ExternalMemoryFeatureFlagsNV::IMPORTABLE.0, "IMPORTABLE"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
 }
 impl fmt::Debug for ExternalMemoryHandleTypeFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN : & [(Flags , & str)] = & [(ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32 . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_ANDROID . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_ANDROID") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION") , (ExternalMemoryHandleTypeFlags :: EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY . 0 , "EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY")] ;
+        const KNOWN: &[(Flags, &str)] = &[
+            (ExternalMemoryHandleTypeFlags::OPAQUE_FD.0, "OPAQUE_FD"),
+            (
+                ExternalMemoryHandleTypeFlags::OPAQUE_WIN32.0,
+                "OPAQUE_WIN32",
+            ),
+            (
+                ExternalMemoryHandleTypeFlags::OPAQUE_WIN32_KMT.0,
+                "OPAQUE_WIN32_KMT",
+            ),
+            (
+                ExternalMemoryHandleTypeFlags::D3D11_TEXTURE.0,
+                "D3D11_TEXTURE",
+            ),
+            (
+                ExternalMemoryHandleTypeFlags::D3D11_TEXTURE_KMT.0,
+                "D3D11_TEXTURE_KMT",
+            ),
+            (ExternalMemoryHandleTypeFlags::D3D12_HEAP.0, "D3D12_HEAP"),
+            (
+                ExternalMemoryHandleTypeFlags::D3D12_RESOURCE.0,
+                "D3D12_RESOURCE",
+            ),
+            (ExternalMemoryHandleTypeFlags::DMA_BUF_EXT.0, "DMA_BUF_EXT"),
+            (
+                ExternalMemoryHandleTypeFlags::ANDROID_HARDWARE_BUFFER_ANDROID.0,
+                "ANDROID_HARDWARE_BUFFER_ANDROID",
+            ),
+            (
+                ExternalMemoryHandleTypeFlags::HOST_ALLOCATION_EXT.0,
+                "HOST_ALLOCATION_EXT",
+            ),
+            (
+                ExternalMemoryHandleTypeFlags::HOST_MAPPED_FOREIGN_MEMORY_EXT.0,
+                "HOST_MAPPED_FOREIGN_MEMORY_EXT",
+            ),
+        ];
         debug_flags(f, KNOWN, self.0)
     }
 }
@@ -1325,20 +1334,20 @@ impl fmt::Debug for ExternalMemoryHandleTypeFlagsNV {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
-                ExternalMemoryHandleTypeFlagsNV::EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NV.0,
-                "EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_NV",
+                ExternalMemoryHandleTypeFlagsNV::OPAQUE_WIN32.0,
+                "OPAQUE_WIN32",
             ),
             (
-                ExternalMemoryHandleTypeFlagsNV::EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_NV.0,
-                "EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_NV",
+                ExternalMemoryHandleTypeFlagsNV::OPAQUE_WIN32_KMT.0,
+                "OPAQUE_WIN32_KMT",
             ),
             (
-                ExternalMemoryHandleTypeFlagsNV::EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_IMAGE_NV.0,
-                "EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_IMAGE_NV",
+                ExternalMemoryHandleTypeFlagsNV::D3D11_IMAGE.0,
+                "D3D11_IMAGE",
             ),
             (
-                ExternalMemoryHandleTypeFlagsNV::EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_IMAGE_KMT_NV.0,
-                "EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_IMAGE_KMT_NV",
+                ExternalMemoryHandleTypeFlagsNV::D3D11_IMAGE_KMT.0,
+                "D3D11_IMAGE_KMT",
             ),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -1347,14 +1356,8 @@ impl fmt::Debug for ExternalMemoryHandleTypeFlagsNV {
 impl fmt::Debug for ExternalSemaphoreFeatureFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
-            (
-                ExternalSemaphoreFeatureFlags::EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE.0,
-                "EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE",
-            ),
-            (
-                ExternalSemaphoreFeatureFlags::EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE.0,
-                "EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE",
-            ),
+            (ExternalSemaphoreFeatureFlags::EXPORTABLE.0, "EXPORTABLE"),
+            (ExternalSemaphoreFeatureFlags::IMPORTABLE.0, "IMPORTABLE"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -1362,33 +1365,27 @@ impl fmt::Debug for ExternalSemaphoreFeatureFlags {
 impl fmt::Debug for ExternalSemaphoreHandleTypeFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
+            (ExternalSemaphoreHandleTypeFlags::OPAQUE_FD.0, "OPAQUE_FD"),
             (
-                ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD.0,
-                "EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD",
+                ExternalSemaphoreHandleTypeFlags::OPAQUE_WIN32.0,
+                "OPAQUE_WIN32",
             ),
             (
-                ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32.0,
-                "EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32",
+                ExternalSemaphoreHandleTypeFlags::OPAQUE_WIN32_KMT.0,
+                "OPAQUE_WIN32_KMT",
             ),
             (
-                ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT.0,
-                "EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT",
+                ExternalSemaphoreHandleTypeFlags::D3D12_FENCE.0,
+                "D3D12_FENCE",
+            ),
+            (ExternalSemaphoreHandleTypeFlags::SYNC_FD.0, "SYNC_FD"),
+            (
+                ExternalSemaphoreHandleTypeFlags::RESERVED_5_NV.0,
+                "RESERVED_5_NV",
             ),
             (
-                ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE.0,
-                "EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE",
-            ),
-            (
-                ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD.0,
-                "EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD",
-            ),
-            (
-                ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_RESERVED_5_NV.0,
-                "EXTERNAL_SEMAPHORE_HANDLE_TYPE_RESERVED_5_NV",
-            ),
-            (
-                ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_RESERVED_6_NV.0,
-                "EXTERNAL_SEMAPHORE_HANDLE_TYPE_RESERVED_6_NV",
+                ExternalSemaphoreHandleTypeFlags::RESERVED_6_NV.0,
+                "RESERVED_6_NV",
             ),
         ];
         debug_flags(f, KNOWN, self.0)

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -5927,53 +5927,43 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_KHR: Self =
-        ExternalMemoryHandleTypeFlags::EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD;
+    pub const OPAQUE_FD_KHR: Self = ExternalMemoryHandleTypeFlags::OPAQUE_FD;
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KHR: Self =
-        ExternalMemoryHandleTypeFlags::EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32;
+    pub const OPAQUE_WIN32_KHR: Self = ExternalMemoryHandleTypeFlags::OPAQUE_WIN32;
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_KHR: Self =
-        ExternalMemoryHandleTypeFlags::EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT;
+    pub const OPAQUE_WIN32_KMT_KHR: Self = ExternalMemoryHandleTypeFlags::OPAQUE_WIN32_KMT;
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KHR: Self =
-        ExternalMemoryHandleTypeFlags::EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE;
+    pub const D3D11_TEXTURE_KHR: Self = ExternalMemoryHandleTypeFlags::D3D11_TEXTURE;
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_KHR: Self =
-        ExternalMemoryHandleTypeFlags::EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT;
+    pub const D3D11_TEXTURE_KMT_KHR: Self = ExternalMemoryHandleTypeFlags::D3D11_TEXTURE_KMT;
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_KHR: Self =
-        ExternalMemoryHandleTypeFlags::EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP;
+    pub const D3D12_HEAP_KHR: Self = ExternalMemoryHandleTypeFlags::D3D12_HEAP;
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_KHR: Self =
-        ExternalMemoryHandleTypeFlags::EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE;
+    pub const D3D12_RESOURCE_KHR: Self = ExternalMemoryHandleTypeFlags::D3D12_RESOURCE;
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryFeatureFlags {
-    pub const EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_KHR: Self =
-        ExternalMemoryFeatureFlags::EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY;
+    pub const DEDICATED_ONLY_KHR: Self = ExternalMemoryFeatureFlags::DEDICATED_ONLY;
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryFeatureFlags {
-    pub const EXTERNAL_MEMORY_FEATURE_EXPORTABLE_KHR: Self =
-        ExternalMemoryFeatureFlags::EXTERNAL_MEMORY_FEATURE_EXPORTABLE;
+    pub const EXPORTABLE_KHR: Self = ExternalMemoryFeatureFlags::EXPORTABLE;
 }
 #[doc = "Generated from 'VK_KHR_external_memory_capabilities'"]
 impl ExternalMemoryFeatureFlags {
-    pub const EXTERNAL_MEMORY_FEATURE_IMPORTABLE_KHR: Self =
-        ExternalMemoryFeatureFlags::EXTERNAL_MEMORY_FEATURE_IMPORTABLE;
+    pub const IMPORTABLE_KHR: Self = ExternalMemoryFeatureFlags::IMPORTABLE;
 }
 impl KhrExternalMemoryFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -6383,38 +6373,31 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_KHR_external_semaphore_capabilities'"]
 impl ExternalSemaphoreHandleTypeFlags {
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_KHR: Self =
-        ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD;
+    pub const OPAQUE_FD_KHR: Self = ExternalSemaphoreHandleTypeFlags::OPAQUE_FD;
 }
 #[doc = "Generated from 'VK_KHR_external_semaphore_capabilities'"]
 impl ExternalSemaphoreHandleTypeFlags {
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KHR: Self =
-        ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32;
+    pub const OPAQUE_WIN32_KHR: Self = ExternalSemaphoreHandleTypeFlags::OPAQUE_WIN32;
 }
 #[doc = "Generated from 'VK_KHR_external_semaphore_capabilities'"]
 impl ExternalSemaphoreHandleTypeFlags {
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_KHR: Self =
-        ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT;
+    pub const OPAQUE_WIN32_KMT_KHR: Self = ExternalSemaphoreHandleTypeFlags::OPAQUE_WIN32_KMT;
 }
 #[doc = "Generated from 'VK_KHR_external_semaphore_capabilities'"]
 impl ExternalSemaphoreHandleTypeFlags {
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_KHR: Self =
-        ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE;
+    pub const D3D12_FENCE_KHR: Self = ExternalSemaphoreHandleTypeFlags::D3D12_FENCE;
 }
 #[doc = "Generated from 'VK_KHR_external_semaphore_capabilities'"]
 impl ExternalSemaphoreHandleTypeFlags {
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_KHR: Self =
-        ExternalSemaphoreHandleTypeFlags::EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD;
+    pub const SYNC_FD_KHR: Self = ExternalSemaphoreHandleTypeFlags::SYNC_FD;
 }
 #[doc = "Generated from 'VK_KHR_external_semaphore_capabilities'"]
 impl ExternalSemaphoreFeatureFlags {
-    pub const EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_KHR: Self =
-        ExternalSemaphoreFeatureFlags::EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE;
+    pub const EXPORTABLE_KHR: Self = ExternalSemaphoreFeatureFlags::EXPORTABLE;
 }
 #[doc = "Generated from 'VK_KHR_external_semaphore_capabilities'"]
 impl ExternalSemaphoreFeatureFlags {
-    pub const EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_KHR: Self =
-        ExternalSemaphoreFeatureFlags::EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE;
+    pub const IMPORTABLE_KHR: Self = ExternalSemaphoreFeatureFlags::IMPORTABLE;
 }
 impl KhrExternalSemaphoreFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -8961,33 +8944,27 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_KHR_external_fence_capabilities'"]
 impl ExternalFenceHandleTypeFlags {
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_KHR: Self =
-        ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD;
+    pub const OPAQUE_FD_KHR: Self = ExternalFenceHandleTypeFlags::OPAQUE_FD;
 }
 #[doc = "Generated from 'VK_KHR_external_fence_capabilities'"]
 impl ExternalFenceHandleTypeFlags {
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KHR: Self =
-        ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32;
+    pub const OPAQUE_WIN32_KHR: Self = ExternalFenceHandleTypeFlags::OPAQUE_WIN32;
 }
 #[doc = "Generated from 'VK_KHR_external_fence_capabilities'"]
 impl ExternalFenceHandleTypeFlags {
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_KHR: Self =
-        ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT;
+    pub const OPAQUE_WIN32_KMT_KHR: Self = ExternalFenceHandleTypeFlags::OPAQUE_WIN32_KMT;
 }
 #[doc = "Generated from 'VK_KHR_external_fence_capabilities'"]
 impl ExternalFenceHandleTypeFlags {
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_KHR: Self =
-        ExternalFenceHandleTypeFlags::EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD;
+    pub const SYNC_FD_KHR: Self = ExternalFenceHandleTypeFlags::SYNC_FD;
 }
 #[doc = "Generated from 'VK_KHR_external_fence_capabilities'"]
 impl ExternalFenceFeatureFlags {
-    pub const EXTERNAL_FENCE_FEATURE_EXPORTABLE_KHR: Self =
-        ExternalFenceFeatureFlags::EXTERNAL_FENCE_FEATURE_EXPORTABLE;
+    pub const EXPORTABLE_KHR: Self = ExternalFenceFeatureFlags::EXPORTABLE;
 }
 #[doc = "Generated from 'VK_KHR_external_fence_capabilities'"]
 impl ExternalFenceFeatureFlags {
-    pub const EXTERNAL_FENCE_FEATURE_IMPORTABLE_KHR: Self =
-        ExternalFenceFeatureFlags::EXTERNAL_FENCE_FEATURE_IMPORTABLE;
+    pub const IMPORTABLE_KHR: Self = ExternalFenceFeatureFlags::IMPORTABLE;
 }
 impl KhrExternalFenceFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -10167,7 +10144,7 @@ impl ExtExternalMemoryDmaBufFn {
 }
 #[doc = "Generated from 'VK_EXT_external_memory_dma_buf'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF: Self = Self(0b10_0000_0000);
+    pub const DMA_BUF_EXT: Self = Self(0b10_0000_0000);
 }
 impl ExtQueueFamilyForeignFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -10786,8 +10763,7 @@ impl AndroidExternalMemoryAndroidHardwareBufferFn {
 }
 #[doc = "Generated from 'VK_ANDROID_external_memory_android_hardware_buffer'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_ANDROID: Self =
-        Self(0b100_0000_0000);
+    pub const ANDROID_HARDWARE_BUFFER_ANDROID: Self = Self(0b100_0000_0000);
 }
 #[doc = "Generated from 'VK_ANDROID_external_memory_android_hardware_buffer'"]
 impl StructureType {
@@ -16075,11 +16051,11 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_EXT_external_memory_host'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION: Self = Self(0b1000_0000);
+    pub const HOST_ALLOCATION_EXT: Self = Self(0b1000_0000);
 }
 #[doc = "Generated from 'VK_EXT_external_memory_host'"]
 impl ExternalMemoryHandleTypeFlags {
-    pub const EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY: Self = Self(0b1_0000_0000);
+    pub const HOST_MAPPED_FOREIGN_MEMORY_EXT: Self = Self(0b1_0000_0000);
 }
 impl AmdBufferMarkerFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -25225,11 +25201,11 @@ impl NvExtension374Fn {
 }
 #[doc = "Generated from 'VK_NV_extension_374'"]
 impl ExternalFenceHandleTypeFlags {
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_RESERVED_4_NV: Self = Self(0b1_0000);
+    pub const RESERVED_4_NV: Self = Self(0b1_0000);
 }
 #[doc = "Generated from 'VK_NV_extension_374'"]
 impl ExternalFenceHandleTypeFlags {
-    pub const EXTERNAL_FENCE_HANDLE_TYPE_RESERVED_5_NV: Self = Self(0b10_0000);
+    pub const RESERVED_5_NV: Self = Self(0b10_0000);
 }
 impl NvExtension375Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -25256,11 +25232,11 @@ impl NvExtension375Fn {
 }
 #[doc = "Generated from 'VK_NV_extension_375'"]
 impl ExternalSemaphoreHandleTypeFlags {
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_RESERVED_5_NV: Self = Self(0b10_0000);
+    pub const RESERVED_5_NV: Self = Self(0b10_0000);
 }
 #[doc = "Generated from 'VK_NV_extension_375'"]
 impl ExternalSemaphoreHandleTypeFlags {
-    pub const EXTERNAL_SEMAPHORE_HANDLE_TYPE_RESERVED_6_NV: Self = Self(0b100_0000);
+    pub const RESERVED_6_NV: Self = Self(0b100_0000);
 }
 impl ExtExtension376Fn {
     pub fn name() -> &'static ::std::ffi::CStr {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1295,13 +1295,13 @@ pub fn variant_ident(enum_name: &str, variant_name: &str) -> Ident {
     // TODO: Also needs to be more robust, vendor names can be substrings from itself, id:4
     // like NVX and NV
     let vendors = ["_NVX", "_KHR", "_EXT", "_NV", "_AMD", "_ANDROID", "_GOOGLE"];
-    let mut struct_name = _name.to_shouty_snake_case();
+    let struct_name = _name.to_shouty_snake_case();
     let vendor = vendors
         .iter()
-        .find(|&vendor| struct_name.contains(vendor))
+        .find(|&vendor| struct_name.ends_with(vendor))
         .cloned()
         .unwrap_or("");
-    struct_name = struct_name.replace(vendor, "");
+    let struct_name = struct_name.strip_suffix(vendor).unwrap();
     let new_variant_name = variant_name.replace(&struct_name, "").replace("VK", "");
     let new_variant_name = new_variant_name
         .trim_matches('_')


### PR DESCRIPTION
Constants (enumeration bitflags) containing the word `external` were not stripped of their common typename, and quick debugging showed the word `VKTERNAL_...` in `struct_name`. `_EXT` would be the first extension to match in `VK_EXTERNAL_...` messing up `struct_name` with a global `.replace`, in turn not removing it from the variant name.
