### PR TITLE
entry_libloading: Do not pass AsRef implementation by reference

### DIFF
--- a/ash/src/entry_libloading.rs
+++ b/ash/src/entry_libloading.rs
@@ -62,7 +62,7 @@ impl EntryCustom<Arc<Library>> {
     /// # Ok(()) }
     /// ```
     pub unsafe fn new() -> Result<Entry, LoadingError> {
-        Self::with_library(&LIB_PATH)
+        Self::with_library(LIB_PATH)
     }
 
     /// Load Vulkan library at `path`
@@ -70,7 +70,7 @@ impl EntryCustom<Arc<Library>> {
     /// # Safety
     /// `dlopen`ing native libraries is inherently unsafe. The safety guidelines
     /// for [`Library::new`] and [`Library::get`] apply here.
-    pub unsafe fn with_library(path: &impl AsRef<OsStr>) -> Result<Entry, LoadingError> {
+    pub unsafe fn with_library(path: impl AsRef<OsStr>) -> Result<Entry, LoadingError> {
         let lib = Library::new(path).map_err(LoadingError).map(Arc::new)?;
 
         Ok(Self::new_custom(lib, |vk_lib, name| {


### PR DESCRIPTION
Fixes #388

All type parameters are implicitly bound by Sized; matching the `&` out of `&str` implies that `str` must be bound by `Sized` which is not true, resulting in:

    18 |         let entry = ash::Entry::with_library("foo")?;
       |                                              ^^^^^ doesn't have a size known at compile-time
       |
      ::: /home/marijn/Code/TraverseResearch/ash/ash/src/entry_libloading.rs:73:39
       |
    73 |     pub unsafe fn with_library(path: &impl AsRef<OsStr>) -> Result<Entry, LoadingError> {
       |                                       ----------------- required by this bound in `ash::entry_libloading::<impl EntryCustom<Arc<libloading::Library>>>::with_library`

After all `Library::new` accepts an `impl AsRef<OsStr>` without borrow, which is what this function is modeled after to pass the same parameter on directly.

Fixes: c6d5d66 ("entry_libloading: Provide Vulkan library loader from custom path (#319)")
