### PR TITLE
Allow upper case acronyms for now

### DIFF
--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::too_many_arguments, clippy::missing_safety_doc, clippy::upper_case_acronyms)]
+#![allow(
+    clippy::too_many_arguments,
+    clippy::missing_safety_doc,
+    clippy::upper_case_acronyms
+)]
 //! # Vulkan API
 //!
 //! <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/index.html>

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::too_many_arguments, clippy::missing_safety_doc)]
+#![allow(clippy::too_many_arguments, clippy::missing_safety_doc, clippy::upper_case_acronyms)]
 //! # Vulkan API
 //!
 //! <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/index.html>


### PR DESCRIPTION
With 1.51 upper case acronyms are not allowed by default in clippy. Lets temporarily disable the lint.