### PR TITLE
ci: Test docs in addition to `cargo t --all-targets`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,16 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: Test all targets
+        uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace --all-targets
+      - name: Test docs
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --doc
 
   fmt:
     name: Rustfmt

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -191,7 +191,7 @@ impl<L> EntryCustom<L> {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateInstanceVersion.html>"]
-    /// ```rust,no_run
+    /// ```no_run
     /// # use ash::{Entry, vk};
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let entry = Entry::new()?;

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -193,8 +193,8 @@ impl<L> EntryCustom<L> {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateInstanceVersion.html>"]
     /// ```no_run
     /// # use ash::{Entry, vk};
-    /// # fn main() -> Result<(), Box<std::error::Error>> {
-    /// let entry = Entry::new()?;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let entry = unsafe { Entry::new() }?;
     /// match entry.try_enumerate_instance_version()? {
     ///     // Vulkan 1.1+
     ///     Some(version) => {

--- a/ash/src/entry_libloading.rs
+++ b/ash/src/entry_libloading.rs
@@ -48,8 +48,8 @@ impl EntryCustom<Arc<Library>> {
     ///
     /// ```no_run
     /// use ash::{vk, Entry, version::EntryV1_0};
-    /// # fn main() -> Result<(), Box<std::error::Error>> {
-    /// let entry = Entry::new()?;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let entry = unsafe { Entry::new() }?;
     /// let app_info = vk::ApplicationInfo {
     ///     api_version: vk::make_version(1, 0, 0),
     ///     ..Default::default()

--- a/ash/src/entry_libloading.rs
+++ b/ash/src/entry_libloading.rs
@@ -46,7 +46,7 @@ impl EntryCustom<Arc<Library>> {
     /// `dlopen`ing native libraries is inherently unsafe. The safety guidelines
     /// for [`Library::new`] and [`Library::get`] apply here.
     ///
-    /// ```rust,no_run
+    /// ```no_run
     /// use ash::{vk, Entry, version::EntryV1_0};
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let entry = Entry::new()?;

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```no_run
 //! use ash::{vk, Entry, version::EntryV1_0};
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let entry = Entry::new()?;
+//! let entry = unsafe { Entry::new() }?;
 //! let app_info = vk::ApplicationInfo {
 //!     api_version: vk::make_version(1, 0, 0),
 //!     ..Default::default()

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Examples
 //!
-//! ```rust,no_run
+//! ```no_run
 //! use ash::{vk, Entry, version::EntryV1_0};
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let entry = Entry::new()?;


### PR DESCRIPTION
Unfortunately docs are not explicitly (build-)tested as part of `--all-targets` allowing broken code to slip in as shown by #390.

Also remove the `rust` listing type which is the default, leaving only `no_run` (until the CI has a loadable Vulkan library).
