### PR TITLE
Add high-level extension wrapper for the 1.1 extension VK_KHR_create_renderpass2

### DIFF
--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -1,23 +1,23 @@
 #![allow(dead_code)]
 use crate::prelude::*;
-use crate::version::{DeviceV1_1, InstanceV1_1};
+use crate::version::{DeviceV1_0, InstanceV1_0};
 use crate::vk;
 use crate::RawPtr;
 use std::ffi::CStr;
 use std::mem;
 
 #[derive(Clone)]
-pub struct CreateRenderPass2KHR {
+pub struct CreateRenderPass2 {
     handle: vk::Device,
     khr_create_renderpass2_fn: vk::KhrCreateRenderpass2Fn,
 }
 
-impl CreateRenderPass2KHR {
-    pub fn new<I: InstanceV1_1, D: DeviceV1_1>(instance: &I, device: &D) -> CreateRenderPass2KHR {
+impl CreateRenderPass2 {
+    pub fn new<I: InstanceV1_0, D: DeviceV1_0>(instance: &I, device: &D) -> CreateRenderPass2 {
         let khr_create_renderpass2_fn = vk::KhrCreateRenderpass2Fn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        CreateRenderPass2KHR {
+        CreateRenderPass2 {
             handle: device.handle(),
             khr_create_renderpass2_fn,
         }
@@ -28,7 +28,7 @@ impl CreateRenderPass2KHR {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateRenderPass2.html>"]
-    unsafe fn create_render_pass2(
+    pub unsafe fn create_render_pass2(
         &self,
         create_info: &vk::RenderPassCreateInfo2,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
@@ -45,7 +45,7 @@ impl CreateRenderPass2KHR {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginRenderPass2.html>"]
-    unsafe fn cmd_begin_render_pass2(
+    pub unsafe fn cmd_begin_render_pass2(
         &self,
         command_buffer: vk::CommandBuffer,
         render_pass_begin_info: &vk::RenderPassBeginInfo,
@@ -59,7 +59,7 @@ impl CreateRenderPass2KHR {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdNextSubpass2.html>"]
-    unsafe fn cmd_next_subpass2(
+    pub unsafe fn cmd_next_subpass2(
         &self,
         command_buffer: vk::CommandBuffer,
         subpass_begin_info: &vk::SubpassBeginInfo,
@@ -70,7 +70,7 @@ impl CreateRenderPass2KHR {
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndRenderPass2.html>"]
-    unsafe fn cmd_end_render_pass2(
+    pub unsafe fn cmd_end_render_pass2(
         &self,
         command_buffer: vk::CommandBuffer,
         subpass_end_info: &vk::SubpassEndInfo,

--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -65,8 +65,11 @@ impl CreateRenderPass2 {
         subpass_begin_info: &vk::SubpassBeginInfo,
         subpass_end_info: &vk::SubpassEndInfo,
     ) {
-        self.khr_create_renderpass2_fn
-            .cmd_next_subpass2_khr(command_buffer, subpass_begin_info, subpass_end_info);
+        self.khr_create_renderpass2_fn.cmd_next_subpass2_khr(
+            command_buffer,
+            subpass_begin_info,
+            subpass_end_info,
+        );
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndRenderPass2.html>"]

--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -1,0 +1,89 @@
+#![allow(dead_code)]
+use crate::prelude::*;
+use crate::version::{DeviceV1_1, InstanceV1_1};
+use crate::vk;
+use crate::RawPtr;
+use std::ffi::CStr;
+use std::mem;
+
+#[derive(Clone)]
+pub struct CreateRenderPass2KHR {
+    handle: vk::Device,
+    khr_create_renderpass2_fn: vk::KhrCreateRenderpass2Fn,
+}
+
+impl CreateRenderPass2KHR {
+    pub fn new<I: InstanceV1_1, D: DeviceV1_1>(instance: &I, device: &D) -> CreateRenderPass2KHR {
+        let khr_create_renderpass2_fn = vk::KhrCreateRenderpass2Fn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        });
+        CreateRenderPass2KHR {
+            handle: device.handle(),
+            khr_create_renderpass2_fn,
+        }
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrCreateRenderpass2Fn::name()
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateRenderPass2.html>"]
+    unsafe fn create_render_pass2(
+        &self,
+        create_info: &vk::RenderPassCreateInfo2,
+        allocation_callbacks: Option<&vk::AllocationCallbacks>,
+    ) -> VkResult<vk::RenderPass> {
+        let mut renderpass = mem::zeroed();
+        self.khr_create_renderpass2_fn
+            .create_render_pass2_khr(
+                self.handle,
+                create_info,
+                allocation_callbacks.as_raw_ptr(),
+                &mut renderpass,
+            )
+            .result_with_success(renderpass)
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginRenderPass2.html>"]
+    unsafe fn cmd_begin_render_pass2(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        render_pass_begin_info: &vk::RenderPassBeginInfo,
+        subpass_begin_info: &vk::SubpassBeginInfo,
+    ) {
+        self.khr_create_renderpass2_fn.cmd_begin_render_pass2_khr(
+            command_buffer,
+            render_pass_begin_info,
+            subpass_begin_info,
+        );
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdNextSubpass2.html>"]
+    unsafe fn cmd_next_subpass2(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        subpass_begin_info: &vk::SubpassBeginInfo,
+        subpass_end_info: &vk::SubpassEndInfo,
+    ) {
+        self.khr_create_renderpass2_fn
+            .cmd_next_subpass2_khr(command_buffer, subpass_begin_info, subpass_end_info);
+    }
+
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndRenderPass2.html>"]
+    unsafe fn cmd_end_render_pass2(
+        &self,
+        command_buffer: vk::CommandBuffer,
+        subpass_end_info: &vk::SubpassEndInfo,
+    ) {
+        self.khr_create_renderpass2_fn
+            .cmd_end_render_pass2_khr(command_buffer, subpass_end_info);
+    }
+
+    pub fn fp(&self) -> &vk::KhrCreateRenderpass2Fn {
+        &self.khr_create_renderpass2_fn
+    }
+
+    pub fn device(&self) -> vk::Device {
+        self.handle
+    }
+}

--- a/ash/src/extensions/khr/mod.rs
+++ b/ash/src/extensions/khr/mod.rs
@@ -24,6 +24,7 @@ pub use self::xlib_surface::XlibSurface;
 mod acceleration_structure;
 mod android_surface;
 mod buffer_device_address;
+mod create_render_pass2;
 mod deferred_host_operations;
 mod display;
 mod display_swapchain;

--- a/ash/src/extensions/khr/mod.rs
+++ b/ash/src/extensions/khr/mod.rs
@@ -1,6 +1,7 @@
 pub use self::acceleration_structure::AccelerationStructure;
 pub use self::android_surface::AndroidSurface;
 pub use self::buffer_device_address::BufferDeviceAddress;
+pub use self::create_render_pass2::CreateRenderPass2;
 pub use self::deferred_host_operations::DeferredHostOperations;
 pub use self::display::Display;
 pub use self::display_swapchain::DisplaySwapchain;


### PR DESCRIPTION
This was made core in 1.2, but I can only use 1.1 so need to load the extension.

Extension doc:

https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_create_renderpass2.html