### PR TITLE
Add VK_NN_vi_surface extension

### DIFF
--- a/ash/src/extensions/mod.rs
+++ b/ash/src/extensions/mod.rs
@@ -2,4 +2,5 @@ pub mod experimental;
 pub mod ext;
 pub mod khr;
 pub mod mvk;
+pub mod nn;
 pub mod nv;

--- a/ash/src/extensions/nn/mod.rs
+++ b/ash/src/extensions/nn/mod.rs
@@ -1,0 +1,3 @@
+pub use self::vi_surface::ViSurface;
+
+mod vi_surface;

--- a/ash/src/extensions/nn/vi_surface.rs
+++ b/ash/src/extensions/nn/vi_surface.rs
@@ -1,0 +1,54 @@
+#![allow(dead_code)]
+use crate::prelude::*;
+use crate::version::{EntryV1_0, InstanceV1_0};
+use crate::vk;
+use crate::RawPtr;
+use std::ffi::CStr;
+use std::mem;
+
+#[derive(Clone)]
+pub struct ViSurface {
+    handle: vk::Instance,
+    vi_surface_fn: vk::NnViSurfaceFn,
+}
+
+impl ViSurface {
+    pub fn new<E: EntryV1_0, I: InstanceV1_0>(entry: &E, instance: &I) -> ViSurface {
+        let surface_fn = vk::NnViSurfaceFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        });
+        ViSurface {
+            handle: instance.handle(),
+            vi_surface_fn: surface_fn,
+        }
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::NnViSurfaceFn::name()
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateViSurfaceNN.html>"]
+    pub unsafe fn create_vi_surface(
+        &self,
+        create_info: &vk::ViSurfaceCreateInfoNN,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+    ) -> VkResult<vk::SurfaceKHR> {
+        let mut surface = mem::zeroed();
+        self.vi_surface_fn
+            .create_vi_surface_nn(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut surface,
+            )
+            .result_with_success(surface)
+    }
+
+    pub fn fp(&self) -> &vk::NnViSurfaceFn {
+        &self.vi_surface_fn
+    }
+
+    pub fn instance(&self) -> vk::Instance {
+        self.handle
+    }
+}


### PR DESCRIPTION
I followed the examples of other surface extensions for this one, so hopefully it's good as-is. I was not sure whether the function names should have `_nn` at the end or not. `create_xlib_surface` doesn't end in `_khr` but `create_mac_os_surface_mvk` does have the `_mvk`. My own preference would be without the suffix, since it's already implicit in the module and struct name.