### PR TITLE
external_memory_fd: Initialize output struct with proper sType

### DIFF
--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -40,7 +40,7 @@ impl ExternalMemoryFd {
         handle_type: vk::ExternalMemoryHandleTypeFlags,
         fd: i32,
     ) -> VkResult<vk::MemoryFdPropertiesKHR> {
-        let mut memory_fd_properties = mem::zeroed();
+        let mut memory_fd_properties = Default::default();
         self.external_memory_fd_fn
             .get_memory_fd_properties_khr(self.handle, handle_type, fd, &mut memory_fd_properties)
             .result_with_success(memory_fd_properties)


### PR DESCRIPTION
`MemoryFdPropertiesKHR` is a struct that, despite being used as output, hsa to be initialized properly with a valid `sType` set, otherwise:

    Validation Error: [ VUID-VkMemoryFdPropertiesKHR-sType-sType ] Object 0: handle = 0x7f035464d648, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xdc6b3a0d | vkGetMemoryFdPropertiesKHR: parameter pMemoryFdProperties->sType must be VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR. The Vulkan spec states: sType must be VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkMemoryFdPropertiesKHR-sType-sType)
