### PR TITLE
generator: Generate enums from vk_parse representation

### DIFF
--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -496,6 +496,8 @@ impl StencilFaceFlags {
     pub const BACK: Self = Self(0b10);
     #[doc = "Front and back faces"]
     pub const FRONT_AND_BACK: Self = Self(0x0000_0003);
+    #[doc = "Alias for backwards compatibility"]
+    pub const STENCIL_FRONT_AND_BACK: Self = Self::FRONT_AND_BACK;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -689,6 +691,7 @@ impl ExternalSemaphoreHandleTypeFlags {
     pub const OPAQUE_WIN32: Self = Self(0b10);
     pub const OPAQUE_WIN32_KMT: Self = Self(0b100);
     pub const D3D12_FENCE: Self = Self(0b1000);
+    pub const D3D11_FENCE: Self = Self::D3D12_FENCE;
     pub const SYNC_FD: Self = Self(0b1_0000);
 }
 #[repr(transparent)]
@@ -743,6 +746,8 @@ pub struct SurfaceCounterFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(SurfaceCounterFlagsEXT, 0b1, Flags);
 impl SurfaceCounterFlagsEXT {
     pub const VBLANK: Self = Self(0b1);
+    #[doc = "Backwards-compatible alias containing a typo"]
+    pub const VBLANK: Self = Self::VBLANK;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -920,7 +925,11 @@ pub struct PerformanceCounterDescriptionFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(PerformanceCounterDescriptionFlagsKHR, 0b11, Flags);
 impl PerformanceCounterDescriptionFlagsKHR {
     pub const PERFORMANCE_IMPACTING: Self = Self(0b1);
+    #[doc = "Backwards-compatible alias containing a typo"]
+    pub const PERFORMANCE_IMPACTING: Self = Self::PERFORMANCE_IMPACTING;
     pub const CONCURRENTLY_IMPACTED: Self = Self(0b10);
+    #[doc = "Backwards-compatible alias containing a typo"]
+    pub const CONCURRENTLY_IMPACTED: Self = Self::CONCURRENTLY_IMPACTED;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -746,8 +746,6 @@ pub struct SurfaceCounterFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(SurfaceCounterFlagsEXT, 0b1, Flags);
 impl SurfaceCounterFlagsEXT {
     pub const VBLANK: Self = Self(0b1);
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const VBLANK: Self = Self::VBLANK;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -925,11 +923,7 @@ pub struct PerformanceCounterDescriptionFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(PerformanceCounterDescriptionFlagsKHR, 0b11, Flags);
 impl PerformanceCounterDescriptionFlagsKHR {
     pub const PERFORMANCE_IMPACTING: Self = Self(0b1);
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const PERFORMANCE_IMPACTING: Self = Self::PERFORMANCE_IMPACTING;
     pub const CONCURRENTLY_IMPACTED: Self = Self(0b10);
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const CONCURRENTLY_IMPACTED: Self = Self::CONCURRENTLY_IMPACTED;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -496,7 +496,7 @@ impl StencilFaceFlags {
     pub const BACK: Self = Self(0b10);
     #[doc = "Front and back faces"]
     pub const FRONT_AND_BACK: Self = Self(0x0000_0003);
-    #[doc = "Alias for backwards compatibility"]
+    #[deprecated = "Alias for backwards compatibility"]
     pub const STENCIL_FRONT_AND_BACK: Self = Self::FRONT_AND_BACK;
 }
 #[repr(transparent)]
@@ -746,7 +746,7 @@ pub struct SurfaceCounterFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(SurfaceCounterFlagsEXT, 0b1, Flags);
 impl SurfaceCounterFlagsEXT {
     pub const VBLANK: Self = Self(0b1);
-    #[doc = "Backwards-compatible alias containing a typo"]
+    #[deprecated = "Backwards-compatible alias containing a typo"]
     pub const VBLANK: Self = Self::VBLANK;
 }
 #[repr(transparent)]
@@ -925,10 +925,10 @@ pub struct PerformanceCounterDescriptionFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(PerformanceCounterDescriptionFlagsKHR, 0b11, Flags);
 impl PerformanceCounterDescriptionFlagsKHR {
     pub const PERFORMANCE_IMPACTING: Self = Self(0b1);
-    #[doc = "Backwards-compatible alias containing a typo"]
+    #[deprecated = "Backwards-compatible alias containing a typo"]
     pub const PERFORMANCE_IMPACTING: Self = Self::PERFORMANCE_IMPACTING;
     pub const CONCURRENTLY_IMPACTED: Self = Self(0b10);
-    #[doc = "Backwards-compatible alias containing a typo"]
+    #[deprecated = "Backwards-compatible alias containing a typo"]
     pub const CONCURRENTLY_IMPACTED: Self = Self::CONCURRENTLY_IMPACTED;
 }
 #[repr(transparent)]

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -537,7 +537,6 @@ impl fmt::Debug for ColorSpaceKHR {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
             Self::SRGB_NONLINEAR => Some("SRGB_NONLINEAR"),
-            Self::COLORSPACE_SRGB_NONLINEAR => Some("COLORSPACE_SRGB_NONLINEAR"),
             Self::DISPLAY_P3_NONLINEAR_EXT => Some("DISPLAY_P3_NONLINEAR_EXT"),
             Self::EXTENDED_SRGB_LINEAR_EXT => Some("EXTENDED_SRGB_LINEAR_EXT"),
             Self::DISPLAY_P3_LINEAR_EXT => Some("DISPLAY_P3_LINEAR_EXT"),
@@ -830,11 +829,9 @@ impl fmt::Debug for DebugReportObjectTypeEXT {
             Self::SURFACE_KHR => Some("SURFACE_KHR"),
             Self::SWAPCHAIN_KHR => Some("SWAPCHAIN_KHR"),
             Self::DEBUG_REPORT_CALLBACK_EXT => Some("DEBUG_REPORT_CALLBACK_EXT"),
-            Self::DEBUG_REPORT => Some("DEBUG_REPORT"),
             Self::DISPLAY_KHR => Some("DISPLAY_KHR"),
             Self::DISPLAY_MODE_KHR => Some("DISPLAY_MODE_KHR"),
             Self::VALIDATION_CACHE_EXT => Some("VALIDATION_CACHE_EXT"),
-            Self::VALIDATION_CACHE => Some("VALIDATION_CACHE"),
             Self::SAMPLER_YCBCR_CONVERSION => Some("SAMPLER_YCBCR_CONVERSION"),
             Self::DESCRIPTOR_UPDATE_TEMPLATE => Some("DESCRIPTOR_UPDATE_TEMPLATE"),
             Self::ACCELERATION_STRUCTURE_KHR => Some("ACCELERATION_STRUCTURE_KHR"),
@@ -1380,10 +1377,6 @@ impl fmt::Debug for ExternalSemaphoreHandleTypeFlags {
             (
                 ExternalSemaphoreHandleTypeFlags::D3D12_FENCE.0,
                 "D3D12_FENCE",
-            ),
-            (
-                ExternalSemaphoreHandleTypeFlags::D3D11_FENCE.0,
-                "D3D11_FENCE",
             ),
             (ExternalSemaphoreHandleTypeFlags::SYNC_FD.0, "SYNC_FD"),
             (
@@ -2386,9 +2379,6 @@ impl fmt::Debug for PerformanceCounterScopeKHR {
             Self::COMMAND_BUFFER => Some("COMMAND_BUFFER"),
             Self::RENDER_PASS => Some("RENDER_PASS"),
             Self::COMMAND => Some("COMMAND"),
-            Self::QUERY_SCOPE_COMMAND_BUFFER => Some("QUERY_SCOPE_COMMAND_BUFFER"),
-            Self::QUERY_SCOPE_RENDER_PASS => Some("QUERY_SCOPE_RENDER_PASS"),
-            Self::QUERY_SCOPE_COMMAND => Some("QUERY_SCOPE_COMMAND"),
             _ => None,
         };
         if let Some(x) = name {
@@ -3503,10 +3493,6 @@ impl fmt::Debug for StencilFaceFlags {
             (StencilFaceFlags::FRONT.0, "FRONT"),
             (StencilFaceFlags::BACK.0, "BACK"),
             (StencilFaceFlags::FRONT_AND_BACK.0, "FRONT_AND_BACK"),
-            (
-                StencilFaceFlags::STENCIL_FRONT_AND_BACK.0,
-                "STENCIL_FRONT_AND_BACK",
-            ),
         ];
         debug_flags(f, KNOWN, self.0)
     }

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -2373,14 +2373,6 @@ impl fmt::Debug for PerformanceCounterDescriptionFlagsKHR {
                 "PERFORMANCE_IMPACTING",
             ),
             (
-                PerformanceCounterDescriptionFlagsKHR::PERFORMANCE_IMPACTING.0,
-                "PERFORMANCE_IMPACTING",
-            ),
-            (
-                PerformanceCounterDescriptionFlagsKHR::CONCURRENTLY_IMPACTED.0,
-                "CONCURRENTLY_IMPACTED",
-            ),
-            (
                 PerformanceCounterDescriptionFlagsKHR::CONCURRENTLY_IMPACTED.0,
                 "CONCURRENTLY_IMPACTED",
             ),
@@ -4650,10 +4642,7 @@ impl fmt::Debug for SubpassDescriptionFlags {
 }
 impl fmt::Debug for SurfaceCounterFlagsEXT {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN: &[(Flags, &str)] = &[
-            (SurfaceCounterFlagsEXT::VBLANK.0, "VBLANK"),
-            (SurfaceCounterFlagsEXT::VBLANK.0, "VBLANK"),
-        ];
+        const KNOWN: &[(Flags, &str)] = &[(SurfaceCounterFlagsEXT::VBLANK.0, "VBLANK")];
         debug_flags(f, KNOWN, self.0)
     }
 }

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -537,6 +537,7 @@ impl fmt::Debug for ColorSpaceKHR {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
             Self::SRGB_NONLINEAR => Some("SRGB_NONLINEAR"),
+            Self::COLORSPACE_SRGB_NONLINEAR => Some("COLORSPACE_SRGB_NONLINEAR"),
             Self::DISPLAY_P3_NONLINEAR_EXT => Some("DISPLAY_P3_NONLINEAR_EXT"),
             Self::EXTENDED_SRGB_LINEAR_EXT => Some("EXTENDED_SRGB_LINEAR_EXT"),
             Self::DISPLAY_P3_LINEAR_EXT => Some("DISPLAY_P3_LINEAR_EXT"),
@@ -829,9 +830,11 @@ impl fmt::Debug for DebugReportObjectTypeEXT {
             Self::SURFACE_KHR => Some("SURFACE_KHR"),
             Self::SWAPCHAIN_KHR => Some("SWAPCHAIN_KHR"),
             Self::DEBUG_REPORT_CALLBACK_EXT => Some("DEBUG_REPORT_CALLBACK_EXT"),
+            Self::DEBUG_REPORT => Some("DEBUG_REPORT"),
             Self::DISPLAY_KHR => Some("DISPLAY_KHR"),
             Self::DISPLAY_MODE_KHR => Some("DISPLAY_MODE_KHR"),
             Self::VALIDATION_CACHE_EXT => Some("VALIDATION_CACHE_EXT"),
+            Self::VALIDATION_CACHE => Some("VALIDATION_CACHE"),
             Self::SAMPLER_YCBCR_CONVERSION => Some("SAMPLER_YCBCR_CONVERSION"),
             Self::DESCRIPTOR_UPDATE_TEMPLATE => Some("DESCRIPTOR_UPDATE_TEMPLATE"),
             Self::ACCELERATION_STRUCTURE_KHR => Some("ACCELERATION_STRUCTURE_KHR"),
@@ -1377,6 +1380,10 @@ impl fmt::Debug for ExternalSemaphoreHandleTypeFlags {
             (
                 ExternalSemaphoreHandleTypeFlags::D3D12_FENCE.0,
                 "D3D12_FENCE",
+            ),
+            (
+                ExternalSemaphoreHandleTypeFlags::D3D11_FENCE.0,
+                "D3D11_FENCE",
             ),
             (ExternalSemaphoreHandleTypeFlags::SYNC_FD.0, "SYNC_FD"),
             (
@@ -2366,6 +2373,14 @@ impl fmt::Debug for PerformanceCounterDescriptionFlagsKHR {
                 "PERFORMANCE_IMPACTING",
             ),
             (
+                PerformanceCounterDescriptionFlagsKHR::PERFORMANCE_IMPACTING.0,
+                "PERFORMANCE_IMPACTING",
+            ),
+            (
+                PerformanceCounterDescriptionFlagsKHR::CONCURRENTLY_IMPACTED.0,
+                "CONCURRENTLY_IMPACTED",
+            ),
+            (
                 PerformanceCounterDescriptionFlagsKHR::CONCURRENTLY_IMPACTED.0,
                 "CONCURRENTLY_IMPACTED",
             ),
@@ -2379,6 +2394,9 @@ impl fmt::Debug for PerformanceCounterScopeKHR {
             Self::COMMAND_BUFFER => Some("COMMAND_BUFFER"),
             Self::RENDER_PASS => Some("RENDER_PASS"),
             Self::COMMAND => Some("COMMAND"),
+            Self::QUERY_SCOPE_COMMAND_BUFFER => Some("QUERY_SCOPE_COMMAND_BUFFER"),
+            Self::QUERY_SCOPE_RENDER_PASS => Some("QUERY_SCOPE_RENDER_PASS"),
+            Self::QUERY_SCOPE_COMMAND => Some("QUERY_SCOPE_COMMAND"),
             _ => None,
         };
         if let Some(x) = name {
@@ -3493,6 +3511,10 @@ impl fmt::Debug for StencilFaceFlags {
             (StencilFaceFlags::FRONT.0, "FRONT"),
             (StencilFaceFlags::BACK.0, "BACK"),
             (StencilFaceFlags::FRONT_AND_BACK.0, "FRONT_AND_BACK"),
+            (
+                StencilFaceFlags::STENCIL_FRONT_AND_BACK.0,
+                "STENCIL_FRONT_AND_BACK",
+            ),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -4628,7 +4650,10 @@ impl fmt::Debug for SubpassDescriptionFlags {
 }
 impl fmt::Debug for SurfaceCounterFlagsEXT {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN: &[(Flags, &str)] = &[(SurfaceCounterFlagsEXT::VBLANK.0, "VBLANK")];
+        const KNOWN: &[(Flags, &str)] = &[
+            (SurfaceCounterFlagsEXT::VBLANK.0, "VBLANK"),
+            (SurfaceCounterFlagsEXT::VBLANK.0, "VBLANK"),
+        ];
         debug_flags(f, KNOWN, self.0)
     }
 }

--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -1128,7 +1128,7 @@ impl ColorSpaceKHR {
 }
 impl ColorSpaceKHR {
     pub const SRGB_NONLINEAR: Self = Self(0);
-    #[doc = "Backwards-compatible alias containing a typo"]
+    #[deprecated = "Backwards-compatible alias containing a typo"]
     pub const COLORSPACE_SRGB_NONLINEAR: Self = Self::SRGB_NONLINEAR;
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1191,12 +1191,12 @@ impl DebugReportObjectTypeEXT {
     pub const SURFACE_KHR: Self = Self(26);
     pub const SWAPCHAIN_KHR: Self = Self(27);
     pub const DEBUG_REPORT_CALLBACK_EXT: Self = Self(28);
-    #[doc = "Backwards-compatible alias containing a typo"]
+    #[deprecated = "Backwards-compatible alias containing a typo"]
     pub const DEBUG_REPORT: Self = Self::DEBUG_REPORT_CALLBACK_EXT;
     pub const DISPLAY_KHR: Self = Self(29);
     pub const DISPLAY_MODE_KHR: Self = Self(30);
     pub const VALIDATION_CACHE_EXT: Self = Self(33);
-    #[doc = "Backwards-compatible alias containing a typo"]
+    #[deprecated = "Backwards-compatible alias containing a typo"]
     pub const VALIDATION_CACHE: Self = Self::VALIDATION_CACHE_EXT;
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]

--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -1128,6 +1128,8 @@ impl ColorSpaceKHR {
 }
 impl ColorSpaceKHR {
     pub const SRGB_NONLINEAR: Self = Self(0);
+    #[doc = "Backwards-compatible alias containing a typo"]
+    pub const COLORSPACE_SRGB_NONLINEAR: Self = Self::SRGB_NONLINEAR;
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -1189,9 +1191,13 @@ impl DebugReportObjectTypeEXT {
     pub const SURFACE_KHR: Self = Self(26);
     pub const SWAPCHAIN_KHR: Self = Self(27);
     pub const DEBUG_REPORT_CALLBACK_EXT: Self = Self(28);
+    #[doc = "Backwards-compatible alias containing a typo"]
+    pub const DEBUG_REPORT: Self = Self::DEBUG_REPORT_CALLBACK_EXT;
     pub const DISPLAY_KHR: Self = Self(29);
     pub const DISPLAY_MODE_KHR: Self = Self(30);
     pub const VALIDATION_CACHE_EXT: Self = Self(33);
+    #[doc = "Backwards-compatible alias containing a typo"]
+    pub const VALIDATION_CACHE: Self = Self::VALIDATION_CACHE_EXT;
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -1974,6 +1980,9 @@ impl PerformanceCounterScopeKHR {
     pub const COMMAND_BUFFER: Self = Self(0);
     pub const RENDER_PASS: Self = Self(1);
     pub const COMMAND: Self = Self(2);
+    pub const QUERY_SCOPE_COMMAND_BUFFER: Self = Self::COMMAND_BUFFER;
+    pub const QUERY_SCOPE_RENDER_PASS: Self = Self::RENDER_PASS;
+    pub const QUERY_SCOPE_COMMAND: Self = Self::COMMAND;
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -404,6 +404,9 @@ pub trait ConstantExt {
     fn constant(&self, enum_name: &str) -> Constant;
     fn variant_ident(&self, enum_name: &str) -> Ident;
     fn notation(&self) -> Option<&str>;
+    fn is_alias(&self) -> bool {
+        false
+    }
 }
 
 impl ConstantExt for vkxml::ExtensionEnum {
@@ -429,6 +432,9 @@ impl ConstantExt for vk_parse::Enum {
     }
     fn notation(&self) -> Option<&str> {
         self.comment.as_deref()
+    }
+    fn is_alias(&self) -> bool {
+        matches!(self.spec, vk_parse::EnumSpec::Alias { .. })
     }
 }
 
@@ -1430,7 +1436,7 @@ pub fn generate_enum<'a>(
         const_cache.insert(constant.name.as_str());
         values.push(ConstantMatchInfo {
             ident: constant.variant_ident(name),
-            is_alias: false,
+            is_alias: constant.is_alias(),
         });
     }
     const_values.insert(ident.clone(), values);

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1370,8 +1370,10 @@ pub fn bitflags_impl_block(
 
     let notations = constants.iter().map(|constant| {
         constant.notation().map(|n| {
-            quote! {
-                #[doc = #n]
+            if n.to_lowercase().contains("backwards") {
+                quote!(#[deprecated = #n])
+            } else {
+                quote!(#[doc = #n])
             }
         })
     });


### PR DESCRIPTION
~Depends on #409~ merged already.

This change prepares for future additions in vk_parse fields ([1]) by converting over the enum generation path from vkxml.  Most of the conversion is easy by repurposing the existing `EnumSpec` parsing logic from extension constants for all enumeration variants, with slight modifications to not bail when `extends` is not set which is specific to extension constants.

As an (unintended) added bonus this unification of the `EnumSpec` codepath allows aliases (for backwards-compatible names) to be generated as discussed earlier in [2].

[1]: https://github.com/krolli/vk-parse/pull/17
[2]: https://github.com/MaikKlein/ash/pull/384#discussion_r588693967

---

@MaikKlein you're probably wondering by now why I'm not helping pushing generator2 over the finish line. Would you mind providing a status/progress update in #344 and clarify the reason behind removing `quote!()`/`syn`, instead opting for manual string manipulation?
