### PR TITLE
Remove the _mvk suffix from the two extensions' functions

### DIFF
--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -28,7 +28,7 @@ impl IOSSurface {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateIOSSurfaceMVK.html>"]
-    pub unsafe fn create_ios_surface_mvk(
+    pub unsafe fn create_ios_surface(
         &self,
         create_info: &vk::IOSSurfaceCreateInfoMVK,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -28,7 +28,7 @@ impl MacOSSurface {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateMacOSSurfaceMVK.html>"]
-    pub unsafe fn create_mac_os_surface_mvk(
+    pub unsafe fn create_mac_os_surface(
         &self,
         create_info: &vk::MacOSSurfaceCreateInfoMVK,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,


### PR DESCRIPTION
Per the discussion at #398, this brings these names in line with the other extensions, which lack the suffix.