### PR TITLE
generator: Use `Self` as return type in builder functions

### DIFF
--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -517,11 +517,11 @@ impl<'a> ::std::ops::DerefMut for Offset2DBuilder<'a> {
     }
 }
 impl<'a> Offset2DBuilder<'a> {
-    pub fn x(mut self, x: i32) -> Offset2DBuilder<'a> {
+    pub fn x(mut self, x: i32) -> Self {
         self.inner.x = x;
         self
     }
-    pub fn y(mut self, y: i32) -> Offset2DBuilder<'a> {
+    pub fn y(mut self, y: i32) -> Self {
         self.inner.y = y;
         self
     }
@@ -565,15 +565,15 @@ impl<'a> ::std::ops::DerefMut for Offset3DBuilder<'a> {
     }
 }
 impl<'a> Offset3DBuilder<'a> {
-    pub fn x(mut self, x: i32) -> Offset3DBuilder<'a> {
+    pub fn x(mut self, x: i32) -> Self {
         self.inner.x = x;
         self
     }
-    pub fn y(mut self, y: i32) -> Offset3DBuilder<'a> {
+    pub fn y(mut self, y: i32) -> Self {
         self.inner.y = y;
         self
     }
-    pub fn z(mut self, z: i32) -> Offset3DBuilder<'a> {
+    pub fn z(mut self, z: i32) -> Self {
         self.inner.z = z;
         self
     }
@@ -616,11 +616,11 @@ impl<'a> ::std::ops::DerefMut for Extent2DBuilder<'a> {
     }
 }
 impl<'a> Extent2DBuilder<'a> {
-    pub fn width(mut self, width: u32) -> Extent2DBuilder<'a> {
+    pub fn width(mut self, width: u32) -> Self {
         self.inner.width = width;
         self
     }
-    pub fn height(mut self, height: u32) -> Extent2DBuilder<'a> {
+    pub fn height(mut self, height: u32) -> Self {
         self.inner.height = height;
         self
     }
@@ -664,15 +664,15 @@ impl<'a> ::std::ops::DerefMut for Extent3DBuilder<'a> {
     }
 }
 impl<'a> Extent3DBuilder<'a> {
-    pub fn width(mut self, width: u32) -> Extent3DBuilder<'a> {
+    pub fn width(mut self, width: u32) -> Self {
         self.inner.width = width;
         self
     }
-    pub fn height(mut self, height: u32) -> Extent3DBuilder<'a> {
+    pub fn height(mut self, height: u32) -> Self {
         self.inner.height = height;
         self
     }
-    pub fn depth(mut self, depth: u32) -> Extent3DBuilder<'a> {
+    pub fn depth(mut self, depth: u32) -> Self {
         self.inner.depth = depth;
         self
     }
@@ -719,27 +719,27 @@ impl<'a> ::std::ops::DerefMut for ViewportBuilder<'a> {
     }
 }
 impl<'a> ViewportBuilder<'a> {
-    pub fn x(mut self, x: f32) -> ViewportBuilder<'a> {
+    pub fn x(mut self, x: f32) -> Self {
         self.inner.x = x;
         self
     }
-    pub fn y(mut self, y: f32) -> ViewportBuilder<'a> {
+    pub fn y(mut self, y: f32) -> Self {
         self.inner.y = y;
         self
     }
-    pub fn width(mut self, width: f32) -> ViewportBuilder<'a> {
+    pub fn width(mut self, width: f32) -> Self {
         self.inner.width = width;
         self
     }
-    pub fn height(mut self, height: f32) -> ViewportBuilder<'a> {
+    pub fn height(mut self, height: f32) -> Self {
         self.inner.height = height;
         self
     }
-    pub fn min_depth(mut self, min_depth: f32) -> ViewportBuilder<'a> {
+    pub fn min_depth(mut self, min_depth: f32) -> Self {
         self.inner.min_depth = min_depth;
         self
     }
-    pub fn max_depth(mut self, max_depth: f32) -> ViewportBuilder<'a> {
+    pub fn max_depth(mut self, max_depth: f32) -> Self {
         self.inner.max_depth = max_depth;
         self
     }
@@ -782,11 +782,11 @@ impl<'a> ::std::ops::DerefMut for Rect2DBuilder<'a> {
     }
 }
 impl<'a> Rect2DBuilder<'a> {
-    pub fn offset(mut self, offset: Offset2D) -> Rect2DBuilder<'a> {
+    pub fn offset(mut self, offset: Offset2D) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn extent(mut self, extent: Extent2D) -> Rect2DBuilder<'a> {
+    pub fn extent(mut self, extent: Extent2D) -> Self {
         self.inner.extent = extent;
         self
     }
@@ -830,15 +830,15 @@ impl<'a> ::std::ops::DerefMut for ClearRectBuilder<'a> {
     }
 }
 impl<'a> ClearRectBuilder<'a> {
-    pub fn rect(mut self, rect: Rect2D) -> ClearRectBuilder<'a> {
+    pub fn rect(mut self, rect: Rect2D) -> Self {
         self.inner.rect = rect;
         self
     }
-    pub fn base_array_layer(mut self, base_array_layer: u32) -> ClearRectBuilder<'a> {
+    pub fn base_array_layer(mut self, base_array_layer: u32) -> Self {
         self.inner.base_array_layer = base_array_layer;
         self
     }
-    pub fn layer_count(mut self, layer_count: u32) -> ClearRectBuilder<'a> {
+    pub fn layer_count(mut self, layer_count: u32) -> Self {
         self.inner.layer_count = layer_count;
         self
     }
@@ -883,19 +883,19 @@ impl<'a> ::std::ops::DerefMut for ComponentMappingBuilder<'a> {
     }
 }
 impl<'a> ComponentMappingBuilder<'a> {
-    pub fn r(mut self, r: ComponentSwizzle) -> ComponentMappingBuilder<'a> {
+    pub fn r(mut self, r: ComponentSwizzle) -> Self {
         self.inner.r = r;
         self
     }
-    pub fn g(mut self, g: ComponentSwizzle) -> ComponentMappingBuilder<'a> {
+    pub fn g(mut self, g: ComponentSwizzle) -> Self {
         self.inner.g = g;
         self
     }
-    pub fn b(mut self, b: ComponentSwizzle) -> ComponentMappingBuilder<'a> {
+    pub fn b(mut self, b: ComponentSwizzle) -> Self {
         self.inner.b = b;
         self
     }
-    pub fn a(mut self, a: ComponentSwizzle) -> ComponentMappingBuilder<'a> {
+    pub fn a(mut self, a: ComponentSwizzle) -> Self {
         self.inner.a = a;
         self
     }
@@ -977,51 +977,39 @@ impl<'a> ::std::ops::DerefMut for PhysicalDevicePropertiesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDevicePropertiesBuilder<'a> {
-    pub fn api_version(mut self, api_version: u32) -> PhysicalDevicePropertiesBuilder<'a> {
+    pub fn api_version(mut self, api_version: u32) -> Self {
         self.inner.api_version = api_version;
         self
     }
-    pub fn driver_version(mut self, driver_version: u32) -> PhysicalDevicePropertiesBuilder<'a> {
+    pub fn driver_version(mut self, driver_version: u32) -> Self {
         self.inner.driver_version = driver_version;
         self
     }
-    pub fn vendor_id(mut self, vendor_id: u32) -> PhysicalDevicePropertiesBuilder<'a> {
+    pub fn vendor_id(mut self, vendor_id: u32) -> Self {
         self.inner.vendor_id = vendor_id;
         self
     }
-    pub fn device_id(mut self, device_id: u32) -> PhysicalDevicePropertiesBuilder<'a> {
+    pub fn device_id(mut self, device_id: u32) -> Self {
         self.inner.device_id = device_id;
         self
     }
-    pub fn device_type(
-        mut self,
-        device_type: PhysicalDeviceType,
-    ) -> PhysicalDevicePropertiesBuilder<'a> {
+    pub fn device_type(mut self, device_type: PhysicalDeviceType) -> Self {
         self.inner.device_type = device_type;
         self
     }
-    pub fn device_name(
-        mut self,
-        device_name: [c_char; MAX_PHYSICAL_DEVICE_NAME_SIZE],
-    ) -> PhysicalDevicePropertiesBuilder<'a> {
+    pub fn device_name(mut self, device_name: [c_char; MAX_PHYSICAL_DEVICE_NAME_SIZE]) -> Self {
         self.inner.device_name = device_name;
         self
     }
-    pub fn pipeline_cache_uuid(
-        mut self,
-        pipeline_cache_uuid: [u8; UUID_SIZE],
-    ) -> PhysicalDevicePropertiesBuilder<'a> {
+    pub fn pipeline_cache_uuid(mut self, pipeline_cache_uuid: [u8; UUID_SIZE]) -> Self {
         self.inner.pipeline_cache_uuid = pipeline_cache_uuid;
         self
     }
-    pub fn limits(mut self, limits: PhysicalDeviceLimits) -> PhysicalDevicePropertiesBuilder<'a> {
+    pub fn limits(mut self, limits: PhysicalDeviceLimits) -> Self {
         self.inner.limits = limits;
         self
     }
-    pub fn sparse_properties(
-        mut self,
-        sparse_properties: PhysicalDeviceSparseProperties,
-    ) -> PhysicalDevicePropertiesBuilder<'a> {
+    pub fn sparse_properties(mut self, sparse_properties: PhysicalDeviceSparseProperties) -> Self {
         self.inner.sparse_properties = sparse_properties;
         self
     }
@@ -1082,14 +1070,11 @@ impl<'a> ::std::ops::DerefMut for ExtensionPropertiesBuilder<'a> {
     }
 }
 impl<'a> ExtensionPropertiesBuilder<'a> {
-    pub fn extension_name(
-        mut self,
-        extension_name: [c_char; MAX_EXTENSION_NAME_SIZE],
-    ) -> ExtensionPropertiesBuilder<'a> {
+    pub fn extension_name(mut self, extension_name: [c_char; MAX_EXTENSION_NAME_SIZE]) -> Self {
         self.inner.extension_name = extension_name;
         self
     }
-    pub fn spec_version(mut self, spec_version: u32) -> ExtensionPropertiesBuilder<'a> {
+    pub fn spec_version(mut self, spec_version: u32) -> Self {
         self.inner.spec_version = spec_version;
         self
     }
@@ -1158,28 +1143,19 @@ impl<'a> ::std::ops::DerefMut for LayerPropertiesBuilder<'a> {
     }
 }
 impl<'a> LayerPropertiesBuilder<'a> {
-    pub fn layer_name(
-        mut self,
-        layer_name: [c_char; MAX_EXTENSION_NAME_SIZE],
-    ) -> LayerPropertiesBuilder<'a> {
+    pub fn layer_name(mut self, layer_name: [c_char; MAX_EXTENSION_NAME_SIZE]) -> Self {
         self.inner.layer_name = layer_name;
         self
     }
-    pub fn spec_version(mut self, spec_version: u32) -> LayerPropertiesBuilder<'a> {
+    pub fn spec_version(mut self, spec_version: u32) -> Self {
         self.inner.spec_version = spec_version;
         self
     }
-    pub fn implementation_version(
-        mut self,
-        implementation_version: u32,
-    ) -> LayerPropertiesBuilder<'a> {
+    pub fn implementation_version(mut self, implementation_version: u32) -> Self {
         self.inner.implementation_version = implementation_version;
         self
     }
-    pub fn description(
-        mut self,
-        description: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> LayerPropertiesBuilder<'a> {
+    pub fn description(mut self, description: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.description = description;
         self
     }
@@ -1241,26 +1217,23 @@ impl<'a> ::std::ops::DerefMut for ApplicationInfoBuilder<'a> {
     }
 }
 impl<'a> ApplicationInfoBuilder<'a> {
-    pub fn application_name(
-        mut self,
-        application_name: &'a ::std::ffi::CStr,
-    ) -> ApplicationInfoBuilder<'a> {
+    pub fn application_name(mut self, application_name: &'a ::std::ffi::CStr) -> Self {
         self.inner.p_application_name = application_name.as_ptr();
         self
     }
-    pub fn application_version(mut self, application_version: u32) -> ApplicationInfoBuilder<'a> {
+    pub fn application_version(mut self, application_version: u32) -> Self {
         self.inner.application_version = application_version;
         self
     }
-    pub fn engine_name(mut self, engine_name: &'a ::std::ffi::CStr) -> ApplicationInfoBuilder<'a> {
+    pub fn engine_name(mut self, engine_name: &'a ::std::ffi::CStr) -> Self {
         self.inner.p_engine_name = engine_name.as_ptr();
         self
     }
-    pub fn engine_version(mut self, engine_version: u32) -> ApplicationInfoBuilder<'a> {
+    pub fn engine_version(mut self, engine_version: u32) -> Self {
         self.inner.engine_version = engine_version;
         self
     }
-    pub fn api_version(mut self, api_version: u32) -> ApplicationInfoBuilder<'a> {
+    pub fn api_version(mut self, api_version: u32) -> Self {
         self.inner.api_version = api_version;
         self
     }
@@ -1269,10 +1242,7 @@ impl<'a> ApplicationInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsApplicationInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> ApplicationInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsApplicationInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -1360,39 +1330,30 @@ impl<'a> ::std::ops::DerefMut for AllocationCallbacksBuilder<'a> {
     }
 }
 impl<'a> AllocationCallbacksBuilder<'a> {
-    pub fn user_data(mut self, user_data: *mut c_void) -> AllocationCallbacksBuilder<'a> {
+    pub fn user_data(mut self, user_data: *mut c_void) -> Self {
         self.inner.p_user_data = user_data;
         self
     }
-    pub fn pfn_allocation(
-        mut self,
-        pfn_allocation: PFN_vkAllocationFunction,
-    ) -> AllocationCallbacksBuilder<'a> {
+    pub fn pfn_allocation(mut self, pfn_allocation: PFN_vkAllocationFunction) -> Self {
         self.inner.pfn_allocation = pfn_allocation;
         self
     }
-    pub fn pfn_reallocation(
-        mut self,
-        pfn_reallocation: PFN_vkReallocationFunction,
-    ) -> AllocationCallbacksBuilder<'a> {
+    pub fn pfn_reallocation(mut self, pfn_reallocation: PFN_vkReallocationFunction) -> Self {
         self.inner.pfn_reallocation = pfn_reallocation;
         self
     }
-    pub fn pfn_free(mut self, pfn_free: PFN_vkFreeFunction) -> AllocationCallbacksBuilder<'a> {
+    pub fn pfn_free(mut self, pfn_free: PFN_vkFreeFunction) -> Self {
         self.inner.pfn_free = pfn_free;
         self
     }
     pub fn pfn_internal_allocation(
         mut self,
         pfn_internal_allocation: PFN_vkInternalAllocationNotification,
-    ) -> AllocationCallbacksBuilder<'a> {
+    ) -> Self {
         self.inner.pfn_internal_allocation = pfn_internal_allocation;
         self
     }
-    pub fn pfn_internal_free(
-        mut self,
-        pfn_internal_free: PFN_vkInternalFreeNotification,
-    ) -> AllocationCallbacksBuilder<'a> {
+    pub fn pfn_internal_free(mut self, pfn_internal_free: PFN_vkInternalFreeNotification) -> Self {
         self.inner.pfn_internal_free = pfn_internal_free;
         self
     }
@@ -1452,21 +1413,15 @@ impl<'a> ::std::ops::DerefMut for DeviceQueueCreateInfoBuilder<'a> {
     }
 }
 impl<'a> DeviceQueueCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: DeviceQueueCreateFlags) -> DeviceQueueCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: DeviceQueueCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn queue_family_index(
-        mut self,
-        queue_family_index: u32,
-    ) -> DeviceQueueCreateInfoBuilder<'a> {
+    pub fn queue_family_index(mut self, queue_family_index: u32) -> Self {
         self.inner.queue_family_index = queue_family_index;
         self
     }
-    pub fn queue_priorities(
-        mut self,
-        queue_priorities: &'a [f32],
-    ) -> DeviceQueueCreateInfoBuilder<'a> {
+    pub fn queue_priorities(mut self, queue_priorities: &'a [f32]) -> Self {
         self.inner.queue_count = queue_priorities.len() as _;
         self.inner.p_queue_priorities = queue_priorities.as_ptr();
         self
@@ -1476,10 +1431,7 @@ impl<'a> DeviceQueueCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDeviceQueueCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> DeviceQueueCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsDeviceQueueCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -1552,38 +1504,26 @@ impl<'a> ::std::ops::DerefMut for DeviceCreateInfoBuilder<'a> {
     }
 }
 impl<'a> DeviceCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: DeviceCreateFlags) -> DeviceCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: DeviceCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn queue_create_infos(
-        mut self,
-        queue_create_infos: &'a [DeviceQueueCreateInfo],
-    ) -> DeviceCreateInfoBuilder<'a> {
+    pub fn queue_create_infos(mut self, queue_create_infos: &'a [DeviceQueueCreateInfo]) -> Self {
         self.inner.queue_create_info_count = queue_create_infos.len() as _;
         self.inner.p_queue_create_infos = queue_create_infos.as_ptr();
         self
     }
-    pub fn enabled_layer_names(
-        mut self,
-        enabled_layer_names: &'a [*const c_char],
-    ) -> DeviceCreateInfoBuilder<'a> {
+    pub fn enabled_layer_names(mut self, enabled_layer_names: &'a [*const c_char]) -> Self {
         self.inner.enabled_layer_count = enabled_layer_names.len() as _;
         self.inner.pp_enabled_layer_names = enabled_layer_names.as_ptr();
         self
     }
-    pub fn enabled_extension_names(
-        mut self,
-        enabled_extension_names: &'a [*const c_char],
-    ) -> DeviceCreateInfoBuilder<'a> {
+    pub fn enabled_extension_names(mut self, enabled_extension_names: &'a [*const c_char]) -> Self {
         self.inner.enabled_extension_count = enabled_extension_names.len() as _;
         self.inner.pp_enabled_extension_names = enabled_extension_names.as_ptr();
         self
     }
-    pub fn enabled_features(
-        mut self,
-        enabled_features: &'a PhysicalDeviceFeatures,
-    ) -> DeviceCreateInfoBuilder<'a> {
+    pub fn enabled_features(mut self, enabled_features: &'a PhysicalDeviceFeatures) -> Self {
         self.inner.p_enabled_features = enabled_features;
         self
     }
@@ -1592,10 +1532,7 @@ impl<'a> DeviceCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDeviceCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> DeviceCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsDeviceCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -1664,29 +1601,20 @@ impl<'a> ::std::ops::DerefMut for InstanceCreateInfoBuilder<'a> {
     }
 }
 impl<'a> InstanceCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: InstanceCreateFlags) -> InstanceCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: InstanceCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn application_info(
-        mut self,
-        application_info: &'a ApplicationInfo,
-    ) -> InstanceCreateInfoBuilder<'a> {
+    pub fn application_info(mut self, application_info: &'a ApplicationInfo) -> Self {
         self.inner.p_application_info = application_info;
         self
     }
-    pub fn enabled_layer_names(
-        mut self,
-        enabled_layer_names: &'a [*const c_char],
-    ) -> InstanceCreateInfoBuilder<'a> {
+    pub fn enabled_layer_names(mut self, enabled_layer_names: &'a [*const c_char]) -> Self {
         self.inner.enabled_layer_count = enabled_layer_names.len() as _;
         self.inner.pp_enabled_layer_names = enabled_layer_names.as_ptr();
         self
     }
-    pub fn enabled_extension_names(
-        mut self,
-        enabled_extension_names: &'a [*const c_char],
-    ) -> InstanceCreateInfoBuilder<'a> {
+    pub fn enabled_extension_names(mut self, enabled_extension_names: &'a [*const c_char]) -> Self {
         self.inner.enabled_extension_count = enabled_extension_names.len() as _;
         self.inner.pp_enabled_extension_names = enabled_extension_names.as_ptr();
         self
@@ -1696,10 +1624,7 @@ impl<'a> InstanceCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsInstanceCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> InstanceCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsInstanceCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -1749,25 +1674,22 @@ impl<'a> ::std::ops::DerefMut for QueueFamilyPropertiesBuilder<'a> {
     }
 }
 impl<'a> QueueFamilyPropertiesBuilder<'a> {
-    pub fn queue_flags(mut self, queue_flags: QueueFlags) -> QueueFamilyPropertiesBuilder<'a> {
+    pub fn queue_flags(mut self, queue_flags: QueueFlags) -> Self {
         self.inner.queue_flags = queue_flags;
         self
     }
-    pub fn queue_count(mut self, queue_count: u32) -> QueueFamilyPropertiesBuilder<'a> {
+    pub fn queue_count(mut self, queue_count: u32) -> Self {
         self.inner.queue_count = queue_count;
         self
     }
-    pub fn timestamp_valid_bits(
-        mut self,
-        timestamp_valid_bits: u32,
-    ) -> QueueFamilyPropertiesBuilder<'a> {
+    pub fn timestamp_valid_bits(mut self, timestamp_valid_bits: u32) -> Self {
         self.inner.timestamp_valid_bits = timestamp_valid_bits;
         self
     }
     pub fn min_image_transfer_granularity(
         mut self,
         min_image_transfer_granularity: Extent3D,
-    ) -> QueueFamilyPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.min_image_transfer_granularity = min_image_transfer_granularity;
         self
     }
@@ -1822,31 +1744,19 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMemoryPropertiesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceMemoryPropertiesBuilder<'a> {
-    pub fn memory_type_count(
-        mut self,
-        memory_type_count: u32,
-    ) -> PhysicalDeviceMemoryPropertiesBuilder<'a> {
+    pub fn memory_type_count(mut self, memory_type_count: u32) -> Self {
         self.inner.memory_type_count = memory_type_count;
         self
     }
-    pub fn memory_types(
-        mut self,
-        memory_types: [MemoryType; MAX_MEMORY_TYPES],
-    ) -> PhysicalDeviceMemoryPropertiesBuilder<'a> {
+    pub fn memory_types(mut self, memory_types: [MemoryType; MAX_MEMORY_TYPES]) -> Self {
         self.inner.memory_types = memory_types;
         self
     }
-    pub fn memory_heap_count(
-        mut self,
-        memory_heap_count: u32,
-    ) -> PhysicalDeviceMemoryPropertiesBuilder<'a> {
+    pub fn memory_heap_count(mut self, memory_heap_count: u32) -> Self {
         self.inner.memory_heap_count = memory_heap_count;
         self
     }
-    pub fn memory_heaps(
-        mut self,
-        memory_heaps: [MemoryHeap; MAX_MEMORY_HEAPS],
-    ) -> PhysicalDeviceMemoryPropertiesBuilder<'a> {
+    pub fn memory_heaps(mut self, memory_heaps: [MemoryHeap; MAX_MEMORY_HEAPS]) -> Self {
         self.inner.memory_heaps = memory_heaps;
         self
     }
@@ -1902,11 +1812,11 @@ impl<'a> ::std::ops::DerefMut for MemoryAllocateInfoBuilder<'a> {
     }
 }
 impl<'a> MemoryAllocateInfoBuilder<'a> {
-    pub fn allocation_size(mut self, allocation_size: DeviceSize) -> MemoryAllocateInfoBuilder<'a> {
+    pub fn allocation_size(mut self, allocation_size: DeviceSize) -> Self {
         self.inner.allocation_size = allocation_size;
         self
     }
-    pub fn memory_type_index(mut self, memory_type_index: u32) -> MemoryAllocateInfoBuilder<'a> {
+    pub fn memory_type_index(mut self, memory_type_index: u32) -> Self {
         self.inner.memory_type_index = memory_type_index;
         self
     }
@@ -1915,10 +1825,7 @@ impl<'a> MemoryAllocateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMemoryAllocateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> MemoryAllocateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsMemoryAllocateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -1967,15 +1874,15 @@ impl<'a> ::std::ops::DerefMut for MemoryRequirementsBuilder<'a> {
     }
 }
 impl<'a> MemoryRequirementsBuilder<'a> {
-    pub fn size(mut self, size: DeviceSize) -> MemoryRequirementsBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
-    pub fn alignment(mut self, alignment: DeviceSize) -> MemoryRequirementsBuilder<'a> {
+    pub fn alignment(mut self, alignment: DeviceSize) -> Self {
         self.inner.alignment = alignment;
         self
     }
-    pub fn memory_type_bits(mut self, memory_type_bits: u32) -> MemoryRequirementsBuilder<'a> {
+    pub fn memory_type_bits(mut self, memory_type_bits: u32) -> Self {
         self.inner.memory_type_bits = memory_type_bits;
         self
     }
@@ -2019,24 +1926,15 @@ impl<'a> ::std::ops::DerefMut for SparseImageFormatPropertiesBuilder<'a> {
     }
 }
 impl<'a> SparseImageFormatPropertiesBuilder<'a> {
-    pub fn aspect_mask(
-        mut self,
-        aspect_mask: ImageAspectFlags,
-    ) -> SparseImageFormatPropertiesBuilder<'a> {
+    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> Self {
         self.inner.aspect_mask = aspect_mask;
         self
     }
-    pub fn image_granularity(
-        mut self,
-        image_granularity: Extent3D,
-    ) -> SparseImageFormatPropertiesBuilder<'a> {
+    pub fn image_granularity(mut self, image_granularity: Extent3D) -> Self {
         self.inner.image_granularity = image_granularity;
         self
     }
-    pub fn flags(
-        mut self,
-        flags: SparseImageFormatFlags,
-    ) -> SparseImageFormatPropertiesBuilder<'a> {
+    pub fn flags(mut self, flags: SparseImageFormatFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -2082,38 +1980,23 @@ impl<'a> ::std::ops::DerefMut for SparseImageMemoryRequirementsBuilder<'a> {
     }
 }
 impl<'a> SparseImageMemoryRequirementsBuilder<'a> {
-    pub fn format_properties(
-        mut self,
-        format_properties: SparseImageFormatProperties,
-    ) -> SparseImageMemoryRequirementsBuilder<'a> {
+    pub fn format_properties(mut self, format_properties: SparseImageFormatProperties) -> Self {
         self.inner.format_properties = format_properties;
         self
     }
-    pub fn image_mip_tail_first_lod(
-        mut self,
-        image_mip_tail_first_lod: u32,
-    ) -> SparseImageMemoryRequirementsBuilder<'a> {
+    pub fn image_mip_tail_first_lod(mut self, image_mip_tail_first_lod: u32) -> Self {
         self.inner.image_mip_tail_first_lod = image_mip_tail_first_lod;
         self
     }
-    pub fn image_mip_tail_size(
-        mut self,
-        image_mip_tail_size: DeviceSize,
-    ) -> SparseImageMemoryRequirementsBuilder<'a> {
+    pub fn image_mip_tail_size(mut self, image_mip_tail_size: DeviceSize) -> Self {
         self.inner.image_mip_tail_size = image_mip_tail_size;
         self
     }
-    pub fn image_mip_tail_offset(
-        mut self,
-        image_mip_tail_offset: DeviceSize,
-    ) -> SparseImageMemoryRequirementsBuilder<'a> {
+    pub fn image_mip_tail_offset(mut self, image_mip_tail_offset: DeviceSize) -> Self {
         self.inner.image_mip_tail_offset = image_mip_tail_offset;
         self
     }
-    pub fn image_mip_tail_stride(
-        mut self,
-        image_mip_tail_stride: DeviceSize,
-    ) -> SparseImageMemoryRequirementsBuilder<'a> {
+    pub fn image_mip_tail_stride(mut self, image_mip_tail_stride: DeviceSize) -> Self {
         self.inner.image_mip_tail_stride = image_mip_tail_stride;
         self
     }
@@ -2156,11 +2039,11 @@ impl<'a> ::std::ops::DerefMut for MemoryTypeBuilder<'a> {
     }
 }
 impl<'a> MemoryTypeBuilder<'a> {
-    pub fn property_flags(mut self, property_flags: MemoryPropertyFlags) -> MemoryTypeBuilder<'a> {
+    pub fn property_flags(mut self, property_flags: MemoryPropertyFlags) -> Self {
         self.inner.property_flags = property_flags;
         self
     }
-    pub fn heap_index(mut self, heap_index: u32) -> MemoryTypeBuilder<'a> {
+    pub fn heap_index(mut self, heap_index: u32) -> Self {
         self.inner.heap_index = heap_index;
         self
     }
@@ -2203,11 +2086,11 @@ impl<'a> ::std::ops::DerefMut for MemoryHeapBuilder<'a> {
     }
 }
 impl<'a> MemoryHeapBuilder<'a> {
-    pub fn size(mut self, size: DeviceSize) -> MemoryHeapBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
-    pub fn flags(mut self, flags: MemoryHeapFlags) -> MemoryHeapBuilder<'a> {
+    pub fn flags(mut self, flags: MemoryHeapFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -2265,15 +2148,15 @@ impl<'a> ::std::ops::DerefMut for MappedMemoryRangeBuilder<'a> {
     }
 }
 impl<'a> MappedMemoryRangeBuilder<'a> {
-    pub fn memory(mut self, memory: DeviceMemory) -> MappedMemoryRangeBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
-    pub fn offset(mut self, offset: DeviceSize) -> MappedMemoryRangeBuilder<'a> {
+    pub fn offset(mut self, offset: DeviceSize) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> MappedMemoryRangeBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
@@ -2282,10 +2165,7 @@ impl<'a> MappedMemoryRangeBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMappedMemoryRange>(
-        mut self,
-        next: &'a mut T,
-    ) -> MappedMemoryRangeBuilder<'a> {
+    pub fn push_next<T: ExtendsMappedMemoryRange>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -2334,24 +2214,15 @@ impl<'a> ::std::ops::DerefMut for FormatPropertiesBuilder<'a> {
     }
 }
 impl<'a> FormatPropertiesBuilder<'a> {
-    pub fn linear_tiling_features(
-        mut self,
-        linear_tiling_features: FormatFeatureFlags,
-    ) -> FormatPropertiesBuilder<'a> {
+    pub fn linear_tiling_features(mut self, linear_tiling_features: FormatFeatureFlags) -> Self {
         self.inner.linear_tiling_features = linear_tiling_features;
         self
     }
-    pub fn optimal_tiling_features(
-        mut self,
-        optimal_tiling_features: FormatFeatureFlags,
-    ) -> FormatPropertiesBuilder<'a> {
+    pub fn optimal_tiling_features(mut self, optimal_tiling_features: FormatFeatureFlags) -> Self {
         self.inner.optimal_tiling_features = optimal_tiling_features;
         self
     }
-    pub fn buffer_features(
-        mut self,
-        buffer_features: FormatFeatureFlags,
-    ) -> FormatPropertiesBuilder<'a> {
+    pub fn buffer_features(mut self, buffer_features: FormatFeatureFlags) -> Self {
         self.inner.buffer_features = buffer_features;
         self
     }
@@ -2397,29 +2268,23 @@ impl<'a> ::std::ops::DerefMut for ImageFormatPropertiesBuilder<'a> {
     }
 }
 impl<'a> ImageFormatPropertiesBuilder<'a> {
-    pub fn max_extent(mut self, max_extent: Extent3D) -> ImageFormatPropertiesBuilder<'a> {
+    pub fn max_extent(mut self, max_extent: Extent3D) -> Self {
         self.inner.max_extent = max_extent;
         self
     }
-    pub fn max_mip_levels(mut self, max_mip_levels: u32) -> ImageFormatPropertiesBuilder<'a> {
+    pub fn max_mip_levels(mut self, max_mip_levels: u32) -> Self {
         self.inner.max_mip_levels = max_mip_levels;
         self
     }
-    pub fn max_array_layers(mut self, max_array_layers: u32) -> ImageFormatPropertiesBuilder<'a> {
+    pub fn max_array_layers(mut self, max_array_layers: u32) -> Self {
         self.inner.max_array_layers = max_array_layers;
         self
     }
-    pub fn sample_counts(
-        mut self,
-        sample_counts: SampleCountFlags,
-    ) -> ImageFormatPropertiesBuilder<'a> {
+    pub fn sample_counts(mut self, sample_counts: SampleCountFlags) -> Self {
         self.inner.sample_counts = sample_counts;
         self
     }
-    pub fn max_resource_size(
-        mut self,
-        max_resource_size: DeviceSize,
-    ) -> ImageFormatPropertiesBuilder<'a> {
+    pub fn max_resource_size(mut self, max_resource_size: DeviceSize) -> Self {
         self.inner.max_resource_size = max_resource_size;
         self
     }
@@ -2463,15 +2328,15 @@ impl<'a> ::std::ops::DerefMut for DescriptorBufferInfoBuilder<'a> {
     }
 }
 impl<'a> DescriptorBufferInfoBuilder<'a> {
-    pub fn buffer(mut self, buffer: Buffer) -> DescriptorBufferInfoBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
-    pub fn offset(mut self, offset: DeviceSize) -> DescriptorBufferInfoBuilder<'a> {
+    pub fn offset(mut self, offset: DeviceSize) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn range(mut self, range: DeviceSize) -> DescriptorBufferInfoBuilder<'a> {
+    pub fn range(mut self, range: DeviceSize) -> Self {
         self.inner.range = range;
         self
     }
@@ -2515,15 +2380,15 @@ impl<'a> ::std::ops::DerefMut for DescriptorImageInfoBuilder<'a> {
     }
 }
 impl<'a> DescriptorImageInfoBuilder<'a> {
-    pub fn sampler(mut self, sampler: Sampler) -> DescriptorImageInfoBuilder<'a> {
+    pub fn sampler(mut self, sampler: Sampler) -> Self {
         self.inner.sampler = sampler;
         self
     }
-    pub fn image_view(mut self, image_view: ImageView) -> DescriptorImageInfoBuilder<'a> {
+    pub fn image_view(mut self, image_view: ImageView) -> Self {
         self.inner.image_view = image_view;
         self
     }
-    pub fn image_layout(mut self, image_layout: ImageLayout) -> DescriptorImageInfoBuilder<'a> {
+    pub fn image_layout(mut self, image_layout: ImageLayout) -> Self {
         self.inner.image_layout = image_layout;
         self
     }
@@ -2591,45 +2456,33 @@ impl<'a> ::std::ops::DerefMut for WriteDescriptorSetBuilder<'a> {
     }
 }
 impl<'a> WriteDescriptorSetBuilder<'a> {
-    pub fn dst_set(mut self, dst_set: DescriptorSet) -> WriteDescriptorSetBuilder<'a> {
+    pub fn dst_set(mut self, dst_set: DescriptorSet) -> Self {
         self.inner.dst_set = dst_set;
         self
     }
-    pub fn dst_binding(mut self, dst_binding: u32) -> WriteDescriptorSetBuilder<'a> {
+    pub fn dst_binding(mut self, dst_binding: u32) -> Self {
         self.inner.dst_binding = dst_binding;
         self
     }
-    pub fn dst_array_element(mut self, dst_array_element: u32) -> WriteDescriptorSetBuilder<'a> {
+    pub fn dst_array_element(mut self, dst_array_element: u32) -> Self {
         self.inner.dst_array_element = dst_array_element;
         self
     }
-    pub fn descriptor_type(
-        mut self,
-        descriptor_type: DescriptorType,
-    ) -> WriteDescriptorSetBuilder<'a> {
+    pub fn descriptor_type(mut self, descriptor_type: DescriptorType) -> Self {
         self.inner.descriptor_type = descriptor_type;
         self
     }
-    pub fn image_info(
-        mut self,
-        image_info: &'a [DescriptorImageInfo],
-    ) -> WriteDescriptorSetBuilder<'a> {
+    pub fn image_info(mut self, image_info: &'a [DescriptorImageInfo]) -> Self {
         self.inner.descriptor_count = image_info.len() as _;
         self.inner.p_image_info = image_info.as_ptr();
         self
     }
-    pub fn buffer_info(
-        mut self,
-        buffer_info: &'a [DescriptorBufferInfo],
-    ) -> WriteDescriptorSetBuilder<'a> {
+    pub fn buffer_info(mut self, buffer_info: &'a [DescriptorBufferInfo]) -> Self {
         self.inner.descriptor_count = buffer_info.len() as _;
         self.inner.p_buffer_info = buffer_info.as_ptr();
         self
     }
-    pub fn texel_buffer_view(
-        mut self,
-        texel_buffer_view: &'a [BufferView],
-    ) -> WriteDescriptorSetBuilder<'a> {
+    pub fn texel_buffer_view(mut self, texel_buffer_view: &'a [BufferView]) -> Self {
         self.inner.descriptor_count = texel_buffer_view.len() as _;
         self.inner.p_texel_buffer_view = texel_buffer_view.as_ptr();
         self
@@ -2639,10 +2492,7 @@ impl<'a> WriteDescriptorSetBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsWriteDescriptorSet>(
-        mut self,
-        next: &'a mut T,
-    ) -> WriteDescriptorSetBuilder<'a> {
+    pub fn push_next<T: ExtendsWriteDescriptorSet>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -2713,31 +2563,31 @@ impl<'a> ::std::ops::DerefMut for CopyDescriptorSetBuilder<'a> {
     }
 }
 impl<'a> CopyDescriptorSetBuilder<'a> {
-    pub fn src_set(mut self, src_set: DescriptorSet) -> CopyDescriptorSetBuilder<'a> {
+    pub fn src_set(mut self, src_set: DescriptorSet) -> Self {
         self.inner.src_set = src_set;
         self
     }
-    pub fn src_binding(mut self, src_binding: u32) -> CopyDescriptorSetBuilder<'a> {
+    pub fn src_binding(mut self, src_binding: u32) -> Self {
         self.inner.src_binding = src_binding;
         self
     }
-    pub fn src_array_element(mut self, src_array_element: u32) -> CopyDescriptorSetBuilder<'a> {
+    pub fn src_array_element(mut self, src_array_element: u32) -> Self {
         self.inner.src_array_element = src_array_element;
         self
     }
-    pub fn dst_set(mut self, dst_set: DescriptorSet) -> CopyDescriptorSetBuilder<'a> {
+    pub fn dst_set(mut self, dst_set: DescriptorSet) -> Self {
         self.inner.dst_set = dst_set;
         self
     }
-    pub fn dst_binding(mut self, dst_binding: u32) -> CopyDescriptorSetBuilder<'a> {
+    pub fn dst_binding(mut self, dst_binding: u32) -> Self {
         self.inner.dst_binding = dst_binding;
         self
     }
-    pub fn dst_array_element(mut self, dst_array_element: u32) -> CopyDescriptorSetBuilder<'a> {
+    pub fn dst_array_element(mut self, dst_array_element: u32) -> Self {
         self.inner.dst_array_element = dst_array_element;
         self
     }
-    pub fn descriptor_count(mut self, descriptor_count: u32) -> CopyDescriptorSetBuilder<'a> {
+    pub fn descriptor_count(mut self, descriptor_count: u32) -> Self {
         self.inner.descriptor_count = descriptor_count;
         self
     }
@@ -2746,10 +2596,7 @@ impl<'a> CopyDescriptorSetBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCopyDescriptorSet>(
-        mut self,
-        next: &'a mut T,
-    ) -> CopyDescriptorSetBuilder<'a> {
+    pub fn push_next<T: ExtendsCopyDescriptorSet>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -2818,26 +2665,23 @@ impl<'a> ::std::ops::DerefMut for BufferCreateInfoBuilder<'a> {
     }
 }
 impl<'a> BufferCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: BufferCreateFlags) -> BufferCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: BufferCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> BufferCreateInfoBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
-    pub fn usage(mut self, usage: BufferUsageFlags) -> BufferCreateInfoBuilder<'a> {
+    pub fn usage(mut self, usage: BufferUsageFlags) -> Self {
         self.inner.usage = usage;
         self
     }
-    pub fn sharing_mode(mut self, sharing_mode: SharingMode) -> BufferCreateInfoBuilder<'a> {
+    pub fn sharing_mode(mut self, sharing_mode: SharingMode) -> Self {
         self.inner.sharing_mode = sharing_mode;
         self
     }
-    pub fn queue_family_indices(
-        mut self,
-        queue_family_indices: &'a [u32],
-    ) -> BufferCreateInfoBuilder<'a> {
+    pub fn queue_family_indices(mut self, queue_family_indices: &'a [u32]) -> Self {
         self.inner.queue_family_index_count = queue_family_indices.len() as _;
         self.inner.p_queue_family_indices = queue_family_indices.as_ptr();
         self
@@ -2847,10 +2691,7 @@ impl<'a> BufferCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBufferCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> BufferCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsBufferCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -2917,23 +2758,23 @@ impl<'a> ::std::ops::DerefMut for BufferViewCreateInfoBuilder<'a> {
     }
 }
 impl<'a> BufferViewCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: BufferViewCreateFlags) -> BufferViewCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: BufferViewCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn buffer(mut self, buffer: Buffer) -> BufferViewCreateInfoBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
-    pub fn format(mut self, format: Format) -> BufferViewCreateInfoBuilder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn offset(mut self, offset: DeviceSize) -> BufferViewCreateInfoBuilder<'a> {
+    pub fn offset(mut self, offset: DeviceSize) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn range(mut self, range: DeviceSize) -> BufferViewCreateInfoBuilder<'a> {
+    pub fn range(mut self, range: DeviceSize) -> Self {
         self.inner.range = range;
         self
     }
@@ -2942,10 +2783,7 @@ impl<'a> BufferViewCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBufferViewCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> BufferViewCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsBufferViewCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -2994,15 +2832,15 @@ impl<'a> ::std::ops::DerefMut for ImageSubresourceBuilder<'a> {
     }
 }
 impl<'a> ImageSubresourceBuilder<'a> {
-    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> ImageSubresourceBuilder<'a> {
+    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> Self {
         self.inner.aspect_mask = aspect_mask;
         self
     }
-    pub fn mip_level(mut self, mip_level: u32) -> ImageSubresourceBuilder<'a> {
+    pub fn mip_level(mut self, mip_level: u32) -> Self {
         self.inner.mip_level = mip_level;
         self
     }
-    pub fn array_layer(mut self, array_layer: u32) -> ImageSubresourceBuilder<'a> {
+    pub fn array_layer(mut self, array_layer: u32) -> Self {
         self.inner.array_layer = array_layer;
         self
     }
@@ -3047,22 +2885,19 @@ impl<'a> ::std::ops::DerefMut for ImageSubresourceLayersBuilder<'a> {
     }
 }
 impl<'a> ImageSubresourceLayersBuilder<'a> {
-    pub fn aspect_mask(
-        mut self,
-        aspect_mask: ImageAspectFlags,
-    ) -> ImageSubresourceLayersBuilder<'a> {
+    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> Self {
         self.inner.aspect_mask = aspect_mask;
         self
     }
-    pub fn mip_level(mut self, mip_level: u32) -> ImageSubresourceLayersBuilder<'a> {
+    pub fn mip_level(mut self, mip_level: u32) -> Self {
         self.inner.mip_level = mip_level;
         self
     }
-    pub fn base_array_layer(mut self, base_array_layer: u32) -> ImageSubresourceLayersBuilder<'a> {
+    pub fn base_array_layer(mut self, base_array_layer: u32) -> Self {
         self.inner.base_array_layer = base_array_layer;
         self
     }
-    pub fn layer_count(mut self, layer_count: u32) -> ImageSubresourceLayersBuilder<'a> {
+    pub fn layer_count(mut self, layer_count: u32) -> Self {
         self.inner.layer_count = layer_count;
         self
     }
@@ -3108,26 +2943,23 @@ impl<'a> ::std::ops::DerefMut for ImageSubresourceRangeBuilder<'a> {
     }
 }
 impl<'a> ImageSubresourceRangeBuilder<'a> {
-    pub fn aspect_mask(
-        mut self,
-        aspect_mask: ImageAspectFlags,
-    ) -> ImageSubresourceRangeBuilder<'a> {
+    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> Self {
         self.inner.aspect_mask = aspect_mask;
         self
     }
-    pub fn base_mip_level(mut self, base_mip_level: u32) -> ImageSubresourceRangeBuilder<'a> {
+    pub fn base_mip_level(mut self, base_mip_level: u32) -> Self {
         self.inner.base_mip_level = base_mip_level;
         self
     }
-    pub fn level_count(mut self, level_count: u32) -> ImageSubresourceRangeBuilder<'a> {
+    pub fn level_count(mut self, level_count: u32) -> Self {
         self.inner.level_count = level_count;
         self
     }
-    pub fn base_array_layer(mut self, base_array_layer: u32) -> ImageSubresourceRangeBuilder<'a> {
+    pub fn base_array_layer(mut self, base_array_layer: u32) -> Self {
         self.inner.base_array_layer = base_array_layer;
         self
     }
-    pub fn layer_count(mut self, layer_count: u32) -> ImageSubresourceRangeBuilder<'a> {
+    pub fn layer_count(mut self, layer_count: u32) -> Self {
         self.inner.layer_count = layer_count;
         self
     }
@@ -3183,11 +3015,11 @@ impl<'a> ::std::ops::DerefMut for MemoryBarrierBuilder<'a> {
     }
 }
 impl<'a> MemoryBarrierBuilder<'a> {
-    pub fn src_access_mask(mut self, src_access_mask: AccessFlags) -> MemoryBarrierBuilder<'a> {
+    pub fn src_access_mask(mut self, src_access_mask: AccessFlags) -> Self {
         self.inner.src_access_mask = src_access_mask;
         self
     }
-    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags) -> MemoryBarrierBuilder<'a> {
+    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags) -> Self {
         self.inner.dst_access_mask = dst_access_mask;
         self
     }
@@ -3196,10 +3028,7 @@ impl<'a> MemoryBarrierBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMemoryBarrier>(
-        mut self,
-        next: &'a mut T,
-    ) -> MemoryBarrierBuilder<'a> {
+    pub fn push_next<T: ExtendsMemoryBarrier>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -3270,43 +3099,31 @@ impl<'a> ::std::ops::DerefMut for BufferMemoryBarrierBuilder<'a> {
     }
 }
 impl<'a> BufferMemoryBarrierBuilder<'a> {
-    pub fn src_access_mask(
-        mut self,
-        src_access_mask: AccessFlags,
-    ) -> BufferMemoryBarrierBuilder<'a> {
+    pub fn src_access_mask(mut self, src_access_mask: AccessFlags) -> Self {
         self.inner.src_access_mask = src_access_mask;
         self
     }
-    pub fn dst_access_mask(
-        mut self,
-        dst_access_mask: AccessFlags,
-    ) -> BufferMemoryBarrierBuilder<'a> {
+    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags) -> Self {
         self.inner.dst_access_mask = dst_access_mask;
         self
     }
-    pub fn src_queue_family_index(
-        mut self,
-        src_queue_family_index: u32,
-    ) -> BufferMemoryBarrierBuilder<'a> {
+    pub fn src_queue_family_index(mut self, src_queue_family_index: u32) -> Self {
         self.inner.src_queue_family_index = src_queue_family_index;
         self
     }
-    pub fn dst_queue_family_index(
-        mut self,
-        dst_queue_family_index: u32,
-    ) -> BufferMemoryBarrierBuilder<'a> {
+    pub fn dst_queue_family_index(mut self, dst_queue_family_index: u32) -> Self {
         self.inner.dst_queue_family_index = dst_queue_family_index;
         self
     }
-    pub fn buffer(mut self, buffer: Buffer) -> BufferMemoryBarrierBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
-    pub fn offset(mut self, offset: DeviceSize) -> BufferMemoryBarrierBuilder<'a> {
+    pub fn offset(mut self, offset: DeviceSize) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> BufferMemoryBarrierBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
@@ -3315,10 +3132,7 @@ impl<'a> BufferMemoryBarrierBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBufferMemoryBarrier>(
-        mut self,
-        next: &'a mut T,
-    ) -> BufferMemoryBarrierBuilder<'a> {
+    pub fn push_next<T: ExtendsBufferMemoryBarrier>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -3391,50 +3205,35 @@ impl<'a> ::std::ops::DerefMut for ImageMemoryBarrierBuilder<'a> {
     }
 }
 impl<'a> ImageMemoryBarrierBuilder<'a> {
-    pub fn src_access_mask(
-        mut self,
-        src_access_mask: AccessFlags,
-    ) -> ImageMemoryBarrierBuilder<'a> {
+    pub fn src_access_mask(mut self, src_access_mask: AccessFlags) -> Self {
         self.inner.src_access_mask = src_access_mask;
         self
     }
-    pub fn dst_access_mask(
-        mut self,
-        dst_access_mask: AccessFlags,
-    ) -> ImageMemoryBarrierBuilder<'a> {
+    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags) -> Self {
         self.inner.dst_access_mask = dst_access_mask;
         self
     }
-    pub fn old_layout(mut self, old_layout: ImageLayout) -> ImageMemoryBarrierBuilder<'a> {
+    pub fn old_layout(mut self, old_layout: ImageLayout) -> Self {
         self.inner.old_layout = old_layout;
         self
     }
-    pub fn new_layout(mut self, new_layout: ImageLayout) -> ImageMemoryBarrierBuilder<'a> {
+    pub fn new_layout(mut self, new_layout: ImageLayout) -> Self {
         self.inner.new_layout = new_layout;
         self
     }
-    pub fn src_queue_family_index(
-        mut self,
-        src_queue_family_index: u32,
-    ) -> ImageMemoryBarrierBuilder<'a> {
+    pub fn src_queue_family_index(mut self, src_queue_family_index: u32) -> Self {
         self.inner.src_queue_family_index = src_queue_family_index;
         self
     }
-    pub fn dst_queue_family_index(
-        mut self,
-        dst_queue_family_index: u32,
-    ) -> ImageMemoryBarrierBuilder<'a> {
+    pub fn dst_queue_family_index(mut self, dst_queue_family_index: u32) -> Self {
         self.inner.dst_queue_family_index = dst_queue_family_index;
         self
     }
-    pub fn image(mut self, image: Image) -> ImageMemoryBarrierBuilder<'a> {
+    pub fn image(mut self, image: Image) -> Self {
         self.inner.image = image;
         self
     }
-    pub fn subresource_range(
-        mut self,
-        subresource_range: ImageSubresourceRange,
-    ) -> ImageMemoryBarrierBuilder<'a> {
+    pub fn subresource_range(mut self, subresource_range: ImageSubresourceRange) -> Self {
         self.inner.subresource_range = subresource_range;
         self
     }
@@ -3443,10 +3242,7 @@ impl<'a> ImageMemoryBarrierBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageMemoryBarrier>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageMemoryBarrierBuilder<'a> {
+    pub fn push_next<T: ExtendsImageMemoryBarrier>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -3529,55 +3325,52 @@ impl<'a> ::std::ops::DerefMut for ImageCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ImageCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: ImageCreateFlags) -> ImageCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: ImageCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn image_type(mut self, image_type: ImageType) -> ImageCreateInfoBuilder<'a> {
+    pub fn image_type(mut self, image_type: ImageType) -> Self {
         self.inner.image_type = image_type;
         self
     }
-    pub fn format(mut self, format: Format) -> ImageCreateInfoBuilder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn extent(mut self, extent: Extent3D) -> ImageCreateInfoBuilder<'a> {
+    pub fn extent(mut self, extent: Extent3D) -> Self {
         self.inner.extent = extent;
         self
     }
-    pub fn mip_levels(mut self, mip_levels: u32) -> ImageCreateInfoBuilder<'a> {
+    pub fn mip_levels(mut self, mip_levels: u32) -> Self {
         self.inner.mip_levels = mip_levels;
         self
     }
-    pub fn array_layers(mut self, array_layers: u32) -> ImageCreateInfoBuilder<'a> {
+    pub fn array_layers(mut self, array_layers: u32) -> Self {
         self.inner.array_layers = array_layers;
         self
     }
-    pub fn samples(mut self, samples: SampleCountFlags) -> ImageCreateInfoBuilder<'a> {
+    pub fn samples(mut self, samples: SampleCountFlags) -> Self {
         self.inner.samples = samples;
         self
     }
-    pub fn tiling(mut self, tiling: ImageTiling) -> ImageCreateInfoBuilder<'a> {
+    pub fn tiling(mut self, tiling: ImageTiling) -> Self {
         self.inner.tiling = tiling;
         self
     }
-    pub fn usage(mut self, usage: ImageUsageFlags) -> ImageCreateInfoBuilder<'a> {
+    pub fn usage(mut self, usage: ImageUsageFlags) -> Self {
         self.inner.usage = usage;
         self
     }
-    pub fn sharing_mode(mut self, sharing_mode: SharingMode) -> ImageCreateInfoBuilder<'a> {
+    pub fn sharing_mode(mut self, sharing_mode: SharingMode) -> Self {
         self.inner.sharing_mode = sharing_mode;
         self
     }
-    pub fn queue_family_indices(
-        mut self,
-        queue_family_indices: &'a [u32],
-    ) -> ImageCreateInfoBuilder<'a> {
+    pub fn queue_family_indices(mut self, queue_family_indices: &'a [u32]) -> Self {
         self.inner.queue_family_index_count = queue_family_indices.len() as _;
         self.inner.p_queue_family_indices = queue_family_indices.as_ptr();
         self
     }
-    pub fn initial_layout(mut self, initial_layout: ImageLayout) -> ImageCreateInfoBuilder<'a> {
+    pub fn initial_layout(mut self, initial_layout: ImageLayout) -> Self {
         self.inner.initial_layout = initial_layout;
         self
     }
@@ -3586,10 +3379,7 @@ impl<'a> ImageCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsImageCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -3640,23 +3430,23 @@ impl<'a> ::std::ops::DerefMut for SubresourceLayoutBuilder<'a> {
     }
 }
 impl<'a> SubresourceLayoutBuilder<'a> {
-    pub fn offset(mut self, offset: DeviceSize) -> SubresourceLayoutBuilder<'a> {
+    pub fn offset(mut self, offset: DeviceSize) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> SubresourceLayoutBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
-    pub fn row_pitch(mut self, row_pitch: DeviceSize) -> SubresourceLayoutBuilder<'a> {
+    pub fn row_pitch(mut self, row_pitch: DeviceSize) -> Self {
         self.inner.row_pitch = row_pitch;
         self
     }
-    pub fn array_pitch(mut self, array_pitch: DeviceSize) -> SubresourceLayoutBuilder<'a> {
+    pub fn array_pitch(mut self, array_pitch: DeviceSize) -> Self {
         self.inner.array_pitch = array_pitch;
         self
     }
-    pub fn depth_pitch(mut self, depth_pitch: DeviceSize) -> SubresourceLayoutBuilder<'a> {
+    pub fn depth_pitch(mut self, depth_pitch: DeviceSize) -> Self {
         self.inner.depth_pitch = depth_pitch;
         self
     }
@@ -3720,30 +3510,27 @@ impl<'a> ::std::ops::DerefMut for ImageViewCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ImageViewCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: ImageViewCreateFlags) -> ImageViewCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: ImageViewCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn image(mut self, image: Image) -> ImageViewCreateInfoBuilder<'a> {
+    pub fn image(mut self, image: Image) -> Self {
         self.inner.image = image;
         self
     }
-    pub fn view_type(mut self, view_type: ImageViewType) -> ImageViewCreateInfoBuilder<'a> {
+    pub fn view_type(mut self, view_type: ImageViewType) -> Self {
         self.inner.view_type = view_type;
         self
     }
-    pub fn format(mut self, format: Format) -> ImageViewCreateInfoBuilder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn components(mut self, components: ComponentMapping) -> ImageViewCreateInfoBuilder<'a> {
+    pub fn components(mut self, components: ComponentMapping) -> Self {
         self.inner.components = components;
         self
     }
-    pub fn subresource_range(
-        mut self,
-        subresource_range: ImageSubresourceRange,
-    ) -> ImageViewCreateInfoBuilder<'a> {
+    pub fn subresource_range(mut self, subresource_range: ImageSubresourceRange) -> Self {
         self.inner.subresource_range = subresource_range;
         self
     }
@@ -3752,10 +3539,7 @@ impl<'a> ImageViewCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageViewCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageViewCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsImageViewCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -3804,15 +3588,15 @@ impl<'a> ::std::ops::DerefMut for BufferCopyBuilder<'a> {
     }
 }
 impl<'a> BufferCopyBuilder<'a> {
-    pub fn src_offset(mut self, src_offset: DeviceSize) -> BufferCopyBuilder<'a> {
+    pub fn src_offset(mut self, src_offset: DeviceSize) -> Self {
         self.inner.src_offset = src_offset;
         self
     }
-    pub fn dst_offset(mut self, dst_offset: DeviceSize) -> BufferCopyBuilder<'a> {
+    pub fn dst_offset(mut self, dst_offset: DeviceSize) -> Self {
         self.inner.dst_offset = dst_offset;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> BufferCopyBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
@@ -3858,23 +3642,23 @@ impl<'a> ::std::ops::DerefMut for SparseMemoryBindBuilder<'a> {
     }
 }
 impl<'a> SparseMemoryBindBuilder<'a> {
-    pub fn resource_offset(mut self, resource_offset: DeviceSize) -> SparseMemoryBindBuilder<'a> {
+    pub fn resource_offset(mut self, resource_offset: DeviceSize) -> Self {
         self.inner.resource_offset = resource_offset;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> SparseMemoryBindBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
-    pub fn memory(mut self, memory: DeviceMemory) -> SparseMemoryBindBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
-    pub fn memory_offset(mut self, memory_offset: DeviceSize) -> SparseMemoryBindBuilder<'a> {
+    pub fn memory_offset(mut self, memory_offset: DeviceSize) -> Self {
         self.inner.memory_offset = memory_offset;
         self
     }
-    pub fn flags(mut self, flags: SparseMemoryBindFlags) -> SparseMemoryBindBuilder<'a> {
+    pub fn flags(mut self, flags: SparseMemoryBindFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -3921,30 +3705,27 @@ impl<'a> ::std::ops::DerefMut for SparseImageMemoryBindBuilder<'a> {
     }
 }
 impl<'a> SparseImageMemoryBindBuilder<'a> {
-    pub fn subresource(
-        mut self,
-        subresource: ImageSubresource,
-    ) -> SparseImageMemoryBindBuilder<'a> {
+    pub fn subresource(mut self, subresource: ImageSubresource) -> Self {
         self.inner.subresource = subresource;
         self
     }
-    pub fn offset(mut self, offset: Offset3D) -> SparseImageMemoryBindBuilder<'a> {
+    pub fn offset(mut self, offset: Offset3D) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn extent(mut self, extent: Extent3D) -> SparseImageMemoryBindBuilder<'a> {
+    pub fn extent(mut self, extent: Extent3D) -> Self {
         self.inner.extent = extent;
         self
     }
-    pub fn memory(mut self, memory: DeviceMemory) -> SparseImageMemoryBindBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
-    pub fn memory_offset(mut self, memory_offset: DeviceSize) -> SparseImageMemoryBindBuilder<'a> {
+    pub fn memory_offset(mut self, memory_offset: DeviceSize) -> Self {
         self.inner.memory_offset = memory_offset;
         self
     }
-    pub fn flags(mut self, flags: SparseMemoryBindFlags) -> SparseImageMemoryBindBuilder<'a> {
+    pub fn flags(mut self, flags: SparseMemoryBindFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -3997,11 +3778,11 @@ impl<'a> ::std::ops::DerefMut for SparseBufferMemoryBindInfoBuilder<'a> {
     }
 }
 impl<'a> SparseBufferMemoryBindInfoBuilder<'a> {
-    pub fn buffer(mut self, buffer: Buffer) -> SparseBufferMemoryBindInfoBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
-    pub fn binds(mut self, binds: &'a [SparseMemoryBind]) -> SparseBufferMemoryBindInfoBuilder<'a> {
+    pub fn binds(mut self, binds: &'a [SparseMemoryBind]) -> Self {
         self.inner.bind_count = binds.len() as _;
         self.inner.p_binds = binds.as_ptr();
         self
@@ -4055,14 +3836,11 @@ impl<'a> ::std::ops::DerefMut for SparseImageOpaqueMemoryBindInfoBuilder<'a> {
     }
 }
 impl<'a> SparseImageOpaqueMemoryBindInfoBuilder<'a> {
-    pub fn image(mut self, image: Image) -> SparseImageOpaqueMemoryBindInfoBuilder<'a> {
+    pub fn image(mut self, image: Image) -> Self {
         self.inner.image = image;
         self
     }
-    pub fn binds(
-        mut self,
-        binds: &'a [SparseMemoryBind],
-    ) -> SparseImageOpaqueMemoryBindInfoBuilder<'a> {
+    pub fn binds(mut self, binds: &'a [SparseMemoryBind]) -> Self {
         self.inner.bind_count = binds.len() as _;
         self.inner.p_binds = binds.as_ptr();
         self
@@ -4116,14 +3894,11 @@ impl<'a> ::std::ops::DerefMut for SparseImageMemoryBindInfoBuilder<'a> {
     }
 }
 impl<'a> SparseImageMemoryBindInfoBuilder<'a> {
-    pub fn image(mut self, image: Image) -> SparseImageMemoryBindInfoBuilder<'a> {
+    pub fn image(mut self, image: Image) -> Self {
         self.inner.image = image;
         self
     }
-    pub fn binds(
-        mut self,
-        binds: &'a [SparseImageMemoryBind],
-    ) -> SparseImageMemoryBindInfoBuilder<'a> {
+    pub fn binds(mut self, binds: &'a [SparseImageMemoryBind]) -> Self {
         self.inner.bind_count = binds.len() as _;
         self.inner.p_binds = binds.as_ptr();
         self
@@ -4196,18 +3971,12 @@ impl<'a> ::std::ops::DerefMut for BindSparseInfoBuilder<'a> {
     }
 }
 impl<'a> BindSparseInfoBuilder<'a> {
-    pub fn wait_semaphores(
-        mut self,
-        wait_semaphores: &'a [Semaphore],
-    ) -> BindSparseInfoBuilder<'a> {
+    pub fn wait_semaphores(mut self, wait_semaphores: &'a [Semaphore]) -> Self {
         self.inner.wait_semaphore_count = wait_semaphores.len() as _;
         self.inner.p_wait_semaphores = wait_semaphores.as_ptr();
         self
     }
-    pub fn buffer_binds(
-        mut self,
-        buffer_binds: &'a [SparseBufferMemoryBindInfo],
-    ) -> BindSparseInfoBuilder<'a> {
+    pub fn buffer_binds(mut self, buffer_binds: &'a [SparseBufferMemoryBindInfo]) -> Self {
         self.inner.buffer_bind_count = buffer_binds.len() as _;
         self.inner.p_buffer_binds = buffer_binds.as_ptr();
         self
@@ -4215,23 +3984,17 @@ impl<'a> BindSparseInfoBuilder<'a> {
     pub fn image_opaque_binds(
         mut self,
         image_opaque_binds: &'a [SparseImageOpaqueMemoryBindInfo],
-    ) -> BindSparseInfoBuilder<'a> {
+    ) -> Self {
         self.inner.image_opaque_bind_count = image_opaque_binds.len() as _;
         self.inner.p_image_opaque_binds = image_opaque_binds.as_ptr();
         self
     }
-    pub fn image_binds(
-        mut self,
-        image_binds: &'a [SparseImageMemoryBindInfo],
-    ) -> BindSparseInfoBuilder<'a> {
+    pub fn image_binds(mut self, image_binds: &'a [SparseImageMemoryBindInfo]) -> Self {
         self.inner.image_bind_count = image_binds.len() as _;
         self.inner.p_image_binds = image_binds.as_ptr();
         self
     }
-    pub fn signal_semaphores(
-        mut self,
-        signal_semaphores: &'a [Semaphore],
-    ) -> BindSparseInfoBuilder<'a> {
+    pub fn signal_semaphores(mut self, signal_semaphores: &'a [Semaphore]) -> Self {
         self.inner.signal_semaphore_count = signal_semaphores.len() as _;
         self.inner.p_signal_semaphores = signal_semaphores.as_ptr();
         self
@@ -4241,10 +4004,7 @@ impl<'a> BindSparseInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBindSparseInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> BindSparseInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsBindSparseInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -4295,29 +4055,23 @@ impl<'a> ::std::ops::DerefMut for ImageCopyBuilder<'a> {
     }
 }
 impl<'a> ImageCopyBuilder<'a> {
-    pub fn src_subresource(
-        mut self,
-        src_subresource: ImageSubresourceLayers,
-    ) -> ImageCopyBuilder<'a> {
+    pub fn src_subresource(mut self, src_subresource: ImageSubresourceLayers) -> Self {
         self.inner.src_subresource = src_subresource;
         self
     }
-    pub fn src_offset(mut self, src_offset: Offset3D) -> ImageCopyBuilder<'a> {
+    pub fn src_offset(mut self, src_offset: Offset3D) -> Self {
         self.inner.src_offset = src_offset;
         self
     }
-    pub fn dst_subresource(
-        mut self,
-        dst_subresource: ImageSubresourceLayers,
-    ) -> ImageCopyBuilder<'a> {
+    pub fn dst_subresource(mut self, dst_subresource: ImageSubresourceLayers) -> Self {
         self.inner.dst_subresource = dst_subresource;
         self
     }
-    pub fn dst_offset(mut self, dst_offset: Offset3D) -> ImageCopyBuilder<'a> {
+    pub fn dst_offset(mut self, dst_offset: Offset3D) -> Self {
         self.inner.dst_offset = dst_offset;
         self
     }
-    pub fn extent(mut self, extent: Extent3D) -> ImageCopyBuilder<'a> {
+    pub fn extent(mut self, extent: Extent3D) -> Self {
         self.inner.extent = extent;
         self
     }
@@ -4372,25 +4126,19 @@ impl<'a> ::std::ops::DerefMut for ImageBlitBuilder<'a> {
     }
 }
 impl<'a> ImageBlitBuilder<'a> {
-    pub fn src_subresource(
-        mut self,
-        src_subresource: ImageSubresourceLayers,
-    ) -> ImageBlitBuilder<'a> {
+    pub fn src_subresource(mut self, src_subresource: ImageSubresourceLayers) -> Self {
         self.inner.src_subresource = src_subresource;
         self
     }
-    pub fn src_offsets(mut self, src_offsets: [Offset3D; 2]) -> ImageBlitBuilder<'a> {
+    pub fn src_offsets(mut self, src_offsets: [Offset3D; 2]) -> Self {
         self.inner.src_offsets = src_offsets;
         self
     }
-    pub fn dst_subresource(
-        mut self,
-        dst_subresource: ImageSubresourceLayers,
-    ) -> ImageBlitBuilder<'a> {
+    pub fn dst_subresource(mut self, dst_subresource: ImageSubresourceLayers) -> Self {
         self.inner.dst_subresource = dst_subresource;
         self
     }
-    pub fn dst_offsets(mut self, dst_offsets: [Offset3D; 2]) -> ImageBlitBuilder<'a> {
+    pub fn dst_offsets(mut self, dst_offsets: [Offset3D; 2]) -> Self {
         self.inner.dst_offsets = dst_offsets;
         self
     }
@@ -4437,30 +4185,27 @@ impl<'a> ::std::ops::DerefMut for BufferImageCopyBuilder<'a> {
     }
 }
 impl<'a> BufferImageCopyBuilder<'a> {
-    pub fn buffer_offset(mut self, buffer_offset: DeviceSize) -> BufferImageCopyBuilder<'a> {
+    pub fn buffer_offset(mut self, buffer_offset: DeviceSize) -> Self {
         self.inner.buffer_offset = buffer_offset;
         self
     }
-    pub fn buffer_row_length(mut self, buffer_row_length: u32) -> BufferImageCopyBuilder<'a> {
+    pub fn buffer_row_length(mut self, buffer_row_length: u32) -> Self {
         self.inner.buffer_row_length = buffer_row_length;
         self
     }
-    pub fn buffer_image_height(mut self, buffer_image_height: u32) -> BufferImageCopyBuilder<'a> {
+    pub fn buffer_image_height(mut self, buffer_image_height: u32) -> Self {
         self.inner.buffer_image_height = buffer_image_height;
         self
     }
-    pub fn image_subresource(
-        mut self,
-        image_subresource: ImageSubresourceLayers,
-    ) -> BufferImageCopyBuilder<'a> {
+    pub fn image_subresource(mut self, image_subresource: ImageSubresourceLayers) -> Self {
         self.inner.image_subresource = image_subresource;
         self
     }
-    pub fn image_offset(mut self, image_offset: Offset3D) -> BufferImageCopyBuilder<'a> {
+    pub fn image_offset(mut self, image_offset: Offset3D) -> Self {
         self.inner.image_offset = image_offset;
         self
     }
-    pub fn image_extent(mut self, image_extent: Extent3D) -> BufferImageCopyBuilder<'a> {
+    pub fn image_extent(mut self, image_extent: Extent3D) -> Self {
         self.inner.image_extent = image_extent;
         self
     }
@@ -4506,29 +4251,23 @@ impl<'a> ::std::ops::DerefMut for ImageResolveBuilder<'a> {
     }
 }
 impl<'a> ImageResolveBuilder<'a> {
-    pub fn src_subresource(
-        mut self,
-        src_subresource: ImageSubresourceLayers,
-    ) -> ImageResolveBuilder<'a> {
+    pub fn src_subresource(mut self, src_subresource: ImageSubresourceLayers) -> Self {
         self.inner.src_subresource = src_subresource;
         self
     }
-    pub fn src_offset(mut self, src_offset: Offset3D) -> ImageResolveBuilder<'a> {
+    pub fn src_offset(mut self, src_offset: Offset3D) -> Self {
         self.inner.src_offset = src_offset;
         self
     }
-    pub fn dst_subresource(
-        mut self,
-        dst_subresource: ImageSubresourceLayers,
-    ) -> ImageResolveBuilder<'a> {
+    pub fn dst_subresource(mut self, dst_subresource: ImageSubresourceLayers) -> Self {
         self.inner.dst_subresource = dst_subresource;
         self
     }
-    pub fn dst_offset(mut self, dst_offset: Offset3D) -> ImageResolveBuilder<'a> {
+    pub fn dst_offset(mut self, dst_offset: Offset3D) -> Self {
         self.inner.dst_offset = dst_offset;
         self
     }
-    pub fn extent(mut self, extent: Extent3D) -> ImageResolveBuilder<'a> {
+    pub fn extent(mut self, extent: Extent3D) -> Self {
         self.inner.extent = extent;
         self
     }
@@ -4586,11 +4325,11 @@ impl<'a> ::std::ops::DerefMut for ShaderModuleCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ShaderModuleCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: ShaderModuleCreateFlags) -> ShaderModuleCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: ShaderModuleCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn code(mut self, code: &'a [u32]) -> ShaderModuleCreateInfoBuilder<'a> {
+    pub fn code(mut self, code: &'a [u32]) -> Self {
         self.inner.code_size = code.len() * 4;
         self.inner.p_code = code.as_ptr() as *const u32;
         self
@@ -4600,10 +4339,7 @@ impl<'a> ShaderModuleCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsShaderModuleCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> ShaderModuleCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsShaderModuleCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -4665,35 +4401,23 @@ impl<'a> ::std::ops::DerefMut for DescriptorSetLayoutBindingBuilder<'a> {
     }
 }
 impl<'a> DescriptorSetLayoutBindingBuilder<'a> {
-    pub fn binding(mut self, binding: u32) -> DescriptorSetLayoutBindingBuilder<'a> {
+    pub fn binding(mut self, binding: u32) -> Self {
         self.inner.binding = binding;
         self
     }
-    pub fn descriptor_type(
-        mut self,
-        descriptor_type: DescriptorType,
-    ) -> DescriptorSetLayoutBindingBuilder<'a> {
+    pub fn descriptor_type(mut self, descriptor_type: DescriptorType) -> Self {
         self.inner.descriptor_type = descriptor_type;
         self
     }
-    pub fn descriptor_count(
-        mut self,
-        descriptor_count: u32,
-    ) -> DescriptorSetLayoutBindingBuilder<'a> {
+    pub fn descriptor_count(mut self, descriptor_count: u32) -> Self {
         self.inner.descriptor_count = descriptor_count;
         self
     }
-    pub fn stage_flags(
-        mut self,
-        stage_flags: ShaderStageFlags,
-    ) -> DescriptorSetLayoutBindingBuilder<'a> {
+    pub fn stage_flags(mut self, stage_flags: ShaderStageFlags) -> Self {
         self.inner.stage_flags = stage_flags;
         self
     }
-    pub fn immutable_samplers(
-        mut self,
-        immutable_samplers: &'a [Sampler],
-    ) -> DescriptorSetLayoutBindingBuilder<'a> {
+    pub fn immutable_samplers(mut self, immutable_samplers: &'a [Sampler]) -> Self {
         self.inner.descriptor_count = immutable_samplers.len() as _;
         self.inner.p_immutable_samplers = immutable_samplers.as_ptr();
         self
@@ -4752,17 +4476,11 @@ impl<'a> ::std::ops::DerefMut for DescriptorSetLayoutCreateInfoBuilder<'a> {
     }
 }
 impl<'a> DescriptorSetLayoutCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DescriptorSetLayoutCreateFlags,
-    ) -> DescriptorSetLayoutCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: DescriptorSetLayoutCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn bindings(
-        mut self,
-        bindings: &'a [DescriptorSetLayoutBinding],
-    ) -> DescriptorSetLayoutCreateInfoBuilder<'a> {
+    pub fn bindings(mut self, bindings: &'a [DescriptorSetLayoutBinding]) -> Self {
         self.inner.binding_count = bindings.len() as _;
         self.inner.p_bindings = bindings.as_ptr();
         self
@@ -4772,10 +4490,7 @@ impl<'a> DescriptorSetLayoutCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDescriptorSetLayoutCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> DescriptorSetLayoutCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsDescriptorSetLayoutCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -4823,11 +4538,11 @@ impl<'a> ::std::ops::DerefMut for DescriptorPoolSizeBuilder<'a> {
     }
 }
 impl<'a> DescriptorPoolSizeBuilder<'a> {
-    pub fn ty(mut self, ty: DescriptorType) -> DescriptorPoolSizeBuilder<'a> {
+    pub fn ty(mut self, ty: DescriptorType) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn descriptor_count(mut self, descriptor_count: u32) -> DescriptorPoolSizeBuilder<'a> {
+    pub fn descriptor_count(mut self, descriptor_count: u32) -> Self {
         self.inner.descriptor_count = descriptor_count;
         self
     }
@@ -4887,21 +4602,15 @@ impl<'a> ::std::ops::DerefMut for DescriptorPoolCreateInfoBuilder<'a> {
     }
 }
 impl<'a> DescriptorPoolCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DescriptorPoolCreateFlags,
-    ) -> DescriptorPoolCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: DescriptorPoolCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn max_sets(mut self, max_sets: u32) -> DescriptorPoolCreateInfoBuilder<'a> {
+    pub fn max_sets(mut self, max_sets: u32) -> Self {
         self.inner.max_sets = max_sets;
         self
     }
-    pub fn pool_sizes(
-        mut self,
-        pool_sizes: &'a [DescriptorPoolSize],
-    ) -> DescriptorPoolCreateInfoBuilder<'a> {
+    pub fn pool_sizes(mut self, pool_sizes: &'a [DescriptorPoolSize]) -> Self {
         self.inner.pool_size_count = pool_sizes.len() as _;
         self.inner.p_pool_sizes = pool_sizes.as_ptr();
         self
@@ -4911,10 +4620,7 @@ impl<'a> DescriptorPoolCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDescriptorPoolCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> DescriptorPoolCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsDescriptorPoolCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -4977,17 +4683,11 @@ impl<'a> ::std::ops::DerefMut for DescriptorSetAllocateInfoBuilder<'a> {
     }
 }
 impl<'a> DescriptorSetAllocateInfoBuilder<'a> {
-    pub fn descriptor_pool(
-        mut self,
-        descriptor_pool: DescriptorPool,
-    ) -> DescriptorSetAllocateInfoBuilder<'a> {
+    pub fn descriptor_pool(mut self, descriptor_pool: DescriptorPool) -> Self {
         self.inner.descriptor_pool = descriptor_pool;
         self
     }
-    pub fn set_layouts(
-        mut self,
-        set_layouts: &'a [DescriptorSetLayout],
-    ) -> DescriptorSetAllocateInfoBuilder<'a> {
+    pub fn set_layouts(mut self, set_layouts: &'a [DescriptorSetLayout]) -> Self {
         self.inner.descriptor_set_count = set_layouts.len() as _;
         self.inner.p_set_layouts = set_layouts.as_ptr();
         self
@@ -4997,10 +4697,7 @@ impl<'a> DescriptorSetAllocateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDescriptorSetAllocateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> DescriptorSetAllocateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsDescriptorSetAllocateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -5049,15 +4746,15 @@ impl<'a> ::std::ops::DerefMut for SpecializationMapEntryBuilder<'a> {
     }
 }
 impl<'a> SpecializationMapEntryBuilder<'a> {
-    pub fn constant_id(mut self, constant_id: u32) -> SpecializationMapEntryBuilder<'a> {
+    pub fn constant_id(mut self, constant_id: u32) -> Self {
         self.inner.constant_id = constant_id;
         self
     }
-    pub fn offset(mut self, offset: u32) -> SpecializationMapEntryBuilder<'a> {
+    pub fn offset(mut self, offset: u32) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn size(mut self, size: usize) -> SpecializationMapEntryBuilder<'a> {
+    pub fn size(mut self, size: usize) -> Self {
         self.inner.size = size;
         self
     }
@@ -5112,15 +4809,12 @@ impl<'a> ::std::ops::DerefMut for SpecializationInfoBuilder<'a> {
     }
 }
 impl<'a> SpecializationInfoBuilder<'a> {
-    pub fn map_entries(
-        mut self,
-        map_entries: &'a [SpecializationMapEntry],
-    ) -> SpecializationInfoBuilder<'a> {
+    pub fn map_entries(mut self, map_entries: &'a [SpecializationMapEntry]) -> Self {
         self.inner.map_entry_count = map_entries.len() as _;
         self.inner.p_map_entries = map_entries.as_ptr();
         self
     }
-    pub fn data(mut self, data: &'a [u8]) -> SpecializationInfoBuilder<'a> {
+    pub fn data(mut self, data: &'a [u8]) -> Self {
         self.inner.data_size = data.len() as _;
         self.inner.p_data = data.as_ptr() as *const c_void;
         self
@@ -5183,29 +4877,23 @@ impl<'a> ::std::ops::DerefMut for PipelineShaderStageCreateInfoBuilder<'a> {
     }
 }
 impl<'a> PipelineShaderStageCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineShaderStageCreateFlags,
-    ) -> PipelineShaderStageCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineShaderStageCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn stage(mut self, stage: ShaderStageFlags) -> PipelineShaderStageCreateInfoBuilder<'a> {
+    pub fn stage(mut self, stage: ShaderStageFlags) -> Self {
         self.inner.stage = stage;
         self
     }
-    pub fn module(mut self, module: ShaderModule) -> PipelineShaderStageCreateInfoBuilder<'a> {
+    pub fn module(mut self, module: ShaderModule) -> Self {
         self.inner.module = module;
         self
     }
-    pub fn name(mut self, name: &'a ::std::ffi::CStr) -> PipelineShaderStageCreateInfoBuilder<'a> {
+    pub fn name(mut self, name: &'a ::std::ffi::CStr) -> Self {
         self.inner.p_name = name.as_ptr();
         self
     }
-    pub fn specialization_info(
-        mut self,
-        specialization_info: &'a SpecializationInfo,
-    ) -> PipelineShaderStageCreateInfoBuilder<'a> {
+    pub fn specialization_info(mut self, specialization_info: &'a SpecializationInfo) -> Self {
         self.inner.p_specialization_info = specialization_info;
         self
     }
@@ -5214,10 +4902,7 @@ impl<'a> PipelineShaderStageCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineShaderStageCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineShaderStageCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineShaderStageCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -5284,32 +4969,23 @@ impl<'a> ::std::ops::DerefMut for ComputePipelineCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ComputePipelineCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: PipelineCreateFlags) -> ComputePipelineCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn stage(
-        mut self,
-        stage: PipelineShaderStageCreateInfo,
-    ) -> ComputePipelineCreateInfoBuilder<'a> {
+    pub fn stage(mut self, stage: PipelineShaderStageCreateInfo) -> Self {
         self.inner.stage = stage;
         self
     }
-    pub fn layout(mut self, layout: PipelineLayout) -> ComputePipelineCreateInfoBuilder<'a> {
+    pub fn layout(mut self, layout: PipelineLayout) -> Self {
         self.inner.layout = layout;
         self
     }
-    pub fn base_pipeline_handle(
-        mut self,
-        base_pipeline_handle: Pipeline,
-    ) -> ComputePipelineCreateInfoBuilder<'a> {
+    pub fn base_pipeline_handle(mut self, base_pipeline_handle: Pipeline) -> Self {
         self.inner.base_pipeline_handle = base_pipeline_handle;
         self
     }
-    pub fn base_pipeline_index(
-        mut self,
-        base_pipeline_index: i32,
-    ) -> ComputePipelineCreateInfoBuilder<'a> {
+    pub fn base_pipeline_index(mut self, base_pipeline_index: i32) -> Self {
         self.inner.base_pipeline_index = base_pipeline_index;
         self
     }
@@ -5318,10 +4994,7 @@ impl<'a> ComputePipelineCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsComputePipelineCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> ComputePipelineCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsComputePipelineCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -5370,18 +5043,15 @@ impl<'a> ::std::ops::DerefMut for VertexInputBindingDescriptionBuilder<'a> {
     }
 }
 impl<'a> VertexInputBindingDescriptionBuilder<'a> {
-    pub fn binding(mut self, binding: u32) -> VertexInputBindingDescriptionBuilder<'a> {
+    pub fn binding(mut self, binding: u32) -> Self {
         self.inner.binding = binding;
         self
     }
-    pub fn stride(mut self, stride: u32) -> VertexInputBindingDescriptionBuilder<'a> {
+    pub fn stride(mut self, stride: u32) -> Self {
         self.inner.stride = stride;
         self
     }
-    pub fn input_rate(
-        mut self,
-        input_rate: VertexInputRate,
-    ) -> VertexInputBindingDescriptionBuilder<'a> {
+    pub fn input_rate(mut self, input_rate: VertexInputRate) -> Self {
         self.inner.input_rate = input_rate;
         self
     }
@@ -5426,19 +5096,19 @@ impl<'a> ::std::ops::DerefMut for VertexInputAttributeDescriptionBuilder<'a> {
     }
 }
 impl<'a> VertexInputAttributeDescriptionBuilder<'a> {
-    pub fn location(mut self, location: u32) -> VertexInputAttributeDescriptionBuilder<'a> {
+    pub fn location(mut self, location: u32) -> Self {
         self.inner.location = location;
         self
     }
-    pub fn binding(mut self, binding: u32) -> VertexInputAttributeDescriptionBuilder<'a> {
+    pub fn binding(mut self, binding: u32) -> Self {
         self.inner.binding = binding;
         self
     }
-    pub fn format(mut self, format: Format) -> VertexInputAttributeDescriptionBuilder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn offset(mut self, offset: u32) -> VertexInputAttributeDescriptionBuilder<'a> {
+    pub fn offset(mut self, offset: u32) -> Self {
         self.inner.offset = offset;
         self
     }
@@ -5500,17 +5170,14 @@ impl<'a> ::std::ops::DerefMut for PipelineVertexInputStateCreateInfoBuilder<'a> 
     }
 }
 impl<'a> PipelineVertexInputStateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineVertexInputStateCreateFlags,
-    ) -> PipelineVertexInputStateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineVertexInputStateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
     pub fn vertex_binding_descriptions(
         mut self,
         vertex_binding_descriptions: &'a [VertexInputBindingDescription],
-    ) -> PipelineVertexInputStateCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.vertex_binding_description_count = vertex_binding_descriptions.len() as _;
         self.inner.p_vertex_binding_descriptions = vertex_binding_descriptions.as_ptr();
         self
@@ -5518,7 +5185,7 @@ impl<'a> PipelineVertexInputStateCreateInfoBuilder<'a> {
     pub fn vertex_attribute_descriptions(
         mut self,
         vertex_attribute_descriptions: &'a [VertexInputAttributeDescription],
-    ) -> PipelineVertexInputStateCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.vertex_attribute_description_count = vertex_attribute_descriptions.len() as _;
         self.inner.p_vertex_attribute_descriptions = vertex_attribute_descriptions.as_ptr();
         self
@@ -5531,7 +5198,7 @@ impl<'a> PipelineVertexInputStateCreateInfoBuilder<'a> {
     pub fn push_next<T: ExtendsPipelineVertexInputStateCreateInfo>(
         mut self,
         next: &'a mut T,
-    ) -> PipelineVertexInputStateCreateInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -5594,24 +5261,15 @@ impl<'a> ::std::ops::DerefMut for PipelineInputAssemblyStateCreateInfoBuilder<'a
     }
 }
 impl<'a> PipelineInputAssemblyStateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineInputAssemblyStateCreateFlags,
-    ) -> PipelineInputAssemblyStateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineInputAssemblyStateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn topology(
-        mut self,
-        topology: PrimitiveTopology,
-    ) -> PipelineInputAssemblyStateCreateInfoBuilder<'a> {
+    pub fn topology(mut self, topology: PrimitiveTopology) -> Self {
         self.inner.topology = topology;
         self
     }
-    pub fn primitive_restart_enable(
-        mut self,
-        primitive_restart_enable: bool,
-    ) -> PipelineInputAssemblyStateCreateInfoBuilder<'a> {
+    pub fn primitive_restart_enable(mut self, primitive_restart_enable: bool) -> Self {
         self.inner.primitive_restart_enable = primitive_restart_enable.into();
         self
     }
@@ -5623,7 +5281,7 @@ impl<'a> PipelineInputAssemblyStateCreateInfoBuilder<'a> {
     pub fn push_next<T: ExtendsPipelineInputAssemblyStateCreateInfo>(
         mut self,
         next: &'a mut T,
-    ) -> PipelineInputAssemblyStateCreateInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -5684,17 +5342,11 @@ impl<'a> ::std::ops::DerefMut for PipelineTessellationStateCreateInfoBuilder<'a>
     }
 }
 impl<'a> PipelineTessellationStateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineTessellationStateCreateFlags,
-    ) -> PipelineTessellationStateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineTessellationStateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn patch_control_points(
-        mut self,
-        patch_control_points: u32,
-    ) -> PipelineTessellationStateCreateInfoBuilder<'a> {
+    pub fn patch_control_points(mut self, patch_control_points: u32) -> Self {
         self.inner.patch_control_points = patch_control_points;
         self
     }
@@ -5706,7 +5358,7 @@ impl<'a> PipelineTessellationStateCreateInfoBuilder<'a> {
     pub fn push_next<T: ExtendsPipelineTessellationStateCreateInfo>(
         mut self,
         next: &'a mut T,
-    ) -> PipelineTessellationStateCreateInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -5773,39 +5425,24 @@ impl<'a> ::std::ops::DerefMut for PipelineViewportStateCreateInfoBuilder<'a> {
     }
 }
 impl<'a> PipelineViewportStateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineViewportStateCreateFlags,
-    ) -> PipelineViewportStateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineViewportStateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn viewport_count(
-        mut self,
-        viewport_count: u32,
-    ) -> PipelineViewportStateCreateInfoBuilder<'a> {
+    pub fn viewport_count(mut self, viewport_count: u32) -> Self {
         self.inner.viewport_count = viewport_count;
         self
     }
-    pub fn viewports(
-        mut self,
-        viewports: &'a [Viewport],
-    ) -> PipelineViewportStateCreateInfoBuilder<'a> {
+    pub fn viewports(mut self, viewports: &'a [Viewport]) -> Self {
         self.inner.viewport_count = viewports.len() as _;
         self.inner.p_viewports = viewports.as_ptr();
         self
     }
-    pub fn scissor_count(
-        mut self,
-        scissor_count: u32,
-    ) -> PipelineViewportStateCreateInfoBuilder<'a> {
+    pub fn scissor_count(mut self, scissor_count: u32) -> Self {
         self.inner.scissor_count = scissor_count;
         self
     }
-    pub fn scissors(
-        mut self,
-        scissors: &'a [Rect2D],
-    ) -> PipelineViewportStateCreateInfoBuilder<'a> {
+    pub fn scissors(mut self, scissors: &'a [Rect2D]) -> Self {
         self.inner.scissor_count = scissors.len() as _;
         self.inner.p_scissors = scissors.as_ptr();
         self
@@ -5815,10 +5452,7 @@ impl<'a> PipelineViewportStateCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineViewportStateCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineViewportStateCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineViewportStateCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -5897,80 +5531,47 @@ impl<'a> ::std::ops::DerefMut for PipelineRasterizationStateCreateInfoBuilder<'a
     }
 }
 impl<'a> PipelineRasterizationStateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineRasterizationStateCreateFlags,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineRasterizationStateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn depth_clamp_enable(
-        mut self,
-        depth_clamp_enable: bool,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn depth_clamp_enable(mut self, depth_clamp_enable: bool) -> Self {
         self.inner.depth_clamp_enable = depth_clamp_enable.into();
         self
     }
-    pub fn rasterizer_discard_enable(
-        mut self,
-        rasterizer_discard_enable: bool,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn rasterizer_discard_enable(mut self, rasterizer_discard_enable: bool) -> Self {
         self.inner.rasterizer_discard_enable = rasterizer_discard_enable.into();
         self
     }
-    pub fn polygon_mode(
-        mut self,
-        polygon_mode: PolygonMode,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn polygon_mode(mut self, polygon_mode: PolygonMode) -> Self {
         self.inner.polygon_mode = polygon_mode;
         self
     }
-    pub fn cull_mode(
-        mut self,
-        cull_mode: CullModeFlags,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn cull_mode(mut self, cull_mode: CullModeFlags) -> Self {
         self.inner.cull_mode = cull_mode;
         self
     }
-    pub fn front_face(
-        mut self,
-        front_face: FrontFace,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn front_face(mut self, front_face: FrontFace) -> Self {
         self.inner.front_face = front_face;
         self
     }
-    pub fn depth_bias_enable(
-        mut self,
-        depth_bias_enable: bool,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn depth_bias_enable(mut self, depth_bias_enable: bool) -> Self {
         self.inner.depth_bias_enable = depth_bias_enable.into();
         self
     }
-    pub fn depth_bias_constant_factor(
-        mut self,
-        depth_bias_constant_factor: f32,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn depth_bias_constant_factor(mut self, depth_bias_constant_factor: f32) -> Self {
         self.inner.depth_bias_constant_factor = depth_bias_constant_factor;
         self
     }
-    pub fn depth_bias_clamp(
-        mut self,
-        depth_bias_clamp: f32,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn depth_bias_clamp(mut self, depth_bias_clamp: f32) -> Self {
         self.inner.depth_bias_clamp = depth_bias_clamp;
         self
     }
-    pub fn depth_bias_slope_factor(
-        mut self,
-        depth_bias_slope_factor: f32,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn depth_bias_slope_factor(mut self, depth_bias_slope_factor: f32) -> Self {
         self.inner.depth_bias_slope_factor = depth_bias_slope_factor;
         self
     }
-    pub fn line_width(
-        mut self,
-        line_width: f32,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    pub fn line_width(mut self, line_width: f32) -> Self {
         self.inner.line_width = line_width;
         self
     }
@@ -5982,7 +5583,7 @@ impl<'a> PipelineRasterizationStateCreateInfoBuilder<'a> {
     pub fn push_next<T: ExtendsPipelineRasterizationStateCreateInfo>(
         mut self,
         next: &'a mut T,
-    ) -> PipelineRasterizationStateCreateInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -6053,52 +5654,31 @@ impl<'a> ::std::ops::DerefMut for PipelineMultisampleStateCreateInfoBuilder<'a> 
     }
 }
 impl<'a> PipelineMultisampleStateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineMultisampleStateCreateFlags,
-    ) -> PipelineMultisampleStateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineMultisampleStateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn rasterization_samples(
-        mut self,
-        rasterization_samples: SampleCountFlags,
-    ) -> PipelineMultisampleStateCreateInfoBuilder<'a> {
+    pub fn rasterization_samples(mut self, rasterization_samples: SampleCountFlags) -> Self {
         self.inner.rasterization_samples = rasterization_samples;
         self
     }
-    pub fn sample_shading_enable(
-        mut self,
-        sample_shading_enable: bool,
-    ) -> PipelineMultisampleStateCreateInfoBuilder<'a> {
+    pub fn sample_shading_enable(mut self, sample_shading_enable: bool) -> Self {
         self.inner.sample_shading_enable = sample_shading_enable.into();
         self
     }
-    pub fn min_sample_shading(
-        mut self,
-        min_sample_shading: f32,
-    ) -> PipelineMultisampleStateCreateInfoBuilder<'a> {
+    pub fn min_sample_shading(mut self, min_sample_shading: f32) -> Self {
         self.inner.min_sample_shading = min_sample_shading;
         self
     }
-    pub fn sample_mask(
-        mut self,
-        sample_mask: &'a [SampleMask],
-    ) -> PipelineMultisampleStateCreateInfoBuilder<'a> {
+    pub fn sample_mask(mut self, sample_mask: &'a [SampleMask]) -> Self {
         self.inner.p_sample_mask = sample_mask.as_ptr() as *const SampleMask;
         self
     }
-    pub fn alpha_to_coverage_enable(
-        mut self,
-        alpha_to_coverage_enable: bool,
-    ) -> PipelineMultisampleStateCreateInfoBuilder<'a> {
+    pub fn alpha_to_coverage_enable(mut self, alpha_to_coverage_enable: bool) -> Self {
         self.inner.alpha_to_coverage_enable = alpha_to_coverage_enable.into();
         self
     }
-    pub fn alpha_to_one_enable(
-        mut self,
-        alpha_to_one_enable: bool,
-    ) -> PipelineMultisampleStateCreateInfoBuilder<'a> {
+    pub fn alpha_to_one_enable(mut self, alpha_to_one_enable: bool) -> Self {
         self.inner.alpha_to_one_enable = alpha_to_one_enable.into();
         self
     }
@@ -6110,7 +5690,7 @@ impl<'a> PipelineMultisampleStateCreateInfoBuilder<'a> {
     pub fn push_next<T: ExtendsPipelineMultisampleStateCreateInfo>(
         mut self,
         next: &'a mut T,
-    ) -> PipelineMultisampleStateCreateInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -6164,59 +5744,35 @@ impl<'a> ::std::ops::DerefMut for PipelineColorBlendAttachmentStateBuilder<'a> {
     }
 }
 impl<'a> PipelineColorBlendAttachmentStateBuilder<'a> {
-    pub fn blend_enable(
-        mut self,
-        blend_enable: bool,
-    ) -> PipelineColorBlendAttachmentStateBuilder<'a> {
+    pub fn blend_enable(mut self, blend_enable: bool) -> Self {
         self.inner.blend_enable = blend_enable.into();
         self
     }
-    pub fn src_color_blend_factor(
-        mut self,
-        src_color_blend_factor: BlendFactor,
-    ) -> PipelineColorBlendAttachmentStateBuilder<'a> {
+    pub fn src_color_blend_factor(mut self, src_color_blend_factor: BlendFactor) -> Self {
         self.inner.src_color_blend_factor = src_color_blend_factor;
         self
     }
-    pub fn dst_color_blend_factor(
-        mut self,
-        dst_color_blend_factor: BlendFactor,
-    ) -> PipelineColorBlendAttachmentStateBuilder<'a> {
+    pub fn dst_color_blend_factor(mut self, dst_color_blend_factor: BlendFactor) -> Self {
         self.inner.dst_color_blend_factor = dst_color_blend_factor;
         self
     }
-    pub fn color_blend_op(
-        mut self,
-        color_blend_op: BlendOp,
-    ) -> PipelineColorBlendAttachmentStateBuilder<'a> {
+    pub fn color_blend_op(mut self, color_blend_op: BlendOp) -> Self {
         self.inner.color_blend_op = color_blend_op;
         self
     }
-    pub fn src_alpha_blend_factor(
-        mut self,
-        src_alpha_blend_factor: BlendFactor,
-    ) -> PipelineColorBlendAttachmentStateBuilder<'a> {
+    pub fn src_alpha_blend_factor(mut self, src_alpha_blend_factor: BlendFactor) -> Self {
         self.inner.src_alpha_blend_factor = src_alpha_blend_factor;
         self
     }
-    pub fn dst_alpha_blend_factor(
-        mut self,
-        dst_alpha_blend_factor: BlendFactor,
-    ) -> PipelineColorBlendAttachmentStateBuilder<'a> {
+    pub fn dst_alpha_blend_factor(mut self, dst_alpha_blend_factor: BlendFactor) -> Self {
         self.inner.dst_alpha_blend_factor = dst_alpha_blend_factor;
         self
     }
-    pub fn alpha_blend_op(
-        mut self,
-        alpha_blend_op: BlendOp,
-    ) -> PipelineColorBlendAttachmentStateBuilder<'a> {
+    pub fn alpha_blend_op(mut self, alpha_blend_op: BlendOp) -> Self {
         self.inner.alpha_blend_op = alpha_blend_op;
         self
     }
-    pub fn color_write_mask(
-        mut self,
-        color_write_mask: ColorComponentFlags,
-    ) -> PipelineColorBlendAttachmentStateBuilder<'a> {
+    pub fn color_write_mask(mut self, color_write_mask: ColorComponentFlags) -> Self {
         self.inner.color_write_mask = color_write_mask;
         self
     }
@@ -6280,36 +5836,24 @@ impl<'a> ::std::ops::DerefMut for PipelineColorBlendStateCreateInfoBuilder<'a> {
     }
 }
 impl<'a> PipelineColorBlendStateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineColorBlendStateCreateFlags,
-    ) -> PipelineColorBlendStateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineColorBlendStateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn logic_op_enable(
-        mut self,
-        logic_op_enable: bool,
-    ) -> PipelineColorBlendStateCreateInfoBuilder<'a> {
+    pub fn logic_op_enable(mut self, logic_op_enable: bool) -> Self {
         self.inner.logic_op_enable = logic_op_enable.into();
         self
     }
-    pub fn logic_op(mut self, logic_op: LogicOp) -> PipelineColorBlendStateCreateInfoBuilder<'a> {
+    pub fn logic_op(mut self, logic_op: LogicOp) -> Self {
         self.inner.logic_op = logic_op;
         self
     }
-    pub fn attachments(
-        mut self,
-        attachments: &'a [PipelineColorBlendAttachmentState],
-    ) -> PipelineColorBlendStateCreateInfoBuilder<'a> {
+    pub fn attachments(mut self, attachments: &'a [PipelineColorBlendAttachmentState]) -> Self {
         self.inner.attachment_count = attachments.len() as _;
         self.inner.p_attachments = attachments.as_ptr();
         self
     }
-    pub fn blend_constants(
-        mut self,
-        blend_constants: [f32; 4],
-    ) -> PipelineColorBlendStateCreateInfoBuilder<'a> {
+    pub fn blend_constants(mut self, blend_constants: [f32; 4]) -> Self {
         self.inner.blend_constants = blend_constants;
         self
     }
@@ -6321,7 +5865,7 @@ impl<'a> PipelineColorBlendStateCreateInfoBuilder<'a> {
     pub fn push_next<T: ExtendsPipelineColorBlendStateCreateInfo>(
         mut self,
         next: &'a mut T,
-    ) -> PipelineColorBlendStateCreateInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -6384,17 +5928,11 @@ impl<'a> ::std::ops::DerefMut for PipelineDynamicStateCreateInfoBuilder<'a> {
     }
 }
 impl<'a> PipelineDynamicStateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineDynamicStateCreateFlags,
-    ) -> PipelineDynamicStateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineDynamicStateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn dynamic_states(
-        mut self,
-        dynamic_states: &'a [DynamicState],
-    ) -> PipelineDynamicStateCreateInfoBuilder<'a> {
+    pub fn dynamic_states(mut self, dynamic_states: &'a [DynamicState]) -> Self {
         self.inner.dynamic_state_count = dynamic_states.len() as _;
         self.inner.p_dynamic_states = dynamic_states.as_ptr();
         self
@@ -6404,10 +5942,7 @@ impl<'a> PipelineDynamicStateCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineDynamicStateCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineDynamicStateCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineDynamicStateCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -6460,31 +5995,31 @@ impl<'a> ::std::ops::DerefMut for StencilOpStateBuilder<'a> {
     }
 }
 impl<'a> StencilOpStateBuilder<'a> {
-    pub fn fail_op(mut self, fail_op: StencilOp) -> StencilOpStateBuilder<'a> {
+    pub fn fail_op(mut self, fail_op: StencilOp) -> Self {
         self.inner.fail_op = fail_op;
         self
     }
-    pub fn pass_op(mut self, pass_op: StencilOp) -> StencilOpStateBuilder<'a> {
+    pub fn pass_op(mut self, pass_op: StencilOp) -> Self {
         self.inner.pass_op = pass_op;
         self
     }
-    pub fn depth_fail_op(mut self, depth_fail_op: StencilOp) -> StencilOpStateBuilder<'a> {
+    pub fn depth_fail_op(mut self, depth_fail_op: StencilOp) -> Self {
         self.inner.depth_fail_op = depth_fail_op;
         self
     }
-    pub fn compare_op(mut self, compare_op: CompareOp) -> StencilOpStateBuilder<'a> {
+    pub fn compare_op(mut self, compare_op: CompareOp) -> Self {
         self.inner.compare_op = compare_op;
         self
     }
-    pub fn compare_mask(mut self, compare_mask: u32) -> StencilOpStateBuilder<'a> {
+    pub fn compare_mask(mut self, compare_mask: u32) -> Self {
         self.inner.compare_mask = compare_mask;
         self
     }
-    pub fn write_mask(mut self, write_mask: u32) -> StencilOpStateBuilder<'a> {
+    pub fn write_mask(mut self, write_mask: u32) -> Self {
         self.inner.write_mask = write_mask;
         self
     }
-    pub fn reference(mut self, reference: u32) -> StencilOpStateBuilder<'a> {
+    pub fn reference(mut self, reference: u32) -> Self {
         self.inner.reference = reference;
         self
     }
@@ -6556,70 +6091,43 @@ impl<'a> ::std::ops::DerefMut for PipelineDepthStencilStateCreateInfoBuilder<'a>
     }
 }
 impl<'a> PipelineDepthStencilStateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineDepthStencilStateCreateFlags,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineDepthStencilStateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn depth_test_enable(
-        mut self,
-        depth_test_enable: bool,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn depth_test_enable(mut self, depth_test_enable: bool) -> Self {
         self.inner.depth_test_enable = depth_test_enable.into();
         self
     }
-    pub fn depth_write_enable(
-        mut self,
-        depth_write_enable: bool,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn depth_write_enable(mut self, depth_write_enable: bool) -> Self {
         self.inner.depth_write_enable = depth_write_enable.into();
         self
     }
-    pub fn depth_compare_op(
-        mut self,
-        depth_compare_op: CompareOp,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn depth_compare_op(mut self, depth_compare_op: CompareOp) -> Self {
         self.inner.depth_compare_op = depth_compare_op;
         self
     }
-    pub fn depth_bounds_test_enable(
-        mut self,
-        depth_bounds_test_enable: bool,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn depth_bounds_test_enable(mut self, depth_bounds_test_enable: bool) -> Self {
         self.inner.depth_bounds_test_enable = depth_bounds_test_enable.into();
         self
     }
-    pub fn stencil_test_enable(
-        mut self,
-        stencil_test_enable: bool,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn stencil_test_enable(mut self, stencil_test_enable: bool) -> Self {
         self.inner.stencil_test_enable = stencil_test_enable.into();
         self
     }
-    pub fn front(
-        mut self,
-        front: StencilOpState,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn front(mut self, front: StencilOpState) -> Self {
         self.inner.front = front;
         self
     }
-    pub fn back(mut self, back: StencilOpState) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn back(mut self, back: StencilOpState) -> Self {
         self.inner.back = back;
         self
     }
-    pub fn min_depth_bounds(
-        mut self,
-        min_depth_bounds: f32,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn min_depth_bounds(mut self, min_depth_bounds: f32) -> Self {
         self.inner.min_depth_bounds = min_depth_bounds;
         self
     }
-    pub fn max_depth_bounds(
-        mut self,
-        max_depth_bounds: f32,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    pub fn max_depth_bounds(mut self, max_depth_bounds: f32) -> Self {
         self.inner.max_depth_bounds = max_depth_bounds;
         self
     }
@@ -6631,7 +6139,7 @@ impl<'a> PipelineDepthStencilStateCreateInfoBuilder<'a> {
     pub fn push_next<T: ExtendsPipelineDepthStencilStateCreateInfo>(
         mut self,
         next: &'a mut T,
-    ) -> PipelineDepthStencilStateCreateInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -6722,14 +6230,11 @@ impl<'a> ::std::ops::DerefMut for GraphicsPipelineCreateInfoBuilder<'a> {
     }
 }
 impl<'a> GraphicsPipelineCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: PipelineCreateFlags) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn stages(
-        mut self,
-        stages: &'a [PipelineShaderStageCreateInfo],
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo]) -> Self {
         self.inner.stage_count = stages.len() as _;
         self.inner.p_stages = stages.as_ptr();
         self
@@ -6737,89 +6242,77 @@ impl<'a> GraphicsPipelineCreateInfoBuilder<'a> {
     pub fn vertex_input_state(
         mut self,
         vertex_input_state: &'a PipelineVertexInputStateCreateInfo,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.p_vertex_input_state = vertex_input_state;
         self
     }
     pub fn input_assembly_state(
         mut self,
         input_assembly_state: &'a PipelineInputAssemblyStateCreateInfo,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.p_input_assembly_state = input_assembly_state;
         self
     }
     pub fn tessellation_state(
         mut self,
         tessellation_state: &'a PipelineTessellationStateCreateInfo,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.p_tessellation_state = tessellation_state;
         self
     }
-    pub fn viewport_state(
-        mut self,
-        viewport_state: &'a PipelineViewportStateCreateInfo,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn viewport_state(mut self, viewport_state: &'a PipelineViewportStateCreateInfo) -> Self {
         self.inner.p_viewport_state = viewport_state;
         self
     }
     pub fn rasterization_state(
         mut self,
         rasterization_state: &'a PipelineRasterizationStateCreateInfo,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.p_rasterization_state = rasterization_state;
         self
     }
     pub fn multisample_state(
         mut self,
         multisample_state: &'a PipelineMultisampleStateCreateInfo,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.p_multisample_state = multisample_state;
         self
     }
     pub fn depth_stencil_state(
         mut self,
         depth_stencil_state: &'a PipelineDepthStencilStateCreateInfo,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.p_depth_stencil_state = depth_stencil_state;
         self
     }
     pub fn color_blend_state(
         mut self,
         color_blend_state: &'a PipelineColorBlendStateCreateInfo,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.p_color_blend_state = color_blend_state;
         self
     }
-    pub fn dynamic_state(
-        mut self,
-        dynamic_state: &'a PipelineDynamicStateCreateInfo,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn dynamic_state(mut self, dynamic_state: &'a PipelineDynamicStateCreateInfo) -> Self {
         self.inner.p_dynamic_state = dynamic_state;
         self
     }
-    pub fn layout(mut self, layout: PipelineLayout) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn layout(mut self, layout: PipelineLayout) -> Self {
         self.inner.layout = layout;
         self
     }
-    pub fn render_pass(mut self, render_pass: RenderPass) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn render_pass(mut self, render_pass: RenderPass) -> Self {
         self.inner.render_pass = render_pass;
         self
     }
-    pub fn subpass(mut self, subpass: u32) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn subpass(mut self, subpass: u32) -> Self {
         self.inner.subpass = subpass;
         self
     }
-    pub fn base_pipeline_handle(
-        mut self,
-        base_pipeline_handle: Pipeline,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn base_pipeline_handle(mut self, base_pipeline_handle: Pipeline) -> Self {
         self.inner.base_pipeline_handle = base_pipeline_handle;
         self
     }
-    pub fn base_pipeline_index(
-        mut self,
-        base_pipeline_index: i32,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn base_pipeline_index(mut self, base_pipeline_index: i32) -> Self {
         self.inner.base_pipeline_index = base_pipeline_index;
         self
     }
@@ -6828,10 +6321,7 @@ impl<'a> GraphicsPipelineCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsGraphicsPipelineCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> GraphicsPipelineCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsGraphicsPipelineCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -6894,11 +6384,11 @@ impl<'a> ::std::ops::DerefMut for PipelineCacheCreateInfoBuilder<'a> {
     }
 }
 impl<'a> PipelineCacheCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: PipelineCacheCreateFlags) -> PipelineCacheCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCacheCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn initial_data(mut self, initial_data: &'a [u8]) -> PipelineCacheCreateInfoBuilder<'a> {
+    pub fn initial_data(mut self, initial_data: &'a [u8]) -> Self {
         self.inner.initial_data_size = initial_data.len() as _;
         self.inner.p_initial_data = initial_data.as_ptr() as *const c_void;
         self
@@ -6908,10 +6398,7 @@ impl<'a> PipelineCacheCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineCacheCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineCacheCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineCacheCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -6960,15 +6447,15 @@ impl<'a> ::std::ops::DerefMut for PushConstantRangeBuilder<'a> {
     }
 }
 impl<'a> PushConstantRangeBuilder<'a> {
-    pub fn stage_flags(mut self, stage_flags: ShaderStageFlags) -> PushConstantRangeBuilder<'a> {
+    pub fn stage_flags(mut self, stage_flags: ShaderStageFlags) -> Self {
         self.inner.stage_flags = stage_flags;
         self
     }
-    pub fn offset(mut self, offset: u32) -> PushConstantRangeBuilder<'a> {
+    pub fn offset(mut self, offset: u32) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn size(mut self, size: u32) -> PushConstantRangeBuilder<'a> {
+    pub fn size(mut self, size: u32) -> Self {
         self.inner.size = size;
         self
     }
@@ -7030,25 +6517,16 @@ impl<'a> ::std::ops::DerefMut for PipelineLayoutCreateInfoBuilder<'a> {
     }
 }
 impl<'a> PipelineLayoutCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineLayoutCreateFlags,
-    ) -> PipelineLayoutCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineLayoutCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn set_layouts(
-        mut self,
-        set_layouts: &'a [DescriptorSetLayout],
-    ) -> PipelineLayoutCreateInfoBuilder<'a> {
+    pub fn set_layouts(mut self, set_layouts: &'a [DescriptorSetLayout]) -> Self {
         self.inner.set_layout_count = set_layouts.len() as _;
         self.inner.p_set_layouts = set_layouts.as_ptr();
         self
     }
-    pub fn push_constant_ranges(
-        mut self,
-        push_constant_ranges: &'a [PushConstantRange],
-    ) -> PipelineLayoutCreateInfoBuilder<'a> {
+    pub fn push_constant_ranges(mut self, push_constant_ranges: &'a [PushConstantRange]) -> Self {
         self.inner.push_constant_range_count = push_constant_ranges.len() as _;
         self.inner.p_push_constant_ranges = push_constant_ranges.as_ptr();
         self
@@ -7058,10 +6536,7 @@ impl<'a> PipelineLayoutCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineLayoutCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineLayoutCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineLayoutCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -7150,79 +6625,67 @@ impl<'a> ::std::ops::DerefMut for SamplerCreateInfoBuilder<'a> {
     }
 }
 impl<'a> SamplerCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: SamplerCreateFlags) -> SamplerCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: SamplerCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn mag_filter(mut self, mag_filter: Filter) -> SamplerCreateInfoBuilder<'a> {
+    pub fn mag_filter(mut self, mag_filter: Filter) -> Self {
         self.inner.mag_filter = mag_filter;
         self
     }
-    pub fn min_filter(mut self, min_filter: Filter) -> SamplerCreateInfoBuilder<'a> {
+    pub fn min_filter(mut self, min_filter: Filter) -> Self {
         self.inner.min_filter = min_filter;
         self
     }
-    pub fn mipmap_mode(mut self, mipmap_mode: SamplerMipmapMode) -> SamplerCreateInfoBuilder<'a> {
+    pub fn mipmap_mode(mut self, mipmap_mode: SamplerMipmapMode) -> Self {
         self.inner.mipmap_mode = mipmap_mode;
         self
     }
-    pub fn address_mode_u(
-        mut self,
-        address_mode_u: SamplerAddressMode,
-    ) -> SamplerCreateInfoBuilder<'a> {
+    pub fn address_mode_u(mut self, address_mode_u: SamplerAddressMode) -> Self {
         self.inner.address_mode_u = address_mode_u;
         self
     }
-    pub fn address_mode_v(
-        mut self,
-        address_mode_v: SamplerAddressMode,
-    ) -> SamplerCreateInfoBuilder<'a> {
+    pub fn address_mode_v(mut self, address_mode_v: SamplerAddressMode) -> Self {
         self.inner.address_mode_v = address_mode_v;
         self
     }
-    pub fn address_mode_w(
-        mut self,
-        address_mode_w: SamplerAddressMode,
-    ) -> SamplerCreateInfoBuilder<'a> {
+    pub fn address_mode_w(mut self, address_mode_w: SamplerAddressMode) -> Self {
         self.inner.address_mode_w = address_mode_w;
         self
     }
-    pub fn mip_lod_bias(mut self, mip_lod_bias: f32) -> SamplerCreateInfoBuilder<'a> {
+    pub fn mip_lod_bias(mut self, mip_lod_bias: f32) -> Self {
         self.inner.mip_lod_bias = mip_lod_bias;
         self
     }
-    pub fn anisotropy_enable(mut self, anisotropy_enable: bool) -> SamplerCreateInfoBuilder<'a> {
+    pub fn anisotropy_enable(mut self, anisotropy_enable: bool) -> Self {
         self.inner.anisotropy_enable = anisotropy_enable.into();
         self
     }
-    pub fn max_anisotropy(mut self, max_anisotropy: f32) -> SamplerCreateInfoBuilder<'a> {
+    pub fn max_anisotropy(mut self, max_anisotropy: f32) -> Self {
         self.inner.max_anisotropy = max_anisotropy;
         self
     }
-    pub fn compare_enable(mut self, compare_enable: bool) -> SamplerCreateInfoBuilder<'a> {
+    pub fn compare_enable(mut self, compare_enable: bool) -> Self {
         self.inner.compare_enable = compare_enable.into();
         self
     }
-    pub fn compare_op(mut self, compare_op: CompareOp) -> SamplerCreateInfoBuilder<'a> {
+    pub fn compare_op(mut self, compare_op: CompareOp) -> Self {
         self.inner.compare_op = compare_op;
         self
     }
-    pub fn min_lod(mut self, min_lod: f32) -> SamplerCreateInfoBuilder<'a> {
+    pub fn min_lod(mut self, min_lod: f32) -> Self {
         self.inner.min_lod = min_lod;
         self
     }
-    pub fn max_lod(mut self, max_lod: f32) -> SamplerCreateInfoBuilder<'a> {
+    pub fn max_lod(mut self, max_lod: f32) -> Self {
         self.inner.max_lod = max_lod;
         self
     }
-    pub fn border_color(mut self, border_color: BorderColor) -> SamplerCreateInfoBuilder<'a> {
+    pub fn border_color(mut self, border_color: BorderColor) -> Self {
         self.inner.border_color = border_color;
         self
     }
-    pub fn unnormalized_coordinates(
-        mut self,
-        unnormalized_coordinates: bool,
-    ) -> SamplerCreateInfoBuilder<'a> {
+    pub fn unnormalized_coordinates(mut self, unnormalized_coordinates: bool) -> Self {
         self.inner.unnormalized_coordinates = unnormalized_coordinates.into();
         self
     }
@@ -7231,10 +6694,7 @@ impl<'a> SamplerCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSamplerCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> SamplerCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsSamplerCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -7295,14 +6755,11 @@ impl<'a> ::std::ops::DerefMut for CommandPoolCreateInfoBuilder<'a> {
     }
 }
 impl<'a> CommandPoolCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: CommandPoolCreateFlags) -> CommandPoolCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: CommandPoolCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn queue_family_index(
-        mut self,
-        queue_family_index: u32,
-    ) -> CommandPoolCreateInfoBuilder<'a> {
+    pub fn queue_family_index(mut self, queue_family_index: u32) -> Self {
         self.inner.queue_family_index = queue_family_index;
         self
     }
@@ -7311,10 +6768,7 @@ impl<'a> CommandPoolCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCommandPoolCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> CommandPoolCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsCommandPoolCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -7377,21 +6831,15 @@ impl<'a> ::std::ops::DerefMut for CommandBufferAllocateInfoBuilder<'a> {
     }
 }
 impl<'a> CommandBufferAllocateInfoBuilder<'a> {
-    pub fn command_pool(
-        mut self,
-        command_pool: CommandPool,
-    ) -> CommandBufferAllocateInfoBuilder<'a> {
+    pub fn command_pool(mut self, command_pool: CommandPool) -> Self {
         self.inner.command_pool = command_pool;
         self
     }
-    pub fn level(mut self, level: CommandBufferLevel) -> CommandBufferAllocateInfoBuilder<'a> {
+    pub fn level(mut self, level: CommandBufferLevel) -> Self {
         self.inner.level = level;
         self
     }
-    pub fn command_buffer_count(
-        mut self,
-        command_buffer_count: u32,
-    ) -> CommandBufferAllocateInfoBuilder<'a> {
+    pub fn command_buffer_count(mut self, command_buffer_count: u32) -> Self {
         self.inner.command_buffer_count = command_buffer_count;
         self
     }
@@ -7400,10 +6848,7 @@ impl<'a> CommandBufferAllocateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCommandBufferAllocateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> CommandBufferAllocateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsCommandBufferAllocateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -7472,42 +6917,27 @@ impl<'a> ::std::ops::DerefMut for CommandBufferInheritanceInfoBuilder<'a> {
     }
 }
 impl<'a> CommandBufferInheritanceInfoBuilder<'a> {
-    pub fn render_pass(
-        mut self,
-        render_pass: RenderPass,
-    ) -> CommandBufferInheritanceInfoBuilder<'a> {
+    pub fn render_pass(mut self, render_pass: RenderPass) -> Self {
         self.inner.render_pass = render_pass;
         self
     }
-    pub fn subpass(mut self, subpass: u32) -> CommandBufferInheritanceInfoBuilder<'a> {
+    pub fn subpass(mut self, subpass: u32) -> Self {
         self.inner.subpass = subpass;
         self
     }
-    pub fn framebuffer(
-        mut self,
-        framebuffer: Framebuffer,
-    ) -> CommandBufferInheritanceInfoBuilder<'a> {
+    pub fn framebuffer(mut self, framebuffer: Framebuffer) -> Self {
         self.inner.framebuffer = framebuffer;
         self
     }
-    pub fn occlusion_query_enable(
-        mut self,
-        occlusion_query_enable: bool,
-    ) -> CommandBufferInheritanceInfoBuilder<'a> {
+    pub fn occlusion_query_enable(mut self, occlusion_query_enable: bool) -> Self {
         self.inner.occlusion_query_enable = occlusion_query_enable.into();
         self
     }
-    pub fn query_flags(
-        mut self,
-        query_flags: QueryControlFlags,
-    ) -> CommandBufferInheritanceInfoBuilder<'a> {
+    pub fn query_flags(mut self, query_flags: QueryControlFlags) -> Self {
         self.inner.query_flags = query_flags;
         self
     }
-    pub fn pipeline_statistics(
-        mut self,
-        pipeline_statistics: QueryPipelineStatisticFlags,
-    ) -> CommandBufferInheritanceInfoBuilder<'a> {
+    pub fn pipeline_statistics(mut self, pipeline_statistics: QueryPipelineStatisticFlags) -> Self {
         self.inner.pipeline_statistics = pipeline_statistics;
         self
     }
@@ -7516,10 +6946,7 @@ impl<'a> CommandBufferInheritanceInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCommandBufferInheritanceInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> CommandBufferInheritanceInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsCommandBufferInheritanceInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -7580,14 +7007,11 @@ impl<'a> ::std::ops::DerefMut for CommandBufferBeginInfoBuilder<'a> {
     }
 }
 impl<'a> CommandBufferBeginInfoBuilder<'a> {
-    pub fn flags(mut self, flags: CommandBufferUsageFlags) -> CommandBufferBeginInfoBuilder<'a> {
+    pub fn flags(mut self, flags: CommandBufferUsageFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn inheritance_info(
-        mut self,
-        inheritance_info: &'a CommandBufferInheritanceInfo,
-    ) -> CommandBufferBeginInfoBuilder<'a> {
+    pub fn inheritance_info(mut self, inheritance_info: &'a CommandBufferInheritanceInfo) -> Self {
         self.inner.p_inheritance_info = inheritance_info;
         self
     }
@@ -7596,10 +7020,7 @@ impl<'a> CommandBufferBeginInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCommandBufferBeginInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> CommandBufferBeginInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsCommandBufferBeginInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -7679,22 +7100,19 @@ impl<'a> ::std::ops::DerefMut for RenderPassBeginInfoBuilder<'a> {
     }
 }
 impl<'a> RenderPassBeginInfoBuilder<'a> {
-    pub fn render_pass(mut self, render_pass: RenderPass) -> RenderPassBeginInfoBuilder<'a> {
+    pub fn render_pass(mut self, render_pass: RenderPass) -> Self {
         self.inner.render_pass = render_pass;
         self
     }
-    pub fn framebuffer(mut self, framebuffer: Framebuffer) -> RenderPassBeginInfoBuilder<'a> {
+    pub fn framebuffer(mut self, framebuffer: Framebuffer) -> Self {
         self.inner.framebuffer = framebuffer;
         self
     }
-    pub fn render_area(mut self, render_area: Rect2D) -> RenderPassBeginInfoBuilder<'a> {
+    pub fn render_area(mut self, render_area: Rect2D) -> Self {
         self.inner.render_area = render_area;
         self
     }
-    pub fn clear_values(
-        mut self,
-        clear_values: &'a [ClearValue],
-    ) -> RenderPassBeginInfoBuilder<'a> {
+    pub fn clear_values(mut self, clear_values: &'a [ClearValue]) -> Self {
         self.inner.clear_value_count = clear_values.len() as _;
         self.inner.p_clear_values = clear_values.as_ptr();
         self
@@ -7704,10 +7122,7 @@ impl<'a> RenderPassBeginInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsRenderPassBeginInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> RenderPassBeginInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsRenderPassBeginInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -7768,11 +7183,11 @@ impl<'a> ::std::ops::DerefMut for ClearDepthStencilValueBuilder<'a> {
     }
 }
 impl<'a> ClearDepthStencilValueBuilder<'a> {
-    pub fn depth(mut self, depth: f32) -> ClearDepthStencilValueBuilder<'a> {
+    pub fn depth(mut self, depth: f32) -> Self {
         self.inner.depth = depth;
         self
     }
-    pub fn stencil(mut self, stencil: u32) -> ClearDepthStencilValueBuilder<'a> {
+    pub fn stencil(mut self, stencil: u32) -> Self {
         self.inner.stencil = stencil;
         self
     }
@@ -7837,15 +7252,15 @@ impl<'a> ::std::ops::DerefMut for ClearAttachmentBuilder<'a> {
     }
 }
 impl<'a> ClearAttachmentBuilder<'a> {
-    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> ClearAttachmentBuilder<'a> {
+    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> Self {
         self.inner.aspect_mask = aspect_mask;
         self
     }
-    pub fn color_attachment(mut self, color_attachment: u32) -> ClearAttachmentBuilder<'a> {
+    pub fn color_attachment(mut self, color_attachment: u32) -> Self {
         self.inner.color_attachment = color_attachment;
         self
     }
-    pub fn clear_value(mut self, clear_value: ClearValue) -> ClearAttachmentBuilder<'a> {
+    pub fn clear_value(mut self, clear_value: ClearValue) -> Self {
         self.inner.clear_value = clear_value;
         self
     }
@@ -7895,48 +7310,39 @@ impl<'a> ::std::ops::DerefMut for AttachmentDescriptionBuilder<'a> {
     }
 }
 impl<'a> AttachmentDescriptionBuilder<'a> {
-    pub fn flags(mut self, flags: AttachmentDescriptionFlags) -> AttachmentDescriptionBuilder<'a> {
+    pub fn flags(mut self, flags: AttachmentDescriptionFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn format(mut self, format: Format) -> AttachmentDescriptionBuilder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn samples(mut self, samples: SampleCountFlags) -> AttachmentDescriptionBuilder<'a> {
+    pub fn samples(mut self, samples: SampleCountFlags) -> Self {
         self.inner.samples = samples;
         self
     }
-    pub fn load_op(mut self, load_op: AttachmentLoadOp) -> AttachmentDescriptionBuilder<'a> {
+    pub fn load_op(mut self, load_op: AttachmentLoadOp) -> Self {
         self.inner.load_op = load_op;
         self
     }
-    pub fn store_op(mut self, store_op: AttachmentStoreOp) -> AttachmentDescriptionBuilder<'a> {
+    pub fn store_op(mut self, store_op: AttachmentStoreOp) -> Self {
         self.inner.store_op = store_op;
         self
     }
-    pub fn stencil_load_op(
-        mut self,
-        stencil_load_op: AttachmentLoadOp,
-    ) -> AttachmentDescriptionBuilder<'a> {
+    pub fn stencil_load_op(mut self, stencil_load_op: AttachmentLoadOp) -> Self {
         self.inner.stencil_load_op = stencil_load_op;
         self
     }
-    pub fn stencil_store_op(
-        mut self,
-        stencil_store_op: AttachmentStoreOp,
-    ) -> AttachmentDescriptionBuilder<'a> {
+    pub fn stencil_store_op(mut self, stencil_store_op: AttachmentStoreOp) -> Self {
         self.inner.stencil_store_op = stencil_store_op;
         self
     }
-    pub fn initial_layout(
-        mut self,
-        initial_layout: ImageLayout,
-    ) -> AttachmentDescriptionBuilder<'a> {
+    pub fn initial_layout(mut self, initial_layout: ImageLayout) -> Self {
         self.inner.initial_layout = initial_layout;
         self
     }
-    pub fn final_layout(mut self, final_layout: ImageLayout) -> AttachmentDescriptionBuilder<'a> {
+    pub fn final_layout(mut self, final_layout: ImageLayout) -> Self {
         self.inner.final_layout = final_layout;
         self
     }
@@ -7979,11 +7385,11 @@ impl<'a> ::std::ops::DerefMut for AttachmentReferenceBuilder<'a> {
     }
 }
 impl<'a> AttachmentReferenceBuilder<'a> {
-    pub fn attachment(mut self, attachment: u32) -> AttachmentReferenceBuilder<'a> {
+    pub fn attachment(mut self, attachment: u32) -> Self {
         self.inner.attachment = attachment;
         self
     }
-    pub fn layout(mut self, layout: ImageLayout) -> AttachmentReferenceBuilder<'a> {
+    pub fn layout(mut self, layout: ImageLayout) -> Self {
         self.inner.layout = layout;
         self
     }
@@ -8050,37 +7456,25 @@ impl<'a> ::std::ops::DerefMut for SubpassDescriptionBuilder<'a> {
     }
 }
 impl<'a> SubpassDescriptionBuilder<'a> {
-    pub fn flags(mut self, flags: SubpassDescriptionFlags) -> SubpassDescriptionBuilder<'a> {
+    pub fn flags(mut self, flags: SubpassDescriptionFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn pipeline_bind_point(
-        mut self,
-        pipeline_bind_point: PipelineBindPoint,
-    ) -> SubpassDescriptionBuilder<'a> {
+    pub fn pipeline_bind_point(mut self, pipeline_bind_point: PipelineBindPoint) -> Self {
         self.inner.pipeline_bind_point = pipeline_bind_point;
         self
     }
-    pub fn input_attachments(
-        mut self,
-        input_attachments: &'a [AttachmentReference],
-    ) -> SubpassDescriptionBuilder<'a> {
+    pub fn input_attachments(mut self, input_attachments: &'a [AttachmentReference]) -> Self {
         self.inner.input_attachment_count = input_attachments.len() as _;
         self.inner.p_input_attachments = input_attachments.as_ptr();
         self
     }
-    pub fn color_attachments(
-        mut self,
-        color_attachments: &'a [AttachmentReference],
-    ) -> SubpassDescriptionBuilder<'a> {
+    pub fn color_attachments(mut self, color_attachments: &'a [AttachmentReference]) -> Self {
         self.inner.color_attachment_count = color_attachments.len() as _;
         self.inner.p_color_attachments = color_attachments.as_ptr();
         self
     }
-    pub fn resolve_attachments(
-        mut self,
-        resolve_attachments: &'a [AttachmentReference],
-    ) -> SubpassDescriptionBuilder<'a> {
+    pub fn resolve_attachments(mut self, resolve_attachments: &'a [AttachmentReference]) -> Self {
         self.inner.color_attachment_count = resolve_attachments.len() as _;
         self.inner.p_resolve_attachments = resolve_attachments.as_ptr();
         self
@@ -8088,14 +7482,11 @@ impl<'a> SubpassDescriptionBuilder<'a> {
     pub fn depth_stencil_attachment(
         mut self,
         depth_stencil_attachment: &'a AttachmentReference,
-    ) -> SubpassDescriptionBuilder<'a> {
+    ) -> Self {
         self.inner.p_depth_stencil_attachment = depth_stencil_attachment;
         self
     }
-    pub fn preserve_attachments(
-        mut self,
-        preserve_attachments: &'a [u32],
-    ) -> SubpassDescriptionBuilder<'a> {
+    pub fn preserve_attachments(mut self, preserve_attachments: &'a [u32]) -> Self {
         self.inner.preserve_attachment_count = preserve_attachments.len() as _;
         self.inner.p_preserve_attachments = preserve_attachments.as_ptr();
         self
@@ -8144,40 +7535,31 @@ impl<'a> ::std::ops::DerefMut for SubpassDependencyBuilder<'a> {
     }
 }
 impl<'a> SubpassDependencyBuilder<'a> {
-    pub fn src_subpass(mut self, src_subpass: u32) -> SubpassDependencyBuilder<'a> {
+    pub fn src_subpass(mut self, src_subpass: u32) -> Self {
         self.inner.src_subpass = src_subpass;
         self
     }
-    pub fn dst_subpass(mut self, dst_subpass: u32) -> SubpassDependencyBuilder<'a> {
+    pub fn dst_subpass(mut self, dst_subpass: u32) -> Self {
         self.inner.dst_subpass = dst_subpass;
         self
     }
-    pub fn src_stage_mask(
-        mut self,
-        src_stage_mask: PipelineStageFlags,
-    ) -> SubpassDependencyBuilder<'a> {
+    pub fn src_stage_mask(mut self, src_stage_mask: PipelineStageFlags) -> Self {
         self.inner.src_stage_mask = src_stage_mask;
         self
     }
-    pub fn dst_stage_mask(
-        mut self,
-        dst_stage_mask: PipelineStageFlags,
-    ) -> SubpassDependencyBuilder<'a> {
+    pub fn dst_stage_mask(mut self, dst_stage_mask: PipelineStageFlags) -> Self {
         self.inner.dst_stage_mask = dst_stage_mask;
         self
     }
-    pub fn src_access_mask(mut self, src_access_mask: AccessFlags) -> SubpassDependencyBuilder<'a> {
+    pub fn src_access_mask(mut self, src_access_mask: AccessFlags) -> Self {
         self.inner.src_access_mask = src_access_mask;
         self
     }
-    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags) -> SubpassDependencyBuilder<'a> {
+    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags) -> Self {
         self.inner.dst_access_mask = dst_access_mask;
         self
     }
-    pub fn dependency_flags(
-        mut self,
-        dependency_flags: DependencyFlags,
-    ) -> SubpassDependencyBuilder<'a> {
+    pub fn dependency_flags(mut self, dependency_flags: DependencyFlags) -> Self {
         self.inner.dependency_flags = dependency_flags;
         self
     }
@@ -8243,30 +7625,21 @@ impl<'a> ::std::ops::DerefMut for RenderPassCreateInfoBuilder<'a> {
     }
 }
 impl<'a> RenderPassCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: RenderPassCreateFlags) -> RenderPassCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: RenderPassCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn attachments(
-        mut self,
-        attachments: &'a [AttachmentDescription],
-    ) -> RenderPassCreateInfoBuilder<'a> {
+    pub fn attachments(mut self, attachments: &'a [AttachmentDescription]) -> Self {
         self.inner.attachment_count = attachments.len() as _;
         self.inner.p_attachments = attachments.as_ptr();
         self
     }
-    pub fn subpasses(
-        mut self,
-        subpasses: &'a [SubpassDescription],
-    ) -> RenderPassCreateInfoBuilder<'a> {
+    pub fn subpasses(mut self, subpasses: &'a [SubpassDescription]) -> Self {
         self.inner.subpass_count = subpasses.len() as _;
         self.inner.p_subpasses = subpasses.as_ptr();
         self
     }
-    pub fn dependencies(
-        mut self,
-        dependencies: &'a [SubpassDependency],
-    ) -> RenderPassCreateInfoBuilder<'a> {
+    pub fn dependencies(mut self, dependencies: &'a [SubpassDependency]) -> Self {
         self.inner.dependency_count = dependencies.len() as _;
         self.inner.p_dependencies = dependencies.as_ptr();
         self
@@ -8276,10 +7649,7 @@ impl<'a> RenderPassCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsRenderPassCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> RenderPassCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsRenderPassCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -8338,7 +7708,7 @@ impl<'a> ::std::ops::DerefMut for EventCreateInfoBuilder<'a> {
     }
 }
 impl<'a> EventCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: EventCreateFlags) -> EventCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: EventCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -8347,10 +7717,7 @@ impl<'a> EventCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsEventCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> EventCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsEventCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -8409,7 +7776,7 @@ impl<'a> ::std::ops::DerefMut for FenceCreateInfoBuilder<'a> {
     }
 }
 impl<'a> FenceCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: FenceCreateFlags) -> FenceCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: FenceCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -8418,10 +7785,7 @@ impl<'a> FenceCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsFenceCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> FenceCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsFenceCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -8522,181 +7886,133 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceFeaturesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceFeaturesBuilder<'a> {
-    pub fn robust_buffer_access(
-        mut self,
-        robust_buffer_access: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn robust_buffer_access(mut self, robust_buffer_access: bool) -> Self {
         self.inner.robust_buffer_access = robust_buffer_access.into();
         self
     }
-    pub fn full_draw_index_uint32(
-        mut self,
-        full_draw_index_uint32: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn full_draw_index_uint32(mut self, full_draw_index_uint32: bool) -> Self {
         self.inner.full_draw_index_uint32 = full_draw_index_uint32.into();
         self
     }
-    pub fn image_cube_array(mut self, image_cube_array: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn image_cube_array(mut self, image_cube_array: bool) -> Self {
         self.inner.image_cube_array = image_cube_array.into();
         self
     }
-    pub fn independent_blend(
-        mut self,
-        independent_blend: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn independent_blend(mut self, independent_blend: bool) -> Self {
         self.inner.independent_blend = independent_blend.into();
         self
     }
-    pub fn geometry_shader(mut self, geometry_shader: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn geometry_shader(mut self, geometry_shader: bool) -> Self {
         self.inner.geometry_shader = geometry_shader.into();
         self
     }
-    pub fn tessellation_shader(
-        mut self,
-        tessellation_shader: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn tessellation_shader(mut self, tessellation_shader: bool) -> Self {
         self.inner.tessellation_shader = tessellation_shader.into();
         self
     }
-    pub fn sample_rate_shading(
-        mut self,
-        sample_rate_shading: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sample_rate_shading(mut self, sample_rate_shading: bool) -> Self {
         self.inner.sample_rate_shading = sample_rate_shading.into();
         self
     }
-    pub fn dual_src_blend(mut self, dual_src_blend: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn dual_src_blend(mut self, dual_src_blend: bool) -> Self {
         self.inner.dual_src_blend = dual_src_blend.into();
         self
     }
-    pub fn logic_op(mut self, logic_op: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn logic_op(mut self, logic_op: bool) -> Self {
         self.inner.logic_op = logic_op.into();
         self
     }
-    pub fn multi_draw_indirect(
-        mut self,
-        multi_draw_indirect: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn multi_draw_indirect(mut self, multi_draw_indirect: bool) -> Self {
         self.inner.multi_draw_indirect = multi_draw_indirect.into();
         self
     }
-    pub fn draw_indirect_first_instance(
-        mut self,
-        draw_indirect_first_instance: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn draw_indirect_first_instance(mut self, draw_indirect_first_instance: bool) -> Self {
         self.inner.draw_indirect_first_instance = draw_indirect_first_instance.into();
         self
     }
-    pub fn depth_clamp(mut self, depth_clamp: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn depth_clamp(mut self, depth_clamp: bool) -> Self {
         self.inner.depth_clamp = depth_clamp.into();
         self
     }
-    pub fn depth_bias_clamp(mut self, depth_bias_clamp: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn depth_bias_clamp(mut self, depth_bias_clamp: bool) -> Self {
         self.inner.depth_bias_clamp = depth_bias_clamp.into();
         self
     }
-    pub fn fill_mode_non_solid(
-        mut self,
-        fill_mode_non_solid: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn fill_mode_non_solid(mut self, fill_mode_non_solid: bool) -> Self {
         self.inner.fill_mode_non_solid = fill_mode_non_solid.into();
         self
     }
-    pub fn depth_bounds(mut self, depth_bounds: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn depth_bounds(mut self, depth_bounds: bool) -> Self {
         self.inner.depth_bounds = depth_bounds.into();
         self
     }
-    pub fn wide_lines(mut self, wide_lines: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn wide_lines(mut self, wide_lines: bool) -> Self {
         self.inner.wide_lines = wide_lines.into();
         self
     }
-    pub fn large_points(mut self, large_points: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn large_points(mut self, large_points: bool) -> Self {
         self.inner.large_points = large_points.into();
         self
     }
-    pub fn alpha_to_one(mut self, alpha_to_one: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn alpha_to_one(mut self, alpha_to_one: bool) -> Self {
         self.inner.alpha_to_one = alpha_to_one.into();
         self
     }
-    pub fn multi_viewport(mut self, multi_viewport: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn multi_viewport(mut self, multi_viewport: bool) -> Self {
         self.inner.multi_viewport = multi_viewport.into();
         self
     }
-    pub fn sampler_anisotropy(
-        mut self,
-        sampler_anisotropy: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sampler_anisotropy(mut self, sampler_anisotropy: bool) -> Self {
         self.inner.sampler_anisotropy = sampler_anisotropy.into();
         self
     }
-    pub fn texture_compression_etc2(
-        mut self,
-        texture_compression_etc2: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn texture_compression_etc2(mut self, texture_compression_etc2: bool) -> Self {
         self.inner.texture_compression_etc2 = texture_compression_etc2.into();
         self
     }
-    pub fn texture_compression_astc_ldr(
-        mut self,
-        texture_compression_astc_ldr: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn texture_compression_astc_ldr(mut self, texture_compression_astc_ldr: bool) -> Self {
         self.inner.texture_compression_astc_ldr = texture_compression_astc_ldr.into();
         self
     }
-    pub fn texture_compression_bc(
-        mut self,
-        texture_compression_bc: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn texture_compression_bc(mut self, texture_compression_bc: bool) -> Self {
         self.inner.texture_compression_bc = texture_compression_bc.into();
         self
     }
-    pub fn occlusion_query_precise(
-        mut self,
-        occlusion_query_precise: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn occlusion_query_precise(mut self, occlusion_query_precise: bool) -> Self {
         self.inner.occlusion_query_precise = occlusion_query_precise.into();
         self
     }
-    pub fn pipeline_statistics_query(
-        mut self,
-        pipeline_statistics_query: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn pipeline_statistics_query(mut self, pipeline_statistics_query: bool) -> Self {
         self.inner.pipeline_statistics_query = pipeline_statistics_query.into();
         self
     }
     pub fn vertex_pipeline_stores_and_atomics(
         mut self,
         vertex_pipeline_stores_and_atomics: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.vertex_pipeline_stores_and_atomics = vertex_pipeline_stores_and_atomics.into();
         self
     }
-    pub fn fragment_stores_and_atomics(
-        mut self,
-        fragment_stores_and_atomics: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn fragment_stores_and_atomics(mut self, fragment_stores_and_atomics: bool) -> Self {
         self.inner.fragment_stores_and_atomics = fragment_stores_and_atomics.into();
         self
     }
     pub fn shader_tessellation_and_geometry_point_size(
         mut self,
         shader_tessellation_and_geometry_point_size: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_tessellation_and_geometry_point_size =
             shader_tessellation_and_geometry_point_size.into();
         self
     }
-    pub fn shader_image_gather_extended(
-        mut self,
-        shader_image_gather_extended: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn shader_image_gather_extended(mut self, shader_image_gather_extended: bool) -> Self {
         self.inner.shader_image_gather_extended = shader_image_gather_extended.into();
         self
     }
     pub fn shader_storage_image_extended_formats(
         mut self,
         shader_storage_image_extended_formats: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_image_extended_formats =
             shader_storage_image_extended_formats.into();
         self
@@ -8704,14 +8020,14 @@ impl<'a> PhysicalDeviceFeaturesBuilder<'a> {
     pub fn shader_storage_image_multisample(
         mut self,
         shader_storage_image_multisample: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_image_multisample = shader_storage_image_multisample.into();
         self
     }
     pub fn shader_storage_image_read_without_format(
         mut self,
         shader_storage_image_read_without_format: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_image_read_without_format =
             shader_storage_image_read_without_format.into();
         self
@@ -8719,7 +8035,7 @@ impl<'a> PhysicalDeviceFeaturesBuilder<'a> {
     pub fn shader_storage_image_write_without_format(
         mut self,
         shader_storage_image_write_without_format: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_image_write_without_format =
             shader_storage_image_write_without_format.into();
         self
@@ -8727,7 +8043,7 @@ impl<'a> PhysicalDeviceFeaturesBuilder<'a> {
     pub fn shader_uniform_buffer_array_dynamic_indexing(
         mut self,
         shader_uniform_buffer_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_uniform_buffer_array_dynamic_indexing =
             shader_uniform_buffer_array_dynamic_indexing.into();
         self
@@ -8735,7 +8051,7 @@ impl<'a> PhysicalDeviceFeaturesBuilder<'a> {
     pub fn shader_sampled_image_array_dynamic_indexing(
         mut self,
         shader_sampled_image_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_sampled_image_array_dynamic_indexing =
             shader_sampled_image_array_dynamic_indexing.into();
         self
@@ -8743,7 +8059,7 @@ impl<'a> PhysicalDeviceFeaturesBuilder<'a> {
     pub fn shader_storage_buffer_array_dynamic_indexing(
         mut self,
         shader_storage_buffer_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_buffer_array_dynamic_indexing =
             shader_storage_buffer_array_dynamic_indexing.into();
         self
@@ -8751,122 +8067,80 @@ impl<'a> PhysicalDeviceFeaturesBuilder<'a> {
     pub fn shader_storage_image_array_dynamic_indexing(
         mut self,
         shader_storage_image_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_image_array_dynamic_indexing =
             shader_storage_image_array_dynamic_indexing.into();
         self
     }
-    pub fn shader_clip_distance(
-        mut self,
-        shader_clip_distance: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn shader_clip_distance(mut self, shader_clip_distance: bool) -> Self {
         self.inner.shader_clip_distance = shader_clip_distance.into();
         self
     }
-    pub fn shader_cull_distance(
-        mut self,
-        shader_cull_distance: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn shader_cull_distance(mut self, shader_cull_distance: bool) -> Self {
         self.inner.shader_cull_distance = shader_cull_distance.into();
         self
     }
-    pub fn shader_float64(mut self, shader_float64: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn shader_float64(mut self, shader_float64: bool) -> Self {
         self.inner.shader_float64 = shader_float64.into();
         self
     }
-    pub fn shader_int64(mut self, shader_int64: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn shader_int64(mut self, shader_int64: bool) -> Self {
         self.inner.shader_int64 = shader_int64.into();
         self
     }
-    pub fn shader_int16(mut self, shader_int16: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn shader_int16(mut self, shader_int16: bool) -> Self {
         self.inner.shader_int16 = shader_int16.into();
         self
     }
-    pub fn shader_resource_residency(
-        mut self,
-        shader_resource_residency: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn shader_resource_residency(mut self, shader_resource_residency: bool) -> Self {
         self.inner.shader_resource_residency = shader_resource_residency.into();
         self
     }
-    pub fn shader_resource_min_lod(
-        mut self,
-        shader_resource_min_lod: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn shader_resource_min_lod(mut self, shader_resource_min_lod: bool) -> Self {
         self.inner.shader_resource_min_lod = shader_resource_min_lod.into();
         self
     }
-    pub fn sparse_binding(mut self, sparse_binding: bool) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sparse_binding(mut self, sparse_binding: bool) -> Self {
         self.inner.sparse_binding = sparse_binding.into();
         self
     }
-    pub fn sparse_residency_buffer(
-        mut self,
-        sparse_residency_buffer: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sparse_residency_buffer(mut self, sparse_residency_buffer: bool) -> Self {
         self.inner.sparse_residency_buffer = sparse_residency_buffer.into();
         self
     }
-    pub fn sparse_residency_image2_d(
-        mut self,
-        sparse_residency_image2_d: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sparse_residency_image2_d(mut self, sparse_residency_image2_d: bool) -> Self {
         self.inner.sparse_residency_image2_d = sparse_residency_image2_d.into();
         self
     }
-    pub fn sparse_residency_image3_d(
-        mut self,
-        sparse_residency_image3_d: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sparse_residency_image3_d(mut self, sparse_residency_image3_d: bool) -> Self {
         self.inner.sparse_residency_image3_d = sparse_residency_image3_d.into();
         self
     }
-    pub fn sparse_residency2_samples(
-        mut self,
-        sparse_residency2_samples: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sparse_residency2_samples(mut self, sparse_residency2_samples: bool) -> Self {
         self.inner.sparse_residency2_samples = sparse_residency2_samples.into();
         self
     }
-    pub fn sparse_residency4_samples(
-        mut self,
-        sparse_residency4_samples: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sparse_residency4_samples(mut self, sparse_residency4_samples: bool) -> Self {
         self.inner.sparse_residency4_samples = sparse_residency4_samples.into();
         self
     }
-    pub fn sparse_residency8_samples(
-        mut self,
-        sparse_residency8_samples: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sparse_residency8_samples(mut self, sparse_residency8_samples: bool) -> Self {
         self.inner.sparse_residency8_samples = sparse_residency8_samples.into();
         self
     }
-    pub fn sparse_residency16_samples(
-        mut self,
-        sparse_residency16_samples: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sparse_residency16_samples(mut self, sparse_residency16_samples: bool) -> Self {
         self.inner.sparse_residency16_samples = sparse_residency16_samples.into();
         self
     }
-    pub fn sparse_residency_aliased(
-        mut self,
-        sparse_residency_aliased: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn sparse_residency_aliased(mut self, sparse_residency_aliased: bool) -> Self {
         self.inner.sparse_residency_aliased = sparse_residency_aliased.into();
         self
     }
-    pub fn variable_multisample_rate(
-        mut self,
-        variable_multisample_rate: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn variable_multisample_rate(mut self, variable_multisample_rate: bool) -> Self {
         self.inner.variable_multisample_rate = variable_multisample_rate.into();
         self
     }
-    pub fn inherited_queries(
-        mut self,
-        inherited_queries: bool,
-    ) -> PhysicalDeviceFeaturesBuilder<'a> {
+    pub fn inherited_queries(mut self, inherited_queries: bool) -> Self {
         self.inner.inherited_queries = inherited_queries.into();
         self
     }
@@ -8915,14 +8189,14 @@ impl<'a> PhysicalDeviceSparsePropertiesBuilder<'a> {
     pub fn residency_standard2_d_block_shape(
         mut self,
         residency_standard2_d_block_shape: bool,
-    ) -> PhysicalDeviceSparsePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.residency_standard2_d_block_shape = residency_standard2_d_block_shape.into();
         self
     }
     pub fn residency_standard2_d_multisample_block_shape(
         mut self,
         residency_standard2_d_multisample_block_shape: bool,
-    ) -> PhysicalDeviceSparsePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.residency_standard2_d_multisample_block_shape =
             residency_standard2_d_multisample_block_shape.into();
         self
@@ -8930,21 +8204,15 @@ impl<'a> PhysicalDeviceSparsePropertiesBuilder<'a> {
     pub fn residency_standard3_d_block_shape(
         mut self,
         residency_standard3_d_block_shape: bool,
-    ) -> PhysicalDeviceSparsePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.residency_standard3_d_block_shape = residency_standard3_d_block_shape.into();
         self
     }
-    pub fn residency_aligned_mip_size(
-        mut self,
-        residency_aligned_mip_size: bool,
-    ) -> PhysicalDeviceSparsePropertiesBuilder<'a> {
+    pub fn residency_aligned_mip_size(mut self, residency_aligned_mip_size: bool) -> Self {
         self.inner.residency_aligned_mip_size = residency_aligned_mip_size.into();
         self
     }
-    pub fn residency_non_resident_strict(
-        mut self,
-        residency_non_resident_strict: bool,
-    ) -> PhysicalDeviceSparsePropertiesBuilder<'a> {
+    pub fn residency_non_resident_strict(mut self, residency_non_resident_strict: bool) -> Self {
         self.inner.residency_non_resident_strict = residency_non_resident_strict.into();
         self
     }
@@ -9203,115 +8471,73 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceLimitsBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceLimitsBuilder<'a> {
-    pub fn max_image_dimension1_d(
-        mut self,
-        max_image_dimension1_d: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_image_dimension1_d(mut self, max_image_dimension1_d: u32) -> Self {
         self.inner.max_image_dimension1_d = max_image_dimension1_d;
         self
     }
-    pub fn max_image_dimension2_d(
-        mut self,
-        max_image_dimension2_d: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_image_dimension2_d(mut self, max_image_dimension2_d: u32) -> Self {
         self.inner.max_image_dimension2_d = max_image_dimension2_d;
         self
     }
-    pub fn max_image_dimension3_d(
-        mut self,
-        max_image_dimension3_d: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_image_dimension3_d(mut self, max_image_dimension3_d: u32) -> Self {
         self.inner.max_image_dimension3_d = max_image_dimension3_d;
         self
     }
-    pub fn max_image_dimension_cube(
-        mut self,
-        max_image_dimension_cube: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_image_dimension_cube(mut self, max_image_dimension_cube: u32) -> Self {
         self.inner.max_image_dimension_cube = max_image_dimension_cube;
         self
     }
-    pub fn max_image_array_layers(
-        mut self,
-        max_image_array_layers: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_image_array_layers(mut self, max_image_array_layers: u32) -> Self {
         self.inner.max_image_array_layers = max_image_array_layers;
         self
     }
-    pub fn max_texel_buffer_elements(
-        mut self,
-        max_texel_buffer_elements: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_texel_buffer_elements(mut self, max_texel_buffer_elements: u32) -> Self {
         self.inner.max_texel_buffer_elements = max_texel_buffer_elements;
         self
     }
-    pub fn max_uniform_buffer_range(
-        mut self,
-        max_uniform_buffer_range: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_uniform_buffer_range(mut self, max_uniform_buffer_range: u32) -> Self {
         self.inner.max_uniform_buffer_range = max_uniform_buffer_range;
         self
     }
-    pub fn max_storage_buffer_range(
-        mut self,
-        max_storage_buffer_range: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_storage_buffer_range(mut self, max_storage_buffer_range: u32) -> Self {
         self.inner.max_storage_buffer_range = max_storage_buffer_range;
         self
     }
-    pub fn max_push_constants_size(
-        mut self,
-        max_push_constants_size: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_push_constants_size(mut self, max_push_constants_size: u32) -> Self {
         self.inner.max_push_constants_size = max_push_constants_size;
         self
     }
-    pub fn max_memory_allocation_count(
-        mut self,
-        max_memory_allocation_count: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_memory_allocation_count(mut self, max_memory_allocation_count: u32) -> Self {
         self.inner.max_memory_allocation_count = max_memory_allocation_count;
         self
     }
-    pub fn max_sampler_allocation_count(
-        mut self,
-        max_sampler_allocation_count: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_sampler_allocation_count(mut self, max_sampler_allocation_count: u32) -> Self {
         self.inner.max_sampler_allocation_count = max_sampler_allocation_count;
         self
     }
-    pub fn buffer_image_granularity(
-        mut self,
-        buffer_image_granularity: DeviceSize,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn buffer_image_granularity(mut self, buffer_image_granularity: DeviceSize) -> Self {
         self.inner.buffer_image_granularity = buffer_image_granularity;
         self
     }
-    pub fn sparse_address_space_size(
-        mut self,
-        sparse_address_space_size: DeviceSize,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn sparse_address_space_size(mut self, sparse_address_space_size: DeviceSize) -> Self {
         self.inner.sparse_address_space_size = sparse_address_space_size;
         self
     }
-    pub fn max_bound_descriptor_sets(
-        mut self,
-        max_bound_descriptor_sets: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_bound_descriptor_sets(mut self, max_bound_descriptor_sets: u32) -> Self {
         self.inner.max_bound_descriptor_sets = max_bound_descriptor_sets;
         self
     }
     pub fn max_per_stage_descriptor_samplers(
         mut self,
         max_per_stage_descriptor_samplers: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_descriptor_samplers = max_per_stage_descriptor_samplers;
         self
     }
     pub fn max_per_stage_descriptor_uniform_buffers(
         mut self,
         max_per_stage_descriptor_uniform_buffers: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_descriptor_uniform_buffers =
             max_per_stage_descriptor_uniform_buffers;
         self
@@ -9319,7 +8545,7 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_per_stage_descriptor_storage_buffers(
         mut self,
         max_per_stage_descriptor_storage_buffers: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_descriptor_storage_buffers =
             max_per_stage_descriptor_storage_buffers;
         self
@@ -9327,7 +8553,7 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_per_stage_descriptor_sampled_images(
         mut self,
         max_per_stage_descriptor_sampled_images: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_descriptor_sampled_images =
             max_per_stage_descriptor_sampled_images;
         self
@@ -9335,7 +8561,7 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_per_stage_descriptor_storage_images(
         mut self,
         max_per_stage_descriptor_storage_images: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_descriptor_storage_images =
             max_per_stage_descriptor_storage_images;
         self
@@ -9343,36 +8569,30 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_per_stage_descriptor_input_attachments(
         mut self,
         max_per_stage_descriptor_input_attachments: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_descriptor_input_attachments =
             max_per_stage_descriptor_input_attachments;
         self
     }
-    pub fn max_per_stage_resources(
-        mut self,
-        max_per_stage_resources: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_per_stage_resources(mut self, max_per_stage_resources: u32) -> Self {
         self.inner.max_per_stage_resources = max_per_stage_resources;
         self
     }
-    pub fn max_descriptor_set_samplers(
-        mut self,
-        max_descriptor_set_samplers: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_descriptor_set_samplers(mut self, max_descriptor_set_samplers: u32) -> Self {
         self.inner.max_descriptor_set_samplers = max_descriptor_set_samplers;
         self
     }
     pub fn max_descriptor_set_uniform_buffers(
         mut self,
         max_descriptor_set_uniform_buffers: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_uniform_buffers = max_descriptor_set_uniform_buffers;
         self
     }
     pub fn max_descriptor_set_uniform_buffers_dynamic(
         mut self,
         max_descriptor_set_uniform_buffers_dynamic: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_uniform_buffers_dynamic =
             max_descriptor_set_uniform_buffers_dynamic;
         self
@@ -9380,14 +8600,14 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_descriptor_set_storage_buffers(
         mut self,
         max_descriptor_set_storage_buffers: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_storage_buffers = max_descriptor_set_storage_buffers;
         self
     }
     pub fn max_descriptor_set_storage_buffers_dynamic(
         mut self,
         max_descriptor_set_storage_buffers_dynamic: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_storage_buffers_dynamic =
             max_descriptor_set_storage_buffers_dynamic;
         self
@@ -9395,77 +8615,62 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_descriptor_set_sampled_images(
         mut self,
         max_descriptor_set_sampled_images: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_sampled_images = max_descriptor_set_sampled_images;
         self
     }
     pub fn max_descriptor_set_storage_images(
         mut self,
         max_descriptor_set_storage_images: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_storage_images = max_descriptor_set_storage_images;
         self
     }
     pub fn max_descriptor_set_input_attachments(
         mut self,
         max_descriptor_set_input_attachments: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_input_attachments = max_descriptor_set_input_attachments;
         self
     }
-    pub fn max_vertex_input_attributes(
-        mut self,
-        max_vertex_input_attributes: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_vertex_input_attributes(mut self, max_vertex_input_attributes: u32) -> Self {
         self.inner.max_vertex_input_attributes = max_vertex_input_attributes;
         self
     }
-    pub fn max_vertex_input_bindings(
-        mut self,
-        max_vertex_input_bindings: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_vertex_input_bindings(mut self, max_vertex_input_bindings: u32) -> Self {
         self.inner.max_vertex_input_bindings = max_vertex_input_bindings;
         self
     }
     pub fn max_vertex_input_attribute_offset(
         mut self,
         max_vertex_input_attribute_offset: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_vertex_input_attribute_offset = max_vertex_input_attribute_offset;
         self
     }
-    pub fn max_vertex_input_binding_stride(
-        mut self,
-        max_vertex_input_binding_stride: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_vertex_input_binding_stride(mut self, max_vertex_input_binding_stride: u32) -> Self {
         self.inner.max_vertex_input_binding_stride = max_vertex_input_binding_stride;
         self
     }
-    pub fn max_vertex_output_components(
-        mut self,
-        max_vertex_output_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_vertex_output_components(mut self, max_vertex_output_components: u32) -> Self {
         self.inner.max_vertex_output_components = max_vertex_output_components;
         self
     }
     pub fn max_tessellation_generation_level(
         mut self,
         max_tessellation_generation_level: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_tessellation_generation_level = max_tessellation_generation_level;
         self
     }
-    pub fn max_tessellation_patch_size(
-        mut self,
-        max_tessellation_patch_size: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_tessellation_patch_size(mut self, max_tessellation_patch_size: u32) -> Self {
         self.inner.max_tessellation_patch_size = max_tessellation_patch_size;
         self
     }
     pub fn max_tessellation_control_per_vertex_input_components(
         mut self,
         max_tessellation_control_per_vertex_input_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_tessellation_control_per_vertex_input_components =
             max_tessellation_control_per_vertex_input_components;
@@ -9474,7 +8679,7 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_tessellation_control_per_vertex_output_components(
         mut self,
         max_tessellation_control_per_vertex_output_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_tessellation_control_per_vertex_output_components =
             max_tessellation_control_per_vertex_output_components;
@@ -9483,7 +8688,7 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_tessellation_control_per_patch_output_components(
         mut self,
         max_tessellation_control_per_patch_output_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_tessellation_control_per_patch_output_components =
             max_tessellation_control_per_patch_output_components;
@@ -9492,7 +8697,7 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_tessellation_control_total_output_components(
         mut self,
         max_tessellation_control_total_output_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_tessellation_control_total_output_components =
             max_tessellation_control_total_output_components;
         self
@@ -9500,7 +8705,7 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_tessellation_evaluation_input_components(
         mut self,
         max_tessellation_evaluation_input_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_tessellation_evaluation_input_components =
             max_tessellation_evaluation_input_components;
         self
@@ -9508,443 +8713,326 @@ impl<'a> PhysicalDeviceLimitsBuilder<'a> {
     pub fn max_tessellation_evaluation_output_components(
         mut self,
         max_tessellation_evaluation_output_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_tessellation_evaluation_output_components =
             max_tessellation_evaluation_output_components;
         self
     }
-    pub fn max_geometry_shader_invocations(
-        mut self,
-        max_geometry_shader_invocations: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_geometry_shader_invocations(mut self, max_geometry_shader_invocations: u32) -> Self {
         self.inner.max_geometry_shader_invocations = max_geometry_shader_invocations;
         self
     }
-    pub fn max_geometry_input_components(
-        mut self,
-        max_geometry_input_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_geometry_input_components(mut self, max_geometry_input_components: u32) -> Self {
         self.inner.max_geometry_input_components = max_geometry_input_components;
         self
     }
-    pub fn max_geometry_output_components(
-        mut self,
-        max_geometry_output_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_geometry_output_components(mut self, max_geometry_output_components: u32) -> Self {
         self.inner.max_geometry_output_components = max_geometry_output_components;
         self
     }
-    pub fn max_geometry_output_vertices(
-        mut self,
-        max_geometry_output_vertices: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_geometry_output_vertices(mut self, max_geometry_output_vertices: u32) -> Self {
         self.inner.max_geometry_output_vertices = max_geometry_output_vertices;
         self
     }
     pub fn max_geometry_total_output_components(
         mut self,
         max_geometry_total_output_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_geometry_total_output_components = max_geometry_total_output_components;
         self
     }
-    pub fn max_fragment_input_components(
-        mut self,
-        max_fragment_input_components: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_fragment_input_components(mut self, max_fragment_input_components: u32) -> Self {
         self.inner.max_fragment_input_components = max_fragment_input_components;
         self
     }
-    pub fn max_fragment_output_attachments(
-        mut self,
-        max_fragment_output_attachments: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_fragment_output_attachments(mut self, max_fragment_output_attachments: u32) -> Self {
         self.inner.max_fragment_output_attachments = max_fragment_output_attachments;
         self
     }
     pub fn max_fragment_dual_src_attachments(
         mut self,
         max_fragment_dual_src_attachments: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_fragment_dual_src_attachments = max_fragment_dual_src_attachments;
         self
     }
     pub fn max_fragment_combined_output_resources(
         mut self,
         max_fragment_combined_output_resources: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_fragment_combined_output_resources = max_fragment_combined_output_resources;
         self
     }
-    pub fn max_compute_shared_memory_size(
-        mut self,
-        max_compute_shared_memory_size: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_compute_shared_memory_size(mut self, max_compute_shared_memory_size: u32) -> Self {
         self.inner.max_compute_shared_memory_size = max_compute_shared_memory_size;
         self
     }
-    pub fn max_compute_work_group_count(
-        mut self,
-        max_compute_work_group_count: [u32; 3],
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_compute_work_group_count(mut self, max_compute_work_group_count: [u32; 3]) -> Self {
         self.inner.max_compute_work_group_count = max_compute_work_group_count;
         self
     }
     pub fn max_compute_work_group_invocations(
         mut self,
         max_compute_work_group_invocations: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_compute_work_group_invocations = max_compute_work_group_invocations;
         self
     }
-    pub fn max_compute_work_group_size(
-        mut self,
-        max_compute_work_group_size: [u32; 3],
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_compute_work_group_size(mut self, max_compute_work_group_size: [u32; 3]) -> Self {
         self.inner.max_compute_work_group_size = max_compute_work_group_size;
         self
     }
-    pub fn sub_pixel_precision_bits(
-        mut self,
-        sub_pixel_precision_bits: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn sub_pixel_precision_bits(mut self, sub_pixel_precision_bits: u32) -> Self {
         self.inner.sub_pixel_precision_bits = sub_pixel_precision_bits;
         self
     }
-    pub fn sub_texel_precision_bits(
-        mut self,
-        sub_texel_precision_bits: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn sub_texel_precision_bits(mut self, sub_texel_precision_bits: u32) -> Self {
         self.inner.sub_texel_precision_bits = sub_texel_precision_bits;
         self
     }
-    pub fn mipmap_precision_bits(
-        mut self,
-        mipmap_precision_bits: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn mipmap_precision_bits(mut self, mipmap_precision_bits: u32) -> Self {
         self.inner.mipmap_precision_bits = mipmap_precision_bits;
         self
     }
-    pub fn max_draw_indexed_index_value(
-        mut self,
-        max_draw_indexed_index_value: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_draw_indexed_index_value(mut self, max_draw_indexed_index_value: u32) -> Self {
         self.inner.max_draw_indexed_index_value = max_draw_indexed_index_value;
         self
     }
-    pub fn max_draw_indirect_count(
-        mut self,
-        max_draw_indirect_count: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_draw_indirect_count(mut self, max_draw_indirect_count: u32) -> Self {
         self.inner.max_draw_indirect_count = max_draw_indirect_count;
         self
     }
-    pub fn max_sampler_lod_bias(
-        mut self,
-        max_sampler_lod_bias: f32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_sampler_lod_bias(mut self, max_sampler_lod_bias: f32) -> Self {
         self.inner.max_sampler_lod_bias = max_sampler_lod_bias;
         self
     }
-    pub fn max_sampler_anisotropy(
-        mut self,
-        max_sampler_anisotropy: f32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_sampler_anisotropy(mut self, max_sampler_anisotropy: f32) -> Self {
         self.inner.max_sampler_anisotropy = max_sampler_anisotropy;
         self
     }
-    pub fn max_viewports(mut self, max_viewports: u32) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_viewports(mut self, max_viewports: u32) -> Self {
         self.inner.max_viewports = max_viewports;
         self
     }
-    pub fn max_viewport_dimensions(
-        mut self,
-        max_viewport_dimensions: [u32; 2],
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_viewport_dimensions(mut self, max_viewport_dimensions: [u32; 2]) -> Self {
         self.inner.max_viewport_dimensions = max_viewport_dimensions;
         self
     }
-    pub fn viewport_bounds_range(
-        mut self,
-        viewport_bounds_range: [f32; 2],
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn viewport_bounds_range(mut self, viewport_bounds_range: [f32; 2]) -> Self {
         self.inner.viewport_bounds_range = viewport_bounds_range;
         self
     }
-    pub fn viewport_sub_pixel_bits(
-        mut self,
-        viewport_sub_pixel_bits: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn viewport_sub_pixel_bits(mut self, viewport_sub_pixel_bits: u32) -> Self {
         self.inner.viewport_sub_pixel_bits = viewport_sub_pixel_bits;
         self
     }
-    pub fn min_memory_map_alignment(
-        mut self,
-        min_memory_map_alignment: usize,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn min_memory_map_alignment(mut self, min_memory_map_alignment: usize) -> Self {
         self.inner.min_memory_map_alignment = min_memory_map_alignment;
         self
     }
     pub fn min_texel_buffer_offset_alignment(
         mut self,
         min_texel_buffer_offset_alignment: DeviceSize,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.min_texel_buffer_offset_alignment = min_texel_buffer_offset_alignment;
         self
     }
     pub fn min_uniform_buffer_offset_alignment(
         mut self,
         min_uniform_buffer_offset_alignment: DeviceSize,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.min_uniform_buffer_offset_alignment = min_uniform_buffer_offset_alignment;
         self
     }
     pub fn min_storage_buffer_offset_alignment(
         mut self,
         min_storage_buffer_offset_alignment: DeviceSize,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.min_storage_buffer_offset_alignment = min_storage_buffer_offset_alignment;
         self
     }
-    pub fn min_texel_offset(mut self, min_texel_offset: i32) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn min_texel_offset(mut self, min_texel_offset: i32) -> Self {
         self.inner.min_texel_offset = min_texel_offset;
         self
     }
-    pub fn max_texel_offset(mut self, max_texel_offset: u32) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_texel_offset(mut self, max_texel_offset: u32) -> Self {
         self.inner.max_texel_offset = max_texel_offset;
         self
     }
-    pub fn min_texel_gather_offset(
-        mut self,
-        min_texel_gather_offset: i32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn min_texel_gather_offset(mut self, min_texel_gather_offset: i32) -> Self {
         self.inner.min_texel_gather_offset = min_texel_gather_offset;
         self
     }
-    pub fn max_texel_gather_offset(
-        mut self,
-        max_texel_gather_offset: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_texel_gather_offset(mut self, max_texel_gather_offset: u32) -> Self {
         self.inner.max_texel_gather_offset = max_texel_gather_offset;
         self
     }
-    pub fn min_interpolation_offset(
-        mut self,
-        min_interpolation_offset: f32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn min_interpolation_offset(mut self, min_interpolation_offset: f32) -> Self {
         self.inner.min_interpolation_offset = min_interpolation_offset;
         self
     }
-    pub fn max_interpolation_offset(
-        mut self,
-        max_interpolation_offset: f32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_interpolation_offset(mut self, max_interpolation_offset: f32) -> Self {
         self.inner.max_interpolation_offset = max_interpolation_offset;
         self
     }
     pub fn sub_pixel_interpolation_offset_bits(
         mut self,
         sub_pixel_interpolation_offset_bits: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.sub_pixel_interpolation_offset_bits = sub_pixel_interpolation_offset_bits;
         self
     }
-    pub fn max_framebuffer_width(
-        mut self,
-        max_framebuffer_width: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_framebuffer_width(mut self, max_framebuffer_width: u32) -> Self {
         self.inner.max_framebuffer_width = max_framebuffer_width;
         self
     }
-    pub fn max_framebuffer_height(
-        mut self,
-        max_framebuffer_height: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_framebuffer_height(mut self, max_framebuffer_height: u32) -> Self {
         self.inner.max_framebuffer_height = max_framebuffer_height;
         self
     }
-    pub fn max_framebuffer_layers(
-        mut self,
-        max_framebuffer_layers: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_framebuffer_layers(mut self, max_framebuffer_layers: u32) -> Self {
         self.inner.max_framebuffer_layers = max_framebuffer_layers;
         self
     }
     pub fn framebuffer_color_sample_counts(
         mut self,
         framebuffer_color_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.framebuffer_color_sample_counts = framebuffer_color_sample_counts;
         self
     }
     pub fn framebuffer_depth_sample_counts(
         mut self,
         framebuffer_depth_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.framebuffer_depth_sample_counts = framebuffer_depth_sample_counts;
         self
     }
     pub fn framebuffer_stencil_sample_counts(
         mut self,
         framebuffer_stencil_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.framebuffer_stencil_sample_counts = framebuffer_stencil_sample_counts;
         self
     }
     pub fn framebuffer_no_attachments_sample_counts(
         mut self,
         framebuffer_no_attachments_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.framebuffer_no_attachments_sample_counts =
             framebuffer_no_attachments_sample_counts;
         self
     }
-    pub fn max_color_attachments(
-        mut self,
-        max_color_attachments: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_color_attachments(mut self, max_color_attachments: u32) -> Self {
         self.inner.max_color_attachments = max_color_attachments;
         self
     }
     pub fn sampled_image_color_sample_counts(
         mut self,
         sampled_image_color_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.sampled_image_color_sample_counts = sampled_image_color_sample_counts;
         self
     }
     pub fn sampled_image_integer_sample_counts(
         mut self,
         sampled_image_integer_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.sampled_image_integer_sample_counts = sampled_image_integer_sample_counts;
         self
     }
     pub fn sampled_image_depth_sample_counts(
         mut self,
         sampled_image_depth_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.sampled_image_depth_sample_counts = sampled_image_depth_sample_counts;
         self
     }
     pub fn sampled_image_stencil_sample_counts(
         mut self,
         sampled_image_stencil_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.sampled_image_stencil_sample_counts = sampled_image_stencil_sample_counts;
         self
     }
     pub fn storage_image_sample_counts(
         mut self,
         storage_image_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.storage_image_sample_counts = storage_image_sample_counts;
         self
     }
-    pub fn max_sample_mask_words(
-        mut self,
-        max_sample_mask_words: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_sample_mask_words(mut self, max_sample_mask_words: u32) -> Self {
         self.inner.max_sample_mask_words = max_sample_mask_words;
         self
     }
-    pub fn timestamp_compute_and_graphics(
-        mut self,
-        timestamp_compute_and_graphics: bool,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn timestamp_compute_and_graphics(mut self, timestamp_compute_and_graphics: bool) -> Self {
         self.inner.timestamp_compute_and_graphics = timestamp_compute_and_graphics.into();
         self
     }
-    pub fn timestamp_period(mut self, timestamp_period: f32) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn timestamp_period(mut self, timestamp_period: f32) -> Self {
         self.inner.timestamp_period = timestamp_period;
         self
     }
-    pub fn max_clip_distances(
-        mut self,
-        max_clip_distances: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_clip_distances(mut self, max_clip_distances: u32) -> Self {
         self.inner.max_clip_distances = max_clip_distances;
         self
     }
-    pub fn max_cull_distances(
-        mut self,
-        max_cull_distances: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn max_cull_distances(mut self, max_cull_distances: u32) -> Self {
         self.inner.max_cull_distances = max_cull_distances;
         self
     }
     pub fn max_combined_clip_and_cull_distances(
         mut self,
         max_combined_clip_and_cull_distances: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.max_combined_clip_and_cull_distances = max_combined_clip_and_cull_distances;
         self
     }
-    pub fn discrete_queue_priorities(
-        mut self,
-        discrete_queue_priorities: u32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn discrete_queue_priorities(mut self, discrete_queue_priorities: u32) -> Self {
         self.inner.discrete_queue_priorities = discrete_queue_priorities;
         self
     }
-    pub fn point_size_range(
-        mut self,
-        point_size_range: [f32; 2],
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn point_size_range(mut self, point_size_range: [f32; 2]) -> Self {
         self.inner.point_size_range = point_size_range;
         self
     }
-    pub fn line_width_range(
-        mut self,
-        line_width_range: [f32; 2],
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn line_width_range(mut self, line_width_range: [f32; 2]) -> Self {
         self.inner.line_width_range = line_width_range;
         self
     }
-    pub fn point_size_granularity(
-        mut self,
-        point_size_granularity: f32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn point_size_granularity(mut self, point_size_granularity: f32) -> Self {
         self.inner.point_size_granularity = point_size_granularity;
         self
     }
-    pub fn line_width_granularity(
-        mut self,
-        line_width_granularity: f32,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn line_width_granularity(mut self, line_width_granularity: f32) -> Self {
         self.inner.line_width_granularity = line_width_granularity;
         self
     }
-    pub fn strict_lines(mut self, strict_lines: bool) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn strict_lines(mut self, strict_lines: bool) -> Self {
         self.inner.strict_lines = strict_lines.into();
         self
     }
-    pub fn standard_sample_locations(
-        mut self,
-        standard_sample_locations: bool,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn standard_sample_locations(mut self, standard_sample_locations: bool) -> Self {
         self.inner.standard_sample_locations = standard_sample_locations.into();
         self
     }
     pub fn optimal_buffer_copy_offset_alignment(
         mut self,
         optimal_buffer_copy_offset_alignment: DeviceSize,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.optimal_buffer_copy_offset_alignment = optimal_buffer_copy_offset_alignment;
         self
     }
     pub fn optimal_buffer_copy_row_pitch_alignment(
         mut self,
         optimal_buffer_copy_row_pitch_alignment: DeviceSize,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    ) -> Self {
         self.inner.optimal_buffer_copy_row_pitch_alignment =
             optimal_buffer_copy_row_pitch_alignment;
         self
     }
-    pub fn non_coherent_atom_size(
-        mut self,
-        non_coherent_atom_size: DeviceSize,
-    ) -> PhysicalDeviceLimitsBuilder<'a> {
+    pub fn non_coherent_atom_size(mut self, non_coherent_atom_size: DeviceSize) -> Self {
         self.inner.non_coherent_atom_size = non_coherent_atom_size;
         self
     }
@@ -9998,7 +9086,7 @@ impl<'a> ::std::ops::DerefMut for SemaphoreCreateInfoBuilder<'a> {
     }
 }
 impl<'a> SemaphoreCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: SemaphoreCreateFlags) -> SemaphoreCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: SemaphoreCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -10007,10 +9095,7 @@ impl<'a> SemaphoreCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSemaphoreCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> SemaphoreCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsSemaphoreCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -10075,22 +9160,19 @@ impl<'a> ::std::ops::DerefMut for QueryPoolCreateInfoBuilder<'a> {
     }
 }
 impl<'a> QueryPoolCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: QueryPoolCreateFlags) -> QueryPoolCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: QueryPoolCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn query_type(mut self, query_type: QueryType) -> QueryPoolCreateInfoBuilder<'a> {
+    pub fn query_type(mut self, query_type: QueryType) -> Self {
         self.inner.query_type = query_type;
         self
     }
-    pub fn query_count(mut self, query_count: u32) -> QueryPoolCreateInfoBuilder<'a> {
+    pub fn query_count(mut self, query_count: u32) -> Self {
         self.inner.query_count = query_count;
         self
     }
-    pub fn pipeline_statistics(
-        mut self,
-        pipeline_statistics: QueryPipelineStatisticFlags,
-    ) -> QueryPoolCreateInfoBuilder<'a> {
+    pub fn pipeline_statistics(mut self, pipeline_statistics: QueryPipelineStatisticFlags) -> Self {
         self.inner.pipeline_statistics = pipeline_statistics;
         self
     }
@@ -10099,10 +9181,7 @@ impl<'a> QueryPoolCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsQueryPoolCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> QueryPoolCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsQueryPoolCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -10173,28 +9252,28 @@ impl<'a> ::std::ops::DerefMut for FramebufferCreateInfoBuilder<'a> {
     }
 }
 impl<'a> FramebufferCreateInfoBuilder<'a> {
-    pub fn flags(mut self, flags: FramebufferCreateFlags) -> FramebufferCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: FramebufferCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn render_pass(mut self, render_pass: RenderPass) -> FramebufferCreateInfoBuilder<'a> {
+    pub fn render_pass(mut self, render_pass: RenderPass) -> Self {
         self.inner.render_pass = render_pass;
         self
     }
-    pub fn attachments(mut self, attachments: &'a [ImageView]) -> FramebufferCreateInfoBuilder<'a> {
+    pub fn attachments(mut self, attachments: &'a [ImageView]) -> Self {
         self.inner.attachment_count = attachments.len() as _;
         self.inner.p_attachments = attachments.as_ptr();
         self
     }
-    pub fn width(mut self, width: u32) -> FramebufferCreateInfoBuilder<'a> {
+    pub fn width(mut self, width: u32) -> Self {
         self.inner.width = width;
         self
     }
-    pub fn height(mut self, height: u32) -> FramebufferCreateInfoBuilder<'a> {
+    pub fn height(mut self, height: u32) -> Self {
         self.inner.height = height;
         self
     }
-    pub fn layers(mut self, layers: u32) -> FramebufferCreateInfoBuilder<'a> {
+    pub fn layers(mut self, layers: u32) -> Self {
         self.inner.layers = layers;
         self
     }
@@ -10203,10 +9282,7 @@ impl<'a> FramebufferCreateInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsFramebufferCreateInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> FramebufferCreateInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsFramebufferCreateInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -10256,19 +9332,19 @@ impl<'a> ::std::ops::DerefMut for DrawIndirectCommandBuilder<'a> {
     }
 }
 impl<'a> DrawIndirectCommandBuilder<'a> {
-    pub fn vertex_count(mut self, vertex_count: u32) -> DrawIndirectCommandBuilder<'a> {
+    pub fn vertex_count(mut self, vertex_count: u32) -> Self {
         self.inner.vertex_count = vertex_count;
         self
     }
-    pub fn instance_count(mut self, instance_count: u32) -> DrawIndirectCommandBuilder<'a> {
+    pub fn instance_count(mut self, instance_count: u32) -> Self {
         self.inner.instance_count = instance_count;
         self
     }
-    pub fn first_vertex(mut self, first_vertex: u32) -> DrawIndirectCommandBuilder<'a> {
+    pub fn first_vertex(mut self, first_vertex: u32) -> Self {
         self.inner.first_vertex = first_vertex;
         self
     }
-    pub fn first_instance(mut self, first_instance: u32) -> DrawIndirectCommandBuilder<'a> {
+    pub fn first_instance(mut self, first_instance: u32) -> Self {
         self.inner.first_instance = first_instance;
         self
     }
@@ -10314,23 +9390,23 @@ impl<'a> ::std::ops::DerefMut for DrawIndexedIndirectCommandBuilder<'a> {
     }
 }
 impl<'a> DrawIndexedIndirectCommandBuilder<'a> {
-    pub fn index_count(mut self, index_count: u32) -> DrawIndexedIndirectCommandBuilder<'a> {
+    pub fn index_count(mut self, index_count: u32) -> Self {
         self.inner.index_count = index_count;
         self
     }
-    pub fn instance_count(mut self, instance_count: u32) -> DrawIndexedIndirectCommandBuilder<'a> {
+    pub fn instance_count(mut self, instance_count: u32) -> Self {
         self.inner.instance_count = instance_count;
         self
     }
-    pub fn first_index(mut self, first_index: u32) -> DrawIndexedIndirectCommandBuilder<'a> {
+    pub fn first_index(mut self, first_index: u32) -> Self {
         self.inner.first_index = first_index;
         self
     }
-    pub fn vertex_offset(mut self, vertex_offset: i32) -> DrawIndexedIndirectCommandBuilder<'a> {
+    pub fn vertex_offset(mut self, vertex_offset: i32) -> Self {
         self.inner.vertex_offset = vertex_offset;
         self
     }
-    pub fn first_instance(mut self, first_instance: u32) -> DrawIndexedIndirectCommandBuilder<'a> {
+    pub fn first_instance(mut self, first_instance: u32) -> Self {
         self.inner.first_instance = first_instance;
         self
     }
@@ -10374,15 +9450,15 @@ impl<'a> ::std::ops::DerefMut for DispatchIndirectCommandBuilder<'a> {
     }
 }
 impl<'a> DispatchIndirectCommandBuilder<'a> {
-    pub fn x(mut self, x: u32) -> DispatchIndirectCommandBuilder<'a> {
+    pub fn x(mut self, x: u32) -> Self {
         self.inner.x = x;
         self
     }
-    pub fn y(mut self, y: u32) -> DispatchIndirectCommandBuilder<'a> {
+    pub fn y(mut self, y: u32) -> Self {
         self.inner.y = y;
         self
     }
-    pub fn z(mut self, z: u32) -> DispatchIndirectCommandBuilder<'a> {
+    pub fn z(mut self, z: u32) -> Self {
         self.inner.z = z;
         self
     }
@@ -10448,31 +9524,22 @@ impl<'a> ::std::ops::DerefMut for SubmitInfoBuilder<'a> {
     }
 }
 impl<'a> SubmitInfoBuilder<'a> {
-    pub fn wait_semaphores(mut self, wait_semaphores: &'a [Semaphore]) -> SubmitInfoBuilder<'a> {
+    pub fn wait_semaphores(mut self, wait_semaphores: &'a [Semaphore]) -> Self {
         self.inner.wait_semaphore_count = wait_semaphores.len() as _;
         self.inner.p_wait_semaphores = wait_semaphores.as_ptr();
         self
     }
-    pub fn wait_dst_stage_mask(
-        mut self,
-        wait_dst_stage_mask: &'a [PipelineStageFlags],
-    ) -> SubmitInfoBuilder<'a> {
+    pub fn wait_dst_stage_mask(mut self, wait_dst_stage_mask: &'a [PipelineStageFlags]) -> Self {
         self.inner.wait_semaphore_count = wait_dst_stage_mask.len() as _;
         self.inner.p_wait_dst_stage_mask = wait_dst_stage_mask.as_ptr();
         self
     }
-    pub fn command_buffers(
-        mut self,
-        command_buffers: &'a [CommandBuffer],
-    ) -> SubmitInfoBuilder<'a> {
+    pub fn command_buffers(mut self, command_buffers: &'a [CommandBuffer]) -> Self {
         self.inner.command_buffer_count = command_buffers.len() as _;
         self.inner.p_command_buffers = command_buffers.as_ptr();
         self
     }
-    pub fn signal_semaphores(
-        mut self,
-        signal_semaphores: &'a [Semaphore],
-    ) -> SubmitInfoBuilder<'a> {
+    pub fn signal_semaphores(mut self, signal_semaphores: &'a [Semaphore]) -> Self {
         self.inner.signal_semaphore_count = signal_semaphores.len() as _;
         self.inner.p_signal_semaphores = signal_semaphores.as_ptr();
         self
@@ -10482,7 +9549,7 @@ impl<'a> SubmitInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubmitInfo>(mut self, next: &'a mut T) -> SubmitInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsSubmitInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -10548,49 +9615,31 @@ impl<'a> ::std::ops::DerefMut for DisplayPropertiesKHRBuilder<'a> {
     }
 }
 impl<'a> DisplayPropertiesKHRBuilder<'a> {
-    pub fn display(mut self, display: DisplayKHR) -> DisplayPropertiesKHRBuilder<'a> {
+    pub fn display(mut self, display: DisplayKHR) -> Self {
         self.inner.display = display;
         self
     }
-    pub fn display_name(
-        mut self,
-        display_name: &'a ::std::ffi::CStr,
-    ) -> DisplayPropertiesKHRBuilder<'a> {
+    pub fn display_name(mut self, display_name: &'a ::std::ffi::CStr) -> Self {
         self.inner.display_name = display_name.as_ptr();
         self
     }
-    pub fn physical_dimensions(
-        mut self,
-        physical_dimensions: Extent2D,
-    ) -> DisplayPropertiesKHRBuilder<'a> {
+    pub fn physical_dimensions(mut self, physical_dimensions: Extent2D) -> Self {
         self.inner.physical_dimensions = physical_dimensions;
         self
     }
-    pub fn physical_resolution(
-        mut self,
-        physical_resolution: Extent2D,
-    ) -> DisplayPropertiesKHRBuilder<'a> {
+    pub fn physical_resolution(mut self, physical_resolution: Extent2D) -> Self {
         self.inner.physical_resolution = physical_resolution;
         self
     }
-    pub fn supported_transforms(
-        mut self,
-        supported_transforms: SurfaceTransformFlagsKHR,
-    ) -> DisplayPropertiesKHRBuilder<'a> {
+    pub fn supported_transforms(mut self, supported_transforms: SurfaceTransformFlagsKHR) -> Self {
         self.inner.supported_transforms = supported_transforms;
         self
     }
-    pub fn plane_reorder_possible(
-        mut self,
-        plane_reorder_possible: bool,
-    ) -> DisplayPropertiesKHRBuilder<'a> {
+    pub fn plane_reorder_possible(mut self, plane_reorder_possible: bool) -> Self {
         self.inner.plane_reorder_possible = plane_reorder_possible.into();
         self
     }
-    pub fn persistent_content(
-        mut self,
-        persistent_content: bool,
-    ) -> DisplayPropertiesKHRBuilder<'a> {
+    pub fn persistent_content(mut self, persistent_content: bool) -> Self {
         self.inner.persistent_content = persistent_content.into();
         self
     }
@@ -10633,17 +9682,11 @@ impl<'a> ::std::ops::DerefMut for DisplayPlanePropertiesKHRBuilder<'a> {
     }
 }
 impl<'a> DisplayPlanePropertiesKHRBuilder<'a> {
-    pub fn current_display(
-        mut self,
-        current_display: DisplayKHR,
-    ) -> DisplayPlanePropertiesKHRBuilder<'a> {
+    pub fn current_display(mut self, current_display: DisplayKHR) -> Self {
         self.inner.current_display = current_display;
         self
     }
-    pub fn current_stack_index(
-        mut self,
-        current_stack_index: u32,
-    ) -> DisplayPlanePropertiesKHRBuilder<'a> {
+    pub fn current_stack_index(mut self, current_stack_index: u32) -> Self {
         self.inner.current_stack_index = current_stack_index;
         self
     }
@@ -10686,14 +9729,11 @@ impl<'a> ::std::ops::DerefMut for DisplayModeParametersKHRBuilder<'a> {
     }
 }
 impl<'a> DisplayModeParametersKHRBuilder<'a> {
-    pub fn visible_region(
-        mut self,
-        visible_region: Extent2D,
-    ) -> DisplayModeParametersKHRBuilder<'a> {
+    pub fn visible_region(mut self, visible_region: Extent2D) -> Self {
         self.inner.visible_region = visible_region;
         self
     }
-    pub fn refresh_rate(mut self, refresh_rate: u32) -> DisplayModeParametersKHRBuilder<'a> {
+    pub fn refresh_rate(mut self, refresh_rate: u32) -> Self {
         self.inner.refresh_rate = refresh_rate;
         self
     }
@@ -10736,17 +9776,11 @@ impl<'a> ::std::ops::DerefMut for DisplayModePropertiesKHRBuilder<'a> {
     }
 }
 impl<'a> DisplayModePropertiesKHRBuilder<'a> {
-    pub fn display_mode(
-        mut self,
-        display_mode: DisplayModeKHR,
-    ) -> DisplayModePropertiesKHRBuilder<'a> {
+    pub fn display_mode(mut self, display_mode: DisplayModeKHR) -> Self {
         self.inner.display_mode = display_mode;
         self
     }
-    pub fn parameters(
-        mut self,
-        parameters: DisplayModeParametersKHR,
-    ) -> DisplayModePropertiesKHRBuilder<'a> {
+    pub fn parameters(mut self, parameters: DisplayModeParametersKHR) -> Self {
         self.inner.parameters = parameters;
         self
     }
@@ -10802,17 +9836,11 @@ impl<'a> ::std::ops::DerefMut for DisplayModeCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> DisplayModeCreateInfoKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DisplayModeCreateFlagsKHR,
-    ) -> DisplayModeCreateInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: DisplayModeCreateFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn parameters(
-        mut self,
-        parameters: DisplayModeParametersKHR,
-    ) -> DisplayModeCreateInfoKHRBuilder<'a> {
+    pub fn parameters(mut self, parameters: DisplayModeParametersKHR) -> Self {
         self.inner.parameters = parameters;
         self
     }
@@ -10821,10 +9849,7 @@ impl<'a> DisplayModeCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDisplayModeCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> DisplayModeCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsDisplayModeCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -10879,66 +9904,39 @@ impl<'a> ::std::ops::DerefMut for DisplayPlaneCapabilitiesKHRBuilder<'a> {
     }
 }
 impl<'a> DisplayPlaneCapabilitiesKHRBuilder<'a> {
-    pub fn supported_alpha(
-        mut self,
-        supported_alpha: DisplayPlaneAlphaFlagsKHR,
-    ) -> DisplayPlaneCapabilitiesKHRBuilder<'a> {
+    pub fn supported_alpha(mut self, supported_alpha: DisplayPlaneAlphaFlagsKHR) -> Self {
         self.inner.supported_alpha = supported_alpha;
         self
     }
-    pub fn min_src_position(
-        mut self,
-        min_src_position: Offset2D,
-    ) -> DisplayPlaneCapabilitiesKHRBuilder<'a> {
+    pub fn min_src_position(mut self, min_src_position: Offset2D) -> Self {
         self.inner.min_src_position = min_src_position;
         self
     }
-    pub fn max_src_position(
-        mut self,
-        max_src_position: Offset2D,
-    ) -> DisplayPlaneCapabilitiesKHRBuilder<'a> {
+    pub fn max_src_position(mut self, max_src_position: Offset2D) -> Self {
         self.inner.max_src_position = max_src_position;
         self
     }
-    pub fn min_src_extent(
-        mut self,
-        min_src_extent: Extent2D,
-    ) -> DisplayPlaneCapabilitiesKHRBuilder<'a> {
+    pub fn min_src_extent(mut self, min_src_extent: Extent2D) -> Self {
         self.inner.min_src_extent = min_src_extent;
         self
     }
-    pub fn max_src_extent(
-        mut self,
-        max_src_extent: Extent2D,
-    ) -> DisplayPlaneCapabilitiesKHRBuilder<'a> {
+    pub fn max_src_extent(mut self, max_src_extent: Extent2D) -> Self {
         self.inner.max_src_extent = max_src_extent;
         self
     }
-    pub fn min_dst_position(
-        mut self,
-        min_dst_position: Offset2D,
-    ) -> DisplayPlaneCapabilitiesKHRBuilder<'a> {
+    pub fn min_dst_position(mut self, min_dst_position: Offset2D) -> Self {
         self.inner.min_dst_position = min_dst_position;
         self
     }
-    pub fn max_dst_position(
-        mut self,
-        max_dst_position: Offset2D,
-    ) -> DisplayPlaneCapabilitiesKHRBuilder<'a> {
+    pub fn max_dst_position(mut self, max_dst_position: Offset2D) -> Self {
         self.inner.max_dst_position = max_dst_position;
         self
     }
-    pub fn min_dst_extent(
-        mut self,
-        min_dst_extent: Extent2D,
-    ) -> DisplayPlaneCapabilitiesKHRBuilder<'a> {
+    pub fn min_dst_extent(mut self, min_dst_extent: Extent2D) -> Self {
         self.inner.min_dst_extent = min_dst_extent;
         self
     }
-    pub fn max_dst_extent(
-        mut self,
-        max_dst_extent: Extent2D,
-    ) -> DisplayPlaneCapabilitiesKHRBuilder<'a> {
+    pub fn max_dst_extent(mut self, max_dst_extent: Extent2D) -> Self {
         self.inner.max_dst_extent = max_dst_extent;
         self
     }
@@ -11006,53 +10004,35 @@ impl<'a> ::std::ops::DerefMut for DisplaySurfaceCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> DisplaySurfaceCreateInfoKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DisplaySurfaceCreateFlagsKHR,
-    ) -> DisplaySurfaceCreateInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: DisplaySurfaceCreateFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn display_mode(
-        mut self,
-        display_mode: DisplayModeKHR,
-    ) -> DisplaySurfaceCreateInfoKHRBuilder<'a> {
+    pub fn display_mode(mut self, display_mode: DisplayModeKHR) -> Self {
         self.inner.display_mode = display_mode;
         self
     }
-    pub fn plane_index(mut self, plane_index: u32) -> DisplaySurfaceCreateInfoKHRBuilder<'a> {
+    pub fn plane_index(mut self, plane_index: u32) -> Self {
         self.inner.plane_index = plane_index;
         self
     }
-    pub fn plane_stack_index(
-        mut self,
-        plane_stack_index: u32,
-    ) -> DisplaySurfaceCreateInfoKHRBuilder<'a> {
+    pub fn plane_stack_index(mut self, plane_stack_index: u32) -> Self {
         self.inner.plane_stack_index = plane_stack_index;
         self
     }
-    pub fn transform(
-        mut self,
-        transform: SurfaceTransformFlagsKHR,
-    ) -> DisplaySurfaceCreateInfoKHRBuilder<'a> {
+    pub fn transform(mut self, transform: SurfaceTransformFlagsKHR) -> Self {
         self.inner.transform = transform;
         self
     }
-    pub fn global_alpha(mut self, global_alpha: f32) -> DisplaySurfaceCreateInfoKHRBuilder<'a> {
+    pub fn global_alpha(mut self, global_alpha: f32) -> Self {
         self.inner.global_alpha = global_alpha;
         self
     }
-    pub fn alpha_mode(
-        mut self,
-        alpha_mode: DisplayPlaneAlphaFlagsKHR,
-    ) -> DisplaySurfaceCreateInfoKHRBuilder<'a> {
+    pub fn alpha_mode(mut self, alpha_mode: DisplayPlaneAlphaFlagsKHR) -> Self {
         self.inner.alpha_mode = alpha_mode;
         self
     }
-    pub fn image_extent(
-        mut self,
-        image_extent: Extent2D,
-    ) -> DisplaySurfaceCreateInfoKHRBuilder<'a> {
+    pub fn image_extent(mut self, image_extent: Extent2D) -> Self {
         self.inner.image_extent = image_extent;
         self
     }
@@ -11061,10 +10041,7 @@ impl<'a> DisplaySurfaceCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDisplaySurfaceCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> DisplaySurfaceCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsDisplaySurfaceCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -11128,15 +10105,15 @@ impl<'a> ::std::ops::DerefMut for DisplayPresentInfoKHRBuilder<'a> {
     }
 }
 impl<'a> DisplayPresentInfoKHRBuilder<'a> {
-    pub fn src_rect(mut self, src_rect: Rect2D) -> DisplayPresentInfoKHRBuilder<'a> {
+    pub fn src_rect(mut self, src_rect: Rect2D) -> Self {
         self.inner.src_rect = src_rect;
         self
     }
-    pub fn dst_rect(mut self, dst_rect: Rect2D) -> DisplayPresentInfoKHRBuilder<'a> {
+    pub fn dst_rect(mut self, dst_rect: Rect2D) -> Self {
         self.inner.dst_rect = dst_rect;
         self
     }
-    pub fn persistent(mut self, persistent: bool) -> DisplayPresentInfoKHRBuilder<'a> {
+    pub fn persistent(mut self, persistent: bool) -> Self {
         self.inner.persistent = persistent.into();
         self
     }
@@ -11187,64 +10164,46 @@ impl<'a> ::std::ops::DerefMut for SurfaceCapabilitiesKHRBuilder<'a> {
     }
 }
 impl<'a> SurfaceCapabilitiesKHRBuilder<'a> {
-    pub fn min_image_count(mut self, min_image_count: u32) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    pub fn min_image_count(mut self, min_image_count: u32) -> Self {
         self.inner.min_image_count = min_image_count;
         self
     }
-    pub fn max_image_count(mut self, max_image_count: u32) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    pub fn max_image_count(mut self, max_image_count: u32) -> Self {
         self.inner.max_image_count = max_image_count;
         self
     }
-    pub fn current_extent(mut self, current_extent: Extent2D) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    pub fn current_extent(mut self, current_extent: Extent2D) -> Self {
         self.inner.current_extent = current_extent;
         self
     }
-    pub fn min_image_extent(
-        mut self,
-        min_image_extent: Extent2D,
-    ) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    pub fn min_image_extent(mut self, min_image_extent: Extent2D) -> Self {
         self.inner.min_image_extent = min_image_extent;
         self
     }
-    pub fn max_image_extent(
-        mut self,
-        max_image_extent: Extent2D,
-    ) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    pub fn max_image_extent(mut self, max_image_extent: Extent2D) -> Self {
         self.inner.max_image_extent = max_image_extent;
         self
     }
-    pub fn max_image_array_layers(
-        mut self,
-        max_image_array_layers: u32,
-    ) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    pub fn max_image_array_layers(mut self, max_image_array_layers: u32) -> Self {
         self.inner.max_image_array_layers = max_image_array_layers;
         self
     }
-    pub fn supported_transforms(
-        mut self,
-        supported_transforms: SurfaceTransformFlagsKHR,
-    ) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    pub fn supported_transforms(mut self, supported_transforms: SurfaceTransformFlagsKHR) -> Self {
         self.inner.supported_transforms = supported_transforms;
         self
     }
-    pub fn current_transform(
-        mut self,
-        current_transform: SurfaceTransformFlagsKHR,
-    ) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    pub fn current_transform(mut self, current_transform: SurfaceTransformFlagsKHR) -> Self {
         self.inner.current_transform = current_transform;
         self
     }
     pub fn supported_composite_alpha(
         mut self,
         supported_composite_alpha: CompositeAlphaFlagsKHR,
-    ) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.supported_composite_alpha = supported_composite_alpha;
         self
     }
-    pub fn supported_usage_flags(
-        mut self,
-        supported_usage_flags: ImageUsageFlags,
-    ) -> SurfaceCapabilitiesKHRBuilder<'a> {
+    pub fn supported_usage_flags(mut self, supported_usage_flags: ImageUsageFlags) -> Self {
         self.inner.supported_usage_flags = supported_usage_flags;
         self
     }
@@ -11300,14 +10259,11 @@ impl<'a> ::std::ops::DerefMut for AndroidSurfaceCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> AndroidSurfaceCreateInfoKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: AndroidSurfaceCreateFlagsKHR,
-    ) -> AndroidSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: AndroidSurfaceCreateFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn window(mut self, window: *mut ANativeWindow) -> AndroidSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn window(mut self, window: *mut ANativeWindow) -> Self {
         self.inner.window = window;
         self
     }
@@ -11316,10 +10272,7 @@ impl<'a> AndroidSurfaceCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsAndroidSurfaceCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> AndroidSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsAndroidSurfaceCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -11380,11 +10333,11 @@ impl<'a> ::std::ops::DerefMut for ViSurfaceCreateInfoNNBuilder<'a> {
     }
 }
 impl<'a> ViSurfaceCreateInfoNNBuilder<'a> {
-    pub fn flags(mut self, flags: ViSurfaceCreateFlagsNN) -> ViSurfaceCreateInfoNNBuilder<'a> {
+    pub fn flags(mut self, flags: ViSurfaceCreateFlagsNN) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn window(mut self, window: *mut c_void) -> ViSurfaceCreateInfoNNBuilder<'a> {
+    pub fn window(mut self, window: *mut c_void) -> Self {
         self.inner.window = window;
         self
     }
@@ -11393,10 +10346,7 @@ impl<'a> ViSurfaceCreateInfoNNBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsViSurfaceCreateInfoNN>(
-        mut self,
-        next: &'a mut T,
-    ) -> ViSurfaceCreateInfoNNBuilder<'a> {
+    pub fn push_next<T: ExtendsViSurfaceCreateInfoNN>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -11459,18 +10409,15 @@ impl<'a> ::std::ops::DerefMut for WaylandSurfaceCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> WaylandSurfaceCreateInfoKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: WaylandSurfaceCreateFlagsKHR,
-    ) -> WaylandSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: WaylandSurfaceCreateFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn display(mut self, display: *mut wl_display) -> WaylandSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn display(mut self, display: *mut wl_display) -> Self {
         self.inner.display = display;
         self
     }
-    pub fn surface(mut self, surface: *mut wl_surface) -> WaylandSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn surface(mut self, surface: *mut wl_surface) -> Self {
         self.inner.surface = surface;
         self
     }
@@ -11479,10 +10426,7 @@ impl<'a> WaylandSurfaceCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsWaylandSurfaceCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> WaylandSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsWaylandSurfaceCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -11545,18 +10489,15 @@ impl<'a> ::std::ops::DerefMut for Win32SurfaceCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> Win32SurfaceCreateInfoKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: Win32SurfaceCreateFlagsKHR,
-    ) -> Win32SurfaceCreateInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: Win32SurfaceCreateFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn hinstance(mut self, hinstance: HINSTANCE) -> Win32SurfaceCreateInfoKHRBuilder<'a> {
+    pub fn hinstance(mut self, hinstance: HINSTANCE) -> Self {
         self.inner.hinstance = hinstance;
         self
     }
-    pub fn hwnd(mut self, hwnd: HWND) -> Win32SurfaceCreateInfoKHRBuilder<'a> {
+    pub fn hwnd(mut self, hwnd: HWND) -> Self {
         self.inner.hwnd = hwnd;
         self
     }
@@ -11565,10 +10506,7 @@ impl<'a> Win32SurfaceCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsWin32SurfaceCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> Win32SurfaceCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsWin32SurfaceCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -11631,18 +10569,15 @@ impl<'a> ::std::ops::DerefMut for XlibSurfaceCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> XlibSurfaceCreateInfoKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: XlibSurfaceCreateFlagsKHR,
-    ) -> XlibSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: XlibSurfaceCreateFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn dpy(mut self, dpy: *mut Display) -> XlibSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn dpy(mut self, dpy: *mut Display) -> Self {
         self.inner.dpy = dpy;
         self
     }
-    pub fn window(mut self, window: Window) -> XlibSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn window(mut self, window: Window) -> Self {
         self.inner.window = window;
         self
     }
@@ -11651,10 +10586,7 @@ impl<'a> XlibSurfaceCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsXlibSurfaceCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> XlibSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsXlibSurfaceCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -11717,18 +10649,15 @@ impl<'a> ::std::ops::DerefMut for XcbSurfaceCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> XcbSurfaceCreateInfoKHRBuilder<'a> {
-    pub fn flags(mut self, flags: XcbSurfaceCreateFlagsKHR) -> XcbSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: XcbSurfaceCreateFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn connection(
-        mut self,
-        connection: *mut xcb_connection_t,
-    ) -> XcbSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn connection(mut self, connection: *mut xcb_connection_t) -> Self {
         self.inner.connection = connection;
         self
     }
-    pub fn window(mut self, window: xcb_window_t) -> XcbSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn window(mut self, window: xcb_window_t) -> Self {
         self.inner.window = window;
         self
     }
@@ -11737,10 +10666,7 @@ impl<'a> XcbSurfaceCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsXcbSurfaceCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> XcbSurfaceCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsXcbSurfaceCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -11803,21 +10729,15 @@ impl<'a> ::std::ops::DerefMut for DirectFBSurfaceCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DirectFBSurfaceCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DirectFBSurfaceCreateFlagsEXT,
-    ) -> DirectFBSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: DirectFBSurfaceCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn dfb(mut self, dfb: *mut IDirectFB) -> DirectFBSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn dfb(mut self, dfb: *mut IDirectFB) -> Self {
         self.inner.dfb = dfb;
         self
     }
-    pub fn surface(
-        mut self,
-        surface: *mut IDirectFBSurface,
-    ) -> DirectFBSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn surface(mut self, surface: *mut IDirectFBSurface) -> Self {
         self.inner.surface = surface;
         self
     }
@@ -11826,10 +10746,7 @@ impl<'a> DirectFBSurfaceCreateInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDirectFBSurfaceCreateInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DirectFBSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDirectFBSurfaceCreateInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -11890,17 +10807,11 @@ impl<'a> ::std::ops::DerefMut for ImagePipeSurfaceCreateInfoFUCHSIABuilder<'a> {
     }
 }
 impl<'a> ImagePipeSurfaceCreateInfoFUCHSIABuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: ImagePipeSurfaceCreateFlagsFUCHSIA,
-    ) -> ImagePipeSurfaceCreateInfoFUCHSIABuilder<'a> {
+    pub fn flags(mut self, flags: ImagePipeSurfaceCreateFlagsFUCHSIA) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn image_pipe_handle(
-        mut self,
-        image_pipe_handle: zx_handle_t,
-    ) -> ImagePipeSurfaceCreateInfoFUCHSIABuilder<'a> {
+    pub fn image_pipe_handle(mut self, image_pipe_handle: zx_handle_t) -> Self {
         self.inner.image_pipe_handle = image_pipe_handle;
         self
     }
@@ -11912,7 +10823,7 @@ impl<'a> ImagePipeSurfaceCreateInfoFUCHSIABuilder<'a> {
     pub fn push_next<T: ExtendsImagePipeSurfaceCreateInfoFUCHSIA>(
         mut self,
         next: &'a mut T,
-    ) -> ImagePipeSurfaceCreateInfoFUCHSIABuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -11973,17 +10884,11 @@ impl<'a> ::std::ops::DerefMut for StreamDescriptorSurfaceCreateInfoGGPBuilder<'a
     }
 }
 impl<'a> StreamDescriptorSurfaceCreateInfoGGPBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: StreamDescriptorSurfaceCreateFlagsGGP,
-    ) -> StreamDescriptorSurfaceCreateInfoGGPBuilder<'a> {
+    pub fn flags(mut self, flags: StreamDescriptorSurfaceCreateFlagsGGP) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn stream_descriptor(
-        mut self,
-        stream_descriptor: GgpStreamDescriptor,
-    ) -> StreamDescriptorSurfaceCreateInfoGGPBuilder<'a> {
+    pub fn stream_descriptor(mut self, stream_descriptor: GgpStreamDescriptor) -> Self {
         self.inner.stream_descriptor = stream_descriptor;
         self
     }
@@ -11995,7 +10900,7 @@ impl<'a> StreamDescriptorSurfaceCreateInfoGGPBuilder<'a> {
     pub fn push_next<T: ExtendsStreamDescriptorSurfaceCreateInfoGGP>(
         mut self,
         next: &'a mut T,
-    ) -> StreamDescriptorSurfaceCreateInfoGGPBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -12043,11 +10948,11 @@ impl<'a> ::std::ops::DerefMut for SurfaceFormatKHRBuilder<'a> {
     }
 }
 impl<'a> SurfaceFormatKHRBuilder<'a> {
-    pub fn format(mut self, format: Format) -> SurfaceFormatKHRBuilder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn color_space(mut self, color_space: ColorSpaceKHR) -> SurfaceFormatKHRBuilder<'a> {
+    pub fn color_space(mut self, color_space: ColorSpaceKHR) -> Self {
         self.inner.color_space = color_space;
         self
     }
@@ -12131,91 +11036,64 @@ impl<'a> ::std::ops::DerefMut for SwapchainCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> SwapchainCreateInfoKHRBuilder<'a> {
-    pub fn flags(mut self, flags: SwapchainCreateFlagsKHR) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: SwapchainCreateFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn surface(mut self, surface: SurfaceKHR) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn surface(mut self, surface: SurfaceKHR) -> Self {
         self.inner.surface = surface;
         self
     }
-    pub fn min_image_count(mut self, min_image_count: u32) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn min_image_count(mut self, min_image_count: u32) -> Self {
         self.inner.min_image_count = min_image_count;
         self
     }
-    pub fn image_format(mut self, image_format: Format) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn image_format(mut self, image_format: Format) -> Self {
         self.inner.image_format = image_format;
         self
     }
-    pub fn image_color_space(
-        mut self,
-        image_color_space: ColorSpaceKHR,
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn image_color_space(mut self, image_color_space: ColorSpaceKHR) -> Self {
         self.inner.image_color_space = image_color_space;
         self
     }
-    pub fn image_extent(mut self, image_extent: Extent2D) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn image_extent(mut self, image_extent: Extent2D) -> Self {
         self.inner.image_extent = image_extent;
         self
     }
-    pub fn image_array_layers(
-        mut self,
-        image_array_layers: u32,
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn image_array_layers(mut self, image_array_layers: u32) -> Self {
         self.inner.image_array_layers = image_array_layers;
         self
     }
-    pub fn image_usage(
-        mut self,
-        image_usage: ImageUsageFlags,
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn image_usage(mut self, image_usage: ImageUsageFlags) -> Self {
         self.inner.image_usage = image_usage;
         self
     }
-    pub fn image_sharing_mode(
-        mut self,
-        image_sharing_mode: SharingMode,
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn image_sharing_mode(mut self, image_sharing_mode: SharingMode) -> Self {
         self.inner.image_sharing_mode = image_sharing_mode;
         self
     }
-    pub fn queue_family_indices(
-        mut self,
-        queue_family_indices: &'a [u32],
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn queue_family_indices(mut self, queue_family_indices: &'a [u32]) -> Self {
         self.inner.queue_family_index_count = queue_family_indices.len() as _;
         self.inner.p_queue_family_indices = queue_family_indices.as_ptr();
         self
     }
-    pub fn pre_transform(
-        mut self,
-        pre_transform: SurfaceTransformFlagsKHR,
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn pre_transform(mut self, pre_transform: SurfaceTransformFlagsKHR) -> Self {
         self.inner.pre_transform = pre_transform;
         self
     }
-    pub fn composite_alpha(
-        mut self,
-        composite_alpha: CompositeAlphaFlagsKHR,
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn composite_alpha(mut self, composite_alpha: CompositeAlphaFlagsKHR) -> Self {
         self.inner.composite_alpha = composite_alpha;
         self
     }
-    pub fn present_mode(
-        mut self,
-        present_mode: PresentModeKHR,
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn present_mode(mut self, present_mode: PresentModeKHR) -> Self {
         self.inner.present_mode = present_mode;
         self
     }
-    pub fn clipped(mut self, clipped: bool) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn clipped(mut self, clipped: bool) -> Self {
         self.inner.clipped = clipped.into();
         self
     }
-    pub fn old_swapchain(
-        mut self,
-        old_swapchain: SwapchainKHR,
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn old_swapchain(mut self, old_swapchain: SwapchainKHR) -> Self {
         self.inner.old_swapchain = old_swapchain;
         self
     }
@@ -12224,10 +11102,7 @@ impl<'a> SwapchainCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSwapchainCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> SwapchainCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsSwapchainCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -12296,25 +11171,22 @@ impl<'a> ::std::ops::DerefMut for PresentInfoKHRBuilder<'a> {
     }
 }
 impl<'a> PresentInfoKHRBuilder<'a> {
-    pub fn wait_semaphores(
-        mut self,
-        wait_semaphores: &'a [Semaphore],
-    ) -> PresentInfoKHRBuilder<'a> {
+    pub fn wait_semaphores(mut self, wait_semaphores: &'a [Semaphore]) -> Self {
         self.inner.wait_semaphore_count = wait_semaphores.len() as _;
         self.inner.p_wait_semaphores = wait_semaphores.as_ptr();
         self
     }
-    pub fn swapchains(mut self, swapchains: &'a [SwapchainKHR]) -> PresentInfoKHRBuilder<'a> {
+    pub fn swapchains(mut self, swapchains: &'a [SwapchainKHR]) -> Self {
         self.inner.swapchain_count = swapchains.len() as _;
         self.inner.p_swapchains = swapchains.as_ptr();
         self
     }
-    pub fn image_indices(mut self, image_indices: &'a [u32]) -> PresentInfoKHRBuilder<'a> {
+    pub fn image_indices(mut self, image_indices: &'a [u32]) -> Self {
         self.inner.swapchain_count = image_indices.len() as _;
         self.inner.p_image_indices = image_indices.as_ptr();
         self
     }
-    pub fn results(mut self, results: &'a mut [Result]) -> PresentInfoKHRBuilder<'a> {
+    pub fn results(mut self, results: &'a mut [Result]) -> Self {
         self.inner.swapchain_count = results.len() as _;
         self.inner.p_results = results.as_mut_ptr();
         self
@@ -12324,10 +11196,7 @@ impl<'a> PresentInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPresentInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> PresentInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsPresentInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -12402,24 +11271,15 @@ impl<'a> ::std::ops::DerefMut for DebugReportCallbackCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DebugReportCallbackCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DebugReportFlagsEXT,
-    ) -> DebugReportCallbackCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: DebugReportFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn pfn_callback(
-        mut self,
-        pfn_callback: PFN_vkDebugReportCallbackEXT,
-    ) -> DebugReportCallbackCreateInfoEXTBuilder<'a> {
+    pub fn pfn_callback(mut self, pfn_callback: PFN_vkDebugReportCallbackEXT) -> Self {
         self.inner.pfn_callback = pfn_callback;
         self
     }
-    pub fn user_data(
-        mut self,
-        user_data: *mut c_void,
-    ) -> DebugReportCallbackCreateInfoEXTBuilder<'a> {
+    pub fn user_data(mut self, user_data: *mut c_void) -> Self {
         self.inner.p_user_data = user_data;
         self
     }
@@ -12479,7 +11339,7 @@ impl<'a> ValidationFlagsEXTBuilder<'a> {
     pub fn disabled_validation_checks(
         mut self,
         disabled_validation_checks: &'a [ValidationCheckEXT],
-    ) -> ValidationFlagsEXTBuilder<'a> {
+    ) -> Self {
         self.inner.disabled_validation_check_count = disabled_validation_checks.len() as _;
         self.inner.p_disabled_validation_checks = disabled_validation_checks.as_ptr();
         self
@@ -12544,7 +11404,7 @@ impl<'a> ValidationFeaturesEXTBuilder<'a> {
     pub fn enabled_validation_features(
         mut self,
         enabled_validation_features: &'a [ValidationFeatureEnableEXT],
-    ) -> ValidationFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.enabled_validation_feature_count = enabled_validation_features.len() as _;
         self.inner.p_enabled_validation_features = enabled_validation_features.as_ptr();
         self
@@ -12552,7 +11412,7 @@ impl<'a> ValidationFeaturesEXTBuilder<'a> {
     pub fn disabled_validation_features(
         mut self,
         disabled_validation_features: &'a [ValidationFeatureDisableEXT],
-    ) -> ValidationFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.disabled_validation_feature_count = disabled_validation_features.len() as _;
         self.inner.p_disabled_validation_features = disabled_validation_features.as_ptr();
         self
@@ -12614,10 +11474,7 @@ impl<'a> ::std::ops::DerefMut for PipelineRasterizationStateRasterizationOrderAM
     }
 }
 impl<'a> PipelineRasterizationStateRasterizationOrderAMDBuilder<'a> {
-    pub fn rasterization_order(
-        mut self,
-        rasterization_order: RasterizationOrderAMD,
-    ) -> PipelineRasterizationStateRasterizationOrderAMDBuilder<'a> {
+    pub fn rasterization_order(mut self, rasterization_order: RasterizationOrderAMD) -> Self {
         self.inner.rasterization_order = rasterization_order;
         self
     }
@@ -12675,21 +11532,15 @@ impl<'a> ::std::ops::DerefMut for DebugMarkerObjectNameInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DebugMarkerObjectNameInfoEXTBuilder<'a> {
-    pub fn object_type(
-        mut self,
-        object_type: DebugReportObjectTypeEXT,
-    ) -> DebugMarkerObjectNameInfoEXTBuilder<'a> {
+    pub fn object_type(mut self, object_type: DebugReportObjectTypeEXT) -> Self {
         self.inner.object_type = object_type;
         self
     }
-    pub fn object(mut self, object: u64) -> DebugMarkerObjectNameInfoEXTBuilder<'a> {
+    pub fn object(mut self, object: u64) -> Self {
         self.inner.object = object;
         self
     }
-    pub fn object_name(
-        mut self,
-        object_name: &'a ::std::ffi::CStr,
-    ) -> DebugMarkerObjectNameInfoEXTBuilder<'a> {
+    pub fn object_name(mut self, object_name: &'a ::std::ffi::CStr) -> Self {
         self.inner.p_object_name = object_name.as_ptr();
         self
     }
@@ -12698,10 +11549,7 @@ impl<'a> DebugMarkerObjectNameInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDebugMarkerObjectNameInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DebugMarkerObjectNameInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDebugMarkerObjectNameInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -12768,22 +11616,19 @@ impl<'a> ::std::ops::DerefMut for DebugMarkerObjectTagInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DebugMarkerObjectTagInfoEXTBuilder<'a> {
-    pub fn object_type(
-        mut self,
-        object_type: DebugReportObjectTypeEXT,
-    ) -> DebugMarkerObjectTagInfoEXTBuilder<'a> {
+    pub fn object_type(mut self, object_type: DebugReportObjectTypeEXT) -> Self {
         self.inner.object_type = object_type;
         self
     }
-    pub fn object(mut self, object: u64) -> DebugMarkerObjectTagInfoEXTBuilder<'a> {
+    pub fn object(mut self, object: u64) -> Self {
         self.inner.object = object;
         self
     }
-    pub fn tag_name(mut self, tag_name: u64) -> DebugMarkerObjectTagInfoEXTBuilder<'a> {
+    pub fn tag_name(mut self, tag_name: u64) -> Self {
         self.inner.tag_name = tag_name;
         self
     }
-    pub fn tag(mut self, tag: &'a [u8]) -> DebugMarkerObjectTagInfoEXTBuilder<'a> {
+    pub fn tag(mut self, tag: &'a [u8]) -> Self {
         self.inner.tag_size = tag.len() as _;
         self.inner.p_tag = tag.as_ptr() as *const c_void;
         self
@@ -12793,10 +11638,7 @@ impl<'a> DebugMarkerObjectTagInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDebugMarkerObjectTagInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DebugMarkerObjectTagInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDebugMarkerObjectTagInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -12857,14 +11699,11 @@ impl<'a> ::std::ops::DerefMut for DebugMarkerMarkerInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DebugMarkerMarkerInfoEXTBuilder<'a> {
-    pub fn marker_name(
-        mut self,
-        marker_name: &'a ::std::ffi::CStr,
-    ) -> DebugMarkerMarkerInfoEXTBuilder<'a> {
+    pub fn marker_name(mut self, marker_name: &'a ::std::ffi::CStr) -> Self {
         self.inner.p_marker_name = marker_name.as_ptr();
         self
     }
-    pub fn color(mut self, color: [f32; 4]) -> DebugMarkerMarkerInfoEXTBuilder<'a> {
+    pub fn color(mut self, color: [f32; 4]) -> Self {
         self.inner.color = color;
         self
     }
@@ -12873,10 +11712,7 @@ impl<'a> DebugMarkerMarkerInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDebugMarkerMarkerInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DebugMarkerMarkerInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDebugMarkerMarkerInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -12936,10 +11772,7 @@ impl<'a> ::std::ops::DerefMut for DedicatedAllocationImageCreateInfoNVBuilder<'a
     }
 }
 impl<'a> DedicatedAllocationImageCreateInfoNVBuilder<'a> {
-    pub fn dedicated_allocation(
-        mut self,
-        dedicated_allocation: bool,
-    ) -> DedicatedAllocationImageCreateInfoNVBuilder<'a> {
+    pub fn dedicated_allocation(mut self, dedicated_allocation: bool) -> Self {
         self.inner.dedicated_allocation = dedicated_allocation.into();
         self
     }
@@ -12994,10 +11827,7 @@ impl<'a> ::std::ops::DerefMut for DedicatedAllocationBufferCreateInfoNVBuilder<'
     }
 }
 impl<'a> DedicatedAllocationBufferCreateInfoNVBuilder<'a> {
-    pub fn dedicated_allocation(
-        mut self,
-        dedicated_allocation: bool,
-    ) -> DedicatedAllocationBufferCreateInfoNVBuilder<'a> {
+    pub fn dedicated_allocation(mut self, dedicated_allocation: bool) -> Self {
         self.inner.dedicated_allocation = dedicated_allocation.into();
         self
     }
@@ -13054,11 +11884,11 @@ impl<'a> ::std::ops::DerefMut for DedicatedAllocationMemoryAllocateInfoNVBuilder
     }
 }
 impl<'a> DedicatedAllocationMemoryAllocateInfoNVBuilder<'a> {
-    pub fn image(mut self, image: Image) -> DedicatedAllocationMemoryAllocateInfoNVBuilder<'a> {
+    pub fn image(mut self, image: Image) -> Self {
         self.inner.image = image;
         self
     }
-    pub fn buffer(mut self, buffer: Buffer) -> DedicatedAllocationMemoryAllocateInfoNVBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
@@ -13106,28 +11936,28 @@ impl<'a> ExternalImageFormatPropertiesNVBuilder<'a> {
     pub fn image_format_properties(
         mut self,
         image_format_properties: ImageFormatProperties,
-    ) -> ExternalImageFormatPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.image_format_properties = image_format_properties;
         self
     }
     pub fn external_memory_features(
         mut self,
         external_memory_features: ExternalMemoryFeatureFlagsNV,
-    ) -> ExternalImageFormatPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.external_memory_features = external_memory_features;
         self
     }
     pub fn export_from_imported_handle_types(
         mut self,
         export_from_imported_handle_types: ExternalMemoryHandleTypeFlagsNV,
-    ) -> ExternalImageFormatPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.export_from_imported_handle_types = export_from_imported_handle_types;
         self
     }
     pub fn compatible_handle_types(
         mut self,
         compatible_handle_types: ExternalMemoryHandleTypeFlagsNV,
-    ) -> ExternalImageFormatPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.compatible_handle_types = compatible_handle_types;
         self
     }
@@ -13182,10 +12012,7 @@ impl<'a> ::std::ops::DerefMut for ExternalMemoryImageCreateInfoNVBuilder<'a> {
     }
 }
 impl<'a> ExternalMemoryImageCreateInfoNVBuilder<'a> {
-    pub fn handle_types(
-        mut self,
-        handle_types: ExternalMemoryHandleTypeFlagsNV,
-    ) -> ExternalMemoryImageCreateInfoNVBuilder<'a> {
+    pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlagsNV) -> Self {
         self.inner.handle_types = handle_types;
         self
     }
@@ -13240,10 +12067,7 @@ impl<'a> ::std::ops::DerefMut for ExportMemoryAllocateInfoNVBuilder<'a> {
     }
 }
 impl<'a> ExportMemoryAllocateInfoNVBuilder<'a> {
-    pub fn handle_types(
-        mut self,
-        handle_types: ExternalMemoryHandleTypeFlagsNV,
-    ) -> ExportMemoryAllocateInfoNVBuilder<'a> {
+    pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlagsNV) -> Self {
         self.inner.handle_types = handle_types;
         self
     }
@@ -13300,14 +12124,11 @@ impl<'a> ::std::ops::DerefMut for ImportMemoryWin32HandleInfoNVBuilder<'a> {
     }
 }
 impl<'a> ImportMemoryWin32HandleInfoNVBuilder<'a> {
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalMemoryHandleTypeFlagsNV,
-    ) -> ImportMemoryWin32HandleInfoNVBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlagsNV) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
-    pub fn handle(mut self, handle: HANDLE) -> ImportMemoryWin32HandleInfoNVBuilder<'a> {
+    pub fn handle(mut self, handle: HANDLE) -> Self {
         self.inner.handle = handle;
         self
     }
@@ -13364,14 +12185,11 @@ impl<'a> ::std::ops::DerefMut for ExportMemoryWin32HandleInfoNVBuilder<'a> {
     }
 }
 impl<'a> ExportMemoryWin32HandleInfoNVBuilder<'a> {
-    pub fn attributes(
-        mut self,
-        attributes: &'a SECURITY_ATTRIBUTES,
-    ) -> ExportMemoryWin32HandleInfoNVBuilder<'a> {
+    pub fn attributes(mut self, attributes: &'a SECURITY_ATTRIBUTES) -> Self {
         self.inner.p_attributes = attributes;
         self
     }
-    pub fn dw_access(mut self, dw_access: DWORD) -> ExportMemoryWin32HandleInfoNVBuilder<'a> {
+    pub fn dw_access(mut self, dw_access: DWORD) -> Self {
         self.inner.dw_access = dw_access;
         self
     }
@@ -13438,42 +12256,27 @@ impl<'a> ::std::ops::DerefMut for Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a>
     }
 }
 impl<'a> Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a> {
-    pub fn acquire_syncs(
-        mut self,
-        acquire_syncs: &'a [DeviceMemory],
-    ) -> Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a> {
+    pub fn acquire_syncs(mut self, acquire_syncs: &'a [DeviceMemory]) -> Self {
         self.inner.acquire_count = acquire_syncs.len() as _;
         self.inner.p_acquire_syncs = acquire_syncs.as_ptr();
         self
     }
-    pub fn acquire_keys(
-        mut self,
-        acquire_keys: &'a [u64],
-    ) -> Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a> {
+    pub fn acquire_keys(mut self, acquire_keys: &'a [u64]) -> Self {
         self.inner.acquire_count = acquire_keys.len() as _;
         self.inner.p_acquire_keys = acquire_keys.as_ptr();
         self
     }
-    pub fn acquire_timeout_milliseconds(
-        mut self,
-        acquire_timeout_milliseconds: &'a [u32],
-    ) -> Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a> {
+    pub fn acquire_timeout_milliseconds(mut self, acquire_timeout_milliseconds: &'a [u32]) -> Self {
         self.inner.acquire_count = acquire_timeout_milliseconds.len() as _;
         self.inner.p_acquire_timeout_milliseconds = acquire_timeout_milliseconds.as_ptr();
         self
     }
-    pub fn release_syncs(
-        mut self,
-        release_syncs: &'a [DeviceMemory],
-    ) -> Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a> {
+    pub fn release_syncs(mut self, release_syncs: &'a [DeviceMemory]) -> Self {
         self.inner.release_count = release_syncs.len() as _;
         self.inner.p_release_syncs = release_syncs.as_ptr();
         self
     }
-    pub fn release_keys(
-        mut self,
-        release_keys: &'a [u64],
-    ) -> Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a> {
+    pub fn release_keys(mut self, release_keys: &'a [u64]) -> Self {
         self.inner.release_count = release_keys.len() as _;
         self.inner.p_release_keys = release_keys.as_ptr();
         self
@@ -13529,10 +12332,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceDeviceGeneratedCommandsFeaturesN
     }
 }
 impl<'a> PhysicalDeviceDeviceGeneratedCommandsFeaturesNVBuilder<'a> {
-    pub fn device_generated_commands(
-        mut self,
-        device_generated_commands: bool,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsFeaturesNVBuilder<'a> {
+    pub fn device_generated_commands(mut self, device_generated_commands: bool) -> Self {
         self.inner.device_generated_commands = device_generated_commands.into();
         self
     }
@@ -13587,10 +12387,7 @@ impl<'a> ::std::ops::DerefMut for DevicePrivateDataCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DevicePrivateDataCreateInfoEXTBuilder<'a> {
-    pub fn private_data_slot_request_count(
-        mut self,
-        private_data_slot_request_count: u32,
-    ) -> DevicePrivateDataCreateInfoEXTBuilder<'a> {
+    pub fn private_data_slot_request_count(mut self, private_data_slot_request_count: u32) -> Self {
         self.inner.private_data_slot_request_count = private_data_slot_request_count;
         self
     }
@@ -13644,10 +12441,7 @@ impl<'a> ::std::ops::DerefMut for PrivateDataSlotCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> PrivateDataSlotCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PrivateDataSlotCreateFlagsEXT,
-    ) -> PrivateDataSlotCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: PrivateDataSlotCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -13656,10 +12450,7 @@ impl<'a> PrivateDataSlotCreateInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPrivateDataSlotCreateInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> PrivateDataSlotCreateInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsPrivateDataSlotCreateInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -13719,10 +12510,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDevicePrivateDataFeaturesEXTBuilder<'a
     }
 }
 impl<'a> PhysicalDevicePrivateDataFeaturesEXTBuilder<'a> {
-    pub fn private_data(
-        mut self,
-        private_data: bool,
-    ) -> PhysicalDevicePrivateDataFeaturesEXTBuilder<'a> {
+    pub fn private_data(mut self, private_data: bool) -> Self {
         self.inner.private_data = private_data.into();
         self
     }
@@ -13796,52 +12584,46 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceDeviceGeneratedCommandsPropertie
     }
 }
 impl<'a> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
-    pub fn max_graphics_shader_group_count(
-        mut self,
-        max_graphics_shader_group_count: u32,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
+    pub fn max_graphics_shader_group_count(mut self, max_graphics_shader_group_count: u32) -> Self {
         self.inner.max_graphics_shader_group_count = max_graphics_shader_group_count;
         self
     }
-    pub fn max_indirect_sequence_count(
-        mut self,
-        max_indirect_sequence_count: u32,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
+    pub fn max_indirect_sequence_count(mut self, max_indirect_sequence_count: u32) -> Self {
         self.inner.max_indirect_sequence_count = max_indirect_sequence_count;
         self
     }
     pub fn max_indirect_commands_token_count(
         mut self,
         max_indirect_commands_token_count: u32,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.max_indirect_commands_token_count = max_indirect_commands_token_count;
         self
     }
     pub fn max_indirect_commands_stream_count(
         mut self,
         max_indirect_commands_stream_count: u32,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.max_indirect_commands_stream_count = max_indirect_commands_stream_count;
         self
     }
     pub fn max_indirect_commands_token_offset(
         mut self,
         max_indirect_commands_token_offset: u32,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.max_indirect_commands_token_offset = max_indirect_commands_token_offset;
         self
     }
     pub fn max_indirect_commands_stream_stride(
         mut self,
         max_indirect_commands_stream_stride: u32,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.max_indirect_commands_stream_stride = max_indirect_commands_stream_stride;
         self
     }
     pub fn min_sequences_count_buffer_offset_alignment(
         mut self,
         min_sequences_count_buffer_offset_alignment: u32,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.min_sequences_count_buffer_offset_alignment =
             min_sequences_count_buffer_offset_alignment;
         self
@@ -13849,7 +12631,7 @@ impl<'a> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
     pub fn min_sequences_index_buffer_offset_alignment(
         mut self,
         min_sequences_index_buffer_offset_alignment: u32,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.min_sequences_index_buffer_offset_alignment =
             min_sequences_index_buffer_offset_alignment;
         self
@@ -13857,7 +12639,7 @@ impl<'a> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
     pub fn min_indirect_commands_buffer_offset_alignment(
         mut self,
         min_indirect_commands_buffer_offset_alignment: u32,
-    ) -> PhysicalDeviceDeviceGeneratedCommandsPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.min_indirect_commands_buffer_offset_alignment =
             min_indirect_commands_buffer_offset_alignment;
         self
@@ -13918,10 +12700,7 @@ impl<'a> ::std::ops::DerefMut for GraphicsShaderGroupCreateInfoNVBuilder<'a> {
     }
 }
 impl<'a> GraphicsShaderGroupCreateInfoNVBuilder<'a> {
-    pub fn stages(
-        mut self,
-        stages: &'a [PipelineShaderStageCreateInfo],
-    ) -> GraphicsShaderGroupCreateInfoNVBuilder<'a> {
+    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo]) -> Self {
         self.inner.stage_count = stages.len() as _;
         self.inner.p_stages = stages.as_ptr();
         self
@@ -13929,14 +12708,14 @@ impl<'a> GraphicsShaderGroupCreateInfoNVBuilder<'a> {
     pub fn vertex_input_state(
         mut self,
         vertex_input_state: &'a PipelineVertexInputStateCreateInfo,
-    ) -> GraphicsShaderGroupCreateInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.p_vertex_input_state = vertex_input_state;
         self
     }
     pub fn tessellation_state(
         mut self,
         tessellation_state: &'a PipelineTessellationStateCreateInfo,
-    ) -> GraphicsShaderGroupCreateInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.p_tessellation_state = tessellation_state;
         self
     }
@@ -13945,10 +12724,7 @@ impl<'a> GraphicsShaderGroupCreateInfoNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsGraphicsShaderGroupCreateInfoNV>(
-        mut self,
-        next: &'a mut T,
-    ) -> GraphicsShaderGroupCreateInfoNVBuilder<'a> {
+    pub fn push_next<T: ExtendsGraphicsShaderGroupCreateInfoNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -14017,18 +12793,12 @@ impl<'a> ::std::ops::DerefMut for GraphicsPipelineShaderGroupsCreateInfoNVBuilde
     }
 }
 impl<'a> GraphicsPipelineShaderGroupsCreateInfoNVBuilder<'a> {
-    pub fn groups(
-        mut self,
-        groups: &'a [GraphicsShaderGroupCreateInfoNV],
-    ) -> GraphicsPipelineShaderGroupsCreateInfoNVBuilder<'a> {
+    pub fn groups(mut self, groups: &'a [GraphicsShaderGroupCreateInfoNV]) -> Self {
         self.inner.group_count = groups.len() as _;
         self.inner.p_groups = groups.as_ptr();
         self
     }
-    pub fn pipelines(
-        mut self,
-        pipelines: &'a [Pipeline],
-    ) -> GraphicsPipelineShaderGroupsCreateInfoNVBuilder<'a> {
+    pub fn pipelines(mut self, pipelines: &'a [Pipeline]) -> Self {
         self.inner.pipeline_count = pipelines.len() as _;
         self.inner.p_pipelines = pipelines.as_ptr();
         self
@@ -14071,7 +12841,7 @@ impl<'a> ::std::ops::DerefMut for BindShaderGroupIndirectCommandNVBuilder<'a> {
     }
 }
 impl<'a> BindShaderGroupIndirectCommandNVBuilder<'a> {
-    pub fn group_index(mut self, group_index: u32) -> BindShaderGroupIndirectCommandNVBuilder<'a> {
+    pub fn group_index(mut self, group_index: u32) -> Self {
         self.inner.group_index = group_index;
         self
     }
@@ -14115,21 +12885,15 @@ impl<'a> ::std::ops::DerefMut for BindIndexBufferIndirectCommandNVBuilder<'a> {
     }
 }
 impl<'a> BindIndexBufferIndirectCommandNVBuilder<'a> {
-    pub fn buffer_address(
-        mut self,
-        buffer_address: DeviceAddress,
-    ) -> BindIndexBufferIndirectCommandNVBuilder<'a> {
+    pub fn buffer_address(mut self, buffer_address: DeviceAddress) -> Self {
         self.inner.buffer_address = buffer_address;
         self
     }
-    pub fn size(mut self, size: u32) -> BindIndexBufferIndirectCommandNVBuilder<'a> {
+    pub fn size(mut self, size: u32) -> Self {
         self.inner.size = size;
         self
     }
-    pub fn index_type(
-        mut self,
-        index_type: IndexType,
-    ) -> BindIndexBufferIndirectCommandNVBuilder<'a> {
+    pub fn index_type(mut self, index_type: IndexType) -> Self {
         self.inner.index_type = index_type;
         self
     }
@@ -14173,18 +12937,15 @@ impl<'a> ::std::ops::DerefMut for BindVertexBufferIndirectCommandNVBuilder<'a> {
     }
 }
 impl<'a> BindVertexBufferIndirectCommandNVBuilder<'a> {
-    pub fn buffer_address(
-        mut self,
-        buffer_address: DeviceAddress,
-    ) -> BindVertexBufferIndirectCommandNVBuilder<'a> {
+    pub fn buffer_address(mut self, buffer_address: DeviceAddress) -> Self {
         self.inner.buffer_address = buffer_address;
         self
     }
-    pub fn size(mut self, size: u32) -> BindVertexBufferIndirectCommandNVBuilder<'a> {
+    pub fn size(mut self, size: u32) -> Self {
         self.inner.size = size;
         self
     }
-    pub fn stride(mut self, stride: u32) -> BindVertexBufferIndirectCommandNVBuilder<'a> {
+    pub fn stride(mut self, stride: u32) -> Self {
         self.inner.stride = stride;
         self
     }
@@ -14226,7 +12987,7 @@ impl<'a> ::std::ops::DerefMut for SetStateFlagsIndirectCommandNVBuilder<'a> {
     }
 }
 impl<'a> SetStateFlagsIndirectCommandNVBuilder<'a> {
-    pub fn data(mut self, data: u32) -> SetStateFlagsIndirectCommandNVBuilder<'a> {
+    pub fn data(mut self, data: u32) -> Self {
         self.inner.data = data;
         self
     }
@@ -14269,11 +13030,11 @@ impl<'a> ::std::ops::DerefMut for IndirectCommandsStreamNVBuilder<'a> {
     }
 }
 impl<'a> IndirectCommandsStreamNVBuilder<'a> {
-    pub fn buffer(mut self, buffer: Buffer) -> IndirectCommandsStreamNVBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
-    pub fn offset(mut self, offset: DeviceSize) -> IndirectCommandsStreamNVBuilder<'a> {
+    pub fn offset(mut self, offset: DeviceSize) -> Self {
         self.inner.offset = offset;
         self
     }
@@ -14351,82 +13112,58 @@ impl<'a> ::std::ops::DerefMut for IndirectCommandsLayoutTokenNVBuilder<'a> {
     }
 }
 impl<'a> IndirectCommandsLayoutTokenNVBuilder<'a> {
-    pub fn token_type(
-        mut self,
-        token_type: IndirectCommandsTokenTypeNV,
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn token_type(mut self, token_type: IndirectCommandsTokenTypeNV) -> Self {
         self.inner.token_type = token_type;
         self
     }
-    pub fn stream(mut self, stream: u32) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn stream(mut self, stream: u32) -> Self {
         self.inner.stream = stream;
         self
     }
-    pub fn offset(mut self, offset: u32) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn offset(mut self, offset: u32) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn vertex_binding_unit(
-        mut self,
-        vertex_binding_unit: u32,
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn vertex_binding_unit(mut self, vertex_binding_unit: u32) -> Self {
         self.inner.vertex_binding_unit = vertex_binding_unit;
         self
     }
-    pub fn vertex_dynamic_stride(
-        mut self,
-        vertex_dynamic_stride: bool,
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn vertex_dynamic_stride(mut self, vertex_dynamic_stride: bool) -> Self {
         self.inner.vertex_dynamic_stride = vertex_dynamic_stride.into();
         self
     }
     pub fn pushconstant_pipeline_layout(
         mut self,
         pushconstant_pipeline_layout: PipelineLayout,
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    ) -> Self {
         self.inner.pushconstant_pipeline_layout = pushconstant_pipeline_layout;
         self
     }
     pub fn pushconstant_shader_stage_flags(
         mut self,
         pushconstant_shader_stage_flags: ShaderStageFlags,
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    ) -> Self {
         self.inner.pushconstant_shader_stage_flags = pushconstant_shader_stage_flags;
         self
     }
-    pub fn pushconstant_offset(
-        mut self,
-        pushconstant_offset: u32,
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn pushconstant_offset(mut self, pushconstant_offset: u32) -> Self {
         self.inner.pushconstant_offset = pushconstant_offset;
         self
     }
-    pub fn pushconstant_size(
-        mut self,
-        pushconstant_size: u32,
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn pushconstant_size(mut self, pushconstant_size: u32) -> Self {
         self.inner.pushconstant_size = pushconstant_size;
         self
     }
-    pub fn indirect_state_flags(
-        mut self,
-        indirect_state_flags: IndirectStateFlagsNV,
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn indirect_state_flags(mut self, indirect_state_flags: IndirectStateFlagsNV) -> Self {
         self.inner.indirect_state_flags = indirect_state_flags;
         self
     }
-    pub fn index_types(
-        mut self,
-        index_types: &'a [IndexType],
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn index_types(mut self, index_types: &'a [IndexType]) -> Self {
         self.inner.index_type_count = index_types.len() as _;
         self.inner.p_index_types = index_types.as_ptr();
         self
     }
-    pub fn index_type_values(
-        mut self,
-        index_type_values: &'a [u32],
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn index_type_values(mut self, index_type_values: &'a [u32]) -> Self {
         self.inner.index_type_count = index_type_values.len() as _;
         self.inner.p_index_type_values = index_type_values.as_ptr();
         self
@@ -14436,10 +13173,7 @@ impl<'a> IndirectCommandsLayoutTokenNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsIndirectCommandsLayoutTokenNV>(
-        mut self,
-        next: &'a mut T,
-    ) -> IndirectCommandsLayoutTokenNVBuilder<'a> {
+    pub fn push_next<T: ExtendsIndirectCommandsLayoutTokenNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -14508,32 +13242,20 @@ impl<'a> ::std::ops::DerefMut for IndirectCommandsLayoutCreateInfoNVBuilder<'a> 
     }
 }
 impl<'a> IndirectCommandsLayoutCreateInfoNVBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: IndirectCommandsLayoutUsageFlagsNV,
-    ) -> IndirectCommandsLayoutCreateInfoNVBuilder<'a> {
+    pub fn flags(mut self, flags: IndirectCommandsLayoutUsageFlagsNV) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn pipeline_bind_point(
-        mut self,
-        pipeline_bind_point: PipelineBindPoint,
-    ) -> IndirectCommandsLayoutCreateInfoNVBuilder<'a> {
+    pub fn pipeline_bind_point(mut self, pipeline_bind_point: PipelineBindPoint) -> Self {
         self.inner.pipeline_bind_point = pipeline_bind_point;
         self
     }
-    pub fn tokens(
-        mut self,
-        tokens: &'a [IndirectCommandsLayoutTokenNV],
-    ) -> IndirectCommandsLayoutCreateInfoNVBuilder<'a> {
+    pub fn tokens(mut self, tokens: &'a [IndirectCommandsLayoutTokenNV]) -> Self {
         self.inner.token_count = tokens.len() as _;
         self.inner.p_tokens = tokens.as_ptr();
         self
     }
-    pub fn stream_strides(
-        mut self,
-        stream_strides: &'a [u32],
-    ) -> IndirectCommandsLayoutCreateInfoNVBuilder<'a> {
+    pub fn stream_strides(mut self, stream_strides: &'a [u32]) -> Self {
         self.inner.stream_count = stream_strides.len() as _;
         self.inner.p_stream_strides = stream_strides.as_ptr();
         self
@@ -14546,7 +13268,7 @@ impl<'a> IndirectCommandsLayoutCreateInfoNVBuilder<'a> {
     pub fn push_next<T: ExtendsIndirectCommandsLayoutCreateInfoNV>(
         mut self,
         next: &'a mut T,
-    ) -> IndirectCommandsLayoutCreateInfoNVBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -14629,82 +13351,55 @@ impl<'a> ::std::ops::DerefMut for GeneratedCommandsInfoNVBuilder<'a> {
     }
 }
 impl<'a> GeneratedCommandsInfoNVBuilder<'a> {
-    pub fn pipeline_bind_point(
-        mut self,
-        pipeline_bind_point: PipelineBindPoint,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn pipeline_bind_point(mut self, pipeline_bind_point: PipelineBindPoint) -> Self {
         self.inner.pipeline_bind_point = pipeline_bind_point;
         self
     }
-    pub fn pipeline(mut self, pipeline: Pipeline) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn pipeline(mut self, pipeline: Pipeline) -> Self {
         self.inner.pipeline = pipeline;
         self
     }
     pub fn indirect_commands_layout(
         mut self,
         indirect_commands_layout: IndirectCommandsLayoutNV,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.indirect_commands_layout = indirect_commands_layout;
         self
     }
-    pub fn streams(
-        mut self,
-        streams: &'a [IndirectCommandsStreamNV],
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn streams(mut self, streams: &'a [IndirectCommandsStreamNV]) -> Self {
         self.inner.stream_count = streams.len() as _;
         self.inner.p_streams = streams.as_ptr();
         self
     }
-    pub fn sequences_count(mut self, sequences_count: u32) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn sequences_count(mut self, sequences_count: u32) -> Self {
         self.inner.sequences_count = sequences_count;
         self
     }
-    pub fn preprocess_buffer(
-        mut self,
-        preprocess_buffer: Buffer,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn preprocess_buffer(mut self, preprocess_buffer: Buffer) -> Self {
         self.inner.preprocess_buffer = preprocess_buffer;
         self
     }
-    pub fn preprocess_offset(
-        mut self,
-        preprocess_offset: DeviceSize,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn preprocess_offset(mut self, preprocess_offset: DeviceSize) -> Self {
         self.inner.preprocess_offset = preprocess_offset;
         self
     }
-    pub fn preprocess_size(
-        mut self,
-        preprocess_size: DeviceSize,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn preprocess_size(mut self, preprocess_size: DeviceSize) -> Self {
         self.inner.preprocess_size = preprocess_size;
         self
     }
-    pub fn sequences_count_buffer(
-        mut self,
-        sequences_count_buffer: Buffer,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn sequences_count_buffer(mut self, sequences_count_buffer: Buffer) -> Self {
         self.inner.sequences_count_buffer = sequences_count_buffer;
         self
     }
-    pub fn sequences_count_offset(
-        mut self,
-        sequences_count_offset: DeviceSize,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn sequences_count_offset(mut self, sequences_count_offset: DeviceSize) -> Self {
         self.inner.sequences_count_offset = sequences_count_offset;
         self
     }
-    pub fn sequences_index_buffer(
-        mut self,
-        sequences_index_buffer: Buffer,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn sequences_index_buffer(mut self, sequences_index_buffer: Buffer) -> Self {
         self.inner.sequences_index_buffer = sequences_index_buffer;
         self
     }
-    pub fn sequences_index_offset(
-        mut self,
-        sequences_index_offset: DeviceSize,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn sequences_index_offset(mut self, sequences_index_offset: DeviceSize) -> Self {
         self.inner.sequences_index_offset = sequences_index_offset;
         self
     }
@@ -14713,10 +13408,7 @@ impl<'a> GeneratedCommandsInfoNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsGeneratedCommandsInfoNV>(
-        mut self,
-        next: &'a mut T,
-    ) -> GeneratedCommandsInfoNVBuilder<'a> {
+    pub fn push_next<T: ExtendsGeneratedCommandsInfoNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -14781,31 +13473,22 @@ impl<'a> ::std::ops::DerefMut for GeneratedCommandsMemoryRequirementsInfoNVBuild
     }
 }
 impl<'a> GeneratedCommandsMemoryRequirementsInfoNVBuilder<'a> {
-    pub fn pipeline_bind_point(
-        mut self,
-        pipeline_bind_point: PipelineBindPoint,
-    ) -> GeneratedCommandsMemoryRequirementsInfoNVBuilder<'a> {
+    pub fn pipeline_bind_point(mut self, pipeline_bind_point: PipelineBindPoint) -> Self {
         self.inner.pipeline_bind_point = pipeline_bind_point;
         self
     }
-    pub fn pipeline(
-        mut self,
-        pipeline: Pipeline,
-    ) -> GeneratedCommandsMemoryRequirementsInfoNVBuilder<'a> {
+    pub fn pipeline(mut self, pipeline: Pipeline) -> Self {
         self.inner.pipeline = pipeline;
         self
     }
     pub fn indirect_commands_layout(
         mut self,
         indirect_commands_layout: IndirectCommandsLayoutNV,
-    ) -> GeneratedCommandsMemoryRequirementsInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.indirect_commands_layout = indirect_commands_layout;
         self
     }
-    pub fn max_sequences_count(
-        mut self,
-        max_sequences_count: u32,
-    ) -> GeneratedCommandsMemoryRequirementsInfoNVBuilder<'a> {
+    pub fn max_sequences_count(mut self, max_sequences_count: u32) -> Self {
         self.inner.max_sequences_count = max_sequences_count;
         self
     }
@@ -14817,7 +13500,7 @@ impl<'a> GeneratedCommandsMemoryRequirementsInfoNVBuilder<'a> {
     pub fn push_next<T: ExtendsGeneratedCommandsMemoryRequirementsInfoNV>(
         mut self,
         next: &'a mut T,
-    ) -> GeneratedCommandsMemoryRequirementsInfoNVBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -14877,10 +13560,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceFeatures2Builder<'a> {
     }
 }
 impl<'a> PhysicalDeviceFeatures2Builder<'a> {
-    pub fn features(
-        mut self,
-        features: PhysicalDeviceFeatures,
-    ) -> PhysicalDeviceFeatures2Builder<'a> {
+    pub fn features(mut self, features: PhysicalDeviceFeatures) -> Self {
         self.inner.features = features;
         self
     }
@@ -14934,10 +13614,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceProperties2Builder<'a> {
     }
 }
 impl<'a> PhysicalDeviceProperties2Builder<'a> {
-    pub fn properties(
-        mut self,
-        properties: PhysicalDeviceProperties,
-    ) -> PhysicalDeviceProperties2Builder<'a> {
+    pub fn properties(mut self, properties: PhysicalDeviceProperties) -> Self {
         self.inner.properties = properties;
         self
     }
@@ -14946,10 +13623,7 @@ impl<'a> PhysicalDeviceProperties2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPhysicalDeviceProperties2>(
-        mut self,
-        next: &'a mut T,
-    ) -> PhysicalDeviceProperties2Builder<'a> {
+    pub fn push_next<T: ExtendsPhysicalDeviceProperties2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -15008,10 +13682,7 @@ impl<'a> ::std::ops::DerefMut for FormatProperties2Builder<'a> {
     }
 }
 impl<'a> FormatProperties2Builder<'a> {
-    pub fn format_properties(
-        mut self,
-        format_properties: FormatProperties,
-    ) -> FormatProperties2Builder<'a> {
+    pub fn format_properties(mut self, format_properties: FormatProperties) -> Self {
         self.inner.format_properties = format_properties;
         self
     }
@@ -15020,10 +13691,7 @@ impl<'a> FormatProperties2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsFormatProperties2>(
-        mut self,
-        next: &'a mut T,
-    ) -> FormatProperties2Builder<'a> {
+    pub fn push_next<T: ExtendsFormatProperties2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -15085,7 +13753,7 @@ impl<'a> ImageFormatProperties2Builder<'a> {
     pub fn image_format_properties(
         mut self,
         image_format_properties: ImageFormatProperties,
-    ) -> ImageFormatProperties2Builder<'a> {
+    ) -> Self {
         self.inner.image_format_properties = image_format_properties;
         self
     }
@@ -15094,10 +13762,7 @@ impl<'a> ImageFormatProperties2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageFormatProperties2>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageFormatProperties2Builder<'a> {
+    pub fn push_next<T: ExtendsImageFormatProperties2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -15164,23 +13829,23 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceImageFormatInfo2Builder<'a> {
     }
 }
 impl<'a> PhysicalDeviceImageFormatInfo2Builder<'a> {
-    pub fn format(mut self, format: Format) -> PhysicalDeviceImageFormatInfo2Builder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn ty(mut self, ty: ImageType) -> PhysicalDeviceImageFormatInfo2Builder<'a> {
+    pub fn ty(mut self, ty: ImageType) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn tiling(mut self, tiling: ImageTiling) -> PhysicalDeviceImageFormatInfo2Builder<'a> {
+    pub fn tiling(mut self, tiling: ImageTiling) -> Self {
         self.inner.tiling = tiling;
         self
     }
-    pub fn usage(mut self, usage: ImageUsageFlags) -> PhysicalDeviceImageFormatInfo2Builder<'a> {
+    pub fn usage(mut self, usage: ImageUsageFlags) -> Self {
         self.inner.usage = usage;
         self
     }
-    pub fn flags(mut self, flags: ImageCreateFlags) -> PhysicalDeviceImageFormatInfo2Builder<'a> {
+    pub fn flags(mut self, flags: ImageCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -15189,10 +13854,7 @@ impl<'a> PhysicalDeviceImageFormatInfo2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPhysicalDeviceImageFormatInfo2>(
-        mut self,
-        next: &'a mut T,
-    ) -> PhysicalDeviceImageFormatInfo2Builder<'a> {
+    pub fn push_next<T: ExtendsPhysicalDeviceImageFormatInfo2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -15254,7 +13916,7 @@ impl<'a> QueueFamilyProperties2Builder<'a> {
     pub fn queue_family_properties(
         mut self,
         queue_family_properties: QueueFamilyProperties,
-    ) -> QueueFamilyProperties2Builder<'a> {
+    ) -> Self {
         self.inner.queue_family_properties = queue_family_properties;
         self
     }
@@ -15263,10 +13925,7 @@ impl<'a> QueueFamilyProperties2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsQueueFamilyProperties2>(
-        mut self,
-        next: &'a mut T,
-    ) -> QueueFamilyProperties2Builder<'a> {
+    pub fn push_next<T: ExtendsQueueFamilyProperties2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -15325,10 +13984,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMemoryProperties2Builder<'a> {
     }
 }
 impl<'a> PhysicalDeviceMemoryProperties2Builder<'a> {
-    pub fn memory_properties(
-        mut self,
-        memory_properties: PhysicalDeviceMemoryProperties,
-    ) -> PhysicalDeviceMemoryProperties2Builder<'a> {
+    pub fn memory_properties(mut self, memory_properties: PhysicalDeviceMemoryProperties) -> Self {
         self.inner.memory_properties = memory_properties;
         self
     }
@@ -15337,10 +13993,7 @@ impl<'a> PhysicalDeviceMemoryProperties2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPhysicalDeviceMemoryProperties2>(
-        mut self,
-        next: &'a mut T,
-    ) -> PhysicalDeviceMemoryProperties2Builder<'a> {
+    pub fn push_next<T: ExtendsPhysicalDeviceMemoryProperties2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -15399,10 +14052,7 @@ impl<'a> ::std::ops::DerefMut for SparseImageFormatProperties2Builder<'a> {
     }
 }
 impl<'a> SparseImageFormatProperties2Builder<'a> {
-    pub fn properties(
-        mut self,
-        properties: SparseImageFormatProperties,
-    ) -> SparseImageFormatProperties2Builder<'a> {
+    pub fn properties(mut self, properties: SparseImageFormatProperties) -> Self {
         self.inner.properties = properties;
         self
     }
@@ -15411,10 +14061,7 @@ impl<'a> SparseImageFormatProperties2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSparseImageFormatProperties2>(
-        mut self,
-        next: &'a mut T,
-    ) -> SparseImageFormatProperties2Builder<'a> {
+    pub fn push_next<T: ExtendsSparseImageFormatProperties2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -15481,32 +14128,23 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceSparseImageFormatInfo2Builder<'a
     }
 }
 impl<'a> PhysicalDeviceSparseImageFormatInfo2Builder<'a> {
-    pub fn format(mut self, format: Format) -> PhysicalDeviceSparseImageFormatInfo2Builder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn ty(mut self, ty: ImageType) -> PhysicalDeviceSparseImageFormatInfo2Builder<'a> {
+    pub fn ty(mut self, ty: ImageType) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn samples(
-        mut self,
-        samples: SampleCountFlags,
-    ) -> PhysicalDeviceSparseImageFormatInfo2Builder<'a> {
+    pub fn samples(mut self, samples: SampleCountFlags) -> Self {
         self.inner.samples = samples;
         self
     }
-    pub fn usage(
-        mut self,
-        usage: ImageUsageFlags,
-    ) -> PhysicalDeviceSparseImageFormatInfo2Builder<'a> {
+    pub fn usage(mut self, usage: ImageUsageFlags) -> Self {
         self.inner.usage = usage;
         self
     }
-    pub fn tiling(
-        mut self,
-        tiling: ImageTiling,
-    ) -> PhysicalDeviceSparseImageFormatInfo2Builder<'a> {
+    pub fn tiling(mut self, tiling: ImageTiling) -> Self {
         self.inner.tiling = tiling;
         self
     }
@@ -15518,7 +14156,7 @@ impl<'a> PhysicalDeviceSparseImageFormatInfo2Builder<'a> {
     pub fn push_next<T: ExtendsPhysicalDeviceSparseImageFormatInfo2>(
         mut self,
         next: &'a mut T,
-    ) -> PhysicalDeviceSparseImageFormatInfo2Builder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -15581,10 +14219,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDevicePushDescriptorPropertiesKHRBuild
     }
 }
 impl<'a> PhysicalDevicePushDescriptorPropertiesKHRBuilder<'a> {
-    pub fn max_push_descriptors(
-        mut self,
-        max_push_descriptors: u32,
-    ) -> PhysicalDevicePushDescriptorPropertiesKHRBuilder<'a> {
+    pub fn max_push_descriptors(mut self, max_push_descriptors: u32) -> Self {
         self.inner.max_push_descriptors = max_push_descriptors;
         self
     }
@@ -15629,19 +14264,19 @@ impl<'a> ::std::ops::DerefMut for ConformanceVersionBuilder<'a> {
     }
 }
 impl<'a> ConformanceVersionBuilder<'a> {
-    pub fn major(mut self, major: u8) -> ConformanceVersionBuilder<'a> {
+    pub fn major(mut self, major: u8) -> Self {
         self.inner.major = major;
         self
     }
-    pub fn minor(mut self, minor: u8) -> ConformanceVersionBuilder<'a> {
+    pub fn minor(mut self, minor: u8) -> Self {
         self.inner.minor = minor;
         self
     }
-    pub fn subminor(mut self, subminor: u8) -> ConformanceVersionBuilder<'a> {
+    pub fn subminor(mut self, subminor: u8) -> Self {
         self.inner.subminor = subminor;
         self
     }
-    pub fn patch(mut self, patch: u8) -> ConformanceVersionBuilder<'a> {
+    pub fn patch(mut self, patch: u8) -> Self {
         self.inner.patch = patch;
         self
     }
@@ -15718,28 +14353,19 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceDriverPropertiesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceDriverPropertiesBuilder<'a> {
-    pub fn driver_id(mut self, driver_id: DriverId) -> PhysicalDeviceDriverPropertiesBuilder<'a> {
+    pub fn driver_id(mut self, driver_id: DriverId) -> Self {
         self.inner.driver_id = driver_id;
         self
     }
-    pub fn driver_name(
-        mut self,
-        driver_name: [c_char; MAX_DRIVER_NAME_SIZE],
-    ) -> PhysicalDeviceDriverPropertiesBuilder<'a> {
+    pub fn driver_name(mut self, driver_name: [c_char; MAX_DRIVER_NAME_SIZE]) -> Self {
         self.inner.driver_name = driver_name;
         self
     }
-    pub fn driver_info(
-        mut self,
-        driver_info: [c_char; MAX_DRIVER_INFO_SIZE],
-    ) -> PhysicalDeviceDriverPropertiesBuilder<'a> {
+    pub fn driver_info(mut self, driver_info: [c_char; MAX_DRIVER_INFO_SIZE]) -> Self {
         self.inner.driver_info = driver_info;
         self
     }
-    pub fn conformance_version(
-        mut self,
-        conformance_version: ConformanceVersion,
-    ) -> PhysicalDeviceDriverPropertiesBuilder<'a> {
+    pub fn conformance_version(mut self, conformance_version: ConformanceVersion) -> Self {
         self.inner.conformance_version = conformance_version;
         self
     }
@@ -15796,7 +14422,7 @@ impl<'a> ::std::ops::DerefMut for PresentRegionsKHRBuilder<'a> {
     }
 }
 impl<'a> PresentRegionsKHRBuilder<'a> {
-    pub fn regions(mut self, regions: &'a [PresentRegionKHR]) -> PresentRegionsKHRBuilder<'a> {
+    pub fn regions(mut self, regions: &'a [PresentRegionKHR]) -> Self {
         self.inner.swapchain_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -15848,7 +14474,7 @@ impl<'a> ::std::ops::DerefMut for PresentRegionKHRBuilder<'a> {
     }
 }
 impl<'a> PresentRegionKHRBuilder<'a> {
-    pub fn rectangles(mut self, rectangles: &'a [RectLayerKHR]) -> PresentRegionKHRBuilder<'a> {
+    pub fn rectangles(mut self, rectangles: &'a [RectLayerKHR]) -> Self {
         self.inner.rectangle_count = rectangles.len() as _;
         self.inner.p_rectangles = rectangles.as_ptr();
         self
@@ -15893,15 +14519,15 @@ impl<'a> ::std::ops::DerefMut for RectLayerKHRBuilder<'a> {
     }
 }
 impl<'a> RectLayerKHRBuilder<'a> {
-    pub fn offset(mut self, offset: Offset2D) -> RectLayerKHRBuilder<'a> {
+    pub fn offset(mut self, offset: Offset2D) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn extent(mut self, extent: Extent2D) -> RectLayerKHRBuilder<'a> {
+    pub fn extent(mut self, extent: Extent2D) -> Self {
         self.inner.extent = extent;
         self
     }
-    pub fn layer(mut self, layer: u32) -> RectLayerKHRBuilder<'a> {
+    pub fn layer(mut self, layer: u32) -> Self {
         self.inner.layer = layer;
         self
     }
@@ -15961,14 +14587,11 @@ impl<'a> PhysicalDeviceVariablePointersFeaturesBuilder<'a> {
     pub fn variable_pointers_storage_buffer(
         mut self,
         variable_pointers_storage_buffer: bool,
-    ) -> PhysicalDeviceVariablePointersFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.variable_pointers_storage_buffer = variable_pointers_storage_buffer.into();
         self
     }
-    pub fn variable_pointers(
-        mut self,
-        variable_pointers: bool,
-    ) -> PhysicalDeviceVariablePointersFeaturesBuilder<'a> {
+    pub fn variable_pointers(mut self, variable_pointers: bool) -> Self {
         self.inner.variable_pointers = variable_pointers.into();
         self
     }
@@ -16015,21 +14638,21 @@ impl<'a> ExternalMemoryPropertiesBuilder<'a> {
     pub fn external_memory_features(
         mut self,
         external_memory_features: ExternalMemoryFeatureFlags,
-    ) -> ExternalMemoryPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.external_memory_features = external_memory_features;
         self
     }
     pub fn export_from_imported_handle_types(
         mut self,
         export_from_imported_handle_types: ExternalMemoryHandleTypeFlags,
-    ) -> ExternalMemoryPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.export_from_imported_handle_types = export_from_imported_handle_types;
         self
     }
     pub fn compatible_handle_types(
         mut self,
         compatible_handle_types: ExternalMemoryHandleTypeFlags,
-    ) -> ExternalMemoryPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.compatible_handle_types = compatible_handle_types;
         self
     }
@@ -16087,10 +14710,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceExternalImageFormatInfoBuilder<'
     }
 }
 impl<'a> PhysicalDeviceExternalImageFormatInfoBuilder<'a> {
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalMemoryHandleTypeFlags,
-    ) -> PhysicalDeviceExternalImageFormatInfoBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -16148,7 +14768,7 @@ impl<'a> ExternalImageFormatPropertiesBuilder<'a> {
     pub fn external_memory_properties(
         mut self,
         external_memory_properties: ExternalMemoryProperties,
-    ) -> ExternalImageFormatPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.external_memory_properties = external_memory_properties;
         self
     }
@@ -16206,21 +14826,15 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceExternalBufferInfoBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceExternalBufferInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: BufferCreateFlags,
-    ) -> PhysicalDeviceExternalBufferInfoBuilder<'a> {
+    pub fn flags(mut self, flags: BufferCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn usage(mut self, usage: BufferUsageFlags) -> PhysicalDeviceExternalBufferInfoBuilder<'a> {
+    pub fn usage(mut self, usage: BufferUsageFlags) -> Self {
         self.inner.usage = usage;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalMemoryHandleTypeFlags,
-    ) -> PhysicalDeviceExternalBufferInfoBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -16232,7 +14846,7 @@ impl<'a> PhysicalDeviceExternalBufferInfoBuilder<'a> {
     pub fn push_next<T: ExtendsPhysicalDeviceExternalBufferInfo>(
         mut self,
         next: &'a mut T,
-    ) -> PhysicalDeviceExternalBufferInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -16294,7 +14908,7 @@ impl<'a> ExternalBufferPropertiesBuilder<'a> {
     pub fn external_memory_properties(
         mut self,
         external_memory_properties: ExternalMemoryProperties,
-    ) -> ExternalBufferPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.external_memory_properties = external_memory_properties;
         self
     }
@@ -16303,10 +14917,7 @@ impl<'a> ExternalBufferPropertiesBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsExternalBufferProperties>(
-        mut self,
-        next: &'a mut T,
-    ) -> ExternalBufferPropertiesBuilder<'a> {
+    pub fn push_next<T: ExtendsExternalBufferProperties>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -16374,38 +14985,23 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceIDPropertiesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceIDPropertiesBuilder<'a> {
-    pub fn device_uuid(
-        mut self,
-        device_uuid: [u8; UUID_SIZE],
-    ) -> PhysicalDeviceIDPropertiesBuilder<'a> {
+    pub fn device_uuid(mut self, device_uuid: [u8; UUID_SIZE]) -> Self {
         self.inner.device_uuid = device_uuid;
         self
     }
-    pub fn driver_uuid(
-        mut self,
-        driver_uuid: [u8; UUID_SIZE],
-    ) -> PhysicalDeviceIDPropertiesBuilder<'a> {
+    pub fn driver_uuid(mut self, driver_uuid: [u8; UUID_SIZE]) -> Self {
         self.inner.driver_uuid = driver_uuid;
         self
     }
-    pub fn device_luid(
-        mut self,
-        device_luid: [u8; LUID_SIZE],
-    ) -> PhysicalDeviceIDPropertiesBuilder<'a> {
+    pub fn device_luid(mut self, device_luid: [u8; LUID_SIZE]) -> Self {
         self.inner.device_luid = device_luid;
         self
     }
-    pub fn device_node_mask(
-        mut self,
-        device_node_mask: u32,
-    ) -> PhysicalDeviceIDPropertiesBuilder<'a> {
+    pub fn device_node_mask(mut self, device_node_mask: u32) -> Self {
         self.inner.device_node_mask = device_node_mask;
         self
     }
-    pub fn device_luid_valid(
-        mut self,
-        device_luid_valid: bool,
-    ) -> PhysicalDeviceIDPropertiesBuilder<'a> {
+    pub fn device_luid_valid(mut self, device_luid_valid: bool) -> Self {
         self.inner.device_luid_valid = device_luid_valid.into();
         self
     }
@@ -16460,10 +15056,7 @@ impl<'a> ::std::ops::DerefMut for ExternalMemoryImageCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ExternalMemoryImageCreateInfoBuilder<'a> {
-    pub fn handle_types(
-        mut self,
-        handle_types: ExternalMemoryHandleTypeFlags,
-    ) -> ExternalMemoryImageCreateInfoBuilder<'a> {
+    pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_types = handle_types;
         self
     }
@@ -16518,10 +15111,7 @@ impl<'a> ::std::ops::DerefMut for ExternalMemoryBufferCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ExternalMemoryBufferCreateInfoBuilder<'a> {
-    pub fn handle_types(
-        mut self,
-        handle_types: ExternalMemoryHandleTypeFlags,
-    ) -> ExternalMemoryBufferCreateInfoBuilder<'a> {
+    pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_types = handle_types;
         self
     }
@@ -16576,10 +15166,7 @@ impl<'a> ::std::ops::DerefMut for ExportMemoryAllocateInfoBuilder<'a> {
     }
 }
 impl<'a> ExportMemoryAllocateInfoBuilder<'a> {
-    pub fn handle_types(
-        mut self,
-        handle_types: ExternalMemoryHandleTypeFlags,
-    ) -> ExportMemoryAllocateInfoBuilder<'a> {
+    pub fn handle_types(mut self, handle_types: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_types = handle_types;
         self
     }
@@ -16638,18 +15225,15 @@ impl<'a> ::std::ops::DerefMut for ImportMemoryWin32HandleInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ImportMemoryWin32HandleInfoKHRBuilder<'a> {
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalMemoryHandleTypeFlags,
-    ) -> ImportMemoryWin32HandleInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
-    pub fn handle(mut self, handle: HANDLE) -> ImportMemoryWin32HandleInfoKHRBuilder<'a> {
+    pub fn handle(mut self, handle: HANDLE) -> Self {
         self.inner.handle = handle;
         self
     }
-    pub fn name(mut self, name: LPCWSTR) -> ImportMemoryWin32HandleInfoKHRBuilder<'a> {
+    pub fn name(mut self, name: LPCWSTR) -> Self {
         self.inner.name = name;
         self
     }
@@ -16708,18 +15292,15 @@ impl<'a> ::std::ops::DerefMut for ExportMemoryWin32HandleInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ExportMemoryWin32HandleInfoKHRBuilder<'a> {
-    pub fn attributes(
-        mut self,
-        attributes: &'a SECURITY_ATTRIBUTES,
-    ) -> ExportMemoryWin32HandleInfoKHRBuilder<'a> {
+    pub fn attributes(mut self, attributes: &'a SECURITY_ATTRIBUTES) -> Self {
         self.inner.p_attributes = attributes;
         self
     }
-    pub fn dw_access(mut self, dw_access: DWORD) -> ExportMemoryWin32HandleInfoKHRBuilder<'a> {
+    pub fn dw_access(mut self, dw_access: DWORD) -> Self {
         self.inner.dw_access = dw_access;
         self
     }
-    pub fn name(mut self, name: LPCWSTR) -> ExportMemoryWin32HandleInfoKHRBuilder<'a> {
+    pub fn name(mut self, name: LPCWSTR) -> Self {
         self.inner.name = name;
         self
     }
@@ -16773,10 +15354,7 @@ impl<'a> ::std::ops::DerefMut for MemoryWin32HandlePropertiesKHRBuilder<'a> {
     }
 }
 impl<'a> MemoryWin32HandlePropertiesKHRBuilder<'a> {
-    pub fn memory_type_bits(
-        mut self,
-        memory_type_bits: u32,
-    ) -> MemoryWin32HandlePropertiesKHRBuilder<'a> {
+    pub fn memory_type_bits(mut self, memory_type_bits: u32) -> Self {
         self.inner.memory_type_bits = memory_type_bits;
         self
     }
@@ -16785,10 +15363,7 @@ impl<'a> MemoryWin32HandlePropertiesKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMemoryWin32HandlePropertiesKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> MemoryWin32HandlePropertiesKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsMemoryWin32HandlePropertiesKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -16849,14 +15424,11 @@ impl<'a> ::std::ops::DerefMut for MemoryGetWin32HandleInfoKHRBuilder<'a> {
     }
 }
 impl<'a> MemoryGetWin32HandleInfoKHRBuilder<'a> {
-    pub fn memory(mut self, memory: DeviceMemory) -> MemoryGetWin32HandleInfoKHRBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalMemoryHandleTypeFlags,
-    ) -> MemoryGetWin32HandleInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -16865,10 +15437,7 @@ impl<'a> MemoryGetWin32HandleInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMemoryGetWin32HandleInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> MemoryGetWin32HandleInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsMemoryGetWin32HandleInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -16930,14 +15499,11 @@ impl<'a> ::std::ops::DerefMut for ImportMemoryFdInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ImportMemoryFdInfoKHRBuilder<'a> {
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalMemoryHandleTypeFlags,
-    ) -> ImportMemoryFdInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
-    pub fn fd(mut self, fd: c_int) -> ImportMemoryFdInfoKHRBuilder<'a> {
+    pub fn fd(mut self, fd: c_int) -> Self {
         self.inner.fd = fd;
         self
     }
@@ -16991,7 +15557,7 @@ impl<'a> ::std::ops::DerefMut for MemoryFdPropertiesKHRBuilder<'a> {
     }
 }
 impl<'a> MemoryFdPropertiesKHRBuilder<'a> {
-    pub fn memory_type_bits(mut self, memory_type_bits: u32) -> MemoryFdPropertiesKHRBuilder<'a> {
+    pub fn memory_type_bits(mut self, memory_type_bits: u32) -> Self {
         self.inner.memory_type_bits = memory_type_bits;
         self
     }
@@ -17000,10 +15566,7 @@ impl<'a> MemoryFdPropertiesKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMemoryFdPropertiesKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> MemoryFdPropertiesKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsMemoryFdPropertiesKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -17064,14 +15627,11 @@ impl<'a> ::std::ops::DerefMut for MemoryGetFdInfoKHRBuilder<'a> {
     }
 }
 impl<'a> MemoryGetFdInfoKHRBuilder<'a> {
-    pub fn memory(mut self, memory: DeviceMemory) -> MemoryGetFdInfoKHRBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalMemoryHandleTypeFlags,
-    ) -> MemoryGetFdInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -17080,10 +15640,7 @@ impl<'a> MemoryGetFdInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMemoryGetFdInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> MemoryGetFdInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsMemoryGetFdInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -17155,42 +15712,27 @@ impl<'a> ::std::ops::DerefMut for Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a
     }
 }
 impl<'a> Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a> {
-    pub fn acquire_syncs(
-        mut self,
-        acquire_syncs: &'a [DeviceMemory],
-    ) -> Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a> {
+    pub fn acquire_syncs(mut self, acquire_syncs: &'a [DeviceMemory]) -> Self {
         self.inner.acquire_count = acquire_syncs.len() as _;
         self.inner.p_acquire_syncs = acquire_syncs.as_ptr();
         self
     }
-    pub fn acquire_keys(
-        mut self,
-        acquire_keys: &'a [u64],
-    ) -> Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a> {
+    pub fn acquire_keys(mut self, acquire_keys: &'a [u64]) -> Self {
         self.inner.acquire_count = acquire_keys.len() as _;
         self.inner.p_acquire_keys = acquire_keys.as_ptr();
         self
     }
-    pub fn acquire_timeouts(
-        mut self,
-        acquire_timeouts: &'a [u32],
-    ) -> Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a> {
+    pub fn acquire_timeouts(mut self, acquire_timeouts: &'a [u32]) -> Self {
         self.inner.acquire_count = acquire_timeouts.len() as _;
         self.inner.p_acquire_timeouts = acquire_timeouts.as_ptr();
         self
     }
-    pub fn release_syncs(
-        mut self,
-        release_syncs: &'a [DeviceMemory],
-    ) -> Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a> {
+    pub fn release_syncs(mut self, release_syncs: &'a [DeviceMemory]) -> Self {
         self.inner.release_count = release_syncs.len() as _;
         self.inner.p_release_syncs = release_syncs.as_ptr();
         self
     }
-    pub fn release_keys(
-        mut self,
-        release_keys: &'a [u64],
-    ) -> Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a> {
+    pub fn release_keys(mut self, release_keys: &'a [u64]) -> Self {
         self.inner.release_count = release_keys.len() as _;
         self.inner.p_release_keys = release_keys.as_ptr();
         self
@@ -17245,10 +15787,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceExternalSemaphoreInfoBuilder<'a>
     }
 }
 impl<'a> PhysicalDeviceExternalSemaphoreInfoBuilder<'a> {
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalSemaphoreHandleTypeFlags,
-    ) -> PhysicalDeviceExternalSemaphoreInfoBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalSemaphoreHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -17260,7 +15799,7 @@ impl<'a> PhysicalDeviceExternalSemaphoreInfoBuilder<'a> {
     pub fn push_next<T: ExtendsPhysicalDeviceExternalSemaphoreInfo>(
         mut self,
         next: &'a mut T,
-    ) -> PhysicalDeviceExternalSemaphoreInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -17326,21 +15865,21 @@ impl<'a> ExternalSemaphorePropertiesBuilder<'a> {
     pub fn export_from_imported_handle_types(
         mut self,
         export_from_imported_handle_types: ExternalSemaphoreHandleTypeFlags,
-    ) -> ExternalSemaphorePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.export_from_imported_handle_types = export_from_imported_handle_types;
         self
     }
     pub fn compatible_handle_types(
         mut self,
         compatible_handle_types: ExternalSemaphoreHandleTypeFlags,
-    ) -> ExternalSemaphorePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.compatible_handle_types = compatible_handle_types;
         self
     }
     pub fn external_semaphore_features(
         mut self,
         external_semaphore_features: ExternalSemaphoreFeatureFlags,
-    ) -> ExternalSemaphorePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.external_semaphore_features = external_semaphore_features;
         self
     }
@@ -17349,10 +15888,7 @@ impl<'a> ExternalSemaphorePropertiesBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsExternalSemaphoreProperties>(
-        mut self,
-        next: &'a mut T,
-    ) -> ExternalSemaphorePropertiesBuilder<'a> {
+    pub fn push_next<T: ExtendsExternalSemaphoreProperties>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -17412,10 +15948,7 @@ impl<'a> ::std::ops::DerefMut for ExportSemaphoreCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ExportSemaphoreCreateInfoBuilder<'a> {
-    pub fn handle_types(
-        mut self,
-        handle_types: ExternalSemaphoreHandleTypeFlags,
-    ) -> ExportSemaphoreCreateInfoBuilder<'a> {
+    pub fn handle_types(mut self, handle_types: ExternalSemaphoreHandleTypeFlags) -> Self {
         self.inner.handle_types = handle_types;
         self
     }
@@ -17477,32 +16010,23 @@ impl<'a> ::std::ops::DerefMut for ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
-    pub fn semaphore(
-        mut self,
-        semaphore: Semaphore,
-    ) -> ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
+    pub fn semaphore(mut self, semaphore: Semaphore) -> Self {
         self.inner.semaphore = semaphore;
         self
     }
-    pub fn flags(
-        mut self,
-        flags: SemaphoreImportFlags,
-    ) -> ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: SemaphoreImportFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalSemaphoreHandleTypeFlags,
-    ) -> ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalSemaphoreHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
-    pub fn handle(mut self, handle: HANDLE) -> ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
+    pub fn handle(mut self, handle: HANDLE) -> Self {
         self.inner.handle = handle;
         self
     }
-    pub fn name(mut self, name: LPCWSTR) -> ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
+    pub fn name(mut self, name: LPCWSTR) -> Self {
         self.inner.name = name;
         self
     }
@@ -17514,7 +16038,7 @@ impl<'a> ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsImportSemaphoreWin32HandleInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> ImportSemaphoreWin32HandleInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -17578,18 +16102,15 @@ impl<'a> ::std::ops::DerefMut for ExportSemaphoreWin32HandleInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ExportSemaphoreWin32HandleInfoKHRBuilder<'a> {
-    pub fn attributes(
-        mut self,
-        attributes: &'a SECURITY_ATTRIBUTES,
-    ) -> ExportSemaphoreWin32HandleInfoKHRBuilder<'a> {
+    pub fn attributes(mut self, attributes: &'a SECURITY_ATTRIBUTES) -> Self {
         self.inner.p_attributes = attributes;
         self
     }
-    pub fn dw_access(mut self, dw_access: DWORD) -> ExportSemaphoreWin32HandleInfoKHRBuilder<'a> {
+    pub fn dw_access(mut self, dw_access: DWORD) -> Self {
         self.inner.dw_access = dw_access;
         self
     }
-    pub fn name(mut self, name: LPCWSTR) -> ExportSemaphoreWin32HandleInfoKHRBuilder<'a> {
+    pub fn name(mut self, name: LPCWSTR) -> Self {
         self.inner.name = name;
         self
     }
@@ -17650,18 +16171,12 @@ impl<'a> ::std::ops::DerefMut for D3D12FenceSubmitInfoKHRBuilder<'a> {
     }
 }
 impl<'a> D3D12FenceSubmitInfoKHRBuilder<'a> {
-    pub fn wait_semaphore_values(
-        mut self,
-        wait_semaphore_values: &'a [u64],
-    ) -> D3D12FenceSubmitInfoKHRBuilder<'a> {
+    pub fn wait_semaphore_values(mut self, wait_semaphore_values: &'a [u64]) -> Self {
         self.inner.wait_semaphore_values_count = wait_semaphore_values.len() as _;
         self.inner.p_wait_semaphore_values = wait_semaphore_values.as_ptr();
         self
     }
-    pub fn signal_semaphore_values(
-        mut self,
-        signal_semaphore_values: &'a [u64],
-    ) -> D3D12FenceSubmitInfoKHRBuilder<'a> {
+    pub fn signal_semaphore_values(mut self, signal_semaphore_values: &'a [u64]) -> Self {
         self.inner.signal_semaphore_values_count = signal_semaphore_values.len() as _;
         self.inner.p_signal_semaphore_values = signal_semaphore_values.as_ptr();
         self
@@ -17718,14 +16233,11 @@ impl<'a> ::std::ops::DerefMut for SemaphoreGetWin32HandleInfoKHRBuilder<'a> {
     }
 }
 impl<'a> SemaphoreGetWin32HandleInfoKHRBuilder<'a> {
-    pub fn semaphore(mut self, semaphore: Semaphore) -> SemaphoreGetWin32HandleInfoKHRBuilder<'a> {
+    pub fn semaphore(mut self, semaphore: Semaphore) -> Self {
         self.inner.semaphore = semaphore;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalSemaphoreHandleTypeFlags,
-    ) -> SemaphoreGetWin32HandleInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalSemaphoreHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -17734,10 +16246,7 @@ impl<'a> SemaphoreGetWin32HandleInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSemaphoreGetWin32HandleInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> SemaphoreGetWin32HandleInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsSemaphoreGetWin32HandleInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -17802,22 +16311,19 @@ impl<'a> ::std::ops::DerefMut for ImportSemaphoreFdInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ImportSemaphoreFdInfoKHRBuilder<'a> {
-    pub fn semaphore(mut self, semaphore: Semaphore) -> ImportSemaphoreFdInfoKHRBuilder<'a> {
+    pub fn semaphore(mut self, semaphore: Semaphore) -> Self {
         self.inner.semaphore = semaphore;
         self
     }
-    pub fn flags(mut self, flags: SemaphoreImportFlags) -> ImportSemaphoreFdInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: SemaphoreImportFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalSemaphoreHandleTypeFlags,
-    ) -> ImportSemaphoreFdInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalSemaphoreHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
-    pub fn fd(mut self, fd: c_int) -> ImportSemaphoreFdInfoKHRBuilder<'a> {
+    pub fn fd(mut self, fd: c_int) -> Self {
         self.inner.fd = fd;
         self
     }
@@ -17826,10 +16332,7 @@ impl<'a> ImportSemaphoreFdInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImportSemaphoreFdInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImportSemaphoreFdInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsImportSemaphoreFdInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -17890,14 +16393,11 @@ impl<'a> ::std::ops::DerefMut for SemaphoreGetFdInfoKHRBuilder<'a> {
     }
 }
 impl<'a> SemaphoreGetFdInfoKHRBuilder<'a> {
-    pub fn semaphore(mut self, semaphore: Semaphore) -> SemaphoreGetFdInfoKHRBuilder<'a> {
+    pub fn semaphore(mut self, semaphore: Semaphore) -> Self {
         self.inner.semaphore = semaphore;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalSemaphoreHandleTypeFlags,
-    ) -> SemaphoreGetFdInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalSemaphoreHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -17906,10 +16406,7 @@ impl<'a> SemaphoreGetFdInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSemaphoreGetFdInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> SemaphoreGetFdInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsSemaphoreGetFdInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -17968,10 +16465,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceExternalFenceInfoBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceExternalFenceInfoBuilder<'a> {
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalFenceHandleTypeFlags,
-    ) -> PhysicalDeviceExternalFenceInfoBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalFenceHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -17980,10 +16474,7 @@ impl<'a> PhysicalDeviceExternalFenceInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPhysicalDeviceExternalFenceInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> PhysicalDeviceExternalFenceInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsPhysicalDeviceExternalFenceInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -18049,21 +16540,21 @@ impl<'a> ExternalFencePropertiesBuilder<'a> {
     pub fn export_from_imported_handle_types(
         mut self,
         export_from_imported_handle_types: ExternalFenceHandleTypeFlags,
-    ) -> ExternalFencePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.export_from_imported_handle_types = export_from_imported_handle_types;
         self
     }
     pub fn compatible_handle_types(
         mut self,
         compatible_handle_types: ExternalFenceHandleTypeFlags,
-    ) -> ExternalFencePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.compatible_handle_types = compatible_handle_types;
         self
     }
     pub fn external_fence_features(
         mut self,
         external_fence_features: ExternalFenceFeatureFlags,
-    ) -> ExternalFencePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.external_fence_features = external_fence_features;
         self
     }
@@ -18072,10 +16563,7 @@ impl<'a> ExternalFencePropertiesBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsExternalFenceProperties>(
-        mut self,
-        next: &'a mut T,
-    ) -> ExternalFencePropertiesBuilder<'a> {
+    pub fn push_next<T: ExtendsExternalFenceProperties>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -18135,10 +16623,7 @@ impl<'a> ::std::ops::DerefMut for ExportFenceCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ExportFenceCreateInfoBuilder<'a> {
-    pub fn handle_types(
-        mut self,
-        handle_types: ExternalFenceHandleTypeFlags,
-    ) -> ExportFenceCreateInfoBuilder<'a> {
+    pub fn handle_types(mut self, handle_types: ExternalFenceHandleTypeFlags) -> Self {
         self.inner.handle_types = handle_types;
         self
     }
@@ -18200,26 +16685,23 @@ impl<'a> ::std::ops::DerefMut for ImportFenceWin32HandleInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ImportFenceWin32HandleInfoKHRBuilder<'a> {
-    pub fn fence(mut self, fence: Fence) -> ImportFenceWin32HandleInfoKHRBuilder<'a> {
+    pub fn fence(mut self, fence: Fence) -> Self {
         self.inner.fence = fence;
         self
     }
-    pub fn flags(mut self, flags: FenceImportFlags) -> ImportFenceWin32HandleInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: FenceImportFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalFenceHandleTypeFlags,
-    ) -> ImportFenceWin32HandleInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalFenceHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
-    pub fn handle(mut self, handle: HANDLE) -> ImportFenceWin32HandleInfoKHRBuilder<'a> {
+    pub fn handle(mut self, handle: HANDLE) -> Self {
         self.inner.handle = handle;
         self
     }
-    pub fn name(mut self, name: LPCWSTR) -> ImportFenceWin32HandleInfoKHRBuilder<'a> {
+    pub fn name(mut self, name: LPCWSTR) -> Self {
         self.inner.name = name;
         self
     }
@@ -18228,10 +16710,7 @@ impl<'a> ImportFenceWin32HandleInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImportFenceWin32HandleInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImportFenceWin32HandleInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsImportFenceWin32HandleInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -18295,18 +16774,15 @@ impl<'a> ::std::ops::DerefMut for ExportFenceWin32HandleInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ExportFenceWin32HandleInfoKHRBuilder<'a> {
-    pub fn attributes(
-        mut self,
-        attributes: &'a SECURITY_ATTRIBUTES,
-    ) -> ExportFenceWin32HandleInfoKHRBuilder<'a> {
+    pub fn attributes(mut self, attributes: &'a SECURITY_ATTRIBUTES) -> Self {
         self.inner.p_attributes = attributes;
         self
     }
-    pub fn dw_access(mut self, dw_access: DWORD) -> ExportFenceWin32HandleInfoKHRBuilder<'a> {
+    pub fn dw_access(mut self, dw_access: DWORD) -> Self {
         self.inner.dw_access = dw_access;
         self
     }
-    pub fn name(mut self, name: LPCWSTR) -> ExportFenceWin32HandleInfoKHRBuilder<'a> {
+    pub fn name(mut self, name: LPCWSTR) -> Self {
         self.inner.name = name;
         self
     }
@@ -18362,14 +16838,11 @@ impl<'a> ::std::ops::DerefMut for FenceGetWin32HandleInfoKHRBuilder<'a> {
     }
 }
 impl<'a> FenceGetWin32HandleInfoKHRBuilder<'a> {
-    pub fn fence(mut self, fence: Fence) -> FenceGetWin32HandleInfoKHRBuilder<'a> {
+    pub fn fence(mut self, fence: Fence) -> Self {
         self.inner.fence = fence;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalFenceHandleTypeFlags,
-    ) -> FenceGetWin32HandleInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalFenceHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -18378,10 +16851,7 @@ impl<'a> FenceGetWin32HandleInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsFenceGetWin32HandleInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> FenceGetWin32HandleInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsFenceGetWin32HandleInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -18446,22 +16916,19 @@ impl<'a> ::std::ops::DerefMut for ImportFenceFdInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ImportFenceFdInfoKHRBuilder<'a> {
-    pub fn fence(mut self, fence: Fence) -> ImportFenceFdInfoKHRBuilder<'a> {
+    pub fn fence(mut self, fence: Fence) -> Self {
         self.inner.fence = fence;
         self
     }
-    pub fn flags(mut self, flags: FenceImportFlags) -> ImportFenceFdInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: FenceImportFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalFenceHandleTypeFlags,
-    ) -> ImportFenceFdInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalFenceHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
-    pub fn fd(mut self, fd: c_int) -> ImportFenceFdInfoKHRBuilder<'a> {
+    pub fn fd(mut self, fd: c_int) -> Self {
         self.inner.fd = fd;
         self
     }
@@ -18470,10 +16937,7 @@ impl<'a> ImportFenceFdInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImportFenceFdInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImportFenceFdInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsImportFenceFdInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -18534,14 +16998,11 @@ impl<'a> ::std::ops::DerefMut for FenceGetFdInfoKHRBuilder<'a> {
     }
 }
 impl<'a> FenceGetFdInfoKHRBuilder<'a> {
-    pub fn fence(mut self, fence: Fence) -> FenceGetFdInfoKHRBuilder<'a> {
+    pub fn fence(mut self, fence: Fence) -> Self {
         self.inner.fence = fence;
         self
     }
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalFenceHandleTypeFlags,
-    ) -> FenceGetFdInfoKHRBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalFenceHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
@@ -18550,10 +17011,7 @@ impl<'a> FenceGetFdInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsFenceGetFdInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> FenceGetFdInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsFenceGetFdInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -18617,21 +17075,15 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMultiviewFeaturesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceMultiviewFeaturesBuilder<'a> {
-    pub fn multiview(mut self, multiview: bool) -> PhysicalDeviceMultiviewFeaturesBuilder<'a> {
+    pub fn multiview(mut self, multiview: bool) -> Self {
         self.inner.multiview = multiview.into();
         self
     }
-    pub fn multiview_geometry_shader(
-        mut self,
-        multiview_geometry_shader: bool,
-    ) -> PhysicalDeviceMultiviewFeaturesBuilder<'a> {
+    pub fn multiview_geometry_shader(mut self, multiview_geometry_shader: bool) -> Self {
         self.inner.multiview_geometry_shader = multiview_geometry_shader.into();
         self
     }
-    pub fn multiview_tessellation_shader(
-        mut self,
-        multiview_tessellation_shader: bool,
-    ) -> PhysicalDeviceMultiviewFeaturesBuilder<'a> {
+    pub fn multiview_tessellation_shader(mut self, multiview_tessellation_shader: bool) -> Self {
         self.inner.multiview_tessellation_shader = multiview_tessellation_shader.into();
         self
     }
@@ -18688,17 +17140,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMultiviewPropertiesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceMultiviewPropertiesBuilder<'a> {
-    pub fn max_multiview_view_count(
-        mut self,
-        max_multiview_view_count: u32,
-    ) -> PhysicalDeviceMultiviewPropertiesBuilder<'a> {
+    pub fn max_multiview_view_count(mut self, max_multiview_view_count: u32) -> Self {
         self.inner.max_multiview_view_count = max_multiview_view_count;
         self
     }
-    pub fn max_multiview_instance_index(
-        mut self,
-        max_multiview_instance_index: u32,
-    ) -> PhysicalDeviceMultiviewPropertiesBuilder<'a> {
+    pub fn max_multiview_instance_index(mut self, max_multiview_instance_index: u32) -> Self {
         self.inner.max_multiview_instance_index = max_multiview_instance_index;
         self
     }
@@ -18763,23 +17209,17 @@ impl<'a> ::std::ops::DerefMut for RenderPassMultiviewCreateInfoBuilder<'a> {
     }
 }
 impl<'a> RenderPassMultiviewCreateInfoBuilder<'a> {
-    pub fn view_masks(mut self, view_masks: &'a [u32]) -> RenderPassMultiviewCreateInfoBuilder<'a> {
+    pub fn view_masks(mut self, view_masks: &'a [u32]) -> Self {
         self.inner.subpass_count = view_masks.len() as _;
         self.inner.p_view_masks = view_masks.as_ptr();
         self
     }
-    pub fn view_offsets(
-        mut self,
-        view_offsets: &'a [i32],
-    ) -> RenderPassMultiviewCreateInfoBuilder<'a> {
+    pub fn view_offsets(mut self, view_offsets: &'a [i32]) -> Self {
         self.inner.dependency_count = view_offsets.len() as _;
         self.inner.p_view_offsets = view_offsets.as_ptr();
         self
     }
-    pub fn correlation_masks(
-        mut self,
-        correlation_masks: &'a [u32],
-    ) -> RenderPassMultiviewCreateInfoBuilder<'a> {
+    pub fn correlation_masks(mut self, correlation_masks: &'a [u32]) -> Self {
         self.inner.correlation_mask_count = correlation_masks.len() as _;
         self.inner.p_correlation_masks = correlation_masks.as_ptr();
         self
@@ -18854,74 +17294,53 @@ impl<'a> ::std::ops::DerefMut for SurfaceCapabilities2EXTBuilder<'a> {
     }
 }
 impl<'a> SurfaceCapabilities2EXTBuilder<'a> {
-    pub fn min_image_count(mut self, min_image_count: u32) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn min_image_count(mut self, min_image_count: u32) -> Self {
         self.inner.min_image_count = min_image_count;
         self
     }
-    pub fn max_image_count(mut self, max_image_count: u32) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn max_image_count(mut self, max_image_count: u32) -> Self {
         self.inner.max_image_count = max_image_count;
         self
     }
-    pub fn current_extent(
-        mut self,
-        current_extent: Extent2D,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn current_extent(mut self, current_extent: Extent2D) -> Self {
         self.inner.current_extent = current_extent;
         self
     }
-    pub fn min_image_extent(
-        mut self,
-        min_image_extent: Extent2D,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn min_image_extent(mut self, min_image_extent: Extent2D) -> Self {
         self.inner.min_image_extent = min_image_extent;
         self
     }
-    pub fn max_image_extent(
-        mut self,
-        max_image_extent: Extent2D,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn max_image_extent(mut self, max_image_extent: Extent2D) -> Self {
         self.inner.max_image_extent = max_image_extent;
         self
     }
-    pub fn max_image_array_layers(
-        mut self,
-        max_image_array_layers: u32,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn max_image_array_layers(mut self, max_image_array_layers: u32) -> Self {
         self.inner.max_image_array_layers = max_image_array_layers;
         self
     }
-    pub fn supported_transforms(
-        mut self,
-        supported_transforms: SurfaceTransformFlagsKHR,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn supported_transforms(mut self, supported_transforms: SurfaceTransformFlagsKHR) -> Self {
         self.inner.supported_transforms = supported_transforms;
         self
     }
-    pub fn current_transform(
-        mut self,
-        current_transform: SurfaceTransformFlagsKHR,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn current_transform(mut self, current_transform: SurfaceTransformFlagsKHR) -> Self {
         self.inner.current_transform = current_transform;
         self
     }
     pub fn supported_composite_alpha(
         mut self,
         supported_composite_alpha: CompositeAlphaFlagsKHR,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    ) -> Self {
         self.inner.supported_composite_alpha = supported_composite_alpha;
         self
     }
-    pub fn supported_usage_flags(
-        mut self,
-        supported_usage_flags: ImageUsageFlags,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn supported_usage_flags(mut self, supported_usage_flags: ImageUsageFlags) -> Self {
         self.inner.supported_usage_flags = supported_usage_flags;
         self
     }
     pub fn supported_surface_counters(
         mut self,
         supported_surface_counters: SurfaceCounterFlagsEXT,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    ) -> Self {
         self.inner.supported_surface_counters = supported_surface_counters;
         self
     }
@@ -18930,10 +17349,7 @@ impl<'a> SurfaceCapabilities2EXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSurfaceCapabilities2EXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> SurfaceCapabilities2EXTBuilder<'a> {
+    pub fn push_next<T: ExtendsSurfaceCapabilities2EXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -18992,10 +17408,7 @@ impl<'a> ::std::ops::DerefMut for DisplayPowerInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DisplayPowerInfoEXTBuilder<'a> {
-    pub fn power_state(
-        mut self,
-        power_state: DisplayPowerStateEXT,
-    ) -> DisplayPowerInfoEXTBuilder<'a> {
+    pub fn power_state(mut self, power_state: DisplayPowerStateEXT) -> Self {
         self.inner.power_state = power_state;
         self
     }
@@ -19004,10 +17417,7 @@ impl<'a> DisplayPowerInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDisplayPowerInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DisplayPowerInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDisplayPowerInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -19066,10 +17476,7 @@ impl<'a> ::std::ops::DerefMut for DeviceEventInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DeviceEventInfoEXTBuilder<'a> {
-    pub fn device_event(
-        mut self,
-        device_event: DeviceEventTypeEXT,
-    ) -> DeviceEventInfoEXTBuilder<'a> {
+    pub fn device_event(mut self, device_event: DeviceEventTypeEXT) -> Self {
         self.inner.device_event = device_event;
         self
     }
@@ -19078,10 +17485,7 @@ impl<'a> DeviceEventInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDeviceEventInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DeviceEventInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDeviceEventInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -19140,10 +17544,7 @@ impl<'a> ::std::ops::DerefMut for DisplayEventInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DisplayEventInfoEXTBuilder<'a> {
-    pub fn display_event(
-        mut self,
-        display_event: DisplayEventTypeEXT,
-    ) -> DisplayEventInfoEXTBuilder<'a> {
+    pub fn display_event(mut self, display_event: DisplayEventTypeEXT) -> Self {
         self.inner.display_event = display_event;
         self
     }
@@ -19152,10 +17553,7 @@ impl<'a> DisplayEventInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDisplayEventInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DisplayEventInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDisplayEventInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -19215,10 +17613,7 @@ impl<'a> ::std::ops::DerefMut for SwapchainCounterCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> SwapchainCounterCreateInfoEXTBuilder<'a> {
-    pub fn surface_counters(
-        mut self,
-        surface_counters: SurfaceCounterFlagsEXT,
-    ) -> SwapchainCounterCreateInfoEXTBuilder<'a> {
+    pub fn surface_counters(mut self, surface_counters: SurfaceCounterFlagsEXT) -> Self {
         self.inner.surface_counters = surface_counters;
         self
     }
@@ -19276,24 +17671,18 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceGroupPropertiesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceGroupPropertiesBuilder<'a> {
-    pub fn physical_device_count(
-        mut self,
-        physical_device_count: u32,
-    ) -> PhysicalDeviceGroupPropertiesBuilder<'a> {
+    pub fn physical_device_count(mut self, physical_device_count: u32) -> Self {
         self.inner.physical_device_count = physical_device_count;
         self
     }
     pub fn physical_devices(
         mut self,
         physical_devices: [PhysicalDevice; MAX_DEVICE_GROUP_SIZE],
-    ) -> PhysicalDeviceGroupPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.physical_devices = physical_devices;
         self
     }
-    pub fn subset_allocation(
-        mut self,
-        subset_allocation: bool,
-    ) -> PhysicalDeviceGroupPropertiesBuilder<'a> {
+    pub fn subset_allocation(mut self, subset_allocation: bool) -> Self {
         self.inner.subset_allocation = subset_allocation.into();
         self
     }
@@ -19302,10 +17691,7 @@ impl<'a> PhysicalDeviceGroupPropertiesBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPhysicalDeviceGroupProperties>(
-        mut self,
-        next: &'a mut T,
-    ) -> PhysicalDeviceGroupPropertiesBuilder<'a> {
+    pub fn push_next<T: ExtendsPhysicalDeviceGroupProperties>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -19367,11 +17753,11 @@ impl<'a> ::std::ops::DerefMut for MemoryAllocateFlagsInfoBuilder<'a> {
     }
 }
 impl<'a> MemoryAllocateFlagsInfoBuilder<'a> {
-    pub fn flags(mut self, flags: MemoryAllocateFlags) -> MemoryAllocateFlagsInfoBuilder<'a> {
+    pub fn flags(mut self, flags: MemoryAllocateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn device_mask(mut self, device_mask: u32) -> MemoryAllocateFlagsInfoBuilder<'a> {
+    pub fn device_mask(mut self, device_mask: u32) -> Self {
         self.inner.device_mask = device_mask;
         self
     }
@@ -19429,15 +17815,15 @@ impl<'a> ::std::ops::DerefMut for BindBufferMemoryInfoBuilder<'a> {
     }
 }
 impl<'a> BindBufferMemoryInfoBuilder<'a> {
-    pub fn buffer(mut self, buffer: Buffer) -> BindBufferMemoryInfoBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
-    pub fn memory(mut self, memory: DeviceMemory) -> BindBufferMemoryInfoBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
-    pub fn memory_offset(mut self, memory_offset: DeviceSize) -> BindBufferMemoryInfoBuilder<'a> {
+    pub fn memory_offset(mut self, memory_offset: DeviceSize) -> Self {
         self.inner.memory_offset = memory_offset;
         self
     }
@@ -19446,10 +17832,7 @@ impl<'a> BindBufferMemoryInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBindBufferMemoryInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> BindBufferMemoryInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsBindBufferMemoryInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -19511,10 +17894,7 @@ impl<'a> ::std::ops::DerefMut for BindBufferMemoryDeviceGroupInfoBuilder<'a> {
     }
 }
 impl<'a> BindBufferMemoryDeviceGroupInfoBuilder<'a> {
-    pub fn device_indices(
-        mut self,
-        device_indices: &'a [u32],
-    ) -> BindBufferMemoryDeviceGroupInfoBuilder<'a> {
+    pub fn device_indices(mut self, device_indices: &'a [u32]) -> Self {
         self.inner.device_index_count = device_indices.len() as _;
         self.inner.p_device_indices = device_indices.as_ptr();
         self
@@ -19573,15 +17953,15 @@ impl<'a> ::std::ops::DerefMut for BindImageMemoryInfoBuilder<'a> {
     }
 }
 impl<'a> BindImageMemoryInfoBuilder<'a> {
-    pub fn image(mut self, image: Image) -> BindImageMemoryInfoBuilder<'a> {
+    pub fn image(mut self, image: Image) -> Self {
         self.inner.image = image;
         self
     }
-    pub fn memory(mut self, memory: DeviceMemory) -> BindImageMemoryInfoBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
-    pub fn memory_offset(mut self, memory_offset: DeviceSize) -> BindImageMemoryInfoBuilder<'a> {
+    pub fn memory_offset(mut self, memory_offset: DeviceSize) -> Self {
         self.inner.memory_offset = memory_offset;
         self
     }
@@ -19590,10 +17970,7 @@ impl<'a> BindImageMemoryInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBindImageMemoryInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> BindImageMemoryInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsBindImageMemoryInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -19659,10 +18036,7 @@ impl<'a> ::std::ops::DerefMut for BindImageMemoryDeviceGroupInfoBuilder<'a> {
     }
 }
 impl<'a> BindImageMemoryDeviceGroupInfoBuilder<'a> {
-    pub fn device_indices(
-        mut self,
-        device_indices: &'a [u32],
-    ) -> BindImageMemoryDeviceGroupInfoBuilder<'a> {
+    pub fn device_indices(mut self, device_indices: &'a [u32]) -> Self {
         self.inner.device_index_count = device_indices.len() as _;
         self.inner.p_device_indices = device_indices.as_ptr();
         self
@@ -19670,7 +18044,7 @@ impl<'a> BindImageMemoryDeviceGroupInfoBuilder<'a> {
     pub fn split_instance_bind_regions(
         mut self,
         split_instance_bind_regions: &'a [Rect2D],
-    ) -> BindImageMemoryDeviceGroupInfoBuilder<'a> {
+    ) -> Self {
         self.inner.split_instance_bind_region_count = split_instance_bind_regions.len() as _;
         self.inner.p_split_instance_bind_regions = split_instance_bind_regions.as_ptr();
         self
@@ -19730,14 +18104,11 @@ impl<'a> ::std::ops::DerefMut for DeviceGroupRenderPassBeginInfoBuilder<'a> {
     }
 }
 impl<'a> DeviceGroupRenderPassBeginInfoBuilder<'a> {
-    pub fn device_mask(mut self, device_mask: u32) -> DeviceGroupRenderPassBeginInfoBuilder<'a> {
+    pub fn device_mask(mut self, device_mask: u32) -> Self {
         self.inner.device_mask = device_mask;
         self
     }
-    pub fn device_render_areas(
-        mut self,
-        device_render_areas: &'a [Rect2D],
-    ) -> DeviceGroupRenderPassBeginInfoBuilder<'a> {
+    pub fn device_render_areas(mut self, device_render_areas: &'a [Rect2D]) -> Self {
         self.inner.device_render_area_count = device_render_areas.len() as _;
         self.inner.p_device_render_areas = device_render_areas.as_ptr();
         self
@@ -19793,7 +18164,7 @@ impl<'a> ::std::ops::DerefMut for DeviceGroupCommandBufferBeginInfoBuilder<'a> {
     }
 }
 impl<'a> DeviceGroupCommandBufferBeginInfoBuilder<'a> {
-    pub fn device_mask(mut self, device_mask: u32) -> DeviceGroupCommandBufferBeginInfoBuilder<'a> {
+    pub fn device_mask(mut self, device_mask: u32) -> Self {
         self.inner.device_mask = device_mask;
         self
     }
@@ -19861,15 +18232,12 @@ impl<'a> DeviceGroupSubmitInfoBuilder<'a> {
     pub fn wait_semaphore_device_indices(
         mut self,
         wait_semaphore_device_indices: &'a [u32],
-    ) -> DeviceGroupSubmitInfoBuilder<'a> {
+    ) -> Self {
         self.inner.wait_semaphore_count = wait_semaphore_device_indices.len() as _;
         self.inner.p_wait_semaphore_device_indices = wait_semaphore_device_indices.as_ptr();
         self
     }
-    pub fn command_buffer_device_masks(
-        mut self,
-        command_buffer_device_masks: &'a [u32],
-    ) -> DeviceGroupSubmitInfoBuilder<'a> {
+    pub fn command_buffer_device_masks(mut self, command_buffer_device_masks: &'a [u32]) -> Self {
         self.inner.command_buffer_count = command_buffer_device_masks.len() as _;
         self.inner.p_command_buffer_device_masks = command_buffer_device_masks.as_ptr();
         self
@@ -19877,7 +18245,7 @@ impl<'a> DeviceGroupSubmitInfoBuilder<'a> {
     pub fn signal_semaphore_device_indices(
         mut self,
         signal_semaphore_device_indices: &'a [u32],
-    ) -> DeviceGroupSubmitInfoBuilder<'a> {
+    ) -> Self {
         self.inner.signal_semaphore_count = signal_semaphore_device_indices.len() as _;
         self.inner.p_signal_semaphore_device_indices = signal_semaphore_device_indices.as_ptr();
         self
@@ -19935,17 +18303,11 @@ impl<'a> ::std::ops::DerefMut for DeviceGroupBindSparseInfoBuilder<'a> {
     }
 }
 impl<'a> DeviceGroupBindSparseInfoBuilder<'a> {
-    pub fn resource_device_index(
-        mut self,
-        resource_device_index: u32,
-    ) -> DeviceGroupBindSparseInfoBuilder<'a> {
+    pub fn resource_device_index(mut self, resource_device_index: u32) -> Self {
         self.inner.resource_device_index = resource_device_index;
         self
     }
-    pub fn memory_device_index(
-        mut self,
-        memory_device_index: u32,
-    ) -> DeviceGroupBindSparseInfoBuilder<'a> {
+    pub fn memory_device_index(mut self, memory_device_index: u32) -> Self {
         self.inner.memory_device_index = memory_device_index;
         self
     }
@@ -20001,17 +18363,11 @@ impl<'a> ::std::ops::DerefMut for DeviceGroupPresentCapabilitiesKHRBuilder<'a> {
     }
 }
 impl<'a> DeviceGroupPresentCapabilitiesKHRBuilder<'a> {
-    pub fn present_mask(
-        mut self,
-        present_mask: [u32; MAX_DEVICE_GROUP_SIZE],
-    ) -> DeviceGroupPresentCapabilitiesKHRBuilder<'a> {
+    pub fn present_mask(mut self, present_mask: [u32; MAX_DEVICE_GROUP_SIZE]) -> Self {
         self.inner.present_mask = present_mask;
         self
     }
-    pub fn modes(
-        mut self,
-        modes: DeviceGroupPresentModeFlagsKHR,
-    ) -> DeviceGroupPresentCapabilitiesKHRBuilder<'a> {
+    pub fn modes(mut self, modes: DeviceGroupPresentModeFlagsKHR) -> Self {
         self.inner.modes = modes;
         self
     }
@@ -20023,7 +18379,7 @@ impl<'a> DeviceGroupPresentCapabilitiesKHRBuilder<'a> {
     pub fn push_next<T: ExtendsDeviceGroupPresentCapabilitiesKHR>(
         mut self,
         next: &'a mut T,
-    ) -> DeviceGroupPresentCapabilitiesKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -20083,7 +18439,7 @@ impl<'a> ::std::ops::DerefMut for ImageSwapchainCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> ImageSwapchainCreateInfoKHRBuilder<'a> {
-    pub fn swapchain(mut self, swapchain: SwapchainKHR) -> ImageSwapchainCreateInfoKHRBuilder<'a> {
+    pub fn swapchain(mut self, swapchain: SwapchainKHR) -> Self {
         self.inner.swapchain = swapchain;
         self
     }
@@ -20140,14 +18496,11 @@ impl<'a> ::std::ops::DerefMut for BindImageMemorySwapchainInfoKHRBuilder<'a> {
     }
 }
 impl<'a> BindImageMemorySwapchainInfoKHRBuilder<'a> {
-    pub fn swapchain(
-        mut self,
-        swapchain: SwapchainKHR,
-    ) -> BindImageMemorySwapchainInfoKHRBuilder<'a> {
+    pub fn swapchain(mut self, swapchain: SwapchainKHR) -> Self {
         self.inner.swapchain = swapchain;
         self
     }
-    pub fn image_index(mut self, image_index: u32) -> BindImageMemorySwapchainInfoKHRBuilder<'a> {
+    pub fn image_index(mut self, image_index: u32) -> Self {
         self.inner.image_index = image_index;
         self
     }
@@ -20209,23 +18562,23 @@ impl<'a> ::std::ops::DerefMut for AcquireNextImageInfoKHRBuilder<'a> {
     }
 }
 impl<'a> AcquireNextImageInfoKHRBuilder<'a> {
-    pub fn swapchain(mut self, swapchain: SwapchainKHR) -> AcquireNextImageInfoKHRBuilder<'a> {
+    pub fn swapchain(mut self, swapchain: SwapchainKHR) -> Self {
         self.inner.swapchain = swapchain;
         self
     }
-    pub fn timeout(mut self, timeout: u64) -> AcquireNextImageInfoKHRBuilder<'a> {
+    pub fn timeout(mut self, timeout: u64) -> Self {
         self.inner.timeout = timeout;
         self
     }
-    pub fn semaphore(mut self, semaphore: Semaphore) -> AcquireNextImageInfoKHRBuilder<'a> {
+    pub fn semaphore(mut self, semaphore: Semaphore) -> Self {
         self.inner.semaphore = semaphore;
         self
     }
-    pub fn fence(mut self, fence: Fence) -> AcquireNextImageInfoKHRBuilder<'a> {
+    pub fn fence(mut self, fence: Fence) -> Self {
         self.inner.fence = fence;
         self
     }
-    pub fn device_mask(mut self, device_mask: u32) -> AcquireNextImageInfoKHRBuilder<'a> {
+    pub fn device_mask(mut self, device_mask: u32) -> Self {
         self.inner.device_mask = device_mask;
         self
     }
@@ -20234,10 +18587,7 @@ impl<'a> AcquireNextImageInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsAcquireNextImageInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> AcquireNextImageInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsAcquireNextImageInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -20301,15 +18651,12 @@ impl<'a> ::std::ops::DerefMut for DeviceGroupPresentInfoKHRBuilder<'a> {
     }
 }
 impl<'a> DeviceGroupPresentInfoKHRBuilder<'a> {
-    pub fn device_masks(mut self, device_masks: &'a [u32]) -> DeviceGroupPresentInfoKHRBuilder<'a> {
+    pub fn device_masks(mut self, device_masks: &'a [u32]) -> Self {
         self.inner.swapchain_count = device_masks.len() as _;
         self.inner.p_device_masks = device_masks.as_ptr();
         self
     }
-    pub fn mode(
-        mut self,
-        mode: DeviceGroupPresentModeFlagsKHR,
-    ) -> DeviceGroupPresentInfoKHRBuilder<'a> {
+    pub fn mode(mut self, mode: DeviceGroupPresentModeFlagsKHR) -> Self {
         self.inner.mode = mode;
         self
     }
@@ -20366,10 +18713,7 @@ impl<'a> ::std::ops::DerefMut for DeviceGroupDeviceCreateInfoBuilder<'a> {
     }
 }
 impl<'a> DeviceGroupDeviceCreateInfoBuilder<'a> {
-    pub fn physical_devices(
-        mut self,
-        physical_devices: &'a [PhysicalDevice],
-    ) -> DeviceGroupDeviceCreateInfoBuilder<'a> {
+    pub fn physical_devices(mut self, physical_devices: &'a [PhysicalDevice]) -> Self {
         self.inner.physical_device_count = physical_devices.len() as _;
         self.inner.p_physical_devices = physical_devices.as_ptr();
         self
@@ -20425,10 +18769,7 @@ impl<'a> ::std::ops::DerefMut for DeviceGroupSwapchainCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> DeviceGroupSwapchainCreateInfoKHRBuilder<'a> {
-    pub fn modes(
-        mut self,
-        modes: DeviceGroupPresentModeFlagsKHR,
-    ) -> DeviceGroupSwapchainCreateInfoKHRBuilder<'a> {
+    pub fn modes(mut self, modes: DeviceGroupPresentModeFlagsKHR) -> Self {
         self.inner.modes = modes;
         self
     }
@@ -20475,36 +18816,27 @@ impl<'a> ::std::ops::DerefMut for DescriptorUpdateTemplateEntryBuilder<'a> {
     }
 }
 impl<'a> DescriptorUpdateTemplateEntryBuilder<'a> {
-    pub fn dst_binding(mut self, dst_binding: u32) -> DescriptorUpdateTemplateEntryBuilder<'a> {
+    pub fn dst_binding(mut self, dst_binding: u32) -> Self {
         self.inner.dst_binding = dst_binding;
         self
     }
-    pub fn dst_array_element(
-        mut self,
-        dst_array_element: u32,
-    ) -> DescriptorUpdateTemplateEntryBuilder<'a> {
+    pub fn dst_array_element(mut self, dst_array_element: u32) -> Self {
         self.inner.dst_array_element = dst_array_element;
         self
     }
-    pub fn descriptor_count(
-        mut self,
-        descriptor_count: u32,
-    ) -> DescriptorUpdateTemplateEntryBuilder<'a> {
+    pub fn descriptor_count(mut self, descriptor_count: u32) -> Self {
         self.inner.descriptor_count = descriptor_count;
         self
     }
-    pub fn descriptor_type(
-        mut self,
-        descriptor_type: DescriptorType,
-    ) -> DescriptorUpdateTemplateEntryBuilder<'a> {
+    pub fn descriptor_type(mut self, descriptor_type: DescriptorType) -> Self {
         self.inner.descriptor_type = descriptor_type;
         self
     }
-    pub fn offset(mut self, offset: usize) -> DescriptorUpdateTemplateEntryBuilder<'a> {
+    pub fn offset(mut self, offset: usize) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn stride(mut self, stride: usize) -> DescriptorUpdateTemplateEntryBuilder<'a> {
+    pub fn stride(mut self, stride: usize) -> Self {
         self.inner.stride = stride;
         self
     }
@@ -20572,50 +18904,35 @@ impl<'a> ::std::ops::DerefMut for DescriptorUpdateTemplateCreateInfoBuilder<'a> 
     }
 }
 impl<'a> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DescriptorUpdateTemplateCreateFlags,
-    ) -> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: DescriptorUpdateTemplateCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
     pub fn descriptor_update_entries(
         mut self,
         descriptor_update_entries: &'a [DescriptorUpdateTemplateEntry],
-    ) -> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.descriptor_update_entry_count = descriptor_update_entries.len() as _;
         self.inner.p_descriptor_update_entries = descriptor_update_entries.as_ptr();
         self
     }
-    pub fn template_type(
-        mut self,
-        template_type: DescriptorUpdateTemplateType,
-    ) -> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
+    pub fn template_type(mut self, template_type: DescriptorUpdateTemplateType) -> Self {
         self.inner.template_type = template_type;
         self
     }
-    pub fn descriptor_set_layout(
-        mut self,
-        descriptor_set_layout: DescriptorSetLayout,
-    ) -> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
+    pub fn descriptor_set_layout(mut self, descriptor_set_layout: DescriptorSetLayout) -> Self {
         self.inner.descriptor_set_layout = descriptor_set_layout;
         self
     }
-    pub fn pipeline_bind_point(
-        mut self,
-        pipeline_bind_point: PipelineBindPoint,
-    ) -> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
+    pub fn pipeline_bind_point(mut self, pipeline_bind_point: PipelineBindPoint) -> Self {
         self.inner.pipeline_bind_point = pipeline_bind_point;
         self
     }
-    pub fn pipeline_layout(
-        mut self,
-        pipeline_layout: PipelineLayout,
-    ) -> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
+    pub fn pipeline_layout(mut self, pipeline_layout: PipelineLayout) -> Self {
         self.inner.pipeline_layout = pipeline_layout;
         self
     }
-    pub fn set(mut self, set: u32) -> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
+    pub fn set(mut self, set: u32) -> Self {
         self.inner.set = set;
         self
     }
@@ -20627,7 +18944,7 @@ impl<'a> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
     pub fn push_next<T: ExtendsDescriptorUpdateTemplateCreateInfo>(
         mut self,
         next: &'a mut T,
-    ) -> DescriptorUpdateTemplateCreateInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -20675,11 +18992,11 @@ impl<'a> ::std::ops::DerefMut for XYColorEXTBuilder<'a> {
     }
 }
 impl<'a> XYColorEXTBuilder<'a> {
-    pub fn x(mut self, x: f32) -> XYColorEXTBuilder<'a> {
+    pub fn x(mut self, x: f32) -> Self {
         self.inner.x = x;
         self
     }
-    pub fn y(mut self, y: f32) -> XYColorEXTBuilder<'a> {
+    pub fn y(mut self, y: f32) -> Self {
         self.inner.y = y;
         self
     }
@@ -20747,50 +19064,35 @@ impl<'a> ::std::ops::DerefMut for HdrMetadataEXTBuilder<'a> {
     }
 }
 impl<'a> HdrMetadataEXTBuilder<'a> {
-    pub fn display_primary_red(
-        mut self,
-        display_primary_red: XYColorEXT,
-    ) -> HdrMetadataEXTBuilder<'a> {
+    pub fn display_primary_red(mut self, display_primary_red: XYColorEXT) -> Self {
         self.inner.display_primary_red = display_primary_red;
         self
     }
-    pub fn display_primary_green(
-        mut self,
-        display_primary_green: XYColorEXT,
-    ) -> HdrMetadataEXTBuilder<'a> {
+    pub fn display_primary_green(mut self, display_primary_green: XYColorEXT) -> Self {
         self.inner.display_primary_green = display_primary_green;
         self
     }
-    pub fn display_primary_blue(
-        mut self,
-        display_primary_blue: XYColorEXT,
-    ) -> HdrMetadataEXTBuilder<'a> {
+    pub fn display_primary_blue(mut self, display_primary_blue: XYColorEXT) -> Self {
         self.inner.display_primary_blue = display_primary_blue;
         self
     }
-    pub fn white_point(mut self, white_point: XYColorEXT) -> HdrMetadataEXTBuilder<'a> {
+    pub fn white_point(mut self, white_point: XYColorEXT) -> Self {
         self.inner.white_point = white_point;
         self
     }
-    pub fn max_luminance(mut self, max_luminance: f32) -> HdrMetadataEXTBuilder<'a> {
+    pub fn max_luminance(mut self, max_luminance: f32) -> Self {
         self.inner.max_luminance = max_luminance;
         self
     }
-    pub fn min_luminance(mut self, min_luminance: f32) -> HdrMetadataEXTBuilder<'a> {
+    pub fn min_luminance(mut self, min_luminance: f32) -> Self {
         self.inner.min_luminance = min_luminance;
         self
     }
-    pub fn max_content_light_level(
-        mut self,
-        max_content_light_level: f32,
-    ) -> HdrMetadataEXTBuilder<'a> {
+    pub fn max_content_light_level(mut self, max_content_light_level: f32) -> Self {
         self.inner.max_content_light_level = max_content_light_level;
         self
     }
-    pub fn max_frame_average_light_level(
-        mut self,
-        max_frame_average_light_level: f32,
-    ) -> HdrMetadataEXTBuilder<'a> {
+    pub fn max_frame_average_light_level(mut self, max_frame_average_light_level: f32) -> Self {
         self.inner.max_frame_average_light_level = max_frame_average_light_level;
         self
     }
@@ -20799,10 +19101,7 @@ impl<'a> HdrMetadataEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsHdrMetadataEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> HdrMetadataEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsHdrMetadataEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -20862,10 +19161,7 @@ impl<'a> ::std::ops::DerefMut for DisplayNativeHdrSurfaceCapabilitiesAMDBuilder<
     }
 }
 impl<'a> DisplayNativeHdrSurfaceCapabilitiesAMDBuilder<'a> {
-    pub fn local_dimming_support(
-        mut self,
-        local_dimming_support: bool,
-    ) -> DisplayNativeHdrSurfaceCapabilitiesAMDBuilder<'a> {
+    pub fn local_dimming_support(mut self, local_dimming_support: bool) -> Self {
         self.inner.local_dimming_support = local_dimming_support.into();
         self
     }
@@ -20920,10 +19216,7 @@ impl<'a> ::std::ops::DerefMut for SwapchainDisplayNativeHdrCreateInfoAMDBuilder<
     }
 }
 impl<'a> SwapchainDisplayNativeHdrCreateInfoAMDBuilder<'a> {
-    pub fn local_dimming_enable(
-        mut self,
-        local_dimming_enable: bool,
-    ) -> SwapchainDisplayNativeHdrCreateInfoAMDBuilder<'a> {
+    pub fn local_dimming_enable(mut self, local_dimming_enable: bool) -> Self {
         self.inner.local_dimming_enable = local_dimming_enable.into();
         self
     }
@@ -20965,10 +19258,7 @@ impl<'a> ::std::ops::DerefMut for RefreshCycleDurationGOOGLEBuilder<'a> {
     }
 }
 impl<'a> RefreshCycleDurationGOOGLEBuilder<'a> {
-    pub fn refresh_duration(
-        mut self,
-        refresh_duration: u64,
-    ) -> RefreshCycleDurationGOOGLEBuilder<'a> {
+    pub fn refresh_duration(mut self, refresh_duration: u64) -> Self {
         self.inner.refresh_duration = refresh_duration;
         self
     }
@@ -21014,35 +19304,23 @@ impl<'a> ::std::ops::DerefMut for PastPresentationTimingGOOGLEBuilder<'a> {
     }
 }
 impl<'a> PastPresentationTimingGOOGLEBuilder<'a> {
-    pub fn present_id(mut self, present_id: u32) -> PastPresentationTimingGOOGLEBuilder<'a> {
+    pub fn present_id(mut self, present_id: u32) -> Self {
         self.inner.present_id = present_id;
         self
     }
-    pub fn desired_present_time(
-        mut self,
-        desired_present_time: u64,
-    ) -> PastPresentationTimingGOOGLEBuilder<'a> {
+    pub fn desired_present_time(mut self, desired_present_time: u64) -> Self {
         self.inner.desired_present_time = desired_present_time;
         self
     }
-    pub fn actual_present_time(
-        mut self,
-        actual_present_time: u64,
-    ) -> PastPresentationTimingGOOGLEBuilder<'a> {
+    pub fn actual_present_time(mut self, actual_present_time: u64) -> Self {
         self.inner.actual_present_time = actual_present_time;
         self
     }
-    pub fn earliest_present_time(
-        mut self,
-        earliest_present_time: u64,
-    ) -> PastPresentationTimingGOOGLEBuilder<'a> {
+    pub fn earliest_present_time(mut self, earliest_present_time: u64) -> Self {
         self.inner.earliest_present_time = earliest_present_time;
         self
     }
-    pub fn present_margin(
-        mut self,
-        present_margin: u64,
-    ) -> PastPresentationTimingGOOGLEBuilder<'a> {
+    pub fn present_margin(mut self, present_margin: u64) -> Self {
         self.inner.present_margin = present_margin;
         self
     }
@@ -21099,7 +19377,7 @@ impl<'a> ::std::ops::DerefMut for PresentTimesInfoGOOGLEBuilder<'a> {
     }
 }
 impl<'a> PresentTimesInfoGOOGLEBuilder<'a> {
-    pub fn times(mut self, times: &'a [PresentTimeGOOGLE]) -> PresentTimesInfoGOOGLEBuilder<'a> {
+    pub fn times(mut self, times: &'a [PresentTimeGOOGLE]) -> Self {
         self.inner.swapchain_count = times.len() as _;
         self.inner.p_times = times.as_ptr();
         self
@@ -21143,14 +19421,11 @@ impl<'a> ::std::ops::DerefMut for PresentTimeGOOGLEBuilder<'a> {
     }
 }
 impl<'a> PresentTimeGOOGLEBuilder<'a> {
-    pub fn present_id(mut self, present_id: u32) -> PresentTimeGOOGLEBuilder<'a> {
+    pub fn present_id(mut self, present_id: u32) -> Self {
         self.inner.present_id = present_id;
         self
     }
-    pub fn desired_present_time(
-        mut self,
-        desired_present_time: u64,
-    ) -> PresentTimeGOOGLEBuilder<'a> {
+    pub fn desired_present_time(mut self, desired_present_time: u64) -> Self {
         self.inner.desired_present_time = desired_present_time;
         self
     }
@@ -21206,11 +19481,11 @@ impl<'a> ::std::ops::DerefMut for IOSSurfaceCreateInfoMVKBuilder<'a> {
     }
 }
 impl<'a> IOSSurfaceCreateInfoMVKBuilder<'a> {
-    pub fn flags(mut self, flags: IOSSurfaceCreateFlagsMVK) -> IOSSurfaceCreateInfoMVKBuilder<'a> {
+    pub fn flags(mut self, flags: IOSSurfaceCreateFlagsMVK) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn view(mut self, view: *const c_void) -> IOSSurfaceCreateInfoMVKBuilder<'a> {
+    pub fn view(mut self, view: *const c_void) -> Self {
         self.inner.p_view = view;
         self
     }
@@ -21219,10 +19494,7 @@ impl<'a> IOSSurfaceCreateInfoMVKBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsIOSSurfaceCreateInfoMVK>(
-        mut self,
-        next: &'a mut T,
-    ) -> IOSSurfaceCreateInfoMVKBuilder<'a> {
+    pub fn push_next<T: ExtendsIOSSurfaceCreateInfoMVK>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -21283,14 +19555,11 @@ impl<'a> ::std::ops::DerefMut for MacOSSurfaceCreateInfoMVKBuilder<'a> {
     }
 }
 impl<'a> MacOSSurfaceCreateInfoMVKBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: MacOSSurfaceCreateFlagsMVK,
-    ) -> MacOSSurfaceCreateInfoMVKBuilder<'a> {
+    pub fn flags(mut self, flags: MacOSSurfaceCreateFlagsMVK) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn view(mut self, view: *const c_void) -> MacOSSurfaceCreateInfoMVKBuilder<'a> {
+    pub fn view(mut self, view: *const c_void) -> Self {
         self.inner.p_view = view;
         self
     }
@@ -21299,10 +19568,7 @@ impl<'a> MacOSSurfaceCreateInfoMVKBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMacOSSurfaceCreateInfoMVK>(
-        mut self,
-        next: &'a mut T,
-    ) -> MacOSSurfaceCreateInfoMVKBuilder<'a> {
+    pub fn push_next<T: ExtendsMacOSSurfaceCreateInfoMVK>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -21363,14 +19629,11 @@ impl<'a> ::std::ops::DerefMut for MetalSurfaceCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> MetalSurfaceCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: MetalSurfaceCreateFlagsEXT,
-    ) -> MetalSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: MetalSurfaceCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn layer(mut self, layer: *const CAMetalLayer) -> MetalSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn layer(mut self, layer: *const CAMetalLayer) -> Self {
         self.inner.p_layer = layer;
         self
     }
@@ -21379,10 +19642,7 @@ impl<'a> MetalSurfaceCreateInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMetalSurfaceCreateInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> MetalSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsMetalSurfaceCreateInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -21430,11 +19690,11 @@ impl<'a> ::std::ops::DerefMut for ViewportWScalingNVBuilder<'a> {
     }
 }
 impl<'a> ViewportWScalingNVBuilder<'a> {
-    pub fn xcoeff(mut self, xcoeff: f32) -> ViewportWScalingNVBuilder<'a> {
+    pub fn xcoeff(mut self, xcoeff: f32) -> Self {
         self.inner.xcoeff = xcoeff;
         self
     }
-    pub fn ycoeff(mut self, ycoeff: f32) -> ViewportWScalingNVBuilder<'a> {
+    pub fn ycoeff(mut self, ycoeff: f32) -> Self {
         self.inner.ycoeff = ycoeff;
         self
     }
@@ -21496,17 +19756,11 @@ impl<'a> ::std::ops::DerefMut for PipelineViewportWScalingStateCreateInfoNVBuild
     }
 }
 impl<'a> PipelineViewportWScalingStateCreateInfoNVBuilder<'a> {
-    pub fn viewport_w_scaling_enable(
-        mut self,
-        viewport_w_scaling_enable: bool,
-    ) -> PipelineViewportWScalingStateCreateInfoNVBuilder<'a> {
+    pub fn viewport_w_scaling_enable(mut self, viewport_w_scaling_enable: bool) -> Self {
         self.inner.viewport_w_scaling_enable = viewport_w_scaling_enable.into();
         self
     }
-    pub fn viewport_w_scalings(
-        mut self,
-        viewport_w_scalings: &'a [ViewportWScalingNV],
-    ) -> PipelineViewportWScalingStateCreateInfoNVBuilder<'a> {
+    pub fn viewport_w_scalings(mut self, viewport_w_scalings: &'a [ViewportWScalingNV]) -> Self {
         self.inner.viewport_count = viewport_w_scalings.len() as _;
         self.inner.p_viewport_w_scalings = viewport_w_scalings.as_ptr();
         self
@@ -21552,19 +19806,19 @@ impl<'a> ::std::ops::DerefMut for ViewportSwizzleNVBuilder<'a> {
     }
 }
 impl<'a> ViewportSwizzleNVBuilder<'a> {
-    pub fn x(mut self, x: ViewportCoordinateSwizzleNV) -> ViewportSwizzleNVBuilder<'a> {
+    pub fn x(mut self, x: ViewportCoordinateSwizzleNV) -> Self {
         self.inner.x = x;
         self
     }
-    pub fn y(mut self, y: ViewportCoordinateSwizzleNV) -> ViewportSwizzleNVBuilder<'a> {
+    pub fn y(mut self, y: ViewportCoordinateSwizzleNV) -> Self {
         self.inner.y = y;
         self
     }
-    pub fn z(mut self, z: ViewportCoordinateSwizzleNV) -> ViewportSwizzleNVBuilder<'a> {
+    pub fn z(mut self, z: ViewportCoordinateSwizzleNV) -> Self {
         self.inner.z = z;
         self
     }
-    pub fn w(mut self, w: ViewportCoordinateSwizzleNV) -> ViewportSwizzleNVBuilder<'a> {
+    pub fn w(mut self, w: ViewportCoordinateSwizzleNV) -> Self {
         self.inner.w = w;
         self
     }
@@ -21626,17 +19880,11 @@ impl<'a> ::std::ops::DerefMut for PipelineViewportSwizzleStateCreateInfoNVBuilde
     }
 }
 impl<'a> PipelineViewportSwizzleStateCreateInfoNVBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineViewportSwizzleStateCreateFlagsNV,
-    ) -> PipelineViewportSwizzleStateCreateInfoNVBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineViewportSwizzleStateCreateFlagsNV) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn viewport_swizzles(
-        mut self,
-        viewport_swizzles: &'a [ViewportSwizzleNV],
-    ) -> PipelineViewportSwizzleStateCreateInfoNVBuilder<'a> {
+    pub fn viewport_swizzles(mut self, viewport_swizzles: &'a [ViewportSwizzleNV]) -> Self {
         self.inner.viewport_count = viewport_swizzles.len() as _;
         self.inner.p_viewport_swizzles = viewport_swizzles.as_ptr();
         self
@@ -21695,10 +19943,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceDiscardRectanglePropertiesEXTBui
     }
 }
 impl<'a> PhysicalDeviceDiscardRectanglePropertiesEXTBuilder<'a> {
-    pub fn max_discard_rectangles(
-        mut self,
-        max_discard_rectangles: u32,
-    ) -> PhysicalDeviceDiscardRectanglePropertiesEXTBuilder<'a> {
+    pub fn max_discard_rectangles(mut self, max_discard_rectangles: u32) -> Self {
         self.inner.max_discard_rectangles = max_discard_rectangles;
         self
     }
@@ -21762,24 +20007,18 @@ impl<'a> ::std::ops::DerefMut for PipelineDiscardRectangleStateCreateInfoEXTBuil
     }
 }
 impl<'a> PipelineDiscardRectangleStateCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineDiscardRectangleStateCreateFlagsEXT,
-    ) -> PipelineDiscardRectangleStateCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineDiscardRectangleStateCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
     pub fn discard_rectangle_mode(
         mut self,
         discard_rectangle_mode: DiscardRectangleModeEXT,
-    ) -> PipelineDiscardRectangleStateCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.discard_rectangle_mode = discard_rectangle_mode;
         self
     }
-    pub fn discard_rectangles(
-        mut self,
-        discard_rectangles: &'a [Rect2D],
-    ) -> PipelineDiscardRectangleStateCreateInfoEXTBuilder<'a> {
+    pub fn discard_rectangles(mut self, discard_rectangles: &'a [Rect2D]) -> Self {
         self.inner.discard_rectangle_count = discard_rectangles.len() as _;
         self.inner.p_discard_rectangles = discard_rectangles.as_ptr();
         self
@@ -21844,7 +20083,7 @@ impl<'a> PhysicalDeviceMultiviewPerViewAttributesPropertiesNVXBuilder<'a> {
     pub fn per_view_position_all_components(
         mut self,
         per_view_position_all_components: bool,
-    ) -> PhysicalDeviceMultiviewPerViewAttributesPropertiesNVXBuilder<'a> {
+    ) -> Self {
         self.inner.per_view_position_all_components = per_view_position_all_components.into();
         self
     }
@@ -21888,21 +20127,15 @@ impl<'a> ::std::ops::DerefMut for InputAttachmentAspectReferenceBuilder<'a> {
     }
 }
 impl<'a> InputAttachmentAspectReferenceBuilder<'a> {
-    pub fn subpass(mut self, subpass: u32) -> InputAttachmentAspectReferenceBuilder<'a> {
+    pub fn subpass(mut self, subpass: u32) -> Self {
         self.inner.subpass = subpass;
         self
     }
-    pub fn input_attachment_index(
-        mut self,
-        input_attachment_index: u32,
-    ) -> InputAttachmentAspectReferenceBuilder<'a> {
+    pub fn input_attachment_index(mut self, input_attachment_index: u32) -> Self {
         self.inner.input_attachment_index = input_attachment_index;
         self
     }
-    pub fn aspect_mask(
-        mut self,
-        aspect_mask: ImageAspectFlags,
-    ) -> InputAttachmentAspectReferenceBuilder<'a> {
+    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> Self {
         self.inner.aspect_mask = aspect_mask;
         self
     }
@@ -21962,7 +20195,7 @@ impl<'a> RenderPassInputAttachmentAspectCreateInfoBuilder<'a> {
     pub fn aspect_references(
         mut self,
         aspect_references: &'a [InputAttachmentAspectReference],
-    ) -> RenderPassInputAttachmentAspectCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.aspect_reference_count = aspect_references.len() as _;
         self.inner.p_aspect_references = aspect_references.as_ptr();
         self
@@ -22017,7 +20250,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceSurfaceInfo2KHRBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceSurfaceInfo2KHRBuilder<'a> {
-    pub fn surface(mut self, surface: SurfaceKHR) -> PhysicalDeviceSurfaceInfo2KHRBuilder<'a> {
+    pub fn surface(mut self, surface: SurfaceKHR) -> Self {
         self.inner.surface = surface;
         self
     }
@@ -22026,10 +20259,7 @@ impl<'a> PhysicalDeviceSurfaceInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPhysicalDeviceSurfaceInfo2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> PhysicalDeviceSurfaceInfo2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsPhysicalDeviceSurfaceInfo2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -22088,10 +20318,7 @@ impl<'a> ::std::ops::DerefMut for SurfaceCapabilities2KHRBuilder<'a> {
     }
 }
 impl<'a> SurfaceCapabilities2KHRBuilder<'a> {
-    pub fn surface_capabilities(
-        mut self,
-        surface_capabilities: SurfaceCapabilitiesKHR,
-    ) -> SurfaceCapabilities2KHRBuilder<'a> {
+    pub fn surface_capabilities(mut self, surface_capabilities: SurfaceCapabilitiesKHR) -> Self {
         self.inner.surface_capabilities = surface_capabilities;
         self
     }
@@ -22100,10 +20327,7 @@ impl<'a> SurfaceCapabilities2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSurfaceCapabilities2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> SurfaceCapabilities2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsSurfaceCapabilities2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -22162,10 +20386,7 @@ impl<'a> ::std::ops::DerefMut for SurfaceFormat2KHRBuilder<'a> {
     }
 }
 impl<'a> SurfaceFormat2KHRBuilder<'a> {
-    pub fn surface_format(
-        mut self,
-        surface_format: SurfaceFormatKHR,
-    ) -> SurfaceFormat2KHRBuilder<'a> {
+    pub fn surface_format(mut self, surface_format: SurfaceFormatKHR) -> Self {
         self.inner.surface_format = surface_format;
         self
     }
@@ -22174,10 +20395,7 @@ impl<'a> SurfaceFormat2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSurfaceFormat2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> SurfaceFormat2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsSurfaceFormat2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -22236,10 +20454,7 @@ impl<'a> ::std::ops::DerefMut for DisplayProperties2KHRBuilder<'a> {
     }
 }
 impl<'a> DisplayProperties2KHRBuilder<'a> {
-    pub fn display_properties(
-        mut self,
-        display_properties: DisplayPropertiesKHR,
-    ) -> DisplayProperties2KHRBuilder<'a> {
+    pub fn display_properties(mut self, display_properties: DisplayPropertiesKHR) -> Self {
         self.inner.display_properties = display_properties;
         self
     }
@@ -22248,10 +20463,7 @@ impl<'a> DisplayProperties2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDisplayProperties2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> DisplayProperties2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsDisplayProperties2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -22313,7 +20525,7 @@ impl<'a> DisplayPlaneProperties2KHRBuilder<'a> {
     pub fn display_plane_properties(
         mut self,
         display_plane_properties: DisplayPlanePropertiesKHR,
-    ) -> DisplayPlaneProperties2KHRBuilder<'a> {
+    ) -> Self {
         self.inner.display_plane_properties = display_plane_properties;
         self
     }
@@ -22322,10 +20534,7 @@ impl<'a> DisplayPlaneProperties2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDisplayPlaneProperties2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> DisplayPlaneProperties2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsDisplayPlaneProperties2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -22387,7 +20596,7 @@ impl<'a> DisplayModeProperties2KHRBuilder<'a> {
     pub fn display_mode_properties(
         mut self,
         display_mode_properties: DisplayModePropertiesKHR,
-    ) -> DisplayModeProperties2KHRBuilder<'a> {
+    ) -> Self {
         self.inner.display_mode_properties = display_mode_properties;
         self
     }
@@ -22396,10 +20605,7 @@ impl<'a> DisplayModeProperties2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDisplayModeProperties2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> DisplayModeProperties2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsDisplayModeProperties2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -22460,11 +20666,11 @@ impl<'a> ::std::ops::DerefMut for DisplayPlaneInfo2KHRBuilder<'a> {
     }
 }
 impl<'a> DisplayPlaneInfo2KHRBuilder<'a> {
-    pub fn mode(mut self, mode: DisplayModeKHR) -> DisplayPlaneInfo2KHRBuilder<'a> {
+    pub fn mode(mut self, mode: DisplayModeKHR) -> Self {
         self.inner.mode = mode;
         self
     }
-    pub fn plane_index(mut self, plane_index: u32) -> DisplayPlaneInfo2KHRBuilder<'a> {
+    pub fn plane_index(mut self, plane_index: u32) -> Self {
         self.inner.plane_index = plane_index;
         self
     }
@@ -22473,10 +20679,7 @@ impl<'a> DisplayPlaneInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDisplayPlaneInfo2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> DisplayPlaneInfo2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsDisplayPlaneInfo2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -22535,10 +20738,7 @@ impl<'a> ::std::ops::DerefMut for DisplayPlaneCapabilities2KHRBuilder<'a> {
     }
 }
 impl<'a> DisplayPlaneCapabilities2KHRBuilder<'a> {
-    pub fn capabilities(
-        mut self,
-        capabilities: DisplayPlaneCapabilitiesKHR,
-    ) -> DisplayPlaneCapabilities2KHRBuilder<'a> {
+    pub fn capabilities(mut self, capabilities: DisplayPlaneCapabilitiesKHR) -> Self {
         self.inner.capabilities = capabilities;
         self
     }
@@ -22547,10 +20747,7 @@ impl<'a> DisplayPlaneCapabilities2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDisplayPlaneCapabilities2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> DisplayPlaneCapabilities2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsDisplayPlaneCapabilities2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -22613,7 +20810,7 @@ impl<'a> SharedPresentSurfaceCapabilitiesKHRBuilder<'a> {
     pub fn shared_present_supported_usage_flags(
         mut self,
         shared_present_supported_usage_flags: ImageUsageFlags,
-    ) -> SharedPresentSurfaceCapabilitiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.shared_present_supported_usage_flags = shared_present_supported_usage_flags;
         self
     }
@@ -22674,32 +20871,23 @@ impl<'a> ::std::ops::DerefMut for PhysicalDevice16BitStorageFeaturesBuilder<'a> 
     }
 }
 impl<'a> PhysicalDevice16BitStorageFeaturesBuilder<'a> {
-    pub fn storage_buffer16_bit_access(
-        mut self,
-        storage_buffer16_bit_access: bool,
-    ) -> PhysicalDevice16BitStorageFeaturesBuilder<'a> {
+    pub fn storage_buffer16_bit_access(mut self, storage_buffer16_bit_access: bool) -> Self {
         self.inner.storage_buffer16_bit_access = storage_buffer16_bit_access.into();
         self
     }
     pub fn uniform_and_storage_buffer16_bit_access(
         mut self,
         uniform_and_storage_buffer16_bit_access: bool,
-    ) -> PhysicalDevice16BitStorageFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.uniform_and_storage_buffer16_bit_access =
             uniform_and_storage_buffer16_bit_access.into();
         self
     }
-    pub fn storage_push_constant16(
-        mut self,
-        storage_push_constant16: bool,
-    ) -> PhysicalDevice16BitStorageFeaturesBuilder<'a> {
+    pub fn storage_push_constant16(mut self, storage_push_constant16: bool) -> Self {
         self.inner.storage_push_constant16 = storage_push_constant16.into();
         self
     }
-    pub fn storage_input_output16(
-        mut self,
-        storage_input_output16: bool,
-    ) -> PhysicalDevice16BitStorageFeaturesBuilder<'a> {
+    pub fn storage_input_output16(mut self, storage_input_output16: bool) -> Self {
         self.inner.storage_input_output16 = storage_input_output16.into();
         self
     }
@@ -22760,31 +20948,19 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceSubgroupPropertiesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceSubgroupPropertiesBuilder<'a> {
-    pub fn subgroup_size(
-        mut self,
-        subgroup_size: u32,
-    ) -> PhysicalDeviceSubgroupPropertiesBuilder<'a> {
+    pub fn subgroup_size(mut self, subgroup_size: u32) -> Self {
         self.inner.subgroup_size = subgroup_size;
         self
     }
-    pub fn supported_stages(
-        mut self,
-        supported_stages: ShaderStageFlags,
-    ) -> PhysicalDeviceSubgroupPropertiesBuilder<'a> {
+    pub fn supported_stages(mut self, supported_stages: ShaderStageFlags) -> Self {
         self.inner.supported_stages = supported_stages;
         self
     }
-    pub fn supported_operations(
-        mut self,
-        supported_operations: SubgroupFeatureFlags,
-    ) -> PhysicalDeviceSubgroupPropertiesBuilder<'a> {
+    pub fn supported_operations(mut self, supported_operations: SubgroupFeatureFlags) -> Self {
         self.inner.supported_operations = supported_operations;
         self
     }
-    pub fn quad_operations_in_all_stages(
-        mut self,
-        quad_operations_in_all_stages: bool,
-    ) -> PhysicalDeviceSubgroupPropertiesBuilder<'a> {
+    pub fn quad_operations_in_all_stages(mut self, quad_operations_in_all_stages: bool) -> Self {
         self.inner.quad_operations_in_all_stages = quad_operations_in_all_stages.into();
         self
     }
@@ -22842,10 +21018,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderSubgroupExtendedTypesFeatu
     }
 }
 impl<'a> PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'a> {
-    pub fn shader_subgroup_extended_types(
-        mut self,
-        shader_subgroup_extended_types: bool,
-    ) -> PhysicalDeviceShaderSubgroupExtendedTypesFeaturesBuilder<'a> {
+    pub fn shader_subgroup_extended_types(mut self, shader_subgroup_extended_types: bool) -> Self {
         self.inner.shader_subgroup_extended_types = shader_subgroup_extended_types.into();
         self
     }
@@ -22899,7 +21072,7 @@ impl<'a> ::std::ops::DerefMut for BufferMemoryRequirementsInfo2Builder<'a> {
     }
 }
 impl<'a> BufferMemoryRequirementsInfo2Builder<'a> {
-    pub fn buffer(mut self, buffer: Buffer) -> BufferMemoryRequirementsInfo2Builder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
@@ -22908,10 +21081,7 @@ impl<'a> BufferMemoryRequirementsInfo2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBufferMemoryRequirementsInfo2>(
-        mut self,
-        next: &'a mut T,
-    ) -> BufferMemoryRequirementsInfo2Builder<'a> {
+    pub fn push_next<T: ExtendsBufferMemoryRequirementsInfo2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -22970,7 +21140,7 @@ impl<'a> ::std::ops::DerefMut for ImageMemoryRequirementsInfo2Builder<'a> {
     }
 }
 impl<'a> ImageMemoryRequirementsInfo2Builder<'a> {
-    pub fn image(mut self, image: Image) -> ImageMemoryRequirementsInfo2Builder<'a> {
+    pub fn image(mut self, image: Image) -> Self {
         self.inner.image = image;
         self
     }
@@ -22979,10 +21149,7 @@ impl<'a> ImageMemoryRequirementsInfo2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageMemoryRequirementsInfo2>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageMemoryRequirementsInfo2Builder<'a> {
+    pub fn push_next<T: ExtendsImageMemoryRequirementsInfo2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -23041,7 +21208,7 @@ impl<'a> ::std::ops::DerefMut for ImageSparseMemoryRequirementsInfo2Builder<'a> 
     }
 }
 impl<'a> ImageSparseMemoryRequirementsInfo2Builder<'a> {
-    pub fn image(mut self, image: Image) -> ImageSparseMemoryRequirementsInfo2Builder<'a> {
+    pub fn image(mut self, image: Image) -> Self {
         self.inner.image = image;
         self
     }
@@ -23053,7 +21220,7 @@ impl<'a> ImageSparseMemoryRequirementsInfo2Builder<'a> {
     pub fn push_next<T: ExtendsImageSparseMemoryRequirementsInfo2>(
         mut self,
         next: &'a mut T,
-    ) -> ImageSparseMemoryRequirementsInfo2Builder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -23112,10 +21279,7 @@ impl<'a> ::std::ops::DerefMut for MemoryRequirements2Builder<'a> {
     }
 }
 impl<'a> MemoryRequirements2Builder<'a> {
-    pub fn memory_requirements(
-        mut self,
-        memory_requirements: MemoryRequirements,
-    ) -> MemoryRequirements2Builder<'a> {
+    pub fn memory_requirements(mut self, memory_requirements: MemoryRequirements) -> Self {
         self.inner.memory_requirements = memory_requirements;
         self
     }
@@ -23124,10 +21288,7 @@ impl<'a> MemoryRequirements2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMemoryRequirements2>(
-        mut self,
-        next: &'a mut T,
-    ) -> MemoryRequirements2Builder<'a> {
+    pub fn push_next<T: ExtendsMemoryRequirements2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -23189,7 +21350,7 @@ impl<'a> SparseImageMemoryRequirements2Builder<'a> {
     pub fn memory_requirements(
         mut self,
         memory_requirements: SparseImageMemoryRequirements,
-    ) -> SparseImageMemoryRequirements2Builder<'a> {
+    ) -> Self {
         self.inner.memory_requirements = memory_requirements;
         self
     }
@@ -23198,10 +21359,7 @@ impl<'a> SparseImageMemoryRequirements2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSparseImageMemoryRequirements2>(
-        mut self,
-        next: &'a mut T,
-    ) -> SparseImageMemoryRequirements2Builder<'a> {
+    pub fn push_next<T: ExtendsSparseImageMemoryRequirements2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -23264,7 +21422,7 @@ impl<'a> PhysicalDevicePointClippingPropertiesBuilder<'a> {
     pub fn point_clipping_behavior(
         mut self,
         point_clipping_behavior: PointClippingBehavior,
-    ) -> PhysicalDevicePointClippingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.point_clipping_behavior = point_clipping_behavior;
         self
     }
@@ -23321,17 +21479,11 @@ impl<'a> ::std::ops::DerefMut for MemoryDedicatedRequirementsBuilder<'a> {
     }
 }
 impl<'a> MemoryDedicatedRequirementsBuilder<'a> {
-    pub fn prefers_dedicated_allocation(
-        mut self,
-        prefers_dedicated_allocation: bool,
-    ) -> MemoryDedicatedRequirementsBuilder<'a> {
+    pub fn prefers_dedicated_allocation(mut self, prefers_dedicated_allocation: bool) -> Self {
         self.inner.prefers_dedicated_allocation = prefers_dedicated_allocation.into();
         self
     }
-    pub fn requires_dedicated_allocation(
-        mut self,
-        requires_dedicated_allocation: bool,
-    ) -> MemoryDedicatedRequirementsBuilder<'a> {
+    pub fn requires_dedicated_allocation(mut self, requires_dedicated_allocation: bool) -> Self {
         self.inner.requires_dedicated_allocation = requires_dedicated_allocation.into();
         self
     }
@@ -23388,11 +21540,11 @@ impl<'a> ::std::ops::DerefMut for MemoryDedicatedAllocateInfoBuilder<'a> {
     }
 }
 impl<'a> MemoryDedicatedAllocateInfoBuilder<'a> {
-    pub fn image(mut self, image: Image) -> MemoryDedicatedAllocateInfoBuilder<'a> {
+    pub fn image(mut self, image: Image) -> Self {
         self.inner.image = image;
         self
     }
-    pub fn buffer(mut self, buffer: Buffer) -> MemoryDedicatedAllocateInfoBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
@@ -23447,7 +21599,7 @@ impl<'a> ::std::ops::DerefMut for ImageViewUsageCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ImageViewUsageCreateInfoBuilder<'a> {
-    pub fn usage(mut self, usage: ImageUsageFlags) -> ImageViewUsageCreateInfoBuilder<'a> {
+    pub fn usage(mut self, usage: ImageUsageFlags) -> Self {
         self.inner.usage = usage;
         self
     }
@@ -23508,10 +21660,7 @@ impl<'a> ::std::ops::DerefMut for PipelineTessellationDomainOriginStateCreateInf
     }
 }
 impl<'a> PipelineTessellationDomainOriginStateCreateInfoBuilder<'a> {
-    pub fn domain_origin(
-        mut self,
-        domain_origin: TessellationDomainOrigin,
-    ) -> PipelineTessellationDomainOriginStateCreateInfoBuilder<'a> {
+    pub fn domain_origin(mut self, domain_origin: TessellationDomainOrigin) -> Self {
         self.inner.domain_origin = domain_origin;
         self
     }
@@ -23568,10 +21717,7 @@ impl<'a> ::std::ops::DerefMut for SamplerYcbcrConversionInfoBuilder<'a> {
     }
 }
 impl<'a> SamplerYcbcrConversionInfoBuilder<'a> {
-    pub fn conversion(
-        mut self,
-        conversion: SamplerYcbcrConversion,
-    ) -> SamplerYcbcrConversionInfoBuilder<'a> {
+    pub fn conversion(mut self, conversion: SamplerYcbcrConversion) -> Self {
         self.inner.conversion = conversion;
         self
     }
@@ -23639,56 +21785,35 @@ impl<'a> ::std::ops::DerefMut for SamplerYcbcrConversionCreateInfoBuilder<'a> {
     }
 }
 impl<'a> SamplerYcbcrConversionCreateInfoBuilder<'a> {
-    pub fn format(mut self, format: Format) -> SamplerYcbcrConversionCreateInfoBuilder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn ycbcr_model(
-        mut self,
-        ycbcr_model: SamplerYcbcrModelConversion,
-    ) -> SamplerYcbcrConversionCreateInfoBuilder<'a> {
+    pub fn ycbcr_model(mut self, ycbcr_model: SamplerYcbcrModelConversion) -> Self {
         self.inner.ycbcr_model = ycbcr_model;
         self
     }
-    pub fn ycbcr_range(
-        mut self,
-        ycbcr_range: SamplerYcbcrRange,
-    ) -> SamplerYcbcrConversionCreateInfoBuilder<'a> {
+    pub fn ycbcr_range(mut self, ycbcr_range: SamplerYcbcrRange) -> Self {
         self.inner.ycbcr_range = ycbcr_range;
         self
     }
-    pub fn components(
-        mut self,
-        components: ComponentMapping,
-    ) -> SamplerYcbcrConversionCreateInfoBuilder<'a> {
+    pub fn components(mut self, components: ComponentMapping) -> Self {
         self.inner.components = components;
         self
     }
-    pub fn x_chroma_offset(
-        mut self,
-        x_chroma_offset: ChromaLocation,
-    ) -> SamplerYcbcrConversionCreateInfoBuilder<'a> {
+    pub fn x_chroma_offset(mut self, x_chroma_offset: ChromaLocation) -> Self {
         self.inner.x_chroma_offset = x_chroma_offset;
         self
     }
-    pub fn y_chroma_offset(
-        mut self,
-        y_chroma_offset: ChromaLocation,
-    ) -> SamplerYcbcrConversionCreateInfoBuilder<'a> {
+    pub fn y_chroma_offset(mut self, y_chroma_offset: ChromaLocation) -> Self {
         self.inner.y_chroma_offset = y_chroma_offset;
         self
     }
-    pub fn chroma_filter(
-        mut self,
-        chroma_filter: Filter,
-    ) -> SamplerYcbcrConversionCreateInfoBuilder<'a> {
+    pub fn chroma_filter(mut self, chroma_filter: Filter) -> Self {
         self.inner.chroma_filter = chroma_filter;
         self
     }
-    pub fn force_explicit_reconstruction(
-        mut self,
-        force_explicit_reconstruction: bool,
-    ) -> SamplerYcbcrConversionCreateInfoBuilder<'a> {
+    pub fn force_explicit_reconstruction(mut self, force_explicit_reconstruction: bool) -> Self {
         self.inner.force_explicit_reconstruction = force_explicit_reconstruction.into();
         self
     }
@@ -23700,7 +21825,7 @@ impl<'a> SamplerYcbcrConversionCreateInfoBuilder<'a> {
     pub fn push_next<T: ExtendsSamplerYcbcrConversionCreateInfo>(
         mut self,
         next: &'a mut T,
-    ) -> SamplerYcbcrConversionCreateInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -23760,10 +21885,7 @@ impl<'a> ::std::ops::DerefMut for BindImagePlaneMemoryInfoBuilder<'a> {
     }
 }
 impl<'a> BindImagePlaneMemoryInfoBuilder<'a> {
-    pub fn plane_aspect(
-        mut self,
-        plane_aspect: ImageAspectFlags,
-    ) -> BindImagePlaneMemoryInfoBuilder<'a> {
+    pub fn plane_aspect(mut self, plane_aspect: ImageAspectFlags) -> Self {
         self.inner.plane_aspect = plane_aspect;
         self
     }
@@ -23818,10 +21940,7 @@ impl<'a> ::std::ops::DerefMut for ImagePlaneMemoryRequirementsInfoBuilder<'a> {
     }
 }
 impl<'a> ImagePlaneMemoryRequirementsInfoBuilder<'a> {
-    pub fn plane_aspect(
-        mut self,
-        plane_aspect: ImageAspectFlags,
-    ) -> ImagePlaneMemoryRequirementsInfoBuilder<'a> {
+    pub fn plane_aspect(mut self, plane_aspect: ImageAspectFlags) -> Self {
         self.inner.plane_aspect = plane_aspect;
         self
     }
@@ -23876,10 +21995,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceSamplerYcbcrConversionFeaturesBu
     }
 }
 impl<'a> PhysicalDeviceSamplerYcbcrConversionFeaturesBuilder<'a> {
-    pub fn sampler_ycbcr_conversion(
-        mut self,
-        sampler_ycbcr_conversion: bool,
-    ) -> PhysicalDeviceSamplerYcbcrConversionFeaturesBuilder<'a> {
+    pub fn sampler_ycbcr_conversion(mut self, sampler_ycbcr_conversion: bool) -> Self {
         self.inner.sampler_ycbcr_conversion = sampler_ycbcr_conversion.into();
         self
     }
@@ -23940,7 +22056,7 @@ impl<'a> SamplerYcbcrConversionImageFormatPropertiesBuilder<'a> {
     pub fn combined_image_sampler_descriptor_count(
         mut self,
         combined_image_sampler_descriptor_count: u32,
-    ) -> SamplerYcbcrConversionImageFormatPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.combined_image_sampler_descriptor_count =
             combined_image_sampler_descriptor_count;
         self
@@ -23999,7 +22115,7 @@ impl<'a> TextureLODGatherFormatPropertiesAMDBuilder<'a> {
     pub fn supports_texture_gather_lod_bias_amd(
         mut self,
         supports_texture_gather_lod_bias_amd: bool,
-    ) -> TextureLODGatherFormatPropertiesAMDBuilder<'a> {
+    ) -> Self {
         self.inner.supports_texture_gather_lod_bias_amd =
             supports_texture_gather_lod_bias_amd.into();
         self
@@ -24058,18 +22174,15 @@ impl<'a> ::std::ops::DerefMut for ConditionalRenderingBeginInfoEXTBuilder<'a> {
     }
 }
 impl<'a> ConditionalRenderingBeginInfoEXTBuilder<'a> {
-    pub fn buffer(mut self, buffer: Buffer) -> ConditionalRenderingBeginInfoEXTBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
-    pub fn offset(mut self, offset: DeviceSize) -> ConditionalRenderingBeginInfoEXTBuilder<'a> {
+    pub fn offset(mut self, offset: DeviceSize) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn flags(
-        mut self,
-        flags: ConditionalRenderingFlagsEXT,
-    ) -> ConditionalRenderingBeginInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: ConditionalRenderingFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -24081,7 +22194,7 @@ impl<'a> ConditionalRenderingBeginInfoEXTBuilder<'a> {
     pub fn push_next<T: ExtendsConditionalRenderingBeginInfoEXT>(
         mut self,
         next: &'a mut T,
-    ) -> ConditionalRenderingBeginInfoEXTBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -24141,7 +22254,7 @@ impl<'a> ::std::ops::DerefMut for ProtectedSubmitInfoBuilder<'a> {
     }
 }
 impl<'a> ProtectedSubmitInfoBuilder<'a> {
-    pub fn protected_submit(mut self, protected_submit: bool) -> ProtectedSubmitInfoBuilder<'a> {
+    pub fn protected_submit(mut self, protected_submit: bool) -> Self {
         self.inner.protected_submit = protected_submit.into();
         self
     }
@@ -24196,10 +22309,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceProtectedMemoryFeaturesBuilder<'
     }
 }
 impl<'a> PhysicalDeviceProtectedMemoryFeaturesBuilder<'a> {
-    pub fn protected_memory(
-        mut self,
-        protected_memory: bool,
-    ) -> PhysicalDeviceProtectedMemoryFeaturesBuilder<'a> {
+    pub fn protected_memory(mut self, protected_memory: bool) -> Self {
         self.inner.protected_memory = protected_memory.into();
         self
     }
@@ -24257,10 +22367,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceProtectedMemoryPropertiesBuilder
     }
 }
 impl<'a> PhysicalDeviceProtectedMemoryPropertiesBuilder<'a> {
-    pub fn protected_no_fault(
-        mut self,
-        protected_no_fault: bool,
-    ) -> PhysicalDeviceProtectedMemoryPropertiesBuilder<'a> {
+    pub fn protected_no_fault(mut self, protected_no_fault: bool) -> Self {
         self.inner.protected_no_fault = protected_no_fault.into();
         self
     }
@@ -24318,15 +22425,15 @@ impl<'a> ::std::ops::DerefMut for DeviceQueueInfo2Builder<'a> {
     }
 }
 impl<'a> DeviceQueueInfo2Builder<'a> {
-    pub fn flags(mut self, flags: DeviceQueueCreateFlags) -> DeviceQueueInfo2Builder<'a> {
+    pub fn flags(mut self, flags: DeviceQueueCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn queue_family_index(mut self, queue_family_index: u32) -> DeviceQueueInfo2Builder<'a> {
+    pub fn queue_family_index(mut self, queue_family_index: u32) -> Self {
         self.inner.queue_family_index = queue_family_index;
         self
     }
-    pub fn queue_index(mut self, queue_index: u32) -> DeviceQueueInfo2Builder<'a> {
+    pub fn queue_index(mut self, queue_index: u32) -> Self {
         self.inner.queue_index = queue_index;
         self
     }
@@ -24335,10 +22442,7 @@ impl<'a> DeviceQueueInfo2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDeviceQueueInfo2>(
-        mut self,
-        next: &'a mut T,
-    ) -> DeviceQueueInfo2Builder<'a> {
+    pub fn push_next<T: ExtendsDeviceQueueInfo2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -24405,24 +22509,15 @@ impl<'a> ::std::ops::DerefMut for PipelineCoverageToColorStateCreateInfoNVBuilde
     }
 }
 impl<'a> PipelineCoverageToColorStateCreateInfoNVBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineCoverageToColorStateCreateFlagsNV,
-    ) -> PipelineCoverageToColorStateCreateInfoNVBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCoverageToColorStateCreateFlagsNV) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn coverage_to_color_enable(
-        mut self,
-        coverage_to_color_enable: bool,
-    ) -> PipelineCoverageToColorStateCreateInfoNVBuilder<'a> {
+    pub fn coverage_to_color_enable(mut self, coverage_to_color_enable: bool) -> Self {
         self.inner.coverage_to_color_enable = coverage_to_color_enable.into();
         self
     }
-    pub fn coverage_to_color_location(
-        mut self,
-        coverage_to_color_location: u32,
-    ) -> PipelineCoverageToColorStateCreateInfoNVBuilder<'a> {
+    pub fn coverage_to_color_location(mut self, coverage_to_color_location: u32) -> Self {
         self.inner.coverage_to_color_location = coverage_to_color_location;
         self
     }
@@ -24485,7 +22580,7 @@ impl<'a> PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
     pub fn filter_minmax_single_component_formats(
         mut self,
         filter_minmax_single_component_formats: bool,
-    ) -> PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.filter_minmax_single_component_formats =
             filter_minmax_single_component_formats.into();
         self
@@ -24493,7 +22588,7 @@ impl<'a> PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
     pub fn filter_minmax_image_component_mapping(
         mut self,
         filter_minmax_image_component_mapping: bool,
-    ) -> PhysicalDeviceSamplerFilterMinmaxPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.filter_minmax_image_component_mapping =
             filter_minmax_image_component_mapping.into();
         self
@@ -24537,11 +22632,11 @@ impl<'a> ::std::ops::DerefMut for SampleLocationEXTBuilder<'a> {
     }
 }
 impl<'a> SampleLocationEXTBuilder<'a> {
-    pub fn x(mut self, x: f32) -> SampleLocationEXTBuilder<'a> {
+    pub fn x(mut self, x: f32) -> Self {
         self.inner.x = x;
         self
     }
-    pub fn y(mut self, y: f32) -> SampleLocationEXTBuilder<'a> {
+    pub fn y(mut self, y: f32) -> Self {
         self.inner.y = y;
         self
     }
@@ -24605,21 +22700,15 @@ impl<'a> SampleLocationsInfoEXTBuilder<'a> {
     pub fn sample_locations_per_pixel(
         mut self,
         sample_locations_per_pixel: SampleCountFlags,
-    ) -> SampleLocationsInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.sample_locations_per_pixel = sample_locations_per_pixel;
         self
     }
-    pub fn sample_location_grid_size(
-        mut self,
-        sample_location_grid_size: Extent2D,
-    ) -> SampleLocationsInfoEXTBuilder<'a> {
+    pub fn sample_location_grid_size(mut self, sample_location_grid_size: Extent2D) -> Self {
         self.inner.sample_location_grid_size = sample_location_grid_size;
         self
     }
-    pub fn sample_locations(
-        mut self,
-        sample_locations: &'a [SampleLocationEXT],
-    ) -> SampleLocationsInfoEXTBuilder<'a> {
+    pub fn sample_locations(mut self, sample_locations: &'a [SampleLocationEXT]) -> Self {
         self.inner.sample_locations_count = sample_locations.len() as _;
         self.inner.p_sample_locations = sample_locations.as_ptr();
         self
@@ -24663,17 +22752,11 @@ impl<'a> ::std::ops::DerefMut for AttachmentSampleLocationsEXTBuilder<'a> {
     }
 }
 impl<'a> AttachmentSampleLocationsEXTBuilder<'a> {
-    pub fn attachment_index(
-        mut self,
-        attachment_index: u32,
-    ) -> AttachmentSampleLocationsEXTBuilder<'a> {
+    pub fn attachment_index(mut self, attachment_index: u32) -> Self {
         self.inner.attachment_index = attachment_index;
         self
     }
-    pub fn sample_locations_info(
-        mut self,
-        sample_locations_info: SampleLocationsInfoEXT,
-    ) -> AttachmentSampleLocationsEXTBuilder<'a> {
+    pub fn sample_locations_info(mut self, sample_locations_info: SampleLocationsInfoEXT) -> Self {
         self.inner.sample_locations_info = sample_locations_info;
         self
     }
@@ -24716,14 +22799,11 @@ impl<'a> ::std::ops::DerefMut for SubpassSampleLocationsEXTBuilder<'a> {
     }
 }
 impl<'a> SubpassSampleLocationsEXTBuilder<'a> {
-    pub fn subpass_index(mut self, subpass_index: u32) -> SubpassSampleLocationsEXTBuilder<'a> {
+    pub fn subpass_index(mut self, subpass_index: u32) -> Self {
         self.inner.subpass_index = subpass_index;
         self
     }
-    pub fn sample_locations_info(
-        mut self,
-        sample_locations_info: SampleLocationsInfoEXT,
-    ) -> SubpassSampleLocationsEXTBuilder<'a> {
+    pub fn sample_locations_info(mut self, sample_locations_info: SampleLocationsInfoEXT) -> Self {
         self.inner.sample_locations_info = sample_locations_info;
         self
     }
@@ -24787,7 +22867,7 @@ impl<'a> RenderPassSampleLocationsBeginInfoEXTBuilder<'a> {
     pub fn attachment_initial_sample_locations(
         mut self,
         attachment_initial_sample_locations: &'a [AttachmentSampleLocationsEXT],
-    ) -> RenderPassSampleLocationsBeginInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.attachment_initial_sample_locations_count =
             attachment_initial_sample_locations.len() as _;
         self.inner.p_attachment_initial_sample_locations =
@@ -24797,7 +22877,7 @@ impl<'a> RenderPassSampleLocationsBeginInfoEXTBuilder<'a> {
     pub fn post_subpass_sample_locations(
         mut self,
         post_subpass_sample_locations: &'a [SubpassSampleLocationsEXT],
-    ) -> RenderPassSampleLocationsBeginInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.post_subpass_sample_locations_count = post_subpass_sample_locations.len() as _;
         self.inner.p_post_subpass_sample_locations = post_subpass_sample_locations.as_ptr();
         self
@@ -24861,17 +22941,11 @@ impl<'a> ::std::ops::DerefMut for PipelineSampleLocationsStateCreateInfoEXTBuild
     }
 }
 impl<'a> PipelineSampleLocationsStateCreateInfoEXTBuilder<'a> {
-    pub fn sample_locations_enable(
-        mut self,
-        sample_locations_enable: bool,
-    ) -> PipelineSampleLocationsStateCreateInfoEXTBuilder<'a> {
+    pub fn sample_locations_enable(mut self, sample_locations_enable: bool) -> Self {
         self.inner.sample_locations_enable = sample_locations_enable.into();
         self
     }
-    pub fn sample_locations_info(
-        mut self,
-        sample_locations_info: SampleLocationsInfoEXT,
-    ) -> PipelineSampleLocationsStateCreateInfoEXTBuilder<'a> {
+    pub fn sample_locations_info(mut self, sample_locations_info: SampleLocationsInfoEXT) -> Self {
         self.inner.sample_locations_info = sample_locations_info;
         self
     }
@@ -24940,35 +23014,29 @@ impl<'a> PhysicalDeviceSampleLocationsPropertiesEXTBuilder<'a> {
     pub fn sample_location_sample_counts(
         mut self,
         sample_location_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceSampleLocationsPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.sample_location_sample_counts = sample_location_sample_counts;
         self
     }
     pub fn max_sample_location_grid_size(
         mut self,
         max_sample_location_grid_size: Extent2D,
-    ) -> PhysicalDeviceSampleLocationsPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_sample_location_grid_size = max_sample_location_grid_size;
         self
     }
     pub fn sample_location_coordinate_range(
         mut self,
         sample_location_coordinate_range: [f32; 2],
-    ) -> PhysicalDeviceSampleLocationsPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.sample_location_coordinate_range = sample_location_coordinate_range;
         self
     }
-    pub fn sample_location_sub_pixel_bits(
-        mut self,
-        sample_location_sub_pixel_bits: u32,
-    ) -> PhysicalDeviceSampleLocationsPropertiesEXTBuilder<'a> {
+    pub fn sample_location_sub_pixel_bits(mut self, sample_location_sub_pixel_bits: u32) -> Self {
         self.inner.sample_location_sub_pixel_bits = sample_location_sub_pixel_bits;
         self
     }
-    pub fn variable_sample_locations(
-        mut self,
-        variable_sample_locations: bool,
-    ) -> PhysicalDeviceSampleLocationsPropertiesEXTBuilder<'a> {
+    pub fn variable_sample_locations(mut self, variable_sample_locations: bool) -> Self {
         self.inner.variable_sample_locations = variable_sample_locations.into();
         self
     }
@@ -25025,7 +23093,7 @@ impl<'a> MultisamplePropertiesEXTBuilder<'a> {
     pub fn max_sample_location_grid_size(
         mut self,
         max_sample_location_grid_size: Extent2D,
-    ) -> MultisamplePropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_sample_location_grid_size = max_sample_location_grid_size;
         self
     }
@@ -25034,10 +23102,7 @@ impl<'a> MultisamplePropertiesEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMultisamplePropertiesEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> MultisamplePropertiesEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsMultisamplePropertiesEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -25097,10 +23162,7 @@ impl<'a> ::std::ops::DerefMut for SamplerReductionModeCreateInfoBuilder<'a> {
     }
 }
 impl<'a> SamplerReductionModeCreateInfoBuilder<'a> {
-    pub fn reduction_mode(
-        mut self,
-        reduction_mode: SamplerReductionMode,
-    ) -> SamplerReductionModeCreateInfoBuilder<'a> {
+    pub fn reduction_mode(mut self, reduction_mode: SamplerReductionMode) -> Self {
         self.inner.reduction_mode = reduction_mode;
         self
     }
@@ -25158,7 +23220,7 @@ impl<'a> PhysicalDeviceBlendOperationAdvancedFeaturesEXTBuilder<'a> {
     pub fn advanced_blend_coherent_operations(
         mut self,
         advanced_blend_coherent_operations: bool,
-    ) -> PhysicalDeviceBlendOperationAdvancedFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.advanced_blend_coherent_operations = advanced_blend_coherent_operations.into();
         self
     }
@@ -25229,21 +23291,21 @@ impl<'a> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
     pub fn advanced_blend_max_color_attachments(
         mut self,
         advanced_blend_max_color_attachments: u32,
-    ) -> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.advanced_blend_max_color_attachments = advanced_blend_max_color_attachments;
         self
     }
     pub fn advanced_blend_independent_blend(
         mut self,
         advanced_blend_independent_blend: bool,
-    ) -> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.advanced_blend_independent_blend = advanced_blend_independent_blend.into();
         self
     }
     pub fn advanced_blend_non_premultiplied_src_color(
         mut self,
         advanced_blend_non_premultiplied_src_color: bool,
-    ) -> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.advanced_blend_non_premultiplied_src_color =
             advanced_blend_non_premultiplied_src_color.into();
         self
@@ -25251,7 +23313,7 @@ impl<'a> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
     pub fn advanced_blend_non_premultiplied_dst_color(
         mut self,
         advanced_blend_non_premultiplied_dst_color: bool,
-    ) -> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.advanced_blend_non_premultiplied_dst_color =
             advanced_blend_non_premultiplied_dst_color.into();
         self
@@ -25259,14 +23321,11 @@ impl<'a> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
     pub fn advanced_blend_correlated_overlap(
         mut self,
         advanced_blend_correlated_overlap: bool,
-    ) -> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.advanced_blend_correlated_overlap = advanced_blend_correlated_overlap.into();
         self
     }
-    pub fn advanced_blend_all_operations(
-        mut self,
-        advanced_blend_all_operations: bool,
-    ) -> PhysicalDeviceBlendOperationAdvancedPropertiesEXTBuilder<'a> {
+    pub fn advanced_blend_all_operations(mut self, advanced_blend_all_operations: bool) -> Self {
         self.inner.advanced_blend_all_operations = advanced_blend_all_operations.into();
         self
     }
@@ -25331,24 +23390,15 @@ impl<'a> ::std::ops::DerefMut for PipelineColorBlendAdvancedStateCreateInfoEXTBu
     }
 }
 impl<'a> PipelineColorBlendAdvancedStateCreateInfoEXTBuilder<'a> {
-    pub fn src_premultiplied(
-        mut self,
-        src_premultiplied: bool,
-    ) -> PipelineColorBlendAdvancedStateCreateInfoEXTBuilder<'a> {
+    pub fn src_premultiplied(mut self, src_premultiplied: bool) -> Self {
         self.inner.src_premultiplied = src_premultiplied.into();
         self
     }
-    pub fn dst_premultiplied(
-        mut self,
-        dst_premultiplied: bool,
-    ) -> PipelineColorBlendAdvancedStateCreateInfoEXTBuilder<'a> {
+    pub fn dst_premultiplied(mut self, dst_premultiplied: bool) -> Self {
         self.inner.dst_premultiplied = dst_premultiplied.into();
         self
     }
-    pub fn blend_overlap(
-        mut self,
-        blend_overlap: BlendOverlapEXT,
-    ) -> PipelineColorBlendAdvancedStateCreateInfoEXTBuilder<'a> {
+    pub fn blend_overlap(mut self, blend_overlap: BlendOverlapEXT) -> Self {
         self.inner.blend_overlap = blend_overlap;
         self
     }
@@ -25405,17 +23455,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceInlineUniformBlockFeaturesEXTBui
     }
 }
 impl<'a> PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
-    pub fn inline_uniform_block(
-        mut self,
-        inline_uniform_block: bool,
-    ) -> PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
+    pub fn inline_uniform_block(mut self, inline_uniform_block: bool) -> Self {
         self.inner.inline_uniform_block = inline_uniform_block.into();
         self
     }
     pub fn descriptor_binding_inline_uniform_block_update_after_bind(
         mut self,
         descriptor_binding_inline_uniform_block_update_after_bind: bool,
-    ) -> PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_inline_uniform_block_update_after_bind =
             descriptor_binding_inline_uniform_block_update_after_bind.into();
@@ -25483,17 +23530,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceInlineUniformBlockPropertiesEXTB
     }
 }
 impl<'a> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
-    pub fn max_inline_uniform_block_size(
-        mut self,
-        max_inline_uniform_block_size: u32,
-    ) -> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
+    pub fn max_inline_uniform_block_size(mut self, max_inline_uniform_block_size: u32) -> Self {
         self.inner.max_inline_uniform_block_size = max_inline_uniform_block_size;
         self
     }
     pub fn max_per_stage_descriptor_inline_uniform_blocks(
         mut self,
         max_per_stage_descriptor_inline_uniform_blocks: u32,
-    ) -> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_descriptor_inline_uniform_blocks =
             max_per_stage_descriptor_inline_uniform_blocks;
         self
@@ -25501,7 +23545,7 @@ impl<'a> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_inline_uniform_blocks(
         mut self,
         max_per_stage_descriptor_update_after_bind_inline_uniform_blocks: u32,
-    ) -> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_inline_uniform_blocks =
             max_per_stage_descriptor_update_after_bind_inline_uniform_blocks;
@@ -25510,7 +23554,7 @@ impl<'a> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_inline_uniform_blocks(
         mut self,
         max_descriptor_set_inline_uniform_blocks: u32,
-    ) -> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_inline_uniform_blocks =
             max_descriptor_set_inline_uniform_blocks;
         self
@@ -25518,7 +23562,7 @@ impl<'a> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_inline_uniform_blocks(
         mut self,
         max_descriptor_set_update_after_bind_inline_uniform_blocks: u32,
-    ) -> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_inline_uniform_blocks =
             max_descriptor_set_update_after_bind_inline_uniform_blocks;
@@ -25577,7 +23621,7 @@ impl<'a> ::std::ops::DerefMut for WriteDescriptorSetInlineUniformBlockEXTBuilder
     }
 }
 impl<'a> WriteDescriptorSetInlineUniformBlockEXTBuilder<'a> {
-    pub fn data(mut self, data: &'a [u8]) -> WriteDescriptorSetInlineUniformBlockEXTBuilder<'a> {
+    pub fn data(mut self, data: &'a [u8]) -> Self {
         self.inner.data_size = data.len() as _;
         self.inner.p_data = data.as_ptr() as *const c_void;
         self
@@ -25639,7 +23683,7 @@ impl<'a> DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'a> {
     pub fn max_inline_uniform_block_bindings(
         mut self,
         max_inline_uniform_block_bindings: u32,
-    ) -> DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_inline_uniform_block_bindings = max_inline_uniform_block_bindings;
         self
     }
@@ -25708,31 +23752,25 @@ impl<'a> ::std::ops::DerefMut for PipelineCoverageModulationStateCreateInfoNVBui
     }
 }
 impl<'a> PipelineCoverageModulationStateCreateInfoNVBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineCoverageModulationStateCreateFlagsNV,
-    ) -> PipelineCoverageModulationStateCreateInfoNVBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCoverageModulationStateCreateFlagsNV) -> Self {
         self.inner.flags = flags;
         self
     }
     pub fn coverage_modulation_mode(
         mut self,
         coverage_modulation_mode: CoverageModulationModeNV,
-    ) -> PipelineCoverageModulationStateCreateInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.coverage_modulation_mode = coverage_modulation_mode;
         self
     }
     pub fn coverage_modulation_table_enable(
         mut self,
         coverage_modulation_table_enable: bool,
-    ) -> PipelineCoverageModulationStateCreateInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.coverage_modulation_table_enable = coverage_modulation_table_enable.into();
         self
     }
-    pub fn coverage_modulation_table(
-        mut self,
-        coverage_modulation_table: &'a [f32],
-    ) -> PipelineCoverageModulationStateCreateInfoNVBuilder<'a> {
+    pub fn coverage_modulation_table(mut self, coverage_modulation_table: &'a [f32]) -> Self {
         self.inner.coverage_modulation_table_count = coverage_modulation_table.len() as _;
         self.inner.p_coverage_modulation_table = coverage_modulation_table.as_ptr();
         self
@@ -25794,10 +23832,7 @@ impl<'a> ::std::ops::DerefMut for ImageFormatListCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ImageFormatListCreateInfoBuilder<'a> {
-    pub fn view_formats(
-        mut self,
-        view_formats: &'a [Format],
-    ) -> ImageFormatListCreateInfoBuilder<'a> {
+    pub fn view_formats(mut self, view_formats: &'a [Format]) -> Self {
         self.inner.view_format_count = view_formats.len() as _;
         self.inner.p_view_formats = view_formats.as_ptr();
         self
@@ -25856,17 +23891,11 @@ impl<'a> ::std::ops::DerefMut for ValidationCacheCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> ValidationCacheCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: ValidationCacheCreateFlagsEXT,
-    ) -> ValidationCacheCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: ValidationCacheCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn initial_data(
-        mut self,
-        initial_data: &'a [u8],
-    ) -> ValidationCacheCreateInfoEXTBuilder<'a> {
+    pub fn initial_data(mut self, initial_data: &'a [u8]) -> Self {
         self.inner.initial_data_size = initial_data.len() as _;
         self.inner.p_initial_data = initial_data.as_ptr() as *const c_void;
         self
@@ -25876,10 +23905,7 @@ impl<'a> ValidationCacheCreateInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsValidationCacheCreateInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> ValidationCacheCreateInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsValidationCacheCreateInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -25939,10 +23965,7 @@ impl<'a> ::std::ops::DerefMut for ShaderModuleValidationCacheCreateInfoEXTBuilde
     }
 }
 impl<'a> ShaderModuleValidationCacheCreateInfoEXTBuilder<'a> {
-    pub fn validation_cache(
-        mut self,
-        validation_cache: ValidationCacheEXT,
-    ) -> ShaderModuleValidationCacheCreateInfoEXTBuilder<'a> {
+    pub fn validation_cache(mut self, validation_cache: ValidationCacheEXT) -> Self {
         self.inner.validation_cache = validation_cache;
         self
     }
@@ -25999,17 +24022,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMaintenance3PropertiesBuilder<'a
     }
 }
 impl<'a> PhysicalDeviceMaintenance3PropertiesBuilder<'a> {
-    pub fn max_per_set_descriptors(
-        mut self,
-        max_per_set_descriptors: u32,
-    ) -> PhysicalDeviceMaintenance3PropertiesBuilder<'a> {
+    pub fn max_per_set_descriptors(mut self, max_per_set_descriptors: u32) -> Self {
         self.inner.max_per_set_descriptors = max_per_set_descriptors;
         self
     }
-    pub fn max_memory_allocation_size(
-        mut self,
-        max_memory_allocation_size: DeviceSize,
-    ) -> PhysicalDeviceMaintenance3PropertiesBuilder<'a> {
+    pub fn max_memory_allocation_size(mut self, max_memory_allocation_size: DeviceSize) -> Self {
         self.inner.max_memory_allocation_size = max_memory_allocation_size;
         self
     }
@@ -26063,7 +24080,7 @@ impl<'a> ::std::ops::DerefMut for DescriptorSetLayoutSupportBuilder<'a> {
     }
 }
 impl<'a> DescriptorSetLayoutSupportBuilder<'a> {
-    pub fn supported(mut self, supported: bool) -> DescriptorSetLayoutSupportBuilder<'a> {
+    pub fn supported(mut self, supported: bool) -> Self {
         self.inner.supported = supported.into();
         self
     }
@@ -26072,10 +24089,7 @@ impl<'a> DescriptorSetLayoutSupportBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDescriptorSetLayoutSupport>(
-        mut self,
-        next: &'a mut T,
-    ) -> DescriptorSetLayoutSupportBuilder<'a> {
+    pub fn push_next<T: ExtendsDescriptorSetLayoutSupport>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -26135,10 +24149,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderDrawParametersFeaturesBuil
     }
 }
 impl<'a> PhysicalDeviceShaderDrawParametersFeaturesBuilder<'a> {
-    pub fn shader_draw_parameters(
-        mut self,
-        shader_draw_parameters: bool,
-    ) -> PhysicalDeviceShaderDrawParametersFeaturesBuilder<'a> {
+    pub fn shader_draw_parameters(mut self, shader_draw_parameters: bool) -> Self {
         self.inner.shader_draw_parameters = shader_draw_parameters.into();
         self
     }
@@ -26195,17 +24206,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderFloat16Int8FeaturesBuilder
     }
 }
 impl<'a> PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
-    pub fn shader_float16(
-        mut self,
-        shader_float16: bool,
-    ) -> PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
+    pub fn shader_float16(mut self, shader_float16: bool) -> Self {
         self.inner.shader_float16 = shader_float16.into();
         self
     }
-    pub fn shader_int8(
-        mut self,
-        shader_int8: bool,
-    ) -> PhysicalDeviceShaderFloat16Int8FeaturesBuilder<'a> {
+    pub fn shader_int8(mut self, shader_int8: bool) -> Self {
         self.inner.shader_int8 = shader_int8.into();
         self
     }
@@ -26295,21 +24300,21 @@ impl<'a> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
     pub fn denorm_behavior_independence(
         mut self,
         denorm_behavior_independence: ShaderFloatControlsIndependence,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.denorm_behavior_independence = denorm_behavior_independence;
         self
     }
     pub fn rounding_mode_independence(
         mut self,
         rounding_mode_independence: ShaderFloatControlsIndependence,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.rounding_mode_independence = rounding_mode_independence;
         self
     }
     pub fn shader_signed_zero_inf_nan_preserve_float16(
         mut self,
         shader_signed_zero_inf_nan_preserve_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_signed_zero_inf_nan_preserve_float16 =
             shader_signed_zero_inf_nan_preserve_float16.into();
         self
@@ -26317,7 +24322,7 @@ impl<'a> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
     pub fn shader_signed_zero_inf_nan_preserve_float32(
         mut self,
         shader_signed_zero_inf_nan_preserve_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_signed_zero_inf_nan_preserve_float32 =
             shader_signed_zero_inf_nan_preserve_float32.into();
         self
@@ -26325,92 +24330,83 @@ impl<'a> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
     pub fn shader_signed_zero_inf_nan_preserve_float64(
         mut self,
         shader_signed_zero_inf_nan_preserve_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_signed_zero_inf_nan_preserve_float64 =
             shader_signed_zero_inf_nan_preserve_float64.into();
         self
     }
-    pub fn shader_denorm_preserve_float16(
-        mut self,
-        shader_denorm_preserve_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    pub fn shader_denorm_preserve_float16(mut self, shader_denorm_preserve_float16: bool) -> Self {
         self.inner.shader_denorm_preserve_float16 = shader_denorm_preserve_float16.into();
         self
     }
-    pub fn shader_denorm_preserve_float32(
-        mut self,
-        shader_denorm_preserve_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    pub fn shader_denorm_preserve_float32(mut self, shader_denorm_preserve_float32: bool) -> Self {
         self.inner.shader_denorm_preserve_float32 = shader_denorm_preserve_float32.into();
         self
     }
-    pub fn shader_denorm_preserve_float64(
-        mut self,
-        shader_denorm_preserve_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    pub fn shader_denorm_preserve_float64(mut self, shader_denorm_preserve_float64: bool) -> Self {
         self.inner.shader_denorm_preserve_float64 = shader_denorm_preserve_float64.into();
         self
     }
     pub fn shader_denorm_flush_to_zero_float16(
         mut self,
         shader_denorm_flush_to_zero_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_denorm_flush_to_zero_float16 = shader_denorm_flush_to_zero_float16.into();
         self
     }
     pub fn shader_denorm_flush_to_zero_float32(
         mut self,
         shader_denorm_flush_to_zero_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_denorm_flush_to_zero_float32 = shader_denorm_flush_to_zero_float32.into();
         self
     }
     pub fn shader_denorm_flush_to_zero_float64(
         mut self,
         shader_denorm_flush_to_zero_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_denorm_flush_to_zero_float64 = shader_denorm_flush_to_zero_float64.into();
         self
     }
     pub fn shader_rounding_mode_rte_float16(
         mut self,
         shader_rounding_mode_rte_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rte_float16 = shader_rounding_mode_rte_float16.into();
         self
     }
     pub fn shader_rounding_mode_rte_float32(
         mut self,
         shader_rounding_mode_rte_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rte_float32 = shader_rounding_mode_rte_float32.into();
         self
     }
     pub fn shader_rounding_mode_rte_float64(
         mut self,
         shader_rounding_mode_rte_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rte_float64 = shader_rounding_mode_rte_float64.into();
         self
     }
     pub fn shader_rounding_mode_rtz_float16(
         mut self,
         shader_rounding_mode_rtz_float16: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rtz_float16 = shader_rounding_mode_rtz_float16.into();
         self
     }
     pub fn shader_rounding_mode_rtz_float32(
         mut self,
         shader_rounding_mode_rtz_float32: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rtz_float32 = shader_rounding_mode_rtz_float32.into();
         self
     }
     pub fn shader_rounding_mode_rtz_float64(
         mut self,
         shader_rounding_mode_rtz_float64: bool,
-    ) -> PhysicalDeviceFloatControlsPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rtz_float64 = shader_rounding_mode_rtz_float64.into();
         self
     }
@@ -26465,10 +24461,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceHostQueryResetFeaturesBuilder<'a
     }
 }
 impl<'a> PhysicalDeviceHostQueryResetFeaturesBuilder<'a> {
-    pub fn host_query_reset(
-        mut self,
-        host_query_reset: bool,
-    ) -> PhysicalDeviceHostQueryResetFeaturesBuilder<'a> {
+    pub fn host_query_reset(mut self, host_query_reset: bool) -> Self {
         self.inner.host_query_reset = host_query_reset.into();
         self
     }
@@ -26511,11 +24504,11 @@ impl<'a> ::std::ops::DerefMut for NativeBufferUsage2ANDROIDBuilder<'a> {
     }
 }
 impl<'a> NativeBufferUsage2ANDROIDBuilder<'a> {
-    pub fn consumer(mut self, consumer: u64) -> NativeBufferUsage2ANDROIDBuilder<'a> {
+    pub fn consumer(mut self, consumer: u64) -> Self {
         self.inner.consumer = consumer;
         self
     }
-    pub fn producer(mut self, producer: u64) -> NativeBufferUsage2ANDROIDBuilder<'a> {
+    pub fn producer(mut self, producer: u64) -> Self {
         self.inner.producer = producer;
         self
     }
@@ -26577,23 +24570,23 @@ impl<'a> ::std::ops::DerefMut for NativeBufferANDROIDBuilder<'a> {
     }
 }
 impl<'a> NativeBufferANDROIDBuilder<'a> {
-    pub fn handle(mut self, handle: *const c_void) -> NativeBufferANDROIDBuilder<'a> {
+    pub fn handle(mut self, handle: *const c_void) -> Self {
         self.inner.handle = handle;
         self
     }
-    pub fn stride(mut self, stride: c_int) -> NativeBufferANDROIDBuilder<'a> {
+    pub fn stride(mut self, stride: c_int) -> Self {
         self.inner.stride = stride;
         self
     }
-    pub fn format(mut self, format: c_int) -> NativeBufferANDROIDBuilder<'a> {
+    pub fn format(mut self, format: c_int) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn usage(mut self, usage: c_int) -> NativeBufferANDROIDBuilder<'a> {
+    pub fn usage(mut self, usage: c_int) -> Self {
         self.inner.usage = usage;
         self
     }
-    pub fn usage2(mut self, usage2: NativeBufferUsage2ANDROID) -> NativeBufferANDROIDBuilder<'a> {
+    pub fn usage2(mut self, usage2: NativeBufferUsage2ANDROID) -> Self {
         self.inner.usage2 = usage2;
         self
     }
@@ -26602,10 +24595,7 @@ impl<'a> NativeBufferANDROIDBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsNativeBufferANDROID>(
-        mut self,
-        next: &'a mut T,
-    ) -> NativeBufferANDROIDBuilder<'a> {
+    pub fn push_next<T: ExtendsNativeBufferANDROID>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -26664,10 +24654,7 @@ impl<'a> ::std::ops::DerefMut for SwapchainImageCreateInfoANDROIDBuilder<'a> {
     }
 }
 impl<'a> SwapchainImageCreateInfoANDROIDBuilder<'a> {
-    pub fn usage(
-        mut self,
-        usage: SwapchainImageUsageFlagsANDROID,
-    ) -> SwapchainImageCreateInfoANDROIDBuilder<'a> {
+    pub fn usage(mut self, usage: SwapchainImageUsageFlagsANDROID) -> Self {
         self.inner.usage = usage;
         self
     }
@@ -26676,10 +24663,7 @@ impl<'a> SwapchainImageCreateInfoANDROIDBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSwapchainImageCreateInfoANDROID>(
-        mut self,
-        next: &'a mut T,
-    ) -> SwapchainImageCreateInfoANDROIDBuilder<'a> {
+    pub fn push_next<T: ExtendsSwapchainImageCreateInfoANDROID>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -26738,10 +24722,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDevicePresentationPropertiesANDROIDBui
     }
 }
 impl<'a> PhysicalDevicePresentationPropertiesANDROIDBuilder<'a> {
-    pub fn shared_image(
-        mut self,
-        shared_image: bool,
-    ) -> PhysicalDevicePresentationPropertiesANDROIDBuilder<'a> {
+    pub fn shared_image(mut self, shared_image: bool) -> Self {
         self.inner.shared_image = shared_image.into();
         self
     }
@@ -26753,7 +24734,7 @@ impl<'a> PhysicalDevicePresentationPropertiesANDROIDBuilder<'a> {
     pub fn push_next<T: ExtendsPhysicalDevicePresentationPropertiesANDROID>(
         mut self,
         next: &'a mut T,
-    ) -> PhysicalDevicePresentationPropertiesANDROIDBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -26804,32 +24785,23 @@ impl<'a> ::std::ops::DerefMut for ShaderResourceUsageAMDBuilder<'a> {
     }
 }
 impl<'a> ShaderResourceUsageAMDBuilder<'a> {
-    pub fn num_used_vgprs(mut self, num_used_vgprs: u32) -> ShaderResourceUsageAMDBuilder<'a> {
+    pub fn num_used_vgprs(mut self, num_used_vgprs: u32) -> Self {
         self.inner.num_used_vgprs = num_used_vgprs;
         self
     }
-    pub fn num_used_sgprs(mut self, num_used_sgprs: u32) -> ShaderResourceUsageAMDBuilder<'a> {
+    pub fn num_used_sgprs(mut self, num_used_sgprs: u32) -> Self {
         self.inner.num_used_sgprs = num_used_sgprs;
         self
     }
-    pub fn lds_size_per_local_work_group(
-        mut self,
-        lds_size_per_local_work_group: u32,
-    ) -> ShaderResourceUsageAMDBuilder<'a> {
+    pub fn lds_size_per_local_work_group(mut self, lds_size_per_local_work_group: u32) -> Self {
         self.inner.lds_size_per_local_work_group = lds_size_per_local_work_group;
         self
     }
-    pub fn lds_usage_size_in_bytes(
-        mut self,
-        lds_usage_size_in_bytes: usize,
-    ) -> ShaderResourceUsageAMDBuilder<'a> {
+    pub fn lds_usage_size_in_bytes(mut self, lds_usage_size_in_bytes: usize) -> Self {
         self.inner.lds_usage_size_in_bytes = lds_usage_size_in_bytes;
         self
     }
-    pub fn scratch_mem_usage_in_bytes(
-        mut self,
-        scratch_mem_usage_in_bytes: usize,
-    ) -> ShaderResourceUsageAMDBuilder<'a> {
+    pub fn scratch_mem_usage_in_bytes(mut self, scratch_mem_usage_in_bytes: usize) -> Self {
         self.inner.scratch_mem_usage_in_bytes = scratch_mem_usage_in_bytes;
         self
     }
@@ -26890,52 +24862,31 @@ impl<'a> ::std::ops::DerefMut for ShaderStatisticsInfoAMDBuilder<'a> {
     }
 }
 impl<'a> ShaderStatisticsInfoAMDBuilder<'a> {
-    pub fn shader_stage_mask(
-        mut self,
-        shader_stage_mask: ShaderStageFlags,
-    ) -> ShaderStatisticsInfoAMDBuilder<'a> {
+    pub fn shader_stage_mask(mut self, shader_stage_mask: ShaderStageFlags) -> Self {
         self.inner.shader_stage_mask = shader_stage_mask;
         self
     }
-    pub fn resource_usage(
-        mut self,
-        resource_usage: ShaderResourceUsageAMD,
-    ) -> ShaderStatisticsInfoAMDBuilder<'a> {
+    pub fn resource_usage(mut self, resource_usage: ShaderResourceUsageAMD) -> Self {
         self.inner.resource_usage = resource_usage;
         self
     }
-    pub fn num_physical_vgprs(
-        mut self,
-        num_physical_vgprs: u32,
-    ) -> ShaderStatisticsInfoAMDBuilder<'a> {
+    pub fn num_physical_vgprs(mut self, num_physical_vgprs: u32) -> Self {
         self.inner.num_physical_vgprs = num_physical_vgprs;
         self
     }
-    pub fn num_physical_sgprs(
-        mut self,
-        num_physical_sgprs: u32,
-    ) -> ShaderStatisticsInfoAMDBuilder<'a> {
+    pub fn num_physical_sgprs(mut self, num_physical_sgprs: u32) -> Self {
         self.inner.num_physical_sgprs = num_physical_sgprs;
         self
     }
-    pub fn num_available_vgprs(
-        mut self,
-        num_available_vgprs: u32,
-    ) -> ShaderStatisticsInfoAMDBuilder<'a> {
+    pub fn num_available_vgprs(mut self, num_available_vgprs: u32) -> Self {
         self.inner.num_available_vgprs = num_available_vgprs;
         self
     }
-    pub fn num_available_sgprs(
-        mut self,
-        num_available_sgprs: u32,
-    ) -> ShaderStatisticsInfoAMDBuilder<'a> {
+    pub fn num_available_sgprs(mut self, num_available_sgprs: u32) -> Self {
         self.inner.num_available_sgprs = num_available_sgprs;
         self
     }
-    pub fn compute_work_group_size(
-        mut self,
-        compute_work_group_size: [u32; 3],
-    ) -> ShaderStatisticsInfoAMDBuilder<'a> {
+    pub fn compute_work_group_size(mut self, compute_work_group_size: [u32; 3]) -> Self {
         self.inner.compute_work_group_size = compute_work_group_size;
         self
     }
@@ -26990,10 +24941,7 @@ impl<'a> ::std::ops::DerefMut for DeviceQueueGlobalPriorityCreateInfoEXTBuilder<
     }
 }
 impl<'a> DeviceQueueGlobalPriorityCreateInfoEXTBuilder<'a> {
-    pub fn global_priority(
-        mut self,
-        global_priority: QueueGlobalPriorityEXT,
-    ) -> DeviceQueueGlobalPriorityCreateInfoEXTBuilder<'a> {
+    pub fn global_priority(mut self, global_priority: QueueGlobalPriorityEXT) -> Self {
         self.inner.global_priority = global_priority;
         self
     }
@@ -27051,21 +24999,15 @@ impl<'a> ::std::ops::DerefMut for DebugUtilsObjectNameInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DebugUtilsObjectNameInfoEXTBuilder<'a> {
-    pub fn object_type(
-        mut self,
-        object_type: ObjectType,
-    ) -> DebugUtilsObjectNameInfoEXTBuilder<'a> {
+    pub fn object_type(mut self, object_type: ObjectType) -> Self {
         self.inner.object_type = object_type;
         self
     }
-    pub fn object_handle(mut self, object_handle: u64) -> DebugUtilsObjectNameInfoEXTBuilder<'a> {
+    pub fn object_handle(mut self, object_handle: u64) -> Self {
         self.inner.object_handle = object_handle;
         self
     }
-    pub fn object_name(
-        mut self,
-        object_name: &'a ::std::ffi::CStr,
-    ) -> DebugUtilsObjectNameInfoEXTBuilder<'a> {
+    pub fn object_name(mut self, object_name: &'a ::std::ffi::CStr) -> Self {
         self.inner.p_object_name = object_name.as_ptr();
         self
     }
@@ -27074,10 +25016,7 @@ impl<'a> DebugUtilsObjectNameInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDebugUtilsObjectNameInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DebugUtilsObjectNameInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDebugUtilsObjectNameInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -27144,19 +25083,19 @@ impl<'a> ::std::ops::DerefMut for DebugUtilsObjectTagInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DebugUtilsObjectTagInfoEXTBuilder<'a> {
-    pub fn object_type(mut self, object_type: ObjectType) -> DebugUtilsObjectTagInfoEXTBuilder<'a> {
+    pub fn object_type(mut self, object_type: ObjectType) -> Self {
         self.inner.object_type = object_type;
         self
     }
-    pub fn object_handle(mut self, object_handle: u64) -> DebugUtilsObjectTagInfoEXTBuilder<'a> {
+    pub fn object_handle(mut self, object_handle: u64) -> Self {
         self.inner.object_handle = object_handle;
         self
     }
-    pub fn tag_name(mut self, tag_name: u64) -> DebugUtilsObjectTagInfoEXTBuilder<'a> {
+    pub fn tag_name(mut self, tag_name: u64) -> Self {
         self.inner.tag_name = tag_name;
         self
     }
-    pub fn tag(mut self, tag: &'a [u8]) -> DebugUtilsObjectTagInfoEXTBuilder<'a> {
+    pub fn tag(mut self, tag: &'a [u8]) -> Self {
         self.inner.tag_size = tag.len() as _;
         self.inner.p_tag = tag.as_ptr() as *const c_void;
         self
@@ -27166,10 +25105,7 @@ impl<'a> DebugUtilsObjectTagInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDebugUtilsObjectTagInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DebugUtilsObjectTagInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDebugUtilsObjectTagInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -27230,11 +25166,11 @@ impl<'a> ::std::ops::DerefMut for DebugUtilsLabelEXTBuilder<'a> {
     }
 }
 impl<'a> DebugUtilsLabelEXTBuilder<'a> {
-    pub fn label_name(mut self, label_name: &'a ::std::ffi::CStr) -> DebugUtilsLabelEXTBuilder<'a> {
+    pub fn label_name(mut self, label_name: &'a ::std::ffi::CStr) -> Self {
         self.inner.p_label_name = label_name.as_ptr();
         self
     }
-    pub fn color(mut self, color: [f32; 4]) -> DebugUtilsLabelEXTBuilder<'a> {
+    pub fn color(mut self, color: [f32; 4]) -> Self {
         self.inner.color = color;
         self
     }
@@ -27243,10 +25179,7 @@ impl<'a> DebugUtilsLabelEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsDebugUtilsLabelEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> DebugUtilsLabelEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsDebugUtilsLabelEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -27330,38 +25263,26 @@ impl<'a> ::std::ops::DerefMut for DebugUtilsMessengerCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> DebugUtilsMessengerCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DebugUtilsMessengerCreateFlagsEXT,
-    ) -> DebugUtilsMessengerCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: DebugUtilsMessengerCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn message_severity(
-        mut self,
-        message_severity: DebugUtilsMessageSeverityFlagsEXT,
-    ) -> DebugUtilsMessengerCreateInfoEXTBuilder<'a> {
+    pub fn message_severity(mut self, message_severity: DebugUtilsMessageSeverityFlagsEXT) -> Self {
         self.inner.message_severity = message_severity;
         self
     }
-    pub fn message_type(
-        mut self,
-        message_type: DebugUtilsMessageTypeFlagsEXT,
-    ) -> DebugUtilsMessengerCreateInfoEXTBuilder<'a> {
+    pub fn message_type(mut self, message_type: DebugUtilsMessageTypeFlagsEXT) -> Self {
         self.inner.message_type = message_type;
         self
     }
     pub fn pfn_user_callback(
         mut self,
         pfn_user_callback: PFN_vkDebugUtilsMessengerCallbackEXT,
-    ) -> DebugUtilsMessengerCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.pfn_user_callback = pfn_user_callback;
         self
     }
-    pub fn user_data(
-        mut self,
-        user_data: *mut c_void,
-    ) -> DebugUtilsMessengerCreateInfoEXTBuilder<'a> {
+    pub fn user_data(mut self, user_data: *mut c_void) -> Self {
         self.inner.p_user_data = user_data;
         self
     }
@@ -27433,54 +25354,33 @@ impl<'a> ::std::ops::DerefMut for DebugUtilsMessengerCallbackDataEXTBuilder<'a> 
     }
 }
 impl<'a> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DebugUtilsMessengerCallbackDataFlagsEXT,
-    ) -> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
+    pub fn flags(mut self, flags: DebugUtilsMessengerCallbackDataFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn message_id_name(
-        mut self,
-        message_id_name: &'a ::std::ffi::CStr,
-    ) -> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
+    pub fn message_id_name(mut self, message_id_name: &'a ::std::ffi::CStr) -> Self {
         self.inner.p_message_id_name = message_id_name.as_ptr();
         self
     }
-    pub fn message_id_number(
-        mut self,
-        message_id_number: i32,
-    ) -> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
+    pub fn message_id_number(mut self, message_id_number: i32) -> Self {
         self.inner.message_id_number = message_id_number;
         self
     }
-    pub fn message(
-        mut self,
-        message: &'a ::std::ffi::CStr,
-    ) -> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
+    pub fn message(mut self, message: &'a ::std::ffi::CStr) -> Self {
         self.inner.p_message = message.as_ptr();
         self
     }
-    pub fn queue_labels(
-        mut self,
-        queue_labels: &'a [DebugUtilsLabelEXT],
-    ) -> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
+    pub fn queue_labels(mut self, queue_labels: &'a [DebugUtilsLabelEXT]) -> Self {
         self.inner.queue_label_count = queue_labels.len() as _;
         self.inner.p_queue_labels = queue_labels.as_ptr();
         self
     }
-    pub fn cmd_buf_labels(
-        mut self,
-        cmd_buf_labels: &'a [DebugUtilsLabelEXT],
-    ) -> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
+    pub fn cmd_buf_labels(mut self, cmd_buf_labels: &'a [DebugUtilsLabelEXT]) -> Self {
         self.inner.cmd_buf_label_count = cmd_buf_labels.len() as _;
         self.inner.p_cmd_buf_labels = cmd_buf_labels.as_ptr();
         self
     }
-    pub fn objects(
-        mut self,
-        objects: &'a [DebugUtilsObjectNameInfoEXT],
-    ) -> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
+    pub fn objects(mut self, objects: &'a [DebugUtilsObjectNameInfoEXT]) -> Self {
         self.inner.object_count = objects.len() as _;
         self.inner.p_objects = objects.as_ptr();
         self
@@ -27493,7 +25393,7 @@ impl<'a> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
     pub fn push_next<T: ExtendsDebugUtilsMessengerCallbackDataEXT>(
         mut self,
         next: &'a mut T,
-    ) -> DebugUtilsMessengerCallbackDataEXTBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -27553,10 +25453,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceDeviceMemoryReportFeaturesEXTBui
     }
 }
 impl<'a> PhysicalDeviceDeviceMemoryReportFeaturesEXTBuilder<'a> {
-    pub fn device_memory_report(
-        mut self,
-        device_memory_report: bool,
-    ) -> PhysicalDeviceDeviceMemoryReportFeaturesEXTBuilder<'a> {
+    pub fn device_memory_report(mut self, device_memory_report: bool) -> Self {
         self.inner.device_memory_report = device_memory_report.into();
         self
     }
@@ -27629,24 +25526,18 @@ impl<'a> ::std::ops::DerefMut for DeviceDeviceMemoryReportCreateInfoEXTBuilder<'
     }
 }
 impl<'a> DeviceDeviceMemoryReportCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DeviceMemoryReportFlagsEXT,
-    ) -> DeviceDeviceMemoryReportCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: DeviceMemoryReportFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
     pub fn pfn_user_callback(
         mut self,
         pfn_user_callback: PFN_vkDeviceMemoryReportCallbackEXT,
-    ) -> DeviceDeviceMemoryReportCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.pfn_user_callback = pfn_user_callback;
         self
     }
-    pub fn user_data(
-        mut self,
-        user_data: *mut c_void,
-    ) -> DeviceDeviceMemoryReportCreateInfoEXTBuilder<'a> {
+    pub fn user_data(mut self, user_data: *mut c_void) -> Self {
         self.inner.p_user_data = user_data;
         self
     }
@@ -27712,46 +25603,31 @@ impl<'a> ::std::ops::DerefMut for DeviceMemoryReportCallbackDataEXTBuilder<'a> {
     }
 }
 impl<'a> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DeviceMemoryReportFlagsEXT,
-    ) -> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
+    pub fn flags(mut self, flags: DeviceMemoryReportFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn ty(
-        mut self,
-        ty: DeviceMemoryReportEventTypeEXT,
-    ) -> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
+    pub fn ty(mut self, ty: DeviceMemoryReportEventTypeEXT) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn memory_object_id(
-        mut self,
-        memory_object_id: u64,
-    ) -> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
+    pub fn memory_object_id(mut self, memory_object_id: u64) -> Self {
         self.inner.memory_object_id = memory_object_id;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
-    pub fn object_type(
-        mut self,
-        object_type: ObjectType,
-    ) -> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
+    pub fn object_type(mut self, object_type: ObjectType) -> Self {
         self.inner.object_type = object_type;
         self
     }
-    pub fn object_handle(
-        mut self,
-        object_handle: u64,
-    ) -> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
+    pub fn object_handle(mut self, object_handle: u64) -> Self {
         self.inner.object_handle = object_handle;
         self
     }
-    pub fn heap_index(mut self, heap_index: u32) -> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
+    pub fn heap_index(mut self, heap_index: u32) -> Self {
         self.inner.heap_index = heap_index;
         self
     }
@@ -27763,7 +25639,7 @@ impl<'a> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
     pub fn push_next<T: ExtendsDeviceMemoryReportCallbackDataEXT>(
         mut self,
         next: &'a mut T,
-    ) -> DeviceMemoryReportCallbackDataEXTBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -27825,17 +25701,11 @@ impl<'a> ::std::ops::DerefMut for ImportMemoryHostPointerInfoEXTBuilder<'a> {
     }
 }
 impl<'a> ImportMemoryHostPointerInfoEXTBuilder<'a> {
-    pub fn handle_type(
-        mut self,
-        handle_type: ExternalMemoryHandleTypeFlags,
-    ) -> ImportMemoryHostPointerInfoEXTBuilder<'a> {
+    pub fn handle_type(mut self, handle_type: ExternalMemoryHandleTypeFlags) -> Self {
         self.inner.handle_type = handle_type;
         self
     }
-    pub fn host_pointer(
-        mut self,
-        host_pointer: *mut c_void,
-    ) -> ImportMemoryHostPointerInfoEXTBuilder<'a> {
+    pub fn host_pointer(mut self, host_pointer: *mut c_void) -> Self {
         self.inner.p_host_pointer = host_pointer;
         self
     }
@@ -27889,10 +25759,7 @@ impl<'a> ::std::ops::DerefMut for MemoryHostPointerPropertiesEXTBuilder<'a> {
     }
 }
 impl<'a> MemoryHostPointerPropertiesEXTBuilder<'a> {
-    pub fn memory_type_bits(
-        mut self,
-        memory_type_bits: u32,
-    ) -> MemoryHostPointerPropertiesEXTBuilder<'a> {
+    pub fn memory_type_bits(mut self, memory_type_bits: u32) -> Self {
         self.inner.memory_type_bits = memory_type_bits;
         self
     }
@@ -27901,10 +25768,7 @@ impl<'a> MemoryHostPointerPropertiesEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsMemoryHostPointerPropertiesEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> MemoryHostPointerPropertiesEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsMemoryHostPointerPropertiesEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -27970,7 +25834,7 @@ impl<'a> PhysicalDeviceExternalMemoryHostPropertiesEXTBuilder<'a> {
     pub fn min_imported_host_pointer_alignment(
         mut self,
         min_imported_host_pointer_alignment: DeviceSize,
-    ) -> PhysicalDeviceExternalMemoryHostPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.min_imported_host_pointer_alignment = min_imported_host_pointer_alignment;
         self
     }
@@ -28047,17 +25911,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceConservativeRasterizationPropert
     }
 }
 impl<'a> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
-    pub fn primitive_overestimation_size(
-        mut self,
-        primitive_overestimation_size: f32,
-    ) -> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
+    pub fn primitive_overestimation_size(mut self, primitive_overestimation_size: f32) -> Self {
         self.inner.primitive_overestimation_size = primitive_overestimation_size;
         self
     }
     pub fn max_extra_primitive_overestimation_size(
         mut self,
         max_extra_primitive_overestimation_size: f32,
-    ) -> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_extra_primitive_overestimation_size =
             max_extra_primitive_overestimation_size;
         self
@@ -28065,22 +25926,19 @@ impl<'a> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
     pub fn extra_primitive_overestimation_size_granularity(
         mut self,
         extra_primitive_overestimation_size_granularity: f32,
-    ) -> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.extra_primitive_overestimation_size_granularity =
             extra_primitive_overestimation_size_granularity;
         self
     }
-    pub fn primitive_underestimation(
-        mut self,
-        primitive_underestimation: bool,
-    ) -> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
+    pub fn primitive_underestimation(mut self, primitive_underestimation: bool) -> Self {
         self.inner.primitive_underestimation = primitive_underestimation.into();
         self
     }
     pub fn conservative_point_and_line_rasterization(
         mut self,
         conservative_point_and_line_rasterization: bool,
-    ) -> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.conservative_point_and_line_rasterization =
             conservative_point_and_line_rasterization.into();
         self
@@ -28088,21 +25946,18 @@ impl<'a> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
     pub fn degenerate_triangles_rasterized(
         mut self,
         degenerate_triangles_rasterized: bool,
-    ) -> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.degenerate_triangles_rasterized = degenerate_triangles_rasterized.into();
         self
     }
-    pub fn degenerate_lines_rasterized(
-        mut self,
-        degenerate_lines_rasterized: bool,
-    ) -> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
+    pub fn degenerate_lines_rasterized(mut self, degenerate_lines_rasterized: bool) -> Self {
         self.inner.degenerate_lines_rasterized = degenerate_lines_rasterized.into();
         self
     }
     pub fn fully_covered_fragment_shader_input_variable(
         mut self,
         fully_covered_fragment_shader_input_variable: bool,
-    ) -> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.fully_covered_fragment_shader_input_variable =
             fully_covered_fragment_shader_input_variable.into();
         self
@@ -28110,7 +25965,7 @@ impl<'a> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
     pub fn conservative_rasterization_post_depth_coverage(
         mut self,
         conservative_rasterization_post_depth_coverage: bool,
-    ) -> PhysicalDeviceConservativeRasterizationPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.conservative_rasterization_post_depth_coverage =
             conservative_rasterization_post_depth_coverage.into();
         self
@@ -28165,10 +26020,7 @@ impl<'a> ::std::ops::DerefMut for CalibratedTimestampInfoEXTBuilder<'a> {
     }
 }
 impl<'a> CalibratedTimestampInfoEXTBuilder<'a> {
-    pub fn time_domain(
-        mut self,
-        time_domain: TimeDomainEXT,
-    ) -> CalibratedTimestampInfoEXTBuilder<'a> {
+    pub fn time_domain(mut self, time_domain: TimeDomainEXT) -> Self {
         self.inner.time_domain = time_domain;
         self
     }
@@ -28177,10 +26029,7 @@ impl<'a> CalibratedTimestampInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCalibratedTimestampInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> CalibratedTimestampInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsCalibratedTimestampInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -28266,101 +26115,59 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderCorePropertiesAMDBuilder<'
     }
 }
 impl<'a> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
-    pub fn shader_engine_count(
-        mut self,
-        shader_engine_count: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn shader_engine_count(mut self, shader_engine_count: u32) -> Self {
         self.inner.shader_engine_count = shader_engine_count;
         self
     }
-    pub fn shader_arrays_per_engine_count(
-        mut self,
-        shader_arrays_per_engine_count: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn shader_arrays_per_engine_count(mut self, shader_arrays_per_engine_count: u32) -> Self {
         self.inner.shader_arrays_per_engine_count = shader_arrays_per_engine_count;
         self
     }
-    pub fn compute_units_per_shader_array(
-        mut self,
-        compute_units_per_shader_array: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn compute_units_per_shader_array(mut self, compute_units_per_shader_array: u32) -> Self {
         self.inner.compute_units_per_shader_array = compute_units_per_shader_array;
         self
     }
-    pub fn simd_per_compute_unit(
-        mut self,
-        simd_per_compute_unit: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn simd_per_compute_unit(mut self, simd_per_compute_unit: u32) -> Self {
         self.inner.simd_per_compute_unit = simd_per_compute_unit;
         self
     }
-    pub fn wavefronts_per_simd(
-        mut self,
-        wavefronts_per_simd: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn wavefronts_per_simd(mut self, wavefronts_per_simd: u32) -> Self {
         self.inner.wavefronts_per_simd = wavefronts_per_simd;
         self
     }
-    pub fn wavefront_size(
-        mut self,
-        wavefront_size: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn wavefront_size(mut self, wavefront_size: u32) -> Self {
         self.inner.wavefront_size = wavefront_size;
         self
     }
-    pub fn sgprs_per_simd(
-        mut self,
-        sgprs_per_simd: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn sgprs_per_simd(mut self, sgprs_per_simd: u32) -> Self {
         self.inner.sgprs_per_simd = sgprs_per_simd;
         self
     }
-    pub fn min_sgpr_allocation(
-        mut self,
-        min_sgpr_allocation: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn min_sgpr_allocation(mut self, min_sgpr_allocation: u32) -> Self {
         self.inner.min_sgpr_allocation = min_sgpr_allocation;
         self
     }
-    pub fn max_sgpr_allocation(
-        mut self,
-        max_sgpr_allocation: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn max_sgpr_allocation(mut self, max_sgpr_allocation: u32) -> Self {
         self.inner.max_sgpr_allocation = max_sgpr_allocation;
         self
     }
-    pub fn sgpr_allocation_granularity(
-        mut self,
-        sgpr_allocation_granularity: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn sgpr_allocation_granularity(mut self, sgpr_allocation_granularity: u32) -> Self {
         self.inner.sgpr_allocation_granularity = sgpr_allocation_granularity;
         self
     }
-    pub fn vgprs_per_simd(
-        mut self,
-        vgprs_per_simd: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn vgprs_per_simd(mut self, vgprs_per_simd: u32) -> Self {
         self.inner.vgprs_per_simd = vgprs_per_simd;
         self
     }
-    pub fn min_vgpr_allocation(
-        mut self,
-        min_vgpr_allocation: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn min_vgpr_allocation(mut self, min_vgpr_allocation: u32) -> Self {
         self.inner.min_vgpr_allocation = min_vgpr_allocation;
         self
     }
-    pub fn max_vgpr_allocation(
-        mut self,
-        max_vgpr_allocation: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn max_vgpr_allocation(mut self, max_vgpr_allocation: u32) -> Self {
         self.inner.max_vgpr_allocation = max_vgpr_allocation;
         self
     }
-    pub fn vgpr_allocation_granularity(
-        mut self,
-        vgpr_allocation_granularity: u32,
-    ) -> PhysicalDeviceShaderCorePropertiesAMDBuilder<'a> {
+    pub fn vgpr_allocation_granularity(mut self, vgpr_allocation_granularity: u32) -> Self {
         self.inner.vgpr_allocation_granularity = vgpr_allocation_granularity;
         self
     }
@@ -28420,14 +26227,11 @@ impl<'a> PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
     pub fn shader_core_features(
         mut self,
         shader_core_features: ShaderCorePropertiesFlagsAMD,
-    ) -> PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
+    ) -> Self {
         self.inner.shader_core_features = shader_core_features;
         self
     }
-    pub fn active_compute_unit_count(
-        mut self,
-        active_compute_unit_count: u32,
-    ) -> PhysicalDeviceShaderCoreProperties2AMDBuilder<'a> {
+    pub fn active_compute_unit_count(mut self, active_compute_unit_count: u32) -> Self {
         self.inner.active_compute_unit_count = active_compute_unit_count;
         self
     }
@@ -28492,24 +26296,21 @@ impl<'a> ::std::ops::DerefMut for PipelineRasterizationConservativeStateCreateIn
     }
 }
 impl<'a> PipelineRasterizationConservativeStateCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineRasterizationConservativeStateCreateFlagsEXT,
-    ) -> PipelineRasterizationConservativeStateCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineRasterizationConservativeStateCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
     pub fn conservative_rasterization_mode(
         mut self,
         conservative_rasterization_mode: ConservativeRasterizationModeEXT,
-    ) -> PipelineRasterizationConservativeStateCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.conservative_rasterization_mode = conservative_rasterization_mode;
         self
     }
     pub fn extra_primitive_overestimation_size(
         mut self,
         extra_primitive_overestimation_size: f32,
-    ) -> PipelineRasterizationConservativeStateCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.extra_primitive_overestimation_size = extra_primitive_overestimation_size;
         self
     }
@@ -28605,7 +26406,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_input_attachment_array_dynamic_indexing(
         mut self,
         shader_input_attachment_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_input_attachment_array_dynamic_indexing =
             shader_input_attachment_array_dynamic_indexing.into();
         self
@@ -28613,7 +26414,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_uniform_texel_buffer_array_dynamic_indexing(
         mut self,
         shader_uniform_texel_buffer_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_uniform_texel_buffer_array_dynamic_indexing =
             shader_uniform_texel_buffer_array_dynamic_indexing.into();
@@ -28622,7 +26423,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_storage_texel_buffer_array_dynamic_indexing(
         mut self,
         shader_storage_texel_buffer_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_storage_texel_buffer_array_dynamic_indexing =
             shader_storage_texel_buffer_array_dynamic_indexing.into();
@@ -28631,7 +26432,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_uniform_buffer_array_non_uniform_indexing(
         mut self,
         shader_uniform_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_uniform_buffer_array_non_uniform_indexing =
             shader_uniform_buffer_array_non_uniform_indexing.into();
         self
@@ -28639,7 +26440,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_sampled_image_array_non_uniform_indexing(
         mut self,
         shader_sampled_image_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_sampled_image_array_non_uniform_indexing =
             shader_sampled_image_array_non_uniform_indexing.into();
         self
@@ -28647,7 +26448,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_storage_buffer_array_non_uniform_indexing(
         mut self,
         shader_storage_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_buffer_array_non_uniform_indexing =
             shader_storage_buffer_array_non_uniform_indexing.into();
         self
@@ -28655,7 +26456,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_storage_image_array_non_uniform_indexing(
         mut self,
         shader_storage_image_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_image_array_non_uniform_indexing =
             shader_storage_image_array_non_uniform_indexing.into();
         self
@@ -28663,7 +26464,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_input_attachment_array_non_uniform_indexing(
         mut self,
         shader_input_attachment_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_input_attachment_array_non_uniform_indexing =
             shader_input_attachment_array_non_uniform_indexing.into();
@@ -28672,7 +26473,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_uniform_texel_buffer_array_non_uniform_indexing(
         mut self,
         shader_uniform_texel_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_uniform_texel_buffer_array_non_uniform_indexing =
             shader_uniform_texel_buffer_array_non_uniform_indexing.into();
@@ -28681,7 +26482,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn shader_storage_texel_buffer_array_non_uniform_indexing(
         mut self,
         shader_storage_texel_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_storage_texel_buffer_array_non_uniform_indexing =
             shader_storage_texel_buffer_array_non_uniform_indexing.into();
@@ -28690,7 +26491,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn descriptor_binding_uniform_buffer_update_after_bind(
         mut self,
         descriptor_binding_uniform_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_uniform_buffer_update_after_bind =
             descriptor_binding_uniform_buffer_update_after_bind.into();
@@ -28699,7 +26500,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn descriptor_binding_sampled_image_update_after_bind(
         mut self,
         descriptor_binding_sampled_image_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_sampled_image_update_after_bind =
             descriptor_binding_sampled_image_update_after_bind.into();
@@ -28708,7 +26509,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn descriptor_binding_storage_image_update_after_bind(
         mut self,
         descriptor_binding_storage_image_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_storage_image_update_after_bind =
             descriptor_binding_storage_image_update_after_bind.into();
@@ -28717,7 +26518,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn descriptor_binding_storage_buffer_update_after_bind(
         mut self,
         descriptor_binding_storage_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_storage_buffer_update_after_bind =
             descriptor_binding_storage_buffer_update_after_bind.into();
@@ -28726,7 +26527,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn descriptor_binding_uniform_texel_buffer_update_after_bind(
         mut self,
         descriptor_binding_uniform_texel_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_uniform_texel_buffer_update_after_bind =
             descriptor_binding_uniform_texel_buffer_update_after_bind.into();
@@ -28735,7 +26536,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn descriptor_binding_storage_texel_buffer_update_after_bind(
         mut self,
         descriptor_binding_storage_texel_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_storage_texel_buffer_update_after_bind =
             descriptor_binding_storage_texel_buffer_update_after_bind.into();
@@ -28744,7 +26545,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn descriptor_binding_update_unused_while_pending(
         mut self,
         descriptor_binding_update_unused_while_pending: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.descriptor_binding_update_unused_while_pending =
             descriptor_binding_update_unused_while_pending.into();
         self
@@ -28752,22 +26553,19 @@ impl<'a> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
     pub fn descriptor_binding_partially_bound(
         mut self,
         descriptor_binding_partially_bound: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.descriptor_binding_partially_bound = descriptor_binding_partially_bound.into();
         self
     }
     pub fn descriptor_binding_variable_descriptor_count(
         mut self,
         descriptor_binding_variable_descriptor_count: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.descriptor_binding_variable_descriptor_count =
             descriptor_binding_variable_descriptor_count.into();
         self
     }
-    pub fn runtime_descriptor_array(
-        mut self,
-        runtime_descriptor_array: bool,
-    ) -> PhysicalDeviceDescriptorIndexingFeaturesBuilder<'a> {
+    pub fn runtime_descriptor_array(mut self, runtime_descriptor_array: bool) -> Self {
         self.inner.runtime_descriptor_array = runtime_descriptor_array.into();
         self
     }
@@ -28872,7 +26670,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_update_after_bind_descriptors_in_all_pools(
         mut self,
         max_update_after_bind_descriptors_in_all_pools: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.max_update_after_bind_descriptors_in_all_pools =
             max_update_after_bind_descriptors_in_all_pools;
         self
@@ -28880,7 +26678,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn shader_uniform_buffer_array_non_uniform_indexing_native(
         mut self,
         shader_uniform_buffer_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_uniform_buffer_array_non_uniform_indexing_native =
             shader_uniform_buffer_array_non_uniform_indexing_native.into();
@@ -28889,7 +26687,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn shader_sampled_image_array_non_uniform_indexing_native(
         mut self,
         shader_sampled_image_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_sampled_image_array_non_uniform_indexing_native =
             shader_sampled_image_array_non_uniform_indexing_native.into();
@@ -28898,7 +26696,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn shader_storage_buffer_array_non_uniform_indexing_native(
         mut self,
         shader_storage_buffer_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_storage_buffer_array_non_uniform_indexing_native =
             shader_storage_buffer_array_non_uniform_indexing_native.into();
@@ -28907,7 +26705,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn shader_storage_image_array_non_uniform_indexing_native(
         mut self,
         shader_storage_image_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_storage_image_array_non_uniform_indexing_native =
             shader_storage_image_array_non_uniform_indexing_native.into();
@@ -28916,7 +26714,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn shader_input_attachment_array_non_uniform_indexing_native(
         mut self,
         shader_input_attachment_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_input_attachment_array_non_uniform_indexing_native =
             shader_input_attachment_array_non_uniform_indexing_native.into();
@@ -28925,22 +26723,19 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn robust_buffer_access_update_after_bind(
         mut self,
         robust_buffer_access_update_after_bind: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.robust_buffer_access_update_after_bind =
             robust_buffer_access_update_after_bind.into();
         self
     }
-    pub fn quad_divergent_implicit_lod(
-        mut self,
-        quad_divergent_implicit_lod: bool,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    pub fn quad_divergent_implicit_lod(mut self, quad_divergent_implicit_lod: bool) -> Self {
         self.inner.quad_divergent_implicit_lod = quad_divergent_implicit_lod.into();
         self
     }
     pub fn max_per_stage_descriptor_update_after_bind_samplers(
         mut self,
         max_per_stage_descriptor_update_after_bind_samplers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_samplers =
             max_per_stage_descriptor_update_after_bind_samplers;
@@ -28949,7 +26744,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_uniform_buffers(
         mut self,
         max_per_stage_descriptor_update_after_bind_uniform_buffers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_uniform_buffers =
             max_per_stage_descriptor_update_after_bind_uniform_buffers;
@@ -28958,7 +26753,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_storage_buffers(
         mut self,
         max_per_stage_descriptor_update_after_bind_storage_buffers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_storage_buffers =
             max_per_stage_descriptor_update_after_bind_storage_buffers;
@@ -28967,7 +26762,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_sampled_images(
         mut self,
         max_per_stage_descriptor_update_after_bind_sampled_images: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_sampled_images =
             max_per_stage_descriptor_update_after_bind_sampled_images;
@@ -28976,7 +26771,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_storage_images(
         mut self,
         max_per_stage_descriptor_update_after_bind_storage_images: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_storage_images =
             max_per_stage_descriptor_update_after_bind_storage_images;
@@ -28985,7 +26780,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_input_attachments(
         mut self,
         max_per_stage_descriptor_update_after_bind_input_attachments: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_input_attachments =
             max_per_stage_descriptor_update_after_bind_input_attachments;
@@ -28994,7 +26789,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_per_stage_update_after_bind_resources(
         mut self,
         max_per_stage_update_after_bind_resources: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_update_after_bind_resources =
             max_per_stage_update_after_bind_resources;
         self
@@ -29002,7 +26797,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_samplers(
         mut self,
         max_descriptor_set_update_after_bind_samplers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_update_after_bind_samplers =
             max_descriptor_set_update_after_bind_samplers;
         self
@@ -29010,7 +26805,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_uniform_buffers(
         mut self,
         max_descriptor_set_update_after_bind_uniform_buffers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_uniform_buffers =
             max_descriptor_set_update_after_bind_uniform_buffers;
@@ -29019,7 +26814,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_uniform_buffers_dynamic(
         mut self,
         max_descriptor_set_update_after_bind_uniform_buffers_dynamic: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_uniform_buffers_dynamic =
             max_descriptor_set_update_after_bind_uniform_buffers_dynamic;
@@ -29028,7 +26823,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_storage_buffers(
         mut self,
         max_descriptor_set_update_after_bind_storage_buffers: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_storage_buffers =
             max_descriptor_set_update_after_bind_storage_buffers;
@@ -29037,7 +26832,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_storage_buffers_dynamic(
         mut self,
         max_descriptor_set_update_after_bind_storage_buffers_dynamic: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_storage_buffers_dynamic =
             max_descriptor_set_update_after_bind_storage_buffers_dynamic;
@@ -29046,7 +26841,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_sampled_images(
         mut self,
         max_descriptor_set_update_after_bind_sampled_images: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_sampled_images =
             max_descriptor_set_update_after_bind_sampled_images;
@@ -29055,7 +26850,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_storage_images(
         mut self,
         max_descriptor_set_update_after_bind_storage_images: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_storage_images =
             max_descriptor_set_update_after_bind_storage_images;
@@ -29064,7 +26859,7 @@ impl<'a> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_input_attachments(
         mut self,
         max_descriptor_set_update_after_bind_input_attachments: u32,
-    ) -> PhysicalDeviceDescriptorIndexingPropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_input_attachments =
             max_descriptor_set_update_after_bind_input_attachments;
@@ -29126,10 +26921,7 @@ impl<'a> ::std::ops::DerefMut for DescriptorSetLayoutBindingFlagsCreateInfoBuild
     }
 }
 impl<'a> DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'a> {
-    pub fn binding_flags(
-        mut self,
-        binding_flags: &'a [DescriptorBindingFlags],
-    ) -> DescriptorSetLayoutBindingFlagsCreateInfoBuilder<'a> {
+    pub fn binding_flags(mut self, binding_flags: &'a [DescriptorBindingFlags]) -> Self {
         self.inner.binding_count = binding_flags.len() as _;
         self.inner.p_binding_flags = binding_flags.as_ptr();
         self
@@ -29190,10 +26982,7 @@ impl<'a> ::std::ops::DerefMut for DescriptorSetVariableDescriptorCountAllocateIn
     }
 }
 impl<'a> DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'a> {
-    pub fn descriptor_counts(
-        mut self,
-        descriptor_counts: &'a [u32],
-    ) -> DescriptorSetVariableDescriptorCountAllocateInfoBuilder<'a> {
+    pub fn descriptor_counts(mut self, descriptor_counts: &'a [u32]) -> Self {
         self.inner.descriptor_set_count = descriptor_counts.len() as _;
         self.inner.p_descriptor_counts = descriptor_counts.as_ptr();
         self
@@ -29255,10 +27044,7 @@ impl<'a> ::std::ops::DerefMut for DescriptorSetVariableDescriptorCountLayoutSupp
     }
 }
 impl<'a> DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'a> {
-    pub fn max_variable_descriptor_count(
-        mut self,
-        max_variable_descriptor_count: u32,
-    ) -> DescriptorSetVariableDescriptorCountLayoutSupportBuilder<'a> {
+    pub fn max_variable_descriptor_count(mut self, max_variable_descriptor_count: u32) -> Self {
         self.inner.max_variable_descriptor_count = max_variable_descriptor_count;
         self
     }
@@ -29328,48 +27114,39 @@ impl<'a> ::std::ops::DerefMut for AttachmentDescription2Builder<'a> {
     }
 }
 impl<'a> AttachmentDescription2Builder<'a> {
-    pub fn flags(mut self, flags: AttachmentDescriptionFlags) -> AttachmentDescription2Builder<'a> {
+    pub fn flags(mut self, flags: AttachmentDescriptionFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn format(mut self, format: Format) -> AttachmentDescription2Builder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn samples(mut self, samples: SampleCountFlags) -> AttachmentDescription2Builder<'a> {
+    pub fn samples(mut self, samples: SampleCountFlags) -> Self {
         self.inner.samples = samples;
         self
     }
-    pub fn load_op(mut self, load_op: AttachmentLoadOp) -> AttachmentDescription2Builder<'a> {
+    pub fn load_op(mut self, load_op: AttachmentLoadOp) -> Self {
         self.inner.load_op = load_op;
         self
     }
-    pub fn store_op(mut self, store_op: AttachmentStoreOp) -> AttachmentDescription2Builder<'a> {
+    pub fn store_op(mut self, store_op: AttachmentStoreOp) -> Self {
         self.inner.store_op = store_op;
         self
     }
-    pub fn stencil_load_op(
-        mut self,
-        stencil_load_op: AttachmentLoadOp,
-    ) -> AttachmentDescription2Builder<'a> {
+    pub fn stencil_load_op(mut self, stencil_load_op: AttachmentLoadOp) -> Self {
         self.inner.stencil_load_op = stencil_load_op;
         self
     }
-    pub fn stencil_store_op(
-        mut self,
-        stencil_store_op: AttachmentStoreOp,
-    ) -> AttachmentDescription2Builder<'a> {
+    pub fn stencil_store_op(mut self, stencil_store_op: AttachmentStoreOp) -> Self {
         self.inner.stencil_store_op = stencil_store_op;
         self
     }
-    pub fn initial_layout(
-        mut self,
-        initial_layout: ImageLayout,
-    ) -> AttachmentDescription2Builder<'a> {
+    pub fn initial_layout(mut self, initial_layout: ImageLayout) -> Self {
         self.inner.initial_layout = initial_layout;
         self
     }
-    pub fn final_layout(mut self, final_layout: ImageLayout) -> AttachmentDescription2Builder<'a> {
+    pub fn final_layout(mut self, final_layout: ImageLayout) -> Self {
         self.inner.final_layout = final_layout;
         self
     }
@@ -29378,10 +27155,7 @@ impl<'a> AttachmentDescription2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsAttachmentDescription2>(
-        mut self,
-        next: &'a mut T,
-    ) -> AttachmentDescription2Builder<'a> {
+    pub fn push_next<T: ExtendsAttachmentDescription2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -29444,15 +27218,15 @@ impl<'a> ::std::ops::DerefMut for AttachmentReference2Builder<'a> {
     }
 }
 impl<'a> AttachmentReference2Builder<'a> {
-    pub fn attachment(mut self, attachment: u32) -> AttachmentReference2Builder<'a> {
+    pub fn attachment(mut self, attachment: u32) -> Self {
         self.inner.attachment = attachment;
         self
     }
-    pub fn layout(mut self, layout: ImageLayout) -> AttachmentReference2Builder<'a> {
+    pub fn layout(mut self, layout: ImageLayout) -> Self {
         self.inner.layout = layout;
         self
     }
-    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> AttachmentReference2Builder<'a> {
+    pub fn aspect_mask(mut self, aspect_mask: ImageAspectFlags) -> Self {
         self.inner.aspect_mask = aspect_mask;
         self
     }
@@ -29461,10 +27235,7 @@ impl<'a> AttachmentReference2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsAttachmentReference2>(
-        mut self,
-        next: &'a mut T,
-    ) -> AttachmentReference2Builder<'a> {
+    pub fn push_next<T: ExtendsAttachmentReference2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -29543,41 +27314,29 @@ impl<'a> ::std::ops::DerefMut for SubpassDescription2Builder<'a> {
     }
 }
 impl<'a> SubpassDescription2Builder<'a> {
-    pub fn flags(mut self, flags: SubpassDescriptionFlags) -> SubpassDescription2Builder<'a> {
+    pub fn flags(mut self, flags: SubpassDescriptionFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn pipeline_bind_point(
-        mut self,
-        pipeline_bind_point: PipelineBindPoint,
-    ) -> SubpassDescription2Builder<'a> {
+    pub fn pipeline_bind_point(mut self, pipeline_bind_point: PipelineBindPoint) -> Self {
         self.inner.pipeline_bind_point = pipeline_bind_point;
         self
     }
-    pub fn view_mask(mut self, view_mask: u32) -> SubpassDescription2Builder<'a> {
+    pub fn view_mask(mut self, view_mask: u32) -> Self {
         self.inner.view_mask = view_mask;
         self
     }
-    pub fn input_attachments(
-        mut self,
-        input_attachments: &'a [AttachmentReference2],
-    ) -> SubpassDescription2Builder<'a> {
+    pub fn input_attachments(mut self, input_attachments: &'a [AttachmentReference2]) -> Self {
         self.inner.input_attachment_count = input_attachments.len() as _;
         self.inner.p_input_attachments = input_attachments.as_ptr();
         self
     }
-    pub fn color_attachments(
-        mut self,
-        color_attachments: &'a [AttachmentReference2],
-    ) -> SubpassDescription2Builder<'a> {
+    pub fn color_attachments(mut self, color_attachments: &'a [AttachmentReference2]) -> Self {
         self.inner.color_attachment_count = color_attachments.len() as _;
         self.inner.p_color_attachments = color_attachments.as_ptr();
         self
     }
-    pub fn resolve_attachments(
-        mut self,
-        resolve_attachments: &'a [AttachmentReference2],
-    ) -> SubpassDescription2Builder<'a> {
+    pub fn resolve_attachments(mut self, resolve_attachments: &'a [AttachmentReference2]) -> Self {
         self.inner.color_attachment_count = resolve_attachments.len() as _;
         self.inner.p_resolve_attachments = resolve_attachments.as_ptr();
         self
@@ -29585,14 +27344,11 @@ impl<'a> SubpassDescription2Builder<'a> {
     pub fn depth_stencil_attachment(
         mut self,
         depth_stencil_attachment: &'a AttachmentReference2,
-    ) -> SubpassDescription2Builder<'a> {
+    ) -> Self {
         self.inner.p_depth_stencil_attachment = depth_stencil_attachment;
         self
     }
-    pub fn preserve_attachments(
-        mut self,
-        preserve_attachments: &'a [u32],
-    ) -> SubpassDescription2Builder<'a> {
+    pub fn preserve_attachments(mut self, preserve_attachments: &'a [u32]) -> Self {
         self.inner.preserve_attachment_count = preserve_attachments.len() as _;
         self.inner.p_preserve_attachments = preserve_attachments.as_ptr();
         self
@@ -29602,10 +27358,7 @@ impl<'a> SubpassDescription2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubpassDescription2>(
-        mut self,
-        next: &'a mut T,
-    ) -> SubpassDescription2Builder<'a> {
+    pub fn push_next<T: ExtendsSubpassDescription2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -29678,50 +27431,35 @@ impl<'a> ::std::ops::DerefMut for SubpassDependency2Builder<'a> {
     }
 }
 impl<'a> SubpassDependency2Builder<'a> {
-    pub fn src_subpass(mut self, src_subpass: u32) -> SubpassDependency2Builder<'a> {
+    pub fn src_subpass(mut self, src_subpass: u32) -> Self {
         self.inner.src_subpass = src_subpass;
         self
     }
-    pub fn dst_subpass(mut self, dst_subpass: u32) -> SubpassDependency2Builder<'a> {
+    pub fn dst_subpass(mut self, dst_subpass: u32) -> Self {
         self.inner.dst_subpass = dst_subpass;
         self
     }
-    pub fn src_stage_mask(
-        mut self,
-        src_stage_mask: PipelineStageFlags,
-    ) -> SubpassDependency2Builder<'a> {
+    pub fn src_stage_mask(mut self, src_stage_mask: PipelineStageFlags) -> Self {
         self.inner.src_stage_mask = src_stage_mask;
         self
     }
-    pub fn dst_stage_mask(
-        mut self,
-        dst_stage_mask: PipelineStageFlags,
-    ) -> SubpassDependency2Builder<'a> {
+    pub fn dst_stage_mask(mut self, dst_stage_mask: PipelineStageFlags) -> Self {
         self.inner.dst_stage_mask = dst_stage_mask;
         self
     }
-    pub fn src_access_mask(
-        mut self,
-        src_access_mask: AccessFlags,
-    ) -> SubpassDependency2Builder<'a> {
+    pub fn src_access_mask(mut self, src_access_mask: AccessFlags) -> Self {
         self.inner.src_access_mask = src_access_mask;
         self
     }
-    pub fn dst_access_mask(
-        mut self,
-        dst_access_mask: AccessFlags,
-    ) -> SubpassDependency2Builder<'a> {
+    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags) -> Self {
         self.inner.dst_access_mask = dst_access_mask;
         self
     }
-    pub fn dependency_flags(
-        mut self,
-        dependency_flags: DependencyFlags,
-    ) -> SubpassDependency2Builder<'a> {
+    pub fn dependency_flags(mut self, dependency_flags: DependencyFlags) -> Self {
         self.inner.dependency_flags = dependency_flags;
         self
     }
-    pub fn view_offset(mut self, view_offset: i32) -> SubpassDependency2Builder<'a> {
+    pub fn view_offset(mut self, view_offset: i32) -> Self {
         self.inner.view_offset = view_offset;
         self
     }
@@ -29730,10 +27468,7 @@ impl<'a> SubpassDependency2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubpassDependency2>(
-        mut self,
-        next: &'a mut T,
-    ) -> SubpassDependency2Builder<'a> {
+    pub fn push_next<T: ExtendsSubpassDependency2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -29808,38 +27543,26 @@ impl<'a> ::std::ops::DerefMut for RenderPassCreateInfo2Builder<'a> {
     }
 }
 impl<'a> RenderPassCreateInfo2Builder<'a> {
-    pub fn flags(mut self, flags: RenderPassCreateFlags) -> RenderPassCreateInfo2Builder<'a> {
+    pub fn flags(mut self, flags: RenderPassCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn attachments(
-        mut self,
-        attachments: &'a [AttachmentDescription2],
-    ) -> RenderPassCreateInfo2Builder<'a> {
+    pub fn attachments(mut self, attachments: &'a [AttachmentDescription2]) -> Self {
         self.inner.attachment_count = attachments.len() as _;
         self.inner.p_attachments = attachments.as_ptr();
         self
     }
-    pub fn subpasses(
-        mut self,
-        subpasses: &'a [SubpassDescription2],
-    ) -> RenderPassCreateInfo2Builder<'a> {
+    pub fn subpasses(mut self, subpasses: &'a [SubpassDescription2]) -> Self {
         self.inner.subpass_count = subpasses.len() as _;
         self.inner.p_subpasses = subpasses.as_ptr();
         self
     }
-    pub fn dependencies(
-        mut self,
-        dependencies: &'a [SubpassDependency2],
-    ) -> RenderPassCreateInfo2Builder<'a> {
+    pub fn dependencies(mut self, dependencies: &'a [SubpassDependency2]) -> Self {
         self.inner.dependency_count = dependencies.len() as _;
         self.inner.p_dependencies = dependencies.as_ptr();
         self
     }
-    pub fn correlated_view_masks(
-        mut self,
-        correlated_view_masks: &'a [u32],
-    ) -> RenderPassCreateInfo2Builder<'a> {
+    pub fn correlated_view_masks(mut self, correlated_view_masks: &'a [u32]) -> Self {
         self.inner.correlated_view_mask_count = correlated_view_masks.len() as _;
         self.inner.p_correlated_view_masks = correlated_view_masks.as_ptr();
         self
@@ -29849,10 +27572,7 @@ impl<'a> RenderPassCreateInfo2Builder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsRenderPassCreateInfo2>(
-        mut self,
-        next: &'a mut T,
-    ) -> RenderPassCreateInfo2Builder<'a> {
+    pub fn push_next<T: ExtendsRenderPassCreateInfo2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -29911,7 +27631,7 @@ impl<'a> ::std::ops::DerefMut for SubpassBeginInfoBuilder<'a> {
     }
 }
 impl<'a> SubpassBeginInfoBuilder<'a> {
-    pub fn contents(mut self, contents: SubpassContents) -> SubpassBeginInfoBuilder<'a> {
+    pub fn contents(mut self, contents: SubpassContents) -> Self {
         self.inner.contents = contents;
         self
     }
@@ -29920,10 +27640,7 @@ impl<'a> SubpassBeginInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubpassBeginInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> SubpassBeginInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsSubpassBeginInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -29985,10 +27702,7 @@ impl<'a> SubpassEndInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubpassEndInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> SubpassEndInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsSubpassEndInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -30048,10 +27762,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceTimelineSemaphoreFeaturesBuilder
     }
 }
 impl<'a> PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'a> {
-    pub fn timeline_semaphore(
-        mut self,
-        timeline_semaphore: bool,
-    ) -> PhysicalDeviceTimelineSemaphoreFeaturesBuilder<'a> {
+    pub fn timeline_semaphore(mut self, timeline_semaphore: bool) -> Self {
         self.inner.timeline_semaphore = timeline_semaphore.into();
         self
     }
@@ -30112,7 +27823,7 @@ impl<'a> PhysicalDeviceTimelineSemaphorePropertiesBuilder<'a> {
     pub fn max_timeline_semaphore_value_difference(
         mut self,
         max_timeline_semaphore_value_difference: u64,
-    ) -> PhysicalDeviceTimelineSemaphorePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.max_timeline_semaphore_value_difference =
             max_timeline_semaphore_value_difference;
         self
@@ -30172,14 +27883,11 @@ impl<'a> ::std::ops::DerefMut for SemaphoreTypeCreateInfoBuilder<'a> {
     }
 }
 impl<'a> SemaphoreTypeCreateInfoBuilder<'a> {
-    pub fn semaphore_type(
-        mut self,
-        semaphore_type: SemaphoreType,
-    ) -> SemaphoreTypeCreateInfoBuilder<'a> {
+    pub fn semaphore_type(mut self, semaphore_type: SemaphoreType) -> Self {
         self.inner.semaphore_type = semaphore_type;
         self
     }
-    pub fn initial_value(mut self, initial_value: u64) -> SemaphoreTypeCreateInfoBuilder<'a> {
+    pub fn initial_value(mut self, initial_value: u64) -> Self {
         self.inner.initial_value = initial_value;
         self
     }
@@ -30242,18 +27950,12 @@ impl<'a> ::std::ops::DerefMut for TimelineSemaphoreSubmitInfoBuilder<'a> {
     }
 }
 impl<'a> TimelineSemaphoreSubmitInfoBuilder<'a> {
-    pub fn wait_semaphore_values(
-        mut self,
-        wait_semaphore_values: &'a [u64],
-    ) -> TimelineSemaphoreSubmitInfoBuilder<'a> {
+    pub fn wait_semaphore_values(mut self, wait_semaphore_values: &'a [u64]) -> Self {
         self.inner.wait_semaphore_value_count = wait_semaphore_values.len() as _;
         self.inner.p_wait_semaphore_values = wait_semaphore_values.as_ptr();
         self
     }
-    pub fn signal_semaphore_values(
-        mut self,
-        signal_semaphore_values: &'a [u64],
-    ) -> TimelineSemaphoreSubmitInfoBuilder<'a> {
+    pub fn signal_semaphore_values(mut self, signal_semaphore_values: &'a [u64]) -> Self {
         self.inner.signal_semaphore_value_count = signal_semaphore_values.len() as _;
         self.inner.p_signal_semaphore_values = signal_semaphore_values.as_ptr();
         self
@@ -30314,16 +28016,16 @@ impl<'a> ::std::ops::DerefMut for SemaphoreWaitInfoBuilder<'a> {
     }
 }
 impl<'a> SemaphoreWaitInfoBuilder<'a> {
-    pub fn flags(mut self, flags: SemaphoreWaitFlags) -> SemaphoreWaitInfoBuilder<'a> {
+    pub fn flags(mut self, flags: SemaphoreWaitFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn semaphores(mut self, semaphores: &'a [Semaphore]) -> SemaphoreWaitInfoBuilder<'a> {
+    pub fn semaphores(mut self, semaphores: &'a [Semaphore]) -> Self {
         self.inner.semaphore_count = semaphores.len() as _;
         self.inner.p_semaphores = semaphores.as_ptr();
         self
     }
-    pub fn values(mut self, values: &'a [u64]) -> SemaphoreWaitInfoBuilder<'a> {
+    pub fn values(mut self, values: &'a [u64]) -> Self {
         self.inner.semaphore_count = values.len() as _;
         self.inner.p_values = values.as_ptr();
         self
@@ -30333,10 +28035,7 @@ impl<'a> SemaphoreWaitInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSemaphoreWaitInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> SemaphoreWaitInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsSemaphoreWaitInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -30397,11 +28096,11 @@ impl<'a> ::std::ops::DerefMut for SemaphoreSignalInfoBuilder<'a> {
     }
 }
 impl<'a> SemaphoreSignalInfoBuilder<'a> {
-    pub fn semaphore(mut self, semaphore: Semaphore) -> SemaphoreSignalInfoBuilder<'a> {
+    pub fn semaphore(mut self, semaphore: Semaphore) -> Self {
         self.inner.semaphore = semaphore;
         self
     }
-    pub fn value(mut self, value: u64) -> SemaphoreSignalInfoBuilder<'a> {
+    pub fn value(mut self, value: u64) -> Self {
         self.inner.value = value;
         self
     }
@@ -30410,10 +28109,7 @@ impl<'a> SemaphoreSignalInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSemaphoreSignalInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> SemaphoreSignalInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsSemaphoreSignalInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -30461,11 +28157,11 @@ impl<'a> ::std::ops::DerefMut for VertexInputBindingDivisorDescriptionEXTBuilder
     }
 }
 impl<'a> VertexInputBindingDivisorDescriptionEXTBuilder<'a> {
-    pub fn binding(mut self, binding: u32) -> VertexInputBindingDivisorDescriptionEXTBuilder<'a> {
+    pub fn binding(mut self, binding: u32) -> Self {
         self.inner.binding = binding;
         self
     }
-    pub fn divisor(mut self, divisor: u32) -> VertexInputBindingDivisorDescriptionEXTBuilder<'a> {
+    pub fn divisor(mut self, divisor: u32) -> Self {
         self.inner.divisor = divisor;
         self
     }
@@ -30531,7 +28227,7 @@ impl<'a> PipelineVertexInputDivisorStateCreateInfoEXTBuilder<'a> {
     pub fn vertex_binding_divisors(
         mut self,
         vertex_binding_divisors: &'a [VertexInputBindingDivisorDescriptionEXT],
-    ) -> PipelineVertexInputDivisorStateCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.vertex_binding_divisor_count = vertex_binding_divisors.len() as _;
         self.inner.p_vertex_binding_divisors = vertex_binding_divisors.as_ptr();
         self
@@ -30590,10 +28286,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceVertexAttributeDivisorProperties
     }
 }
 impl<'a> PhysicalDeviceVertexAttributeDivisorPropertiesEXTBuilder<'a> {
-    pub fn max_vertex_attrib_divisor(
-        mut self,
-        max_vertex_attrib_divisor: u32,
-    ) -> PhysicalDeviceVertexAttributeDivisorPropertiesEXTBuilder<'a> {
+    pub fn max_vertex_attrib_divisor(mut self, max_vertex_attrib_divisor: u32) -> Self {
         self.inner.max_vertex_attrib_divisor = max_vertex_attrib_divisor;
         self
     }
@@ -30654,28 +28347,19 @@ impl<'a> ::std::ops::DerefMut for PhysicalDevicePCIBusInfoPropertiesEXTBuilder<'
     }
 }
 impl<'a> PhysicalDevicePCIBusInfoPropertiesEXTBuilder<'a> {
-    pub fn pci_domain(
-        mut self,
-        pci_domain: u32,
-    ) -> PhysicalDevicePCIBusInfoPropertiesEXTBuilder<'a> {
+    pub fn pci_domain(mut self, pci_domain: u32) -> Self {
         self.inner.pci_domain = pci_domain;
         self
     }
-    pub fn pci_bus(mut self, pci_bus: u32) -> PhysicalDevicePCIBusInfoPropertiesEXTBuilder<'a> {
+    pub fn pci_bus(mut self, pci_bus: u32) -> Self {
         self.inner.pci_bus = pci_bus;
         self
     }
-    pub fn pci_device(
-        mut self,
-        pci_device: u32,
-    ) -> PhysicalDevicePCIBusInfoPropertiesEXTBuilder<'a> {
+    pub fn pci_device(mut self, pci_device: u32) -> Self {
         self.inner.pci_device = pci_device;
         self
     }
-    pub fn pci_function(
-        mut self,
-        pci_function: u32,
-    ) -> PhysicalDevicePCIBusInfoPropertiesEXTBuilder<'a> {
+    pub fn pci_function(mut self, pci_function: u32) -> Self {
         self.inner.pci_function = pci_function;
         self
     }
@@ -30730,10 +28414,7 @@ impl<'a> ::std::ops::DerefMut for ImportAndroidHardwareBufferInfoANDROIDBuilder<
     }
 }
 impl<'a> ImportAndroidHardwareBufferInfoANDROIDBuilder<'a> {
-    pub fn buffer(
-        mut self,
-        buffer: *mut AHardwareBuffer,
-    ) -> ImportAndroidHardwareBufferInfoANDROIDBuilder<'a> {
+    pub fn buffer(mut self, buffer: *mut AHardwareBuffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
@@ -30788,10 +28469,7 @@ impl<'a> ::std::ops::DerefMut for AndroidHardwareBufferUsageANDROIDBuilder<'a> {
     }
 }
 impl<'a> AndroidHardwareBufferUsageANDROIDBuilder<'a> {
-    pub fn android_hardware_buffer_usage(
-        mut self,
-        android_hardware_buffer_usage: u64,
-    ) -> AndroidHardwareBufferUsageANDROIDBuilder<'a> {
+    pub fn android_hardware_buffer_usage(mut self, android_hardware_buffer_usage: u64) -> Self {
         self.inner.android_hardware_buffer_usage = android_hardware_buffer_usage;
         self
     }
@@ -30847,17 +28525,11 @@ impl<'a> ::std::ops::DerefMut for AndroidHardwareBufferPropertiesANDROIDBuilder<
     }
 }
 impl<'a> AndroidHardwareBufferPropertiesANDROIDBuilder<'a> {
-    pub fn allocation_size(
-        mut self,
-        allocation_size: DeviceSize,
-    ) -> AndroidHardwareBufferPropertiesANDROIDBuilder<'a> {
+    pub fn allocation_size(mut self, allocation_size: DeviceSize) -> Self {
         self.inner.allocation_size = allocation_size;
         self
     }
-    pub fn memory_type_bits(
-        mut self,
-        memory_type_bits: u32,
-    ) -> AndroidHardwareBufferPropertiesANDROIDBuilder<'a> {
+    pub fn memory_type_bits(mut self, memory_type_bits: u32) -> Self {
         self.inner.memory_type_bits = memory_type_bits;
         self
     }
@@ -30869,7 +28541,7 @@ impl<'a> AndroidHardwareBufferPropertiesANDROIDBuilder<'a> {
     pub fn push_next<T: ExtendsAndroidHardwareBufferPropertiesANDROID>(
         mut self,
         next: &'a mut T,
-    ) -> AndroidHardwareBufferPropertiesANDROIDBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -30928,10 +28600,7 @@ impl<'a> ::std::ops::DerefMut for MemoryGetAndroidHardwareBufferInfoANDROIDBuild
     }
 }
 impl<'a> MemoryGetAndroidHardwareBufferInfoANDROIDBuilder<'a> {
-    pub fn memory(
-        mut self,
-        memory: DeviceMemory,
-    ) -> MemoryGetAndroidHardwareBufferInfoANDROIDBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
@@ -30943,7 +28612,7 @@ impl<'a> MemoryGetAndroidHardwareBufferInfoANDROIDBuilder<'a> {
     pub fn push_next<T: ExtendsMemoryGetAndroidHardwareBufferInfoANDROID>(
         mut self,
         next: &'a mut T,
-    ) -> MemoryGetAndroidHardwareBufferInfoANDROIDBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -31023,59 +28692,41 @@ impl<'a> ::std::ops::DerefMut for AndroidHardwareBufferFormatPropertiesANDROIDBu
     }
 }
 impl<'a> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
-    pub fn format(
-        mut self,
-        format: Format,
-    ) -> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn external_format(
-        mut self,
-        external_format: u64,
-    ) -> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
+    pub fn external_format(mut self, external_format: u64) -> Self {
         self.inner.external_format = external_format;
         self
     }
-    pub fn format_features(
-        mut self,
-        format_features: FormatFeatureFlags,
-    ) -> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
+    pub fn format_features(mut self, format_features: FormatFeatureFlags) -> Self {
         self.inner.format_features = format_features;
         self
     }
     pub fn sampler_ycbcr_conversion_components(
         mut self,
         sampler_ycbcr_conversion_components: ComponentMapping,
-    ) -> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
+    ) -> Self {
         self.inner.sampler_ycbcr_conversion_components = sampler_ycbcr_conversion_components;
         self
     }
     pub fn suggested_ycbcr_model(
         mut self,
         suggested_ycbcr_model: SamplerYcbcrModelConversion,
-    ) -> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
+    ) -> Self {
         self.inner.suggested_ycbcr_model = suggested_ycbcr_model;
         self
     }
-    pub fn suggested_ycbcr_range(
-        mut self,
-        suggested_ycbcr_range: SamplerYcbcrRange,
-    ) -> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
+    pub fn suggested_ycbcr_range(mut self, suggested_ycbcr_range: SamplerYcbcrRange) -> Self {
         self.inner.suggested_ycbcr_range = suggested_ycbcr_range;
         self
     }
-    pub fn suggested_x_chroma_offset(
-        mut self,
-        suggested_x_chroma_offset: ChromaLocation,
-    ) -> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
+    pub fn suggested_x_chroma_offset(mut self, suggested_x_chroma_offset: ChromaLocation) -> Self {
         self.inner.suggested_x_chroma_offset = suggested_x_chroma_offset;
         self
     }
-    pub fn suggested_y_chroma_offset(
-        mut self,
-        suggested_y_chroma_offset: ChromaLocation,
-    ) -> AndroidHardwareBufferFormatPropertiesANDROIDBuilder<'a> {
+    pub fn suggested_y_chroma_offset(mut self, suggested_y_chroma_offset: ChromaLocation) -> Self {
         self.inner.suggested_y_chroma_offset = suggested_y_chroma_offset;
         self
     }
@@ -31136,10 +28787,7 @@ impl<'a> ::std::ops::DerefMut for CommandBufferInheritanceConditionalRenderingIn
     }
 }
 impl<'a> CommandBufferInheritanceConditionalRenderingInfoEXTBuilder<'a> {
-    pub fn conditional_rendering_enable(
-        mut self,
-        conditional_rendering_enable: bool,
-    ) -> CommandBufferInheritanceConditionalRenderingInfoEXTBuilder<'a> {
+    pub fn conditional_rendering_enable(mut self, conditional_rendering_enable: bool) -> Self {
         self.inner.conditional_rendering_enable = conditional_rendering_enable.into();
         self
     }
@@ -31196,7 +28844,7 @@ impl<'a> ::std::ops::DerefMut for ExternalFormatANDROIDBuilder<'a> {
     }
 }
 impl<'a> ExternalFormatANDROIDBuilder<'a> {
-    pub fn external_format(mut self, external_format: u64) -> ExternalFormatANDROIDBuilder<'a> {
+    pub fn external_format(mut self, external_format: u64) -> Self {
         self.inner.external_format = external_format;
         self
     }
@@ -31255,25 +28903,19 @@ impl<'a> ::std::ops::DerefMut for PhysicalDevice8BitStorageFeaturesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
-    pub fn storage_buffer8_bit_access(
-        mut self,
-        storage_buffer8_bit_access: bool,
-    ) -> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
+    pub fn storage_buffer8_bit_access(mut self, storage_buffer8_bit_access: bool) -> Self {
         self.inner.storage_buffer8_bit_access = storage_buffer8_bit_access.into();
         self
     }
     pub fn uniform_and_storage_buffer8_bit_access(
         mut self,
         uniform_and_storage_buffer8_bit_access: bool,
-    ) -> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.uniform_and_storage_buffer8_bit_access =
             uniform_and_storage_buffer8_bit_access.into();
         self
     }
-    pub fn storage_push_constant8(
-        mut self,
-        storage_push_constant8: bool,
-    ) -> PhysicalDevice8BitStorageFeaturesBuilder<'a> {
+    pub fn storage_push_constant8(mut self, storage_push_constant8: bool) -> Self {
         self.inner.storage_push_constant8 = storage_push_constant8.into();
         self
     }
@@ -31330,17 +28972,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceConditionalRenderingFeaturesEXTB
     }
 }
 impl<'a> PhysicalDeviceConditionalRenderingFeaturesEXTBuilder<'a> {
-    pub fn conditional_rendering(
-        mut self,
-        conditional_rendering: bool,
-    ) -> PhysicalDeviceConditionalRenderingFeaturesEXTBuilder<'a> {
+    pub fn conditional_rendering(mut self, conditional_rendering: bool) -> Self {
         self.inner.conditional_rendering = conditional_rendering.into();
         self
     }
     pub fn inherited_conditional_rendering(
         mut self,
         inherited_conditional_rendering: bool,
-    ) -> PhysicalDeviceConditionalRenderingFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.inherited_conditional_rendering = inherited_conditional_rendering.into();
         self
     }
@@ -31399,24 +29038,21 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkanMemoryModelFeaturesBuilder
     }
 }
 impl<'a> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
-    pub fn vulkan_memory_model(
-        mut self,
-        vulkan_memory_model: bool,
-    ) -> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
+    pub fn vulkan_memory_model(mut self, vulkan_memory_model: bool) -> Self {
         self.inner.vulkan_memory_model = vulkan_memory_model.into();
         self
     }
     pub fn vulkan_memory_model_device_scope(
         mut self,
         vulkan_memory_model_device_scope: bool,
-    ) -> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.vulkan_memory_model_device_scope = vulkan_memory_model_device_scope.into();
         self
     }
     pub fn vulkan_memory_model_availability_visibility_chains(
         mut self,
         vulkan_memory_model_availability_visibility_chains: bool,
-    ) -> PhysicalDeviceVulkanMemoryModelFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .vulkan_memory_model_availability_visibility_chains =
             vulkan_memory_model_availability_visibility_chains.into();
@@ -31475,17 +29111,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderAtomicInt64FeaturesBuilder
     }
 }
 impl<'a> PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
-    pub fn shader_buffer_int64_atomics(
-        mut self,
-        shader_buffer_int64_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
+    pub fn shader_buffer_int64_atomics(mut self, shader_buffer_int64_atomics: bool) -> Self {
         self.inner.shader_buffer_int64_atomics = shader_buffer_int64_atomics.into();
         self
     }
-    pub fn shader_shared_int64_atomics(
-        mut self,
-        shader_shared_int64_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicInt64FeaturesBuilder<'a> {
+    pub fn shader_shared_int64_atomics(mut self, shader_shared_int64_atomics: bool) -> Self {
         self.inner.shader_shared_int64_atomics = shader_shared_int64_atomics.into();
         self
     }
@@ -31562,87 +29192,69 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderAtomicFloatFeaturesEXTBuil
     }
 }
 impl<'a> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
-    pub fn shader_buffer_float32_atomics(
-        mut self,
-        shader_buffer_float32_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    pub fn shader_buffer_float32_atomics(mut self, shader_buffer_float32_atomics: bool) -> Self {
         self.inner.shader_buffer_float32_atomics = shader_buffer_float32_atomics.into();
         self
     }
     pub fn shader_buffer_float32_atomic_add(
         mut self,
         shader_buffer_float32_atomic_add: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.shader_buffer_float32_atomic_add = shader_buffer_float32_atomic_add.into();
         self
     }
-    pub fn shader_buffer_float64_atomics(
-        mut self,
-        shader_buffer_float64_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    pub fn shader_buffer_float64_atomics(mut self, shader_buffer_float64_atomics: bool) -> Self {
         self.inner.shader_buffer_float64_atomics = shader_buffer_float64_atomics.into();
         self
     }
     pub fn shader_buffer_float64_atomic_add(
         mut self,
         shader_buffer_float64_atomic_add: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.shader_buffer_float64_atomic_add = shader_buffer_float64_atomic_add.into();
         self
     }
-    pub fn shader_shared_float32_atomics(
-        mut self,
-        shader_shared_float32_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    pub fn shader_shared_float32_atomics(mut self, shader_shared_float32_atomics: bool) -> Self {
         self.inner.shader_shared_float32_atomics = shader_shared_float32_atomics.into();
         self
     }
     pub fn shader_shared_float32_atomic_add(
         mut self,
         shader_shared_float32_atomic_add: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.shader_shared_float32_atomic_add = shader_shared_float32_atomic_add.into();
         self
     }
-    pub fn shader_shared_float64_atomics(
-        mut self,
-        shader_shared_float64_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    pub fn shader_shared_float64_atomics(mut self, shader_shared_float64_atomics: bool) -> Self {
         self.inner.shader_shared_float64_atomics = shader_shared_float64_atomics.into();
         self
     }
     pub fn shader_shared_float64_atomic_add(
         mut self,
         shader_shared_float64_atomic_add: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.shader_shared_float64_atomic_add = shader_shared_float64_atomic_add.into();
         self
     }
-    pub fn shader_image_float32_atomics(
-        mut self,
-        shader_image_float32_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    pub fn shader_image_float32_atomics(mut self, shader_image_float32_atomics: bool) -> Self {
         self.inner.shader_image_float32_atomics = shader_image_float32_atomics.into();
         self
     }
     pub fn shader_image_float32_atomic_add(
         mut self,
         shader_image_float32_atomic_add: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.shader_image_float32_atomic_add = shader_image_float32_atomic_add.into();
         self
     }
-    pub fn sparse_image_float32_atomics(
-        mut self,
-        sparse_image_float32_atomics: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    pub fn sparse_image_float32_atomics(mut self, sparse_image_float32_atomics: bool) -> Self {
         self.inner.sparse_image_float32_atomics = sparse_image_float32_atomics.into();
         self
     }
     pub fn sparse_image_float32_atomic_add(
         mut self,
         sparse_image_float32_atomic_add: bool,
-    ) -> PhysicalDeviceShaderAtomicFloatFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.sparse_image_float32_atomic_add = sparse_image_float32_atomic_add.into();
         self
     }
@@ -31702,7 +29314,7 @@ impl<'a> PhysicalDeviceVertexAttributeDivisorFeaturesEXTBuilder<'a> {
     pub fn vertex_attribute_instance_rate_divisor(
         mut self,
         vertex_attribute_instance_rate_divisor: bool,
-    ) -> PhysicalDeviceVertexAttributeDivisorFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.vertex_attribute_instance_rate_divisor =
             vertex_attribute_instance_rate_divisor.into();
         self
@@ -31710,7 +29322,7 @@ impl<'a> PhysicalDeviceVertexAttributeDivisorFeaturesEXTBuilder<'a> {
     pub fn vertex_attribute_instance_rate_zero_divisor(
         mut self,
         vertex_attribute_instance_rate_zero_divisor: bool,
-    ) -> PhysicalDeviceVertexAttributeDivisorFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.vertex_attribute_instance_rate_zero_divisor =
             vertex_attribute_instance_rate_zero_divisor.into();
         self
@@ -31769,7 +29381,7 @@ impl<'a> QueueFamilyCheckpointPropertiesNVBuilder<'a> {
     pub fn checkpoint_execution_stage_mask(
         mut self,
         checkpoint_execution_stage_mask: PipelineStageFlags,
-    ) -> QueueFamilyCheckpointPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.checkpoint_execution_stage_mask = checkpoint_execution_stage_mask;
         self
     }
@@ -31825,14 +29437,11 @@ impl<'a> ::std::ops::DerefMut for CheckpointDataNVBuilder<'a> {
     }
 }
 impl<'a> CheckpointDataNVBuilder<'a> {
-    pub fn stage(mut self, stage: PipelineStageFlags) -> CheckpointDataNVBuilder<'a> {
+    pub fn stage(mut self, stage: PipelineStageFlags) -> Self {
         self.inner.stage = stage;
         self
     }
-    pub fn checkpoint_marker(
-        mut self,
-        checkpoint_marker: *mut c_void,
-    ) -> CheckpointDataNVBuilder<'a> {
+    pub fn checkpoint_marker(mut self, checkpoint_marker: *mut c_void) -> Self {
         self.inner.p_checkpoint_marker = checkpoint_marker;
         self
     }
@@ -31841,10 +29450,7 @@ impl<'a> CheckpointDataNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCheckpointDataNV>(
-        mut self,
-        next: &'a mut T,
-    ) -> CheckpointDataNVBuilder<'a> {
+    pub fn push_next<T: ExtendsCheckpointDataNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -31916,28 +29522,22 @@ impl<'a> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
     pub fn supported_depth_resolve_modes(
         mut self,
         supported_depth_resolve_modes: ResolveModeFlags,
-    ) -> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.supported_depth_resolve_modes = supported_depth_resolve_modes;
         self
     }
     pub fn supported_stencil_resolve_modes(
         mut self,
         supported_stencil_resolve_modes: ResolveModeFlags,
-    ) -> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.supported_stencil_resolve_modes = supported_stencil_resolve_modes;
         self
     }
-    pub fn independent_resolve_none(
-        mut self,
-        independent_resolve_none: bool,
-    ) -> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
+    pub fn independent_resolve_none(mut self, independent_resolve_none: bool) -> Self {
         self.inner.independent_resolve_none = independent_resolve_none.into();
         self
     }
-    pub fn independent_resolve(
-        mut self,
-        independent_resolve: bool,
-    ) -> PhysicalDeviceDepthStencilResolvePropertiesBuilder<'a> {
+    pub fn independent_resolve(mut self, independent_resolve: bool) -> Self {
         self.inner.independent_resolve = independent_resolve.into();
         self
     }
@@ -31996,24 +29596,18 @@ impl<'a> ::std::ops::DerefMut for SubpassDescriptionDepthStencilResolveBuilder<'
     }
 }
 impl<'a> SubpassDescriptionDepthStencilResolveBuilder<'a> {
-    pub fn depth_resolve_mode(
-        mut self,
-        depth_resolve_mode: ResolveModeFlags,
-    ) -> SubpassDescriptionDepthStencilResolveBuilder<'a> {
+    pub fn depth_resolve_mode(mut self, depth_resolve_mode: ResolveModeFlags) -> Self {
         self.inner.depth_resolve_mode = depth_resolve_mode;
         self
     }
-    pub fn stencil_resolve_mode(
-        mut self,
-        stencil_resolve_mode: ResolveModeFlags,
-    ) -> SubpassDescriptionDepthStencilResolveBuilder<'a> {
+    pub fn stencil_resolve_mode(mut self, stencil_resolve_mode: ResolveModeFlags) -> Self {
         self.inner.stencil_resolve_mode = stencil_resolve_mode;
         self
     }
     pub fn depth_stencil_resolve_attachment(
         mut self,
         depth_stencil_resolve_attachment: &'a AttachmentReference2,
-    ) -> SubpassDescriptionDepthStencilResolveBuilder<'a> {
+    ) -> Self {
         self.inner.p_depth_stencil_resolve_attachment = depth_stencil_resolve_attachment;
         self
     }
@@ -32068,7 +29662,7 @@ impl<'a> ::std::ops::DerefMut for ImageViewASTCDecodeModeEXTBuilder<'a> {
     }
 }
 impl<'a> ImageViewASTCDecodeModeEXTBuilder<'a> {
-    pub fn decode_mode(mut self, decode_mode: Format) -> ImageViewASTCDecodeModeEXTBuilder<'a> {
+    pub fn decode_mode(mut self, decode_mode: Format) -> Self {
         self.inner.decode_mode = decode_mode;
         self
     }
@@ -32123,10 +29717,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceASTCDecodeFeaturesEXTBuilder<'a>
     }
 }
 impl<'a> PhysicalDeviceASTCDecodeFeaturesEXTBuilder<'a> {
-    pub fn decode_mode_shared_exponent(
-        mut self,
-        decode_mode_shared_exponent: bool,
-    ) -> PhysicalDeviceASTCDecodeFeaturesEXTBuilder<'a> {
+    pub fn decode_mode_shared_exponent(mut self, decode_mode_shared_exponent: bool) -> Self {
         self.inner.decode_mode_shared_exponent = decode_mode_shared_exponent.into();
         self
     }
@@ -32183,17 +29774,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceTransformFeedbackFeaturesEXTBuil
     }
 }
 impl<'a> PhysicalDeviceTransformFeedbackFeaturesEXTBuilder<'a> {
-    pub fn transform_feedback(
-        mut self,
-        transform_feedback: bool,
-    ) -> PhysicalDeviceTransformFeedbackFeaturesEXTBuilder<'a> {
+    pub fn transform_feedback(mut self, transform_feedback: bool) -> Self {
         self.inner.transform_feedback = transform_feedback.into();
         self
     }
-    pub fn geometry_streams(
-        mut self,
-        geometry_streams: bool,
-    ) -> PhysicalDeviceTransformFeedbackFeaturesEXTBuilder<'a> {
+    pub fn geometry_streams(mut self, geometry_streams: bool) -> Self {
         self.inner.geometry_streams = geometry_streams.into();
         self
     }
@@ -32269,31 +29854,25 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceTransformFeedbackPropertiesEXTBu
     }
 }
 impl<'a> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
-    pub fn max_transform_feedback_streams(
-        mut self,
-        max_transform_feedback_streams: u32,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    pub fn max_transform_feedback_streams(mut self, max_transform_feedback_streams: u32) -> Self {
         self.inner.max_transform_feedback_streams = max_transform_feedback_streams;
         self
     }
-    pub fn max_transform_feedback_buffers(
-        mut self,
-        max_transform_feedback_buffers: u32,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    pub fn max_transform_feedback_buffers(mut self, max_transform_feedback_buffers: u32) -> Self {
         self.inner.max_transform_feedback_buffers = max_transform_feedback_buffers;
         self
     }
     pub fn max_transform_feedback_buffer_size(
         mut self,
         max_transform_feedback_buffer_size: DeviceSize,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_transform_feedback_buffer_size = max_transform_feedback_buffer_size;
         self
     }
     pub fn max_transform_feedback_stream_data_size(
         mut self,
         max_transform_feedback_stream_data_size: u32,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_transform_feedback_stream_data_size =
             max_transform_feedback_stream_data_size;
         self
@@ -32301,7 +29880,7 @@ impl<'a> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
     pub fn max_transform_feedback_buffer_data_size(
         mut self,
         max_transform_feedback_buffer_data_size: u32,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_transform_feedback_buffer_data_size =
             max_transform_feedback_buffer_data_size;
         self
@@ -32309,22 +29888,19 @@ impl<'a> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
     pub fn max_transform_feedback_buffer_data_stride(
         mut self,
         max_transform_feedback_buffer_data_stride: u32,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_transform_feedback_buffer_data_stride =
             max_transform_feedback_buffer_data_stride;
         self
     }
-    pub fn transform_feedback_queries(
-        mut self,
-        transform_feedback_queries: bool,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    pub fn transform_feedback_queries(mut self, transform_feedback_queries: bool) -> Self {
         self.inner.transform_feedback_queries = transform_feedback_queries.into();
         self
     }
     pub fn transform_feedback_streams_lines_triangles(
         mut self,
         transform_feedback_streams_lines_triangles: bool,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.transform_feedback_streams_lines_triangles =
             transform_feedback_streams_lines_triangles.into();
         self
@@ -32332,15 +29908,12 @@ impl<'a> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
     pub fn transform_feedback_rasterization_stream_select(
         mut self,
         transform_feedback_rasterization_stream_select: bool,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.transform_feedback_rasterization_stream_select =
             transform_feedback_rasterization_stream_select.into();
         self
     }
-    pub fn transform_feedback_draw(
-        mut self,
-        transform_feedback_draw: bool,
-    ) -> PhysicalDeviceTransformFeedbackPropertiesEXTBuilder<'a> {
+    pub fn transform_feedback_draw(mut self, transform_feedback_draw: bool) -> Self {
         self.inner.transform_feedback_draw = transform_feedback_draw.into();
         self
     }
@@ -32403,17 +29976,11 @@ impl<'a> ::std::ops::DerefMut for PipelineRasterizationStateStreamCreateInfoEXTB
     }
 }
 impl<'a> PipelineRasterizationStateStreamCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineRasterizationStateStreamCreateFlagsEXT,
-    ) -> PipelineRasterizationStateStreamCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineRasterizationStateStreamCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn rasterization_stream(
-        mut self,
-        rasterization_stream: u32,
-    ) -> PipelineRasterizationStateStreamCreateInfoEXTBuilder<'a> {
+    pub fn rasterization_stream(mut self, rasterization_stream: u32) -> Self {
         self.inner.rasterization_stream = rasterization_stream;
         self
     }
@@ -32471,10 +30038,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceRepresentativeFragmentTestFeatur
     }
 }
 impl<'a> PhysicalDeviceRepresentativeFragmentTestFeaturesNVBuilder<'a> {
-    pub fn representative_fragment_test(
-        mut self,
-        representative_fragment_test: bool,
-    ) -> PhysicalDeviceRepresentativeFragmentTestFeaturesNVBuilder<'a> {
+    pub fn representative_fragment_test(mut self, representative_fragment_test: bool) -> Self {
         self.inner.representative_fragment_test = representative_fragment_test.into();
         self
     }
@@ -32538,7 +30102,7 @@ impl<'a> PipelineRepresentativeFragmentTestStateCreateInfoNVBuilder<'a> {
     pub fn representative_fragment_test_enable(
         mut self,
         representative_fragment_test_enable: bool,
-    ) -> PipelineRepresentativeFragmentTestStateCreateInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.representative_fragment_test_enable = representative_fragment_test_enable.into();
         self
     }
@@ -32593,10 +30157,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceExclusiveScissorFeaturesNVBuilde
     }
 }
 impl<'a> PhysicalDeviceExclusiveScissorFeaturesNVBuilder<'a> {
-    pub fn exclusive_scissor(
-        mut self,
-        exclusive_scissor: bool,
-    ) -> PhysicalDeviceExclusiveScissorFeaturesNVBuilder<'a> {
+    pub fn exclusive_scissor(mut self, exclusive_scissor: bool) -> Self {
         self.inner.exclusive_scissor = exclusive_scissor.into();
         self
     }
@@ -32659,10 +30220,7 @@ impl<'a> ::std::ops::DerefMut for PipelineViewportExclusiveScissorStateCreateInf
     }
 }
 impl<'a> PipelineViewportExclusiveScissorStateCreateInfoNVBuilder<'a> {
-    pub fn exclusive_scissors(
-        mut self,
-        exclusive_scissors: &'a [Rect2D],
-    ) -> PipelineViewportExclusiveScissorStateCreateInfoNVBuilder<'a> {
+    pub fn exclusive_scissors(mut self, exclusive_scissors: &'a [Rect2D]) -> Self {
         self.inner.exclusive_scissor_count = exclusive_scissors.len() as _;
         self.inner.p_exclusive_scissors = exclusive_scissors.as_ptr();
         self
@@ -32718,10 +30276,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceCornerSampledImageFeaturesNVBuil
     }
 }
 impl<'a> PhysicalDeviceCornerSampledImageFeaturesNVBuilder<'a> {
-    pub fn corner_sampled_image(
-        mut self,
-        corner_sampled_image: bool,
-    ) -> PhysicalDeviceCornerSampledImageFeaturesNVBuilder<'a> {
+    pub fn corner_sampled_image(mut self, corner_sampled_image: bool) -> Self {
         self.inner.corner_sampled_image = corner_sampled_image.into();
         self
     }
@@ -32781,17 +30336,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceComputeShaderDerivativesFeatures
     }
 }
 impl<'a> PhysicalDeviceComputeShaderDerivativesFeaturesNVBuilder<'a> {
-    pub fn compute_derivative_group_quads(
-        mut self,
-        compute_derivative_group_quads: bool,
-    ) -> PhysicalDeviceComputeShaderDerivativesFeaturesNVBuilder<'a> {
+    pub fn compute_derivative_group_quads(mut self, compute_derivative_group_quads: bool) -> Self {
         self.inner.compute_derivative_group_quads = compute_derivative_group_quads.into();
         self
     }
     pub fn compute_derivative_group_linear(
         mut self,
         compute_derivative_group_linear: bool,
-    ) -> PhysicalDeviceComputeShaderDerivativesFeaturesNVBuilder<'a> {
+    ) -> Self {
         self.inner.compute_derivative_group_linear = compute_derivative_group_linear.into();
         self
     }
@@ -32849,10 +30401,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceFragmentShaderBarycentricFeature
     }
 }
 impl<'a> PhysicalDeviceFragmentShaderBarycentricFeaturesNVBuilder<'a> {
-    pub fn fragment_shader_barycentric(
-        mut self,
-        fragment_shader_barycentric: bool,
-    ) -> PhysicalDeviceFragmentShaderBarycentricFeaturesNVBuilder<'a> {
+    pub fn fragment_shader_barycentric(mut self, fragment_shader_barycentric: bool) -> Self {
         self.inner.fragment_shader_barycentric = fragment_shader_barycentric.into();
         self
     }
@@ -32907,10 +30456,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderImageFootprintFeaturesNVBu
     }
 }
 impl<'a> PhysicalDeviceShaderImageFootprintFeaturesNVBuilder<'a> {
-    pub fn image_footprint(
-        mut self,
-        image_footprint: bool,
-    ) -> PhysicalDeviceShaderImageFootprintFeaturesNVBuilder<'a> {
+    pub fn image_footprint(mut self, image_footprint: bool) -> Self {
         self.inner.image_footprint = image_footprint.into();
         self
     }
@@ -32973,7 +30519,7 @@ impl<'a> PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNVBuilder<'a> {
     pub fn dedicated_allocation_image_aliasing(
         mut self,
         dedicated_allocation_image_aliasing: bool,
-    ) -> PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNVBuilder<'a> {
+    ) -> Self {
         self.inner.dedicated_allocation_image_aliasing = dedicated_allocation_image_aliasing.into();
         self
     }
@@ -33027,7 +30573,7 @@ impl<'a> ShadingRatePaletteNVBuilder<'a> {
     pub fn shading_rate_palette_entries(
         mut self,
         shading_rate_palette_entries: &'a [ShadingRatePaletteEntryNV],
-    ) -> ShadingRatePaletteNVBuilder<'a> {
+    ) -> Self {
         self.inner.shading_rate_palette_entry_count = shading_rate_palette_entries.len() as _;
         self.inner.p_shading_rate_palette_entries = shading_rate_palette_entries.as_ptr();
         self
@@ -33093,17 +30639,14 @@ impl<'a> ::std::ops::DerefMut for PipelineViewportShadingRateImageStateCreateInf
     }
 }
 impl<'a> PipelineViewportShadingRateImageStateCreateInfoNVBuilder<'a> {
-    pub fn shading_rate_image_enable(
-        mut self,
-        shading_rate_image_enable: bool,
-    ) -> PipelineViewportShadingRateImageStateCreateInfoNVBuilder<'a> {
+    pub fn shading_rate_image_enable(mut self, shading_rate_image_enable: bool) -> Self {
         self.inner.shading_rate_image_enable = shading_rate_image_enable.into();
         self
     }
     pub fn shading_rate_palettes(
         mut self,
         shading_rate_palettes: &'a [ShadingRatePaletteNV],
-    ) -> PipelineViewportShadingRateImageStateCreateInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.viewport_count = shading_rate_palettes.len() as _;
         self.inner.p_shading_rate_palettes = shading_rate_palettes.as_ptr();
         self
@@ -33161,17 +30704,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShadingRateImageFeaturesNVBuilde
     }
 }
 impl<'a> PhysicalDeviceShadingRateImageFeaturesNVBuilder<'a> {
-    pub fn shading_rate_image(
-        mut self,
-        shading_rate_image: bool,
-    ) -> PhysicalDeviceShadingRateImageFeaturesNVBuilder<'a> {
+    pub fn shading_rate_image(mut self, shading_rate_image: bool) -> Self {
         self.inner.shading_rate_image = shading_rate_image.into();
         self
     }
     pub fn shading_rate_coarse_sample_order(
         mut self,
         shading_rate_coarse_sample_order: bool,
-    ) -> PhysicalDeviceShadingRateImageFeaturesNVBuilder<'a> {
+    ) -> Self {
         self.inner.shading_rate_coarse_sample_order = shading_rate_coarse_sample_order.into();
         self
     }
@@ -33233,24 +30773,15 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShadingRateImagePropertiesNVBuil
     }
 }
 impl<'a> PhysicalDeviceShadingRateImagePropertiesNVBuilder<'a> {
-    pub fn shading_rate_texel_size(
-        mut self,
-        shading_rate_texel_size: Extent2D,
-    ) -> PhysicalDeviceShadingRateImagePropertiesNVBuilder<'a> {
+    pub fn shading_rate_texel_size(mut self, shading_rate_texel_size: Extent2D) -> Self {
         self.inner.shading_rate_texel_size = shading_rate_texel_size;
         self
     }
-    pub fn shading_rate_palette_size(
-        mut self,
-        shading_rate_palette_size: u32,
-    ) -> PhysicalDeviceShadingRateImagePropertiesNVBuilder<'a> {
+    pub fn shading_rate_palette_size(mut self, shading_rate_palette_size: u32) -> Self {
         self.inner.shading_rate_palette_size = shading_rate_palette_size;
         self
     }
-    pub fn shading_rate_max_coarse_samples(
-        mut self,
-        shading_rate_max_coarse_samples: u32,
-    ) -> PhysicalDeviceShadingRateImagePropertiesNVBuilder<'a> {
+    pub fn shading_rate_max_coarse_samples(mut self, shading_rate_max_coarse_samples: u32) -> Self {
         self.inner.shading_rate_max_coarse_samples = shading_rate_max_coarse_samples;
         self
     }
@@ -33294,15 +30825,15 @@ impl<'a> ::std::ops::DerefMut for CoarseSampleLocationNVBuilder<'a> {
     }
 }
 impl<'a> CoarseSampleLocationNVBuilder<'a> {
-    pub fn pixel_x(mut self, pixel_x: u32) -> CoarseSampleLocationNVBuilder<'a> {
+    pub fn pixel_x(mut self, pixel_x: u32) -> Self {
         self.inner.pixel_x = pixel_x;
         self
     }
-    pub fn pixel_y(mut self, pixel_y: u32) -> CoarseSampleLocationNVBuilder<'a> {
+    pub fn pixel_y(mut self, pixel_y: u32) -> Self {
         self.inner.pixel_y = pixel_y;
         self
     }
-    pub fn sample(mut self, sample: u32) -> CoarseSampleLocationNVBuilder<'a> {
+    pub fn sample(mut self, sample: u32) -> Self {
         self.inner.sample = sample;
         self
     }
@@ -33357,21 +30888,15 @@ impl<'a> ::std::ops::DerefMut for CoarseSampleOrderCustomNVBuilder<'a> {
     }
 }
 impl<'a> CoarseSampleOrderCustomNVBuilder<'a> {
-    pub fn shading_rate(
-        mut self,
-        shading_rate: ShadingRatePaletteEntryNV,
-    ) -> CoarseSampleOrderCustomNVBuilder<'a> {
+    pub fn shading_rate(mut self, shading_rate: ShadingRatePaletteEntryNV) -> Self {
         self.inner.shading_rate = shading_rate;
         self
     }
-    pub fn sample_count(mut self, sample_count: u32) -> CoarseSampleOrderCustomNVBuilder<'a> {
+    pub fn sample_count(mut self, sample_count: u32) -> Self {
         self.inner.sample_count = sample_count;
         self
     }
-    pub fn sample_locations(
-        mut self,
-        sample_locations: &'a [CoarseSampleLocationNV],
-    ) -> CoarseSampleOrderCustomNVBuilder<'a> {
+    pub fn sample_locations(mut self, sample_locations: &'a [CoarseSampleLocationNV]) -> Self {
         self.inner.sample_location_count = sample_locations.len() as _;
         self.inner.p_sample_locations = sample_locations.as_ptr();
         self
@@ -33437,17 +30962,14 @@ impl<'a> ::std::ops::DerefMut for PipelineViewportCoarseSampleOrderStateCreateIn
     }
 }
 impl<'a> PipelineViewportCoarseSampleOrderStateCreateInfoNVBuilder<'a> {
-    pub fn sample_order_type(
-        mut self,
-        sample_order_type: CoarseSampleOrderTypeNV,
-    ) -> PipelineViewportCoarseSampleOrderStateCreateInfoNVBuilder<'a> {
+    pub fn sample_order_type(mut self, sample_order_type: CoarseSampleOrderTypeNV) -> Self {
         self.inner.sample_order_type = sample_order_type;
         self
     }
     pub fn custom_sample_orders(
         mut self,
         custom_sample_orders: &'a [CoarseSampleOrderCustomNV],
-    ) -> PipelineViewportCoarseSampleOrderStateCreateInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.custom_sample_order_count = custom_sample_orders.len() as _;
         self.inner.p_custom_sample_orders = custom_sample_orders.as_ptr();
         self
@@ -33505,17 +31027,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMeshShaderFeaturesNVBuilder<'a> 
     }
 }
 impl<'a> PhysicalDeviceMeshShaderFeaturesNVBuilder<'a> {
-    pub fn task_shader(
-        mut self,
-        task_shader: bool,
-    ) -> PhysicalDeviceMeshShaderFeaturesNVBuilder<'a> {
+    pub fn task_shader(mut self, task_shader: bool) -> Self {
         self.inner.task_shader = task_shader.into();
         self
     }
-    pub fn mesh_shader(
-        mut self,
-        mesh_shader: bool,
-    ) -> PhysicalDeviceMeshShaderFeaturesNVBuilder<'a> {
+    pub fn mesh_shader(mut self, mesh_shader: bool) -> Self {
         self.inner.mesh_shader = mesh_shader.into();
         self
     }
@@ -33594,94 +31110,61 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMeshShaderPropertiesNVBuilder<'a
     }
 }
 impl<'a> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
-    pub fn max_draw_mesh_tasks_count(
-        mut self,
-        max_draw_mesh_tasks_count: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_draw_mesh_tasks_count(mut self, max_draw_mesh_tasks_count: u32) -> Self {
         self.inner.max_draw_mesh_tasks_count = max_draw_mesh_tasks_count;
         self
     }
-    pub fn max_task_work_group_invocations(
-        mut self,
-        max_task_work_group_invocations: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_task_work_group_invocations(mut self, max_task_work_group_invocations: u32) -> Self {
         self.inner.max_task_work_group_invocations = max_task_work_group_invocations;
         self
     }
-    pub fn max_task_work_group_size(
-        mut self,
-        max_task_work_group_size: [u32; 3],
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_task_work_group_size(mut self, max_task_work_group_size: [u32; 3]) -> Self {
         self.inner.max_task_work_group_size = max_task_work_group_size;
         self
     }
-    pub fn max_task_total_memory_size(
-        mut self,
-        max_task_total_memory_size: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_task_total_memory_size(mut self, max_task_total_memory_size: u32) -> Self {
         self.inner.max_task_total_memory_size = max_task_total_memory_size;
         self
     }
-    pub fn max_task_output_count(
-        mut self,
-        max_task_output_count: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_task_output_count(mut self, max_task_output_count: u32) -> Self {
         self.inner.max_task_output_count = max_task_output_count;
         self
     }
-    pub fn max_mesh_work_group_invocations(
-        mut self,
-        max_mesh_work_group_invocations: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_mesh_work_group_invocations(mut self, max_mesh_work_group_invocations: u32) -> Self {
         self.inner.max_mesh_work_group_invocations = max_mesh_work_group_invocations;
         self
     }
-    pub fn max_mesh_work_group_size(
-        mut self,
-        max_mesh_work_group_size: [u32; 3],
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_mesh_work_group_size(mut self, max_mesh_work_group_size: [u32; 3]) -> Self {
         self.inner.max_mesh_work_group_size = max_mesh_work_group_size;
         self
     }
-    pub fn max_mesh_total_memory_size(
-        mut self,
-        max_mesh_total_memory_size: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_mesh_total_memory_size(mut self, max_mesh_total_memory_size: u32) -> Self {
         self.inner.max_mesh_total_memory_size = max_mesh_total_memory_size;
         self
     }
-    pub fn max_mesh_output_vertices(
-        mut self,
-        max_mesh_output_vertices: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_mesh_output_vertices(mut self, max_mesh_output_vertices: u32) -> Self {
         self.inner.max_mesh_output_vertices = max_mesh_output_vertices;
         self
     }
-    pub fn max_mesh_output_primitives(
-        mut self,
-        max_mesh_output_primitives: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_mesh_output_primitives(mut self, max_mesh_output_primitives: u32) -> Self {
         self.inner.max_mesh_output_primitives = max_mesh_output_primitives;
         self
     }
-    pub fn max_mesh_multiview_view_count(
-        mut self,
-        max_mesh_multiview_view_count: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    pub fn max_mesh_multiview_view_count(mut self, max_mesh_multiview_view_count: u32) -> Self {
         self.inner.max_mesh_multiview_view_count = max_mesh_multiview_view_count;
         self
     }
     pub fn mesh_output_per_vertex_granularity(
         mut self,
         mesh_output_per_vertex_granularity: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.mesh_output_per_vertex_granularity = mesh_output_per_vertex_granularity;
         self
     }
     pub fn mesh_output_per_primitive_granularity(
         mut self,
         mesh_output_per_primitive_granularity: u32,
-    ) -> PhysicalDeviceMeshShaderPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.mesh_output_per_primitive_granularity = mesh_output_per_primitive_granularity;
         self
     }
@@ -33724,11 +31207,11 @@ impl<'a> ::std::ops::DerefMut for DrawMeshTasksIndirectCommandNVBuilder<'a> {
     }
 }
 impl<'a> DrawMeshTasksIndirectCommandNVBuilder<'a> {
-    pub fn task_count(mut self, task_count: u32) -> DrawMeshTasksIndirectCommandNVBuilder<'a> {
+    pub fn task_count(mut self, task_count: u32) -> Self {
         self.inner.task_count = task_count;
         self
     }
-    pub fn first_task(mut self, first_task: u32) -> DrawMeshTasksIndirectCommandNVBuilder<'a> {
+    pub fn first_task(mut self, first_task: u32) -> Self {
         self.inner.first_task = first_task;
         self
     }
@@ -33790,38 +31273,23 @@ impl<'a> ::std::ops::DerefMut for RayTracingShaderGroupCreateInfoNVBuilder<'a> {
     }
 }
 impl<'a> RayTracingShaderGroupCreateInfoNVBuilder<'a> {
-    pub fn ty(
-        mut self,
-        ty: RayTracingShaderGroupTypeKHR,
-    ) -> RayTracingShaderGroupCreateInfoNVBuilder<'a> {
+    pub fn ty(mut self, ty: RayTracingShaderGroupTypeKHR) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn general_shader(
-        mut self,
-        general_shader: u32,
-    ) -> RayTracingShaderGroupCreateInfoNVBuilder<'a> {
+    pub fn general_shader(mut self, general_shader: u32) -> Self {
         self.inner.general_shader = general_shader;
         self
     }
-    pub fn closest_hit_shader(
-        mut self,
-        closest_hit_shader: u32,
-    ) -> RayTracingShaderGroupCreateInfoNVBuilder<'a> {
+    pub fn closest_hit_shader(mut self, closest_hit_shader: u32) -> Self {
         self.inner.closest_hit_shader = closest_hit_shader;
         self
     }
-    pub fn any_hit_shader(
-        mut self,
-        any_hit_shader: u32,
-    ) -> RayTracingShaderGroupCreateInfoNVBuilder<'a> {
+    pub fn any_hit_shader(mut self, any_hit_shader: u32) -> Self {
         self.inner.any_hit_shader = any_hit_shader;
         self
     }
-    pub fn intersection_shader(
-        mut self,
-        intersection_shader: u32,
-    ) -> RayTracingShaderGroupCreateInfoNVBuilder<'a> {
+    pub fn intersection_shader(mut self, intersection_shader: u32) -> Self {
         self.inner.intersection_shader = intersection_shader;
         self
     }
@@ -33833,7 +31301,7 @@ impl<'a> RayTracingShaderGroupCreateInfoNVBuilder<'a> {
     pub fn push_next<T: ExtendsRayTracingShaderGroupCreateInfoNV>(
         mut self,
         next: &'a mut T,
-    ) -> RayTracingShaderGroupCreateInfoNVBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -33902,45 +31370,30 @@ impl<'a> ::std::ops::DerefMut for RayTracingShaderGroupCreateInfoKHRBuilder<'a> 
     }
 }
 impl<'a> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
-    pub fn ty(
-        mut self,
-        ty: RayTracingShaderGroupTypeKHR,
-    ) -> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
+    pub fn ty(mut self, ty: RayTracingShaderGroupTypeKHR) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn general_shader(
-        mut self,
-        general_shader: u32,
-    ) -> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
+    pub fn general_shader(mut self, general_shader: u32) -> Self {
         self.inner.general_shader = general_shader;
         self
     }
-    pub fn closest_hit_shader(
-        mut self,
-        closest_hit_shader: u32,
-    ) -> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
+    pub fn closest_hit_shader(mut self, closest_hit_shader: u32) -> Self {
         self.inner.closest_hit_shader = closest_hit_shader;
         self
     }
-    pub fn any_hit_shader(
-        mut self,
-        any_hit_shader: u32,
-    ) -> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
+    pub fn any_hit_shader(mut self, any_hit_shader: u32) -> Self {
         self.inner.any_hit_shader = any_hit_shader;
         self
     }
-    pub fn intersection_shader(
-        mut self,
-        intersection_shader: u32,
-    ) -> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
+    pub fn intersection_shader(mut self, intersection_shader: u32) -> Self {
         self.inner.intersection_shader = intersection_shader;
         self
     }
     pub fn shader_group_capture_replay_handle(
         mut self,
         shader_group_capture_replay_handle: *const c_void,
-    ) -> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.p_shader_group_capture_replay_handle = shader_group_capture_replay_handle;
         self
     }
@@ -33952,7 +31405,7 @@ impl<'a> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsRayTracingShaderGroupCreateInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> RayTracingShaderGroupCreateInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -34027,51 +31480,33 @@ impl<'a> ::std::ops::DerefMut for RayTracingPipelineCreateInfoNVBuilder<'a> {
     }
 }
 impl<'a> RayTracingPipelineCreateInfoNVBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineCreateFlags,
-    ) -> RayTracingPipelineCreateInfoNVBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn stages(
-        mut self,
-        stages: &'a [PipelineShaderStageCreateInfo],
-    ) -> RayTracingPipelineCreateInfoNVBuilder<'a> {
+    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo]) -> Self {
         self.inner.stage_count = stages.len() as _;
         self.inner.p_stages = stages.as_ptr();
         self
     }
-    pub fn groups(
-        mut self,
-        groups: &'a [RayTracingShaderGroupCreateInfoNV],
-    ) -> RayTracingPipelineCreateInfoNVBuilder<'a> {
+    pub fn groups(mut self, groups: &'a [RayTracingShaderGroupCreateInfoNV]) -> Self {
         self.inner.group_count = groups.len() as _;
         self.inner.p_groups = groups.as_ptr();
         self
     }
-    pub fn max_recursion_depth(
-        mut self,
-        max_recursion_depth: u32,
-    ) -> RayTracingPipelineCreateInfoNVBuilder<'a> {
+    pub fn max_recursion_depth(mut self, max_recursion_depth: u32) -> Self {
         self.inner.max_recursion_depth = max_recursion_depth;
         self
     }
-    pub fn layout(mut self, layout: PipelineLayout) -> RayTracingPipelineCreateInfoNVBuilder<'a> {
+    pub fn layout(mut self, layout: PipelineLayout) -> Self {
         self.inner.layout = layout;
         self
     }
-    pub fn base_pipeline_handle(
-        mut self,
-        base_pipeline_handle: Pipeline,
-    ) -> RayTracingPipelineCreateInfoNVBuilder<'a> {
+    pub fn base_pipeline_handle(mut self, base_pipeline_handle: Pipeline) -> Self {
         self.inner.base_pipeline_handle = base_pipeline_handle;
         self
     }
-    pub fn base_pipeline_index(
-        mut self,
-        base_pipeline_index: i32,
-    ) -> RayTracingPipelineCreateInfoNVBuilder<'a> {
+    pub fn base_pipeline_index(mut self, base_pipeline_index: i32) -> Self {
         self.inner.base_pipeline_index = base_pipeline_index;
         self
     }
@@ -34080,10 +31515,7 @@ impl<'a> RayTracingPipelineCreateInfoNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsRayTracingPipelineCreateInfoNV>(
-        mut self,
-        next: &'a mut T,
-    ) -> RayTracingPipelineCreateInfoNVBuilder<'a> {
+    pub fn push_next<T: ExtendsRayTracingPipelineCreateInfoNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -34164,25 +31596,16 @@ impl<'a> ::std::ops::DerefMut for RayTracingPipelineCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> RayTracingPipelineCreateInfoKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineCreateFlags,
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn stages(
-        mut self,
-        stages: &'a [PipelineShaderStageCreateInfo],
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    pub fn stages(mut self, stages: &'a [PipelineShaderStageCreateInfo]) -> Self {
         self.inner.stage_count = stages.len() as _;
         self.inner.p_stages = stages.as_ptr();
         self
     }
-    pub fn groups(
-        mut self,
-        groups: &'a [RayTracingShaderGroupCreateInfoKHR],
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    pub fn groups(mut self, groups: &'a [RayTracingShaderGroupCreateInfoKHR]) -> Self {
         self.inner.group_count = groups.len() as _;
         self.inner.p_groups = groups.as_ptr();
         self
@@ -34190,46 +31613,34 @@ impl<'a> RayTracingPipelineCreateInfoKHRBuilder<'a> {
     pub fn max_pipeline_ray_recursion_depth(
         mut self,
         max_pipeline_ray_recursion_depth: u32,
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.max_pipeline_ray_recursion_depth = max_pipeline_ray_recursion_depth;
         self
     }
-    pub fn library_info(
-        mut self,
-        library_info: &'a PipelineLibraryCreateInfoKHR,
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    pub fn library_info(mut self, library_info: &'a PipelineLibraryCreateInfoKHR) -> Self {
         self.inner.p_library_info = library_info;
         self
     }
     pub fn library_interface(
         mut self,
         library_interface: &'a RayTracingPipelineInterfaceCreateInfoKHR,
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.p_library_interface = library_interface;
         self
     }
-    pub fn dynamic_state(
-        mut self,
-        dynamic_state: &'a PipelineDynamicStateCreateInfo,
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    pub fn dynamic_state(mut self, dynamic_state: &'a PipelineDynamicStateCreateInfo) -> Self {
         self.inner.p_dynamic_state = dynamic_state;
         self
     }
-    pub fn layout(mut self, layout: PipelineLayout) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    pub fn layout(mut self, layout: PipelineLayout) -> Self {
         self.inner.layout = layout;
         self
     }
-    pub fn base_pipeline_handle(
-        mut self,
-        base_pipeline_handle: Pipeline,
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    pub fn base_pipeline_handle(mut self, base_pipeline_handle: Pipeline) -> Self {
         self.inner.base_pipeline_handle = base_pipeline_handle;
         self
     }
-    pub fn base_pipeline_index(
-        mut self,
-        base_pipeline_index: i32,
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    pub fn base_pipeline_index(mut self, base_pipeline_index: i32) -> Self {
         self.inner.base_pipeline_index = base_pipeline_index;
         self
     }
@@ -34238,10 +31649,7 @@ impl<'a> RayTracingPipelineCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsRayTracingPipelineCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> RayTracingPipelineCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsRayTracingPipelineCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -34320,50 +31728,47 @@ impl<'a> ::std::ops::DerefMut for GeometryTrianglesNVBuilder<'a> {
     }
 }
 impl<'a> GeometryTrianglesNVBuilder<'a> {
-    pub fn vertex_data(mut self, vertex_data: Buffer) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn vertex_data(mut self, vertex_data: Buffer) -> Self {
         self.inner.vertex_data = vertex_data;
         self
     }
-    pub fn vertex_offset(mut self, vertex_offset: DeviceSize) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn vertex_offset(mut self, vertex_offset: DeviceSize) -> Self {
         self.inner.vertex_offset = vertex_offset;
         self
     }
-    pub fn vertex_count(mut self, vertex_count: u32) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn vertex_count(mut self, vertex_count: u32) -> Self {
         self.inner.vertex_count = vertex_count;
         self
     }
-    pub fn vertex_stride(mut self, vertex_stride: DeviceSize) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn vertex_stride(mut self, vertex_stride: DeviceSize) -> Self {
         self.inner.vertex_stride = vertex_stride;
         self
     }
-    pub fn vertex_format(mut self, vertex_format: Format) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn vertex_format(mut self, vertex_format: Format) -> Self {
         self.inner.vertex_format = vertex_format;
         self
     }
-    pub fn index_data(mut self, index_data: Buffer) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn index_data(mut self, index_data: Buffer) -> Self {
         self.inner.index_data = index_data;
         self
     }
-    pub fn index_offset(mut self, index_offset: DeviceSize) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn index_offset(mut self, index_offset: DeviceSize) -> Self {
         self.inner.index_offset = index_offset;
         self
     }
-    pub fn index_count(mut self, index_count: u32) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn index_count(mut self, index_count: u32) -> Self {
         self.inner.index_count = index_count;
         self
     }
-    pub fn index_type(mut self, index_type: IndexType) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn index_type(mut self, index_type: IndexType) -> Self {
         self.inner.index_type = index_type;
         self
     }
-    pub fn transform_data(mut self, transform_data: Buffer) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn transform_data(mut self, transform_data: Buffer) -> Self {
         self.inner.transform_data = transform_data;
         self
     }
-    pub fn transform_offset(
-        mut self,
-        transform_offset: DeviceSize,
-    ) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn transform_offset(mut self, transform_offset: DeviceSize) -> Self {
         self.inner.transform_offset = transform_offset;
         self
     }
@@ -34372,10 +31777,7 @@ impl<'a> GeometryTrianglesNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsGeometryTrianglesNV>(
-        mut self,
-        next: &'a mut T,
-    ) -> GeometryTrianglesNVBuilder<'a> {
+    pub fn push_next<T: ExtendsGeometryTrianglesNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -34440,19 +31842,19 @@ impl<'a> ::std::ops::DerefMut for GeometryAABBNVBuilder<'a> {
     }
 }
 impl<'a> GeometryAABBNVBuilder<'a> {
-    pub fn aabb_data(mut self, aabb_data: Buffer) -> GeometryAABBNVBuilder<'a> {
+    pub fn aabb_data(mut self, aabb_data: Buffer) -> Self {
         self.inner.aabb_data = aabb_data;
         self
     }
-    pub fn num_aab_bs(mut self, num_aab_bs: u32) -> GeometryAABBNVBuilder<'a> {
+    pub fn num_aab_bs(mut self, num_aab_bs: u32) -> Self {
         self.inner.num_aab_bs = num_aab_bs;
         self
     }
-    pub fn stride(mut self, stride: u32) -> GeometryAABBNVBuilder<'a> {
+    pub fn stride(mut self, stride: u32) -> Self {
         self.inner.stride = stride;
         self
     }
-    pub fn offset(mut self, offset: DeviceSize) -> GeometryAABBNVBuilder<'a> {
+    pub fn offset(mut self, offset: DeviceSize) -> Self {
         self.inner.offset = offset;
         self
     }
@@ -34461,10 +31863,7 @@ impl<'a> GeometryAABBNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsGeometryAABBNV>(
-        mut self,
-        next: &'a mut T,
-    ) -> GeometryAABBNVBuilder<'a> {
+    pub fn push_next<T: ExtendsGeometryAABBNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -34512,11 +31911,11 @@ impl<'a> ::std::ops::DerefMut for GeometryDataNVBuilder<'a> {
     }
 }
 impl<'a> GeometryDataNVBuilder<'a> {
-    pub fn triangles(mut self, triangles: GeometryTrianglesNV) -> GeometryDataNVBuilder<'a> {
+    pub fn triangles(mut self, triangles: GeometryTrianglesNV) -> Self {
         self.inner.triangles = triangles;
         self
     }
-    pub fn aabbs(mut self, aabbs: GeometryAABBNV) -> GeometryDataNVBuilder<'a> {
+    pub fn aabbs(mut self, aabbs: GeometryAABBNV) -> Self {
         self.inner.aabbs = aabbs;
         self
     }
@@ -34574,15 +31973,15 @@ impl<'a> ::std::ops::DerefMut for GeometryNVBuilder<'a> {
     }
 }
 impl<'a> GeometryNVBuilder<'a> {
-    pub fn geometry_type(mut self, geometry_type: GeometryTypeKHR) -> GeometryNVBuilder<'a> {
+    pub fn geometry_type(mut self, geometry_type: GeometryTypeKHR) -> Self {
         self.inner.geometry_type = geometry_type;
         self
     }
-    pub fn geometry(mut self, geometry: GeometryDataNV) -> GeometryNVBuilder<'a> {
+    pub fn geometry(mut self, geometry: GeometryDataNV) -> Self {
         self.inner.geometry = geometry;
         self
     }
-    pub fn flags(mut self, flags: GeometryFlagsKHR) -> GeometryNVBuilder<'a> {
+    pub fn flags(mut self, flags: GeometryFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -34591,7 +31990,7 @@ impl<'a> GeometryNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsGeometryNV>(mut self, next: &'a mut T) -> GeometryNVBuilder<'a> {
+    pub fn push_next<T: ExtendsGeometryNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -34658,25 +32057,19 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureInfoNVBuilder<'a> {
     }
 }
 impl<'a> AccelerationStructureInfoNVBuilder<'a> {
-    pub fn ty(mut self, ty: AccelerationStructureTypeNV) -> AccelerationStructureInfoNVBuilder<'a> {
+    pub fn ty(mut self, ty: AccelerationStructureTypeNV) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn flags(
-        mut self,
-        flags: BuildAccelerationStructureFlagsNV,
-    ) -> AccelerationStructureInfoNVBuilder<'a> {
+    pub fn flags(mut self, flags: BuildAccelerationStructureFlagsNV) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn instance_count(mut self, instance_count: u32) -> AccelerationStructureInfoNVBuilder<'a> {
+    pub fn instance_count(mut self, instance_count: u32) -> Self {
         self.inner.instance_count = instance_count;
         self
     }
-    pub fn geometries(
-        mut self,
-        geometries: &'a [GeometryNV],
-    ) -> AccelerationStructureInfoNVBuilder<'a> {
+    pub fn geometries(mut self, geometries: &'a [GeometryNV]) -> Self {
         self.inner.geometry_count = geometries.len() as _;
         self.inner.p_geometries = geometries.as_ptr();
         self
@@ -34686,10 +32079,7 @@ impl<'a> AccelerationStructureInfoNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsAccelerationStructureInfoNV>(
-        mut self,
-        next: &'a mut T,
-    ) -> AccelerationStructureInfoNVBuilder<'a> {
+    pub fn push_next<T: ExtendsAccelerationStructureInfoNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -34750,17 +32140,11 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureCreateInfoNVBuilder<'a> {
     }
 }
 impl<'a> AccelerationStructureCreateInfoNVBuilder<'a> {
-    pub fn compacted_size(
-        mut self,
-        compacted_size: DeviceSize,
-    ) -> AccelerationStructureCreateInfoNVBuilder<'a> {
+    pub fn compacted_size(mut self, compacted_size: DeviceSize) -> Self {
         self.inner.compacted_size = compacted_size;
         self
     }
-    pub fn info(
-        mut self,
-        info: AccelerationStructureInfoNV,
-    ) -> AccelerationStructureCreateInfoNVBuilder<'a> {
+    pub fn info(mut self, info: AccelerationStructureInfoNV) -> Self {
         self.inner.info = info;
         self
     }
@@ -34772,7 +32156,7 @@ impl<'a> AccelerationStructureCreateInfoNVBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureCreateInfoNV>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureCreateInfoNVBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -34842,28 +32226,19 @@ impl<'a> BindAccelerationStructureMemoryInfoNVBuilder<'a> {
     pub fn acceleration_structure(
         mut self,
         acceleration_structure: AccelerationStructureNV,
-    ) -> BindAccelerationStructureMemoryInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.acceleration_structure = acceleration_structure;
         self
     }
-    pub fn memory(
-        mut self,
-        memory: DeviceMemory,
-    ) -> BindAccelerationStructureMemoryInfoNVBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
-    pub fn memory_offset(
-        mut self,
-        memory_offset: DeviceSize,
-    ) -> BindAccelerationStructureMemoryInfoNVBuilder<'a> {
+    pub fn memory_offset(mut self, memory_offset: DeviceSize) -> Self {
         self.inner.memory_offset = memory_offset;
         self
     }
-    pub fn device_indices(
-        mut self,
-        device_indices: &'a [u32],
-    ) -> BindAccelerationStructureMemoryInfoNVBuilder<'a> {
+    pub fn device_indices(mut self, device_indices: &'a [u32]) -> Self {
         self.inner.device_index_count = device_indices.len() as _;
         self.inner.p_device_indices = device_indices.as_ptr();
         self
@@ -34876,7 +32251,7 @@ impl<'a> BindAccelerationStructureMemoryInfoNVBuilder<'a> {
     pub fn push_next<T: ExtendsBindAccelerationStructureMemoryInfoNV>(
         mut self,
         next: &'a mut T,
-    ) -> BindAccelerationStructureMemoryInfoNVBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -34941,7 +32316,7 @@ impl<'a> WriteDescriptorSetAccelerationStructureKHRBuilder<'a> {
     pub fn acceleration_structures(
         mut self,
         acceleration_structures: &'a [AccelerationStructureKHR],
-    ) -> WriteDescriptorSetAccelerationStructureKHRBuilder<'a> {
+    ) -> Self {
         self.inner.acceleration_structure_count = acceleration_structures.len() as _;
         self.inner.p_acceleration_structures = acceleration_structures.as_ptr();
         self
@@ -35002,7 +32377,7 @@ impl<'a> WriteDescriptorSetAccelerationStructureNVBuilder<'a> {
     pub fn acceleration_structures(
         mut self,
         acceleration_structures: &'a [AccelerationStructureNV],
-    ) -> WriteDescriptorSetAccelerationStructureNVBuilder<'a> {
+    ) -> Self {
         self.inner.acceleration_structure_count = acceleration_structures.len() as _;
         self.inner.p_acceleration_structures = acceleration_structures.as_ptr();
         self
@@ -35059,17 +32434,14 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureMemoryRequirementsInfoNVB
     }
 }
 impl<'a> AccelerationStructureMemoryRequirementsInfoNVBuilder<'a> {
-    pub fn ty(
-        mut self,
-        ty: AccelerationStructureMemoryRequirementsTypeNV,
-    ) -> AccelerationStructureMemoryRequirementsInfoNVBuilder<'a> {
+    pub fn ty(mut self, ty: AccelerationStructureMemoryRequirementsTypeNV) -> Self {
         self.inner.ty = ty;
         self
     }
     pub fn acceleration_structure(
         mut self,
         acceleration_structure: AccelerationStructureNV,
-    ) -> AccelerationStructureMemoryRequirementsInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.acceleration_structure = acceleration_structure;
         self
     }
@@ -35081,7 +32453,7 @@ impl<'a> AccelerationStructureMemoryRequirementsInfoNVBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureMemoryRequirementsInfoNV>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureMemoryRequirementsInfoNVBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -35149,17 +32521,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceAccelerationStructureFeaturesKHR
     }
 }
 impl<'a> PhysicalDeviceAccelerationStructureFeaturesKHRBuilder<'a> {
-    pub fn acceleration_structure(
-        mut self,
-        acceleration_structure: bool,
-    ) -> PhysicalDeviceAccelerationStructureFeaturesKHRBuilder<'a> {
+    pub fn acceleration_structure(mut self, acceleration_structure: bool) -> Self {
         self.inner.acceleration_structure = acceleration_structure.into();
         self
     }
     pub fn acceleration_structure_capture_replay(
         mut self,
         acceleration_structure_capture_replay: bool,
-    ) -> PhysicalDeviceAccelerationStructureFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.acceleration_structure_capture_replay =
             acceleration_structure_capture_replay.into();
         self
@@ -35167,7 +32536,7 @@ impl<'a> PhysicalDeviceAccelerationStructureFeaturesKHRBuilder<'a> {
     pub fn acceleration_structure_indirect_build(
         mut self,
         acceleration_structure_indirect_build: bool,
-    ) -> PhysicalDeviceAccelerationStructureFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.acceleration_structure_indirect_build =
             acceleration_structure_indirect_build.into();
         self
@@ -35175,7 +32544,7 @@ impl<'a> PhysicalDeviceAccelerationStructureFeaturesKHRBuilder<'a> {
     pub fn acceleration_structure_host_commands(
         mut self,
         acceleration_structure_host_commands: bool,
-    ) -> PhysicalDeviceAccelerationStructureFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.acceleration_structure_host_commands =
             acceleration_structure_host_commands.into();
         self
@@ -35183,7 +32552,7 @@ impl<'a> PhysicalDeviceAccelerationStructureFeaturesKHRBuilder<'a> {
     pub fn descriptor_binding_acceleration_structure_update_after_bind(
         mut self,
         descriptor_binding_acceleration_structure_update_after_bind: bool,
-    ) -> PhysicalDeviceAccelerationStructureFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_acceleration_structure_update_after_bind =
             descriptor_binding_acceleration_structure_update_after_bind.into();
@@ -35248,17 +32617,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceRayTracingPipelineFeaturesKHRBui
     }
 }
 impl<'a> PhysicalDeviceRayTracingPipelineFeaturesKHRBuilder<'a> {
-    pub fn ray_tracing_pipeline(
-        mut self,
-        ray_tracing_pipeline: bool,
-    ) -> PhysicalDeviceRayTracingPipelineFeaturesKHRBuilder<'a> {
+    pub fn ray_tracing_pipeline(mut self, ray_tracing_pipeline: bool) -> Self {
         self.inner.ray_tracing_pipeline = ray_tracing_pipeline.into();
         self
     }
     pub fn ray_tracing_pipeline_shader_group_handle_capture_replay(
         mut self,
         ray_tracing_pipeline_shader_group_handle_capture_replay: bool,
-    ) -> PhysicalDeviceRayTracingPipelineFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .ray_tracing_pipeline_shader_group_handle_capture_replay =
             ray_tracing_pipeline_shader_group_handle_capture_replay.into();
@@ -35267,7 +32633,7 @@ impl<'a> PhysicalDeviceRayTracingPipelineFeaturesKHRBuilder<'a> {
     pub fn ray_tracing_pipeline_shader_group_handle_capture_replay_mixed(
         mut self,
         ray_tracing_pipeline_shader_group_handle_capture_replay_mixed: bool,
-    ) -> PhysicalDeviceRayTracingPipelineFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .ray_tracing_pipeline_shader_group_handle_capture_replay_mixed =
             ray_tracing_pipeline_shader_group_handle_capture_replay_mixed.into();
@@ -35276,7 +32642,7 @@ impl<'a> PhysicalDeviceRayTracingPipelineFeaturesKHRBuilder<'a> {
     pub fn ray_tracing_pipeline_trace_rays_indirect(
         mut self,
         ray_tracing_pipeline_trace_rays_indirect: bool,
-    ) -> PhysicalDeviceRayTracingPipelineFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.ray_tracing_pipeline_trace_rays_indirect =
             ray_tracing_pipeline_trace_rays_indirect.into();
         self
@@ -35284,7 +32650,7 @@ impl<'a> PhysicalDeviceRayTracingPipelineFeaturesKHRBuilder<'a> {
     pub fn ray_traversal_primitive_culling(
         mut self,
         ray_traversal_primitive_culling: bool,
-    ) -> PhysicalDeviceRayTracingPipelineFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.ray_traversal_primitive_culling = ray_traversal_primitive_culling.into();
         self
     }
@@ -35339,7 +32705,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceRayQueryFeaturesKHRBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceRayQueryFeaturesKHRBuilder<'a> {
-    pub fn ray_query(mut self, ray_query: bool) -> PhysicalDeviceRayQueryFeaturesKHRBuilder<'a> {
+    pub fn ray_query(mut self, ray_query: bool) -> Self {
         self.inner.ray_query = ray_query.into();
         self
     }
@@ -35411,31 +32777,22 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceAccelerationStructurePropertiesK
     }
 }
 impl<'a> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
-    pub fn max_geometry_count(
-        mut self,
-        max_geometry_count: u64,
-    ) -> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
+    pub fn max_geometry_count(mut self, max_geometry_count: u64) -> Self {
         self.inner.max_geometry_count = max_geometry_count;
         self
     }
-    pub fn max_instance_count(
-        mut self,
-        max_instance_count: u64,
-    ) -> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
+    pub fn max_instance_count(mut self, max_instance_count: u64) -> Self {
         self.inner.max_instance_count = max_instance_count;
         self
     }
-    pub fn max_primitive_count(
-        mut self,
-        max_primitive_count: u64,
-    ) -> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
+    pub fn max_primitive_count(mut self, max_primitive_count: u64) -> Self {
         self.inner.max_primitive_count = max_primitive_count;
         self
     }
     pub fn max_per_stage_descriptor_acceleration_structures(
         mut self,
         max_per_stage_descriptor_acceleration_structures: u32,
-    ) -> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_descriptor_acceleration_structures =
             max_per_stage_descriptor_acceleration_structures;
         self
@@ -35443,7 +32800,7 @@ impl<'a> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_acceleration_structures(
         mut self,
         max_per_stage_descriptor_update_after_bind_acceleration_structures: u32,
-    ) -> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_acceleration_structures =
             max_per_stage_descriptor_update_after_bind_acceleration_structures;
@@ -35452,7 +32809,7 @@ impl<'a> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
     pub fn max_descriptor_set_acceleration_structures(
         mut self,
         max_descriptor_set_acceleration_structures: u32,
-    ) -> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_acceleration_structures =
             max_descriptor_set_acceleration_structures;
         self
@@ -35460,7 +32817,7 @@ impl<'a> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_acceleration_structures(
         mut self,
         max_descriptor_set_update_after_bind_acceleration_structures: u32,
-    ) -> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_acceleration_structures =
             max_descriptor_set_update_after_bind_acceleration_structures;
@@ -35469,7 +32826,7 @@ impl<'a> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
     pub fn min_acceleration_structure_scratch_offset_alignment(
         mut self,
         min_acceleration_structure_scratch_offset_alignment: u32,
-    ) -> PhysicalDeviceAccelerationStructurePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .min_acceleration_structure_scratch_offset_alignment =
             min_acceleration_structure_scratch_offset_alignment;
@@ -35543,38 +32900,26 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceRayTracingPipelinePropertiesKHRB
     }
 }
 impl<'a> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
-    pub fn shader_group_handle_size(
-        mut self,
-        shader_group_handle_size: u32,
-    ) -> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
+    pub fn shader_group_handle_size(mut self, shader_group_handle_size: u32) -> Self {
         self.inner.shader_group_handle_size = shader_group_handle_size;
         self
     }
-    pub fn max_ray_recursion_depth(
-        mut self,
-        max_ray_recursion_depth: u32,
-    ) -> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
+    pub fn max_ray_recursion_depth(mut self, max_ray_recursion_depth: u32) -> Self {
         self.inner.max_ray_recursion_depth = max_ray_recursion_depth;
         self
     }
-    pub fn max_shader_group_stride(
-        mut self,
-        max_shader_group_stride: u32,
-    ) -> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
+    pub fn max_shader_group_stride(mut self, max_shader_group_stride: u32) -> Self {
         self.inner.max_shader_group_stride = max_shader_group_stride;
         self
     }
-    pub fn shader_group_base_alignment(
-        mut self,
-        shader_group_base_alignment: u32,
-    ) -> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
+    pub fn shader_group_base_alignment(mut self, shader_group_base_alignment: u32) -> Self {
         self.inner.shader_group_base_alignment = shader_group_base_alignment;
         self
     }
     pub fn shader_group_handle_capture_replay_size(
         mut self,
         shader_group_handle_capture_replay_size: u32,
-    ) -> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.shader_group_handle_capture_replay_size =
             shader_group_handle_capture_replay_size;
         self
@@ -35582,21 +32927,15 @@ impl<'a> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
     pub fn max_ray_dispatch_invocation_count(
         mut self,
         max_ray_dispatch_invocation_count: u32,
-    ) -> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.max_ray_dispatch_invocation_count = max_ray_dispatch_invocation_count;
         self
     }
-    pub fn shader_group_handle_alignment(
-        mut self,
-        shader_group_handle_alignment: u32,
-    ) -> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
+    pub fn shader_group_handle_alignment(mut self, shader_group_handle_alignment: u32) -> Self {
         self.inner.shader_group_handle_alignment = shader_group_handle_alignment;
         self
     }
-    pub fn max_ray_hit_attribute_size(
-        mut self,
-        max_ray_hit_attribute_size: u32,
-    ) -> PhysicalDeviceRayTracingPipelinePropertiesKHRBuilder<'a> {
+    pub fn max_ray_hit_attribute_size(mut self, max_ray_hit_attribute_size: u32) -> Self {
         self.inner.max_ray_hit_attribute_size = max_ray_hit_attribute_size;
         self
     }
@@ -35665,59 +33004,38 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceRayTracingPropertiesNVBuilder<'a
     }
 }
 impl<'a> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
-    pub fn shader_group_handle_size(
-        mut self,
-        shader_group_handle_size: u32,
-    ) -> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
+    pub fn shader_group_handle_size(mut self, shader_group_handle_size: u32) -> Self {
         self.inner.shader_group_handle_size = shader_group_handle_size;
         self
     }
-    pub fn max_recursion_depth(
-        mut self,
-        max_recursion_depth: u32,
-    ) -> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
+    pub fn max_recursion_depth(mut self, max_recursion_depth: u32) -> Self {
         self.inner.max_recursion_depth = max_recursion_depth;
         self
     }
-    pub fn max_shader_group_stride(
-        mut self,
-        max_shader_group_stride: u32,
-    ) -> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
+    pub fn max_shader_group_stride(mut self, max_shader_group_stride: u32) -> Self {
         self.inner.max_shader_group_stride = max_shader_group_stride;
         self
     }
-    pub fn shader_group_base_alignment(
-        mut self,
-        shader_group_base_alignment: u32,
-    ) -> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
+    pub fn shader_group_base_alignment(mut self, shader_group_base_alignment: u32) -> Self {
         self.inner.shader_group_base_alignment = shader_group_base_alignment;
         self
     }
-    pub fn max_geometry_count(
-        mut self,
-        max_geometry_count: u64,
-    ) -> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
+    pub fn max_geometry_count(mut self, max_geometry_count: u64) -> Self {
         self.inner.max_geometry_count = max_geometry_count;
         self
     }
-    pub fn max_instance_count(
-        mut self,
-        max_instance_count: u64,
-    ) -> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
+    pub fn max_instance_count(mut self, max_instance_count: u64) -> Self {
         self.inner.max_instance_count = max_instance_count;
         self
     }
-    pub fn max_triangle_count(
-        mut self,
-        max_triangle_count: u64,
-    ) -> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
+    pub fn max_triangle_count(mut self, max_triangle_count: u64) -> Self {
         self.inner.max_triangle_count = max_triangle_count;
         self
     }
     pub fn max_descriptor_set_acceleration_structures(
         mut self,
         max_descriptor_set_acceleration_structures: u32,
-    ) -> PhysicalDeviceRayTracingPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_acceleration_structures =
             max_descriptor_set_acceleration_structures;
         self
@@ -35762,18 +33080,15 @@ impl<'a> ::std::ops::DerefMut for StridedDeviceAddressRegionKHRBuilder<'a> {
     }
 }
 impl<'a> StridedDeviceAddressRegionKHRBuilder<'a> {
-    pub fn device_address(
-        mut self,
-        device_address: DeviceAddress,
-    ) -> StridedDeviceAddressRegionKHRBuilder<'a> {
+    pub fn device_address(mut self, device_address: DeviceAddress) -> Self {
         self.inner.device_address = device_address;
         self
     }
-    pub fn stride(mut self, stride: DeviceSize) -> StridedDeviceAddressRegionKHRBuilder<'a> {
+    pub fn stride(mut self, stride: DeviceSize) -> Self {
         self.inner.stride = stride;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> StridedDeviceAddressRegionKHRBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
@@ -35817,15 +33132,15 @@ impl<'a> ::std::ops::DerefMut for TraceRaysIndirectCommandKHRBuilder<'a> {
     }
 }
 impl<'a> TraceRaysIndirectCommandKHRBuilder<'a> {
-    pub fn width(mut self, width: u32) -> TraceRaysIndirectCommandKHRBuilder<'a> {
+    pub fn width(mut self, width: u32) -> Self {
         self.inner.width = width;
         self
     }
-    pub fn height(mut self, height: u32) -> TraceRaysIndirectCommandKHRBuilder<'a> {
+    pub fn height(mut self, height: u32) -> Self {
         self.inner.height = height;
         self
     }
-    pub fn depth(mut self, depth: u32) -> TraceRaysIndirectCommandKHRBuilder<'a> {
+    pub fn depth(mut self, depth: u32) -> Self {
         self.inner.depth = depth;
         self
     }
@@ -35885,7 +33200,7 @@ impl<'a> DrmFormatModifierPropertiesListEXTBuilder<'a> {
     pub fn drm_format_modifier_properties(
         mut self,
         drm_format_modifier_properties: &'a mut [DrmFormatModifierPropertiesEXT],
-    ) -> DrmFormatModifierPropertiesListEXTBuilder<'a> {
+    ) -> Self {
         self.inner.drm_format_modifier_count = drm_format_modifier_properties.len() as _;
         self.inner.p_drm_format_modifier_properties = drm_format_modifier_properties.as_mut_ptr();
         self
@@ -35930,24 +33245,18 @@ impl<'a> ::std::ops::DerefMut for DrmFormatModifierPropertiesEXTBuilder<'a> {
     }
 }
 impl<'a> DrmFormatModifierPropertiesEXTBuilder<'a> {
-    pub fn drm_format_modifier(
-        mut self,
-        drm_format_modifier: u64,
-    ) -> DrmFormatModifierPropertiesEXTBuilder<'a> {
+    pub fn drm_format_modifier(mut self, drm_format_modifier: u64) -> Self {
         self.inner.drm_format_modifier = drm_format_modifier;
         self
     }
-    pub fn drm_format_modifier_plane_count(
-        mut self,
-        drm_format_modifier_plane_count: u32,
-    ) -> DrmFormatModifierPropertiesEXTBuilder<'a> {
+    pub fn drm_format_modifier_plane_count(mut self, drm_format_modifier_plane_count: u32) -> Self {
         self.inner.drm_format_modifier_plane_count = drm_format_modifier_plane_count;
         self
     }
     pub fn drm_format_modifier_tiling_features(
         mut self,
         drm_format_modifier_tiling_features: FormatFeatureFlags,
-    ) -> DrmFormatModifierPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.drm_format_modifier_tiling_features = drm_format_modifier_tiling_features;
         self
     }
@@ -36011,24 +33320,15 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceImageDrmFormatModifierInfoEXTBui
     }
 }
 impl<'a> PhysicalDeviceImageDrmFormatModifierInfoEXTBuilder<'a> {
-    pub fn drm_format_modifier(
-        mut self,
-        drm_format_modifier: u64,
-    ) -> PhysicalDeviceImageDrmFormatModifierInfoEXTBuilder<'a> {
+    pub fn drm_format_modifier(mut self, drm_format_modifier: u64) -> Self {
         self.inner.drm_format_modifier = drm_format_modifier;
         self
     }
-    pub fn sharing_mode(
-        mut self,
-        sharing_mode: SharingMode,
-    ) -> PhysicalDeviceImageDrmFormatModifierInfoEXTBuilder<'a> {
+    pub fn sharing_mode(mut self, sharing_mode: SharingMode) -> Self {
         self.inner.sharing_mode = sharing_mode;
         self
     }
-    pub fn queue_family_indices(
-        mut self,
-        queue_family_indices: &'a [u32],
-    ) -> PhysicalDeviceImageDrmFormatModifierInfoEXTBuilder<'a> {
+    pub fn queue_family_indices(mut self, queue_family_indices: &'a [u32]) -> Self {
         self.inner.queue_family_index_count = queue_family_indices.len() as _;
         self.inner.p_queue_family_indices = queue_family_indices.as_ptr();
         self
@@ -36086,10 +33386,7 @@ impl<'a> ::std::ops::DerefMut for ImageDrmFormatModifierListCreateInfoEXTBuilder
     }
 }
 impl<'a> ImageDrmFormatModifierListCreateInfoEXTBuilder<'a> {
-    pub fn drm_format_modifiers(
-        mut self,
-        drm_format_modifiers: &'a [u64],
-    ) -> ImageDrmFormatModifierListCreateInfoEXTBuilder<'a> {
+    pub fn drm_format_modifiers(mut self, drm_format_modifiers: &'a [u64]) -> Self {
         self.inner.drm_format_modifier_count = drm_format_modifiers.len() as _;
         self.inner.p_drm_format_modifiers = drm_format_modifiers.as_ptr();
         self
@@ -36149,17 +33446,11 @@ impl<'a> ::std::ops::DerefMut for ImageDrmFormatModifierExplicitCreateInfoEXTBui
     }
 }
 impl<'a> ImageDrmFormatModifierExplicitCreateInfoEXTBuilder<'a> {
-    pub fn drm_format_modifier(
-        mut self,
-        drm_format_modifier: u64,
-    ) -> ImageDrmFormatModifierExplicitCreateInfoEXTBuilder<'a> {
+    pub fn drm_format_modifier(mut self, drm_format_modifier: u64) -> Self {
         self.inner.drm_format_modifier = drm_format_modifier;
         self
     }
-    pub fn plane_layouts(
-        mut self,
-        plane_layouts: &'a [SubresourceLayout],
-    ) -> ImageDrmFormatModifierExplicitCreateInfoEXTBuilder<'a> {
+    pub fn plane_layouts(mut self, plane_layouts: &'a [SubresourceLayout]) -> Self {
         self.inner.drm_format_modifier_plane_count = plane_layouts.len() as _;
         self.inner.p_plane_layouts = plane_layouts.as_ptr();
         self
@@ -36214,10 +33505,7 @@ impl<'a> ::std::ops::DerefMut for ImageDrmFormatModifierPropertiesEXTBuilder<'a>
     }
 }
 impl<'a> ImageDrmFormatModifierPropertiesEXTBuilder<'a> {
-    pub fn drm_format_modifier(
-        mut self,
-        drm_format_modifier: u64,
-    ) -> ImageDrmFormatModifierPropertiesEXTBuilder<'a> {
+    pub fn drm_format_modifier(mut self, drm_format_modifier: u64) -> Self {
         self.inner.drm_format_modifier = drm_format_modifier;
         self
     }
@@ -36229,7 +33517,7 @@ impl<'a> ImageDrmFormatModifierPropertiesEXTBuilder<'a> {
     pub fn push_next<T: ExtendsImageDrmFormatModifierPropertiesEXT>(
         mut self,
         next: &'a mut T,
-    ) -> ImageDrmFormatModifierPropertiesEXTBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -36291,10 +33579,7 @@ impl<'a> ::std::ops::DerefMut for ImageStencilUsageCreateInfoBuilder<'a> {
     }
 }
 impl<'a> ImageStencilUsageCreateInfoBuilder<'a> {
-    pub fn stencil_usage(
-        mut self,
-        stencil_usage: ImageUsageFlags,
-    ) -> ImageStencilUsageCreateInfoBuilder<'a> {
+    pub fn stencil_usage(mut self, stencil_usage: ImageUsageFlags) -> Self {
         self.inner.stencil_usage = stencil_usage;
         self
     }
@@ -36352,7 +33637,7 @@ impl<'a> DeviceMemoryOverallocationCreateInfoAMDBuilder<'a> {
     pub fn overallocation_behavior(
         mut self,
         overallocation_behavior: MemoryOverallocationBehaviorAMD,
-    ) -> DeviceMemoryOverallocationCreateInfoAMDBuilder<'a> {
+    ) -> Self {
         self.inner.overallocation_behavior = overallocation_behavior;
         self
     }
@@ -36411,24 +33696,18 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceFragmentDensityMapFeaturesEXTBui
     }
 }
 impl<'a> PhysicalDeviceFragmentDensityMapFeaturesEXTBuilder<'a> {
-    pub fn fragment_density_map(
-        mut self,
-        fragment_density_map: bool,
-    ) -> PhysicalDeviceFragmentDensityMapFeaturesEXTBuilder<'a> {
+    pub fn fragment_density_map(mut self, fragment_density_map: bool) -> Self {
         self.inner.fragment_density_map = fragment_density_map.into();
         self
     }
-    pub fn fragment_density_map_dynamic(
-        mut self,
-        fragment_density_map_dynamic: bool,
-    ) -> PhysicalDeviceFragmentDensityMapFeaturesEXTBuilder<'a> {
+    pub fn fragment_density_map_dynamic(mut self, fragment_density_map_dynamic: bool) -> Self {
         self.inner.fragment_density_map_dynamic = fragment_density_map_dynamic.into();
         self
     }
     pub fn fragment_density_map_non_subsampled_images(
         mut self,
         fragment_density_map_non_subsampled_images: bool,
-    ) -> PhysicalDeviceFragmentDensityMapFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.fragment_density_map_non_subsampled_images =
             fragment_density_map_non_subsampled_images.into();
         self
@@ -36484,10 +33763,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceFragmentDensityMap2FeaturesEXTBu
     }
 }
 impl<'a> PhysicalDeviceFragmentDensityMap2FeaturesEXTBuilder<'a> {
-    pub fn fragment_density_map_deferred(
-        mut self,
-        fragment_density_map_deferred: bool,
-    ) -> PhysicalDeviceFragmentDensityMap2FeaturesEXTBuilder<'a> {
+    pub fn fragment_density_map_deferred(mut self, fragment_density_map_deferred: bool) -> Self {
         self.inner.fragment_density_map_deferred = fragment_density_map_deferred.into();
         self
     }
@@ -36552,21 +33828,18 @@ impl<'a> PhysicalDeviceFragmentDensityMapPropertiesEXTBuilder<'a> {
     pub fn min_fragment_density_texel_size(
         mut self,
         min_fragment_density_texel_size: Extent2D,
-    ) -> PhysicalDeviceFragmentDensityMapPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.min_fragment_density_texel_size = min_fragment_density_texel_size;
         self
     }
     pub fn max_fragment_density_texel_size(
         mut self,
         max_fragment_density_texel_size: Extent2D,
-    ) -> PhysicalDeviceFragmentDensityMapPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_fragment_density_texel_size = max_fragment_density_texel_size;
         self
     }
-    pub fn fragment_density_invocations(
-        mut self,
-        fragment_density_invocations: bool,
-    ) -> PhysicalDeviceFragmentDensityMapPropertiesEXTBuilder<'a> {
+    pub fn fragment_density_invocations(mut self, fragment_density_invocations: bool) -> Self {
         self.inner.fragment_density_invocations = fragment_density_invocations.into();
         self
     }
@@ -36630,32 +33903,26 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceFragmentDensityMap2PropertiesEXT
     }
 }
 impl<'a> PhysicalDeviceFragmentDensityMap2PropertiesEXTBuilder<'a> {
-    pub fn subsampled_loads(
-        mut self,
-        subsampled_loads: bool,
-    ) -> PhysicalDeviceFragmentDensityMap2PropertiesEXTBuilder<'a> {
+    pub fn subsampled_loads(mut self, subsampled_loads: bool) -> Self {
         self.inner.subsampled_loads = subsampled_loads.into();
         self
     }
     pub fn subsampled_coarse_reconstruction_early_access(
         mut self,
         subsampled_coarse_reconstruction_early_access: bool,
-    ) -> PhysicalDeviceFragmentDensityMap2PropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.subsampled_coarse_reconstruction_early_access =
             subsampled_coarse_reconstruction_early_access.into();
         self
     }
-    pub fn max_subsampled_array_layers(
-        mut self,
-        max_subsampled_array_layers: u32,
-    ) -> PhysicalDeviceFragmentDensityMap2PropertiesEXTBuilder<'a> {
+    pub fn max_subsampled_array_layers(mut self, max_subsampled_array_layers: u32) -> Self {
         self.inner.max_subsampled_array_layers = max_subsampled_array_layers;
         self
     }
     pub fn max_descriptor_set_subsampled_samplers(
         mut self,
         max_descriptor_set_subsampled_samplers: u32,
-    ) -> PhysicalDeviceFragmentDensityMap2PropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_subsampled_samplers = max_descriptor_set_subsampled_samplers;
         self
     }
@@ -36715,7 +33982,7 @@ impl<'a> RenderPassFragmentDensityMapCreateInfoEXTBuilder<'a> {
     pub fn fragment_density_map_attachment(
         mut self,
         fragment_density_map_attachment: AttachmentReference,
-    ) -> RenderPassFragmentDensityMapCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.fragment_density_map_attachment = fragment_density_map_attachment;
         self
     }
@@ -36770,10 +34037,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceScalarBlockLayoutFeaturesBuilder
     }
 }
 impl<'a> PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'a> {
-    pub fn scalar_block_layout(
-        mut self,
-        scalar_block_layout: bool,
-    ) -> PhysicalDeviceScalarBlockLayoutFeaturesBuilder<'a> {
+    pub fn scalar_block_layout(mut self, scalar_block_layout: bool) -> Self {
         self.inner.scalar_block_layout = scalar_block_layout.into();
         self
     }
@@ -36828,10 +34092,7 @@ impl<'a> ::std::ops::DerefMut for SurfaceProtectedCapabilitiesKHRBuilder<'a> {
     }
 }
 impl<'a> SurfaceProtectedCapabilitiesKHRBuilder<'a> {
-    pub fn supports_protected(
-        mut self,
-        supports_protected: bool,
-    ) -> SurfaceProtectedCapabilitiesKHRBuilder<'a> {
+    pub fn supports_protected(mut self, supports_protected: bool) -> Self {
         self.inner.supports_protected = supports_protected.into();
         self
     }
@@ -36889,10 +34150,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceUniformBufferStandardLayoutFeatu
     }
 }
 impl<'a> PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'a> {
-    pub fn uniform_buffer_standard_layout(
-        mut self,
-        uniform_buffer_standard_layout: bool,
-    ) -> PhysicalDeviceUniformBufferStandardLayoutFeaturesBuilder<'a> {
+    pub fn uniform_buffer_standard_layout(mut self, uniform_buffer_standard_layout: bool) -> Self {
         self.inner.uniform_buffer_standard_layout = uniform_buffer_standard_layout.into();
         self
     }
@@ -36947,10 +34205,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceDepthClipEnableFeaturesEXTBuilde
     }
 }
 impl<'a> PhysicalDeviceDepthClipEnableFeaturesEXTBuilder<'a> {
-    pub fn depth_clip_enable(
-        mut self,
-        depth_clip_enable: bool,
-    ) -> PhysicalDeviceDepthClipEnableFeaturesEXTBuilder<'a> {
+    pub fn depth_clip_enable(mut self, depth_clip_enable: bool) -> Self {
         self.inner.depth_clip_enable = depth_clip_enable.into();
         self
     }
@@ -37013,17 +34268,11 @@ impl<'a> ::std::ops::DerefMut for PipelineRasterizationDepthClipStateCreateInfoE
     }
 }
 impl<'a> PipelineRasterizationDepthClipStateCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineRasterizationDepthClipStateCreateFlagsEXT,
-    ) -> PipelineRasterizationDepthClipStateCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineRasterizationDepthClipStateCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn depth_clip_enable(
-        mut self,
-        depth_clip_enable: bool,
-    ) -> PipelineRasterizationDepthClipStateCreateInfoEXTBuilder<'a> {
+    pub fn depth_clip_enable(mut self, depth_clip_enable: bool) -> Self {
         self.inner.depth_clip_enable = depth_clip_enable.into();
         self
     }
@@ -37083,17 +34332,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMemoryBudgetPropertiesEXTBuilder
     }
 }
 impl<'a> PhysicalDeviceMemoryBudgetPropertiesEXTBuilder<'a> {
-    pub fn heap_budget(
-        mut self,
-        heap_budget: [DeviceSize; MAX_MEMORY_HEAPS],
-    ) -> PhysicalDeviceMemoryBudgetPropertiesEXTBuilder<'a> {
+    pub fn heap_budget(mut self, heap_budget: [DeviceSize; MAX_MEMORY_HEAPS]) -> Self {
         self.inner.heap_budget = heap_budget;
         self
     }
-    pub fn heap_usage(
-        mut self,
-        heap_usage: [DeviceSize; MAX_MEMORY_HEAPS],
-    ) -> PhysicalDeviceMemoryBudgetPropertiesEXTBuilder<'a> {
+    pub fn heap_usage(mut self, heap_usage: [DeviceSize; MAX_MEMORY_HEAPS]) -> Self {
         self.inner.heap_usage = heap_usage;
         self
     }
@@ -37148,10 +34391,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMemoryPriorityFeaturesEXTBuilder
     }
 }
 impl<'a> PhysicalDeviceMemoryPriorityFeaturesEXTBuilder<'a> {
-    pub fn memory_priority(
-        mut self,
-        memory_priority: bool,
-    ) -> PhysicalDeviceMemoryPriorityFeaturesEXTBuilder<'a> {
+    pub fn memory_priority(mut self, memory_priority: bool) -> Self {
         self.inner.memory_priority = memory_priority.into();
         self
     }
@@ -37206,7 +34446,7 @@ impl<'a> ::std::ops::DerefMut for MemoryPriorityAllocateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> MemoryPriorityAllocateInfoEXTBuilder<'a> {
-    pub fn priority(mut self, priority: f32) -> MemoryPriorityAllocateInfoEXTBuilder<'a> {
+    pub fn priority(mut self, priority: f32) -> Self {
         self.inner.priority = priority;
         self
     }
@@ -37265,17 +34505,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceBufferDeviceAddressFeaturesBuild
     }
 }
 impl<'a> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
-    pub fn buffer_device_address(
-        mut self,
-        buffer_device_address: bool,
-    ) -> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+    pub fn buffer_device_address(mut self, buffer_device_address: bool) -> Self {
         self.inner.buffer_device_address = buffer_device_address.into();
         self
     }
     pub fn buffer_device_address_capture_replay(
         mut self,
         buffer_device_address_capture_replay: bool,
-    ) -> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.buffer_device_address_capture_replay =
             buffer_device_address_capture_replay.into();
         self
@@ -37283,7 +34520,7 @@ impl<'a> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
     pub fn buffer_device_address_multi_device(
         mut self,
         buffer_device_address_multi_device: bool,
-    ) -> PhysicalDeviceBufferDeviceAddressFeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.buffer_device_address_multi_device = buffer_device_address_multi_device.into();
         self
     }
@@ -37342,17 +34579,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceBufferDeviceAddressFeaturesEXTBu
     }
 }
 impl<'a> PhysicalDeviceBufferDeviceAddressFeaturesEXTBuilder<'a> {
-    pub fn buffer_device_address(
-        mut self,
-        buffer_device_address: bool,
-    ) -> PhysicalDeviceBufferDeviceAddressFeaturesEXTBuilder<'a> {
+    pub fn buffer_device_address(mut self, buffer_device_address: bool) -> Self {
         self.inner.buffer_device_address = buffer_device_address.into();
         self
     }
     pub fn buffer_device_address_capture_replay(
         mut self,
         buffer_device_address_capture_replay: bool,
-    ) -> PhysicalDeviceBufferDeviceAddressFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.buffer_device_address_capture_replay =
             buffer_device_address_capture_replay.into();
         self
@@ -37360,7 +34594,7 @@ impl<'a> PhysicalDeviceBufferDeviceAddressFeaturesEXTBuilder<'a> {
     pub fn buffer_device_address_multi_device(
         mut self,
         buffer_device_address_multi_device: bool,
-    ) -> PhysicalDeviceBufferDeviceAddressFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.buffer_device_address_multi_device = buffer_device_address_multi_device.into();
         self
     }
@@ -37414,7 +34648,7 @@ impl<'a> ::std::ops::DerefMut for BufferDeviceAddressInfoBuilder<'a> {
     }
 }
 impl<'a> BufferDeviceAddressInfoBuilder<'a> {
-    pub fn buffer(mut self, buffer: Buffer) -> BufferDeviceAddressInfoBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
@@ -37423,10 +34657,7 @@ impl<'a> BufferDeviceAddressInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBufferDeviceAddressInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> BufferDeviceAddressInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsBufferDeviceAddressInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -37486,10 +34717,7 @@ impl<'a> ::std::ops::DerefMut for BufferOpaqueCaptureAddressCreateInfoBuilder<'a
     }
 }
 impl<'a> BufferOpaqueCaptureAddressCreateInfoBuilder<'a> {
-    pub fn opaque_capture_address(
-        mut self,
-        opaque_capture_address: u64,
-    ) -> BufferOpaqueCaptureAddressCreateInfoBuilder<'a> {
+    pub fn opaque_capture_address(mut self, opaque_capture_address: u64) -> Self {
         self.inner.opaque_capture_address = opaque_capture_address;
         self
     }
@@ -37544,10 +34772,7 @@ impl<'a> ::std::ops::DerefMut for BufferDeviceAddressCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> BufferDeviceAddressCreateInfoEXTBuilder<'a> {
-    pub fn device_address(
-        mut self,
-        device_address: DeviceAddress,
-    ) -> BufferDeviceAddressCreateInfoEXTBuilder<'a> {
+    pub fn device_address(mut self, device_address: DeviceAddress) -> Self {
         self.inner.device_address = device_address;
         self
     }
@@ -37605,10 +34830,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceImageViewImageFormatInfoEXTBuild
     }
 }
 impl<'a> PhysicalDeviceImageViewImageFormatInfoEXTBuilder<'a> {
-    pub fn image_view_type(
-        mut self,
-        image_view_type: ImageViewType,
-    ) -> PhysicalDeviceImageViewImageFormatInfoEXTBuilder<'a> {
+    pub fn image_view_type(mut self, image_view_type: ImageViewType) -> Self {
         self.inner.image_view_type = image_view_type;
         self
     }
@@ -37668,17 +34890,11 @@ impl<'a> ::std::ops::DerefMut for FilterCubicImageViewImageFormatPropertiesEXTBu
     }
 }
 impl<'a> FilterCubicImageViewImageFormatPropertiesEXTBuilder<'a> {
-    pub fn filter_cubic(
-        mut self,
-        filter_cubic: bool,
-    ) -> FilterCubicImageViewImageFormatPropertiesEXTBuilder<'a> {
+    pub fn filter_cubic(mut self, filter_cubic: bool) -> Self {
         self.inner.filter_cubic = filter_cubic.into();
         self
     }
-    pub fn filter_cubic_minmax(
-        mut self,
-        filter_cubic_minmax: bool,
-    ) -> FilterCubicImageViewImageFormatPropertiesEXTBuilder<'a> {
+    pub fn filter_cubic_minmax(mut self, filter_cubic_minmax: bool) -> Self {
         self.inner.filter_cubic_minmax = filter_cubic_minmax.into();
         self
     }
@@ -37733,10 +34949,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceImagelessFramebufferFeaturesBuil
     }
 }
 impl<'a> PhysicalDeviceImagelessFramebufferFeaturesBuilder<'a> {
-    pub fn imageless_framebuffer(
-        mut self,
-        imageless_framebuffer: bool,
-    ) -> PhysicalDeviceImagelessFramebufferFeaturesBuilder<'a> {
+    pub fn imageless_framebuffer(mut self, imageless_framebuffer: bool) -> Self {
         self.inner.imageless_framebuffer = imageless_framebuffer.into();
         self
     }
@@ -37796,7 +35009,7 @@ impl<'a> FramebufferAttachmentsCreateInfoBuilder<'a> {
     pub fn attachment_image_infos(
         mut self,
         attachment_image_infos: &'a [FramebufferAttachmentImageInfo],
-    ) -> FramebufferAttachmentsCreateInfoBuilder<'a> {
+    ) -> Self {
         self.inner.attachment_image_info_count = attachment_image_infos.len() as _;
         self.inner.p_attachment_image_infos = attachment_image_infos.as_ptr();
         self
@@ -37863,30 +35076,27 @@ impl<'a> ::std::ops::DerefMut for FramebufferAttachmentImageInfoBuilder<'a> {
     }
 }
 impl<'a> FramebufferAttachmentImageInfoBuilder<'a> {
-    pub fn flags(mut self, flags: ImageCreateFlags) -> FramebufferAttachmentImageInfoBuilder<'a> {
+    pub fn flags(mut self, flags: ImageCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn usage(mut self, usage: ImageUsageFlags) -> FramebufferAttachmentImageInfoBuilder<'a> {
+    pub fn usage(mut self, usage: ImageUsageFlags) -> Self {
         self.inner.usage = usage;
         self
     }
-    pub fn width(mut self, width: u32) -> FramebufferAttachmentImageInfoBuilder<'a> {
+    pub fn width(mut self, width: u32) -> Self {
         self.inner.width = width;
         self
     }
-    pub fn height(mut self, height: u32) -> FramebufferAttachmentImageInfoBuilder<'a> {
+    pub fn height(mut self, height: u32) -> Self {
         self.inner.height = height;
         self
     }
-    pub fn layer_count(mut self, layer_count: u32) -> FramebufferAttachmentImageInfoBuilder<'a> {
+    pub fn layer_count(mut self, layer_count: u32) -> Self {
         self.inner.layer_count = layer_count;
         self
     }
-    pub fn view_formats(
-        mut self,
-        view_formats: &'a [Format],
-    ) -> FramebufferAttachmentImageInfoBuilder<'a> {
+    pub fn view_formats(mut self, view_formats: &'a [Format]) -> Self {
         self.inner.view_format_count = view_formats.len() as _;
         self.inner.p_view_formats = view_formats.as_ptr();
         self
@@ -37896,10 +35106,7 @@ impl<'a> FramebufferAttachmentImageInfoBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsFramebufferAttachmentImageInfo>(
-        mut self,
-        next: &'a mut T,
-    ) -> FramebufferAttachmentImageInfoBuilder<'a> {
+    pub fn push_next<T: ExtendsFramebufferAttachmentImageInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -37961,10 +35168,7 @@ impl<'a> ::std::ops::DerefMut for RenderPassAttachmentBeginInfoBuilder<'a> {
     }
 }
 impl<'a> RenderPassAttachmentBeginInfoBuilder<'a> {
-    pub fn attachments(
-        mut self,
-        attachments: &'a [ImageView],
-    ) -> RenderPassAttachmentBeginInfoBuilder<'a> {
+    pub fn attachments(mut self, attachments: &'a [ImageView]) -> Self {
         self.inner.attachment_count = attachments.len() as _;
         self.inner.p_attachments = attachments.as_ptr();
         self
@@ -38023,10 +35227,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceTextureCompressionASTCHDRFeature
     }
 }
 impl<'a> PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'a> {
-    pub fn texture_compression_astc_hdr(
-        mut self,
-        texture_compression_astc_hdr: bool,
-    ) -> PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'a> {
+    pub fn texture_compression_astc_hdr(mut self, texture_compression_astc_hdr: bool) -> Self {
         self.inner.texture_compression_astc_hdr = texture_compression_astc_hdr.into();
         self
     }
@@ -38083,17 +35284,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceCooperativeMatrixFeaturesNVBuild
     }
 }
 impl<'a> PhysicalDeviceCooperativeMatrixFeaturesNVBuilder<'a> {
-    pub fn cooperative_matrix(
-        mut self,
-        cooperative_matrix: bool,
-    ) -> PhysicalDeviceCooperativeMatrixFeaturesNVBuilder<'a> {
+    pub fn cooperative_matrix(mut self, cooperative_matrix: bool) -> Self {
         self.inner.cooperative_matrix = cooperative_matrix.into();
         self
     }
     pub fn cooperative_matrix_robust_buffer_access(
         mut self,
         cooperative_matrix_robust_buffer_access: bool,
-    ) -> PhysicalDeviceCooperativeMatrixFeaturesNVBuilder<'a> {
+    ) -> Self {
         self.inner.cooperative_matrix_robust_buffer_access =
             cooperative_matrix_robust_buffer_access.into();
         self
@@ -38155,7 +35353,7 @@ impl<'a> PhysicalDeviceCooperativeMatrixPropertiesNVBuilder<'a> {
     pub fn cooperative_matrix_supported_stages(
         mut self,
         cooperative_matrix_supported_stages: ShaderStageFlags,
-    ) -> PhysicalDeviceCooperativeMatrixPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.cooperative_matrix_supported_stages = cooperative_matrix_supported_stages;
         self
     }
@@ -38223,35 +35421,35 @@ impl<'a> ::std::ops::DerefMut for CooperativeMatrixPropertiesNVBuilder<'a> {
     }
 }
 impl<'a> CooperativeMatrixPropertiesNVBuilder<'a> {
-    pub fn m_size(mut self, m_size: u32) -> CooperativeMatrixPropertiesNVBuilder<'a> {
+    pub fn m_size(mut self, m_size: u32) -> Self {
         self.inner.m_size = m_size;
         self
     }
-    pub fn n_size(mut self, n_size: u32) -> CooperativeMatrixPropertiesNVBuilder<'a> {
+    pub fn n_size(mut self, n_size: u32) -> Self {
         self.inner.n_size = n_size;
         self
     }
-    pub fn k_size(mut self, k_size: u32) -> CooperativeMatrixPropertiesNVBuilder<'a> {
+    pub fn k_size(mut self, k_size: u32) -> Self {
         self.inner.k_size = k_size;
         self
     }
-    pub fn a_type(mut self, a_type: ComponentTypeNV) -> CooperativeMatrixPropertiesNVBuilder<'a> {
+    pub fn a_type(mut self, a_type: ComponentTypeNV) -> Self {
         self.inner.a_type = a_type;
         self
     }
-    pub fn b_type(mut self, b_type: ComponentTypeNV) -> CooperativeMatrixPropertiesNVBuilder<'a> {
+    pub fn b_type(mut self, b_type: ComponentTypeNV) -> Self {
         self.inner.b_type = b_type;
         self
     }
-    pub fn c_type(mut self, c_type: ComponentTypeNV) -> CooperativeMatrixPropertiesNVBuilder<'a> {
+    pub fn c_type(mut self, c_type: ComponentTypeNV) -> Self {
         self.inner.c_type = c_type;
         self
     }
-    pub fn d_type(mut self, d_type: ComponentTypeNV) -> CooperativeMatrixPropertiesNVBuilder<'a> {
+    pub fn d_type(mut self, d_type: ComponentTypeNV) -> Self {
         self.inner.d_type = d_type;
         self
     }
-    pub fn scope(mut self, scope: ScopeNV) -> CooperativeMatrixPropertiesNVBuilder<'a> {
+    pub fn scope(mut self, scope: ScopeNV) -> Self {
         self.inner.scope = scope;
         self
     }
@@ -38260,10 +35458,7 @@ impl<'a> CooperativeMatrixPropertiesNVBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCooperativeMatrixPropertiesNV>(
-        mut self,
-        next: &'a mut T,
-    ) -> CooperativeMatrixPropertiesNVBuilder<'a> {
+    pub fn push_next<T: ExtendsCooperativeMatrixPropertiesNV>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -38323,10 +35518,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceYcbcrImageArraysFeaturesEXTBuild
     }
 }
 impl<'a> PhysicalDeviceYcbcrImageArraysFeaturesEXTBuilder<'a> {
-    pub fn ycbcr_image_arrays(
-        mut self,
-        ycbcr_image_arrays: bool,
-    ) -> PhysicalDeviceYcbcrImageArraysFeaturesEXTBuilder<'a> {
+    pub fn ycbcr_image_arrays(mut self, ycbcr_image_arrays: bool) -> Self {
         self.inner.ycbcr_image_arrays = ycbcr_image_arrays.into();
         self
     }
@@ -38384,18 +35576,15 @@ impl<'a> ::std::ops::DerefMut for ImageViewHandleInfoNVXBuilder<'a> {
     }
 }
 impl<'a> ImageViewHandleInfoNVXBuilder<'a> {
-    pub fn image_view(mut self, image_view: ImageView) -> ImageViewHandleInfoNVXBuilder<'a> {
+    pub fn image_view(mut self, image_view: ImageView) -> Self {
         self.inner.image_view = image_view;
         self
     }
-    pub fn descriptor_type(
-        mut self,
-        descriptor_type: DescriptorType,
-    ) -> ImageViewHandleInfoNVXBuilder<'a> {
+    pub fn descriptor_type(mut self, descriptor_type: DescriptorType) -> Self {
         self.inner.descriptor_type = descriptor_type;
         self
     }
-    pub fn sampler(mut self, sampler: Sampler) -> ImageViewHandleInfoNVXBuilder<'a> {
+    pub fn sampler(mut self, sampler: Sampler) -> Self {
         self.inner.sampler = sampler;
         self
     }
@@ -38404,10 +35593,7 @@ impl<'a> ImageViewHandleInfoNVXBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageViewHandleInfoNVX>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageViewHandleInfoNVXBuilder<'a> {
+    pub fn push_next<T: ExtendsImageViewHandleInfoNVX>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -38468,14 +35654,11 @@ impl<'a> ::std::ops::DerefMut for ImageViewAddressPropertiesNVXBuilder<'a> {
     }
 }
 impl<'a> ImageViewAddressPropertiesNVXBuilder<'a> {
-    pub fn device_address(
-        mut self,
-        device_address: DeviceAddress,
-    ) -> ImageViewAddressPropertiesNVXBuilder<'a> {
+    pub fn device_address(mut self, device_address: DeviceAddress) -> Self {
         self.inner.device_address = device_address;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> ImageViewAddressPropertiesNVXBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
@@ -38484,10 +35667,7 @@ impl<'a> ImageViewAddressPropertiesNVXBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageViewAddressPropertiesNVX>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageViewAddressPropertiesNVXBuilder<'a> {
+    pub fn push_next<T: ExtendsImageViewAddressPropertiesNVX>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -38547,7 +35727,7 @@ impl<'a> ::std::ops::DerefMut for PresentFrameTokenGGPBuilder<'a> {
     }
 }
 impl<'a> PresentFrameTokenGGPBuilder<'a> {
-    pub fn frame_token(mut self, frame_token: GgpFrameToken) -> PresentFrameTokenGGPBuilder<'a> {
+    pub fn frame_token(mut self, frame_token: GgpFrameToken) -> Self {
         self.inner.frame_token = frame_token;
         self
     }
@@ -38590,14 +35770,11 @@ impl<'a> ::std::ops::DerefMut for PipelineCreationFeedbackEXTBuilder<'a> {
     }
 }
 impl<'a> PipelineCreationFeedbackEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineCreationFeedbackFlagsEXT,
-    ) -> PipelineCreationFeedbackEXTBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCreationFeedbackFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn duration(mut self, duration: u64) -> PipelineCreationFeedbackEXTBuilder<'a> {
+    pub fn duration(mut self, duration: u64) -> Self {
         self.inner.duration = duration;
         self
     }
@@ -38671,14 +35848,14 @@ impl<'a> PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
     pub fn pipeline_creation_feedback(
         mut self,
         pipeline_creation_feedback: &'a mut PipelineCreationFeedbackEXT,
-    ) -> PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.p_pipeline_creation_feedback = pipeline_creation_feedback;
         self
     }
     pub fn pipeline_stage_creation_feedbacks(
         mut self,
         pipeline_stage_creation_feedbacks: &'a mut [PipelineCreationFeedbackEXT],
-    ) -> PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.pipeline_stage_creation_feedback_count =
             pipeline_stage_creation_feedbacks.len() as _;
         self.inner.p_pipeline_stage_creation_feedbacks =
@@ -38738,10 +35915,7 @@ impl<'a> ::std::ops::DerefMut for SurfaceFullScreenExclusiveInfoEXTBuilder<'a> {
     }
 }
 impl<'a> SurfaceFullScreenExclusiveInfoEXTBuilder<'a> {
-    pub fn full_screen_exclusive(
-        mut self,
-        full_screen_exclusive: FullScreenExclusiveEXT,
-    ) -> SurfaceFullScreenExclusiveInfoEXTBuilder<'a> {
+    pub fn full_screen_exclusive(mut self, full_screen_exclusive: FullScreenExclusiveEXT) -> Self {
         self.inner.full_screen_exclusive = full_screen_exclusive;
         self
     }
@@ -38801,10 +35975,7 @@ impl<'a> ::std::ops::DerefMut for SurfaceFullScreenExclusiveWin32InfoEXTBuilder<
     }
 }
 impl<'a> SurfaceFullScreenExclusiveWin32InfoEXTBuilder<'a> {
-    pub fn hmonitor(
-        mut self,
-        hmonitor: HMONITOR,
-    ) -> SurfaceFullScreenExclusiveWin32InfoEXTBuilder<'a> {
+    pub fn hmonitor(mut self, hmonitor: HMONITOR) -> Self {
         self.inner.hmonitor = hmonitor;
         self
     }
@@ -38865,7 +36036,7 @@ impl<'a> SurfaceCapabilitiesFullScreenExclusiveEXTBuilder<'a> {
     pub fn full_screen_exclusive_supported(
         mut self,
         full_screen_exclusive_supported: bool,
-    ) -> SurfaceCapabilitiesFullScreenExclusiveEXTBuilder<'a> {
+    ) -> Self {
         self.inner.full_screen_exclusive_supported = full_screen_exclusive_supported.into();
         self
     }
@@ -38925,14 +36096,14 @@ impl<'a> PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
     pub fn performance_counter_query_pools(
         mut self,
         performance_counter_query_pools: bool,
-    ) -> PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.performance_counter_query_pools = performance_counter_query_pools.into();
         self
     }
     pub fn performance_counter_multiple_query_pools(
         mut self,
         performance_counter_multiple_query_pools: bool,
-    ) -> PhysicalDevicePerformanceQueryFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.performance_counter_multiple_query_pools =
             performance_counter_multiple_query_pools.into();
         self
@@ -38994,7 +36165,7 @@ impl<'a> PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'a> {
     pub fn allow_command_buffer_query_copies(
         mut self,
         allow_command_buffer_query_copies: bool,
-    ) -> PhysicalDevicePerformanceQueryPropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.allow_command_buffer_query_copies = allow_command_buffer_query_copies.into();
         self
     }
@@ -39054,22 +36225,19 @@ impl<'a> ::std::ops::DerefMut for PerformanceCounterKHRBuilder<'a> {
     }
 }
 impl<'a> PerformanceCounterKHRBuilder<'a> {
-    pub fn unit(mut self, unit: PerformanceCounterUnitKHR) -> PerformanceCounterKHRBuilder<'a> {
+    pub fn unit(mut self, unit: PerformanceCounterUnitKHR) -> Self {
         self.inner.unit = unit;
         self
     }
-    pub fn scope(mut self, scope: PerformanceCounterScopeKHR) -> PerformanceCounterKHRBuilder<'a> {
+    pub fn scope(mut self, scope: PerformanceCounterScopeKHR) -> Self {
         self.inner.scope = scope;
         self
     }
-    pub fn storage(
-        mut self,
-        storage: PerformanceCounterStorageKHR,
-    ) -> PerformanceCounterKHRBuilder<'a> {
+    pub fn storage(mut self, storage: PerformanceCounterStorageKHR) -> Self {
         self.inner.storage = storage;
         self
     }
-    pub fn uuid(mut self, uuid: [u8; UUID_SIZE]) -> PerformanceCounterKHRBuilder<'a> {
+    pub fn uuid(mut self, uuid: [u8; UUID_SIZE]) -> Self {
         self.inner.uuid = uuid;
         self
     }
@@ -39078,10 +36246,7 @@ impl<'a> PerformanceCounterKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPerformanceCounterKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> PerformanceCounterKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsPerformanceCounterKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -39164,31 +36329,19 @@ impl<'a> ::std::ops::DerefMut for PerformanceCounterDescriptionKHRBuilder<'a> {
     }
 }
 impl<'a> PerformanceCounterDescriptionKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PerformanceCounterDescriptionFlagsKHR,
-    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+    pub fn flags(mut self, flags: PerformanceCounterDescriptionFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn name(
-        mut self,
-        name: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+    pub fn name(mut self, name: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.name = name;
         self
     }
-    pub fn category(
-        mut self,
-        category: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+    pub fn category(mut self, category: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.category = category;
         self
     }
-    pub fn description(
-        mut self,
-        description: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+    pub fn description(mut self, description: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.description = description;
         self
     }
@@ -39200,7 +36353,7 @@ impl<'a> PerformanceCounterDescriptionKHRBuilder<'a> {
     pub fn push_next<T: ExtendsPerformanceCounterDescriptionKHR>(
         mut self,
         next: &'a mut T,
-    ) -> PerformanceCounterDescriptionKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -39264,17 +36417,11 @@ impl<'a> ::std::ops::DerefMut for QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
-    pub fn queue_family_index(
-        mut self,
-        queue_family_index: u32,
-    ) -> QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
+    pub fn queue_family_index(mut self, queue_family_index: u32) -> Self {
         self.inner.queue_family_index = queue_family_index;
         self
     }
-    pub fn counter_indices(
-        mut self,
-        counter_indices: &'a [u32],
-    ) -> QueryPoolPerformanceCreateInfoKHRBuilder<'a> {
+    pub fn counter_indices(mut self, counter_indices: &'a [u32]) -> Self {
         self.inner.counter_index_count = counter_indices.len() as _;
         self.inner.p_counter_indices = counter_indices.as_ptr();
         self
@@ -39347,14 +36494,11 @@ impl<'a> ::std::ops::DerefMut for AcquireProfilingLockInfoKHRBuilder<'a> {
     }
 }
 impl<'a> AcquireProfilingLockInfoKHRBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: AcquireProfilingLockFlagsKHR,
-    ) -> AcquireProfilingLockInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: AcquireProfilingLockFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn timeout(mut self, timeout: u64) -> AcquireProfilingLockInfoKHRBuilder<'a> {
+    pub fn timeout(mut self, timeout: u64) -> Self {
         self.inner.timeout = timeout;
         self
     }
@@ -39363,10 +36507,7 @@ impl<'a> AcquireProfilingLockInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsAcquireProfilingLockInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> AcquireProfilingLockInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsAcquireProfilingLockInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -39426,10 +36567,7 @@ impl<'a> ::std::ops::DerefMut for PerformanceQuerySubmitInfoKHRBuilder<'a> {
     }
 }
 impl<'a> PerformanceQuerySubmitInfoKHRBuilder<'a> {
-    pub fn counter_pass_index(
-        mut self,
-        counter_pass_index: u32,
-    ) -> PerformanceQuerySubmitInfoKHRBuilder<'a> {
+    pub fn counter_pass_index(mut self, counter_pass_index: u32) -> Self {
         self.inner.counter_pass_index = counter_pass_index;
         self
     }
@@ -39483,10 +36621,7 @@ impl<'a> ::std::ops::DerefMut for HeadlessSurfaceCreateInfoEXTBuilder<'a> {
     }
 }
 impl<'a> HeadlessSurfaceCreateInfoEXTBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: HeadlessSurfaceCreateFlagsEXT,
-    ) -> HeadlessSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn flags(mut self, flags: HeadlessSurfaceCreateFlagsEXT) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -39495,10 +36630,7 @@ impl<'a> HeadlessSurfaceCreateInfoEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsHeadlessSurfaceCreateInfoEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> HeadlessSurfaceCreateInfoEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsHeadlessSurfaceCreateInfoEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -39558,10 +36690,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceCoverageReductionModeFeaturesNVB
     }
 }
 impl<'a> PhysicalDeviceCoverageReductionModeFeaturesNVBuilder<'a> {
-    pub fn coverage_reduction_mode(
-        mut self,
-        coverage_reduction_mode: bool,
-    ) -> PhysicalDeviceCoverageReductionModeFeaturesNVBuilder<'a> {
+    pub fn coverage_reduction_mode(mut self, coverage_reduction_mode: bool) -> Self {
         self.inner.coverage_reduction_mode = coverage_reduction_mode.into();
         self
     }
@@ -39624,17 +36753,14 @@ impl<'a> ::std::ops::DerefMut for PipelineCoverageReductionStateCreateInfoNVBuil
     }
 }
 impl<'a> PipelineCoverageReductionStateCreateInfoNVBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: PipelineCoverageReductionStateCreateFlagsNV,
-    ) -> PipelineCoverageReductionStateCreateInfoNVBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCoverageReductionStateCreateFlagsNV) -> Self {
         self.inner.flags = flags;
         self
     }
     pub fn coverage_reduction_mode(
         mut self,
         coverage_reduction_mode: CoverageReductionModeNV,
-    ) -> PipelineCoverageReductionStateCreateInfoNVBuilder<'a> {
+    ) -> Self {
         self.inner.coverage_reduction_mode = coverage_reduction_mode;
         self
     }
@@ -39697,28 +36823,19 @@ impl<'a> FramebufferMixedSamplesCombinationNVBuilder<'a> {
     pub fn coverage_reduction_mode(
         mut self,
         coverage_reduction_mode: CoverageReductionModeNV,
-    ) -> FramebufferMixedSamplesCombinationNVBuilder<'a> {
+    ) -> Self {
         self.inner.coverage_reduction_mode = coverage_reduction_mode;
         self
     }
-    pub fn rasterization_samples(
-        mut self,
-        rasterization_samples: SampleCountFlags,
-    ) -> FramebufferMixedSamplesCombinationNVBuilder<'a> {
+    pub fn rasterization_samples(mut self, rasterization_samples: SampleCountFlags) -> Self {
         self.inner.rasterization_samples = rasterization_samples;
         self
     }
-    pub fn depth_stencil_samples(
-        mut self,
-        depth_stencil_samples: SampleCountFlags,
-    ) -> FramebufferMixedSamplesCombinationNVBuilder<'a> {
+    pub fn depth_stencil_samples(mut self, depth_stencil_samples: SampleCountFlags) -> Self {
         self.inner.depth_stencil_samples = depth_stencil_samples;
         self
     }
-    pub fn color_samples(
-        mut self,
-        color_samples: SampleCountFlags,
-    ) -> FramebufferMixedSamplesCombinationNVBuilder<'a> {
+    pub fn color_samples(mut self, color_samples: SampleCountFlags) -> Self {
         self.inner.color_samples = color_samples;
         self
     }
@@ -39730,7 +36847,7 @@ impl<'a> FramebufferMixedSamplesCombinationNVBuilder<'a> {
     pub fn push_next<T: ExtendsFramebufferMixedSamplesCombinationNV>(
         mut self,
         next: &'a mut T,
-    ) -> FramebufferMixedSamplesCombinationNVBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -39793,10 +36910,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderIntegerFunctions2FeaturesI
     }
 }
 impl<'a> PhysicalDeviceShaderIntegerFunctions2FeaturesINTELBuilder<'a> {
-    pub fn shader_integer_functions2(
-        mut self,
-        shader_integer_functions2: bool,
-    ) -> PhysicalDeviceShaderIntegerFunctions2FeaturesINTELBuilder<'a> {
+    pub fn shader_integer_functions2(mut self, shader_integer_functions2: bool) -> Self {
         self.inner.shader_integer_functions2 = shader_integer_functions2.into();
         self
     }
@@ -39862,11 +36976,11 @@ impl<'a> ::std::ops::DerefMut for PerformanceValueINTELBuilder<'a> {
     }
 }
 impl<'a> PerformanceValueINTELBuilder<'a> {
-    pub fn ty(mut self, ty: PerformanceValueTypeINTEL) -> PerformanceValueINTELBuilder<'a> {
+    pub fn ty(mut self, ty: PerformanceValueTypeINTEL) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn data(mut self, data: PerformanceValueDataINTEL) -> PerformanceValueINTELBuilder<'a> {
+    pub fn data(mut self, data: PerformanceValueDataINTEL) -> Self {
         self.inner.data = data;
         self
     }
@@ -39920,10 +37034,7 @@ impl<'a> ::std::ops::DerefMut for InitializePerformanceApiInfoINTELBuilder<'a> {
     }
 }
 impl<'a> InitializePerformanceApiInfoINTELBuilder<'a> {
-    pub fn user_data(
-        mut self,
-        user_data: *mut c_void,
-    ) -> InitializePerformanceApiInfoINTELBuilder<'a> {
+    pub fn user_data(mut self, user_data: *mut c_void) -> Self {
         self.inner.p_user_data = user_data;
         self
     }
@@ -39935,7 +37046,7 @@ impl<'a> InitializePerformanceApiInfoINTELBuilder<'a> {
     pub fn push_next<T: ExtendsInitializePerformanceApiInfoINTEL>(
         mut self,
         next: &'a mut T,
-    ) -> InitializePerformanceApiInfoINTELBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -39998,7 +37109,7 @@ impl<'a> QueryPoolPerformanceQueryCreateInfoINTELBuilder<'a> {
     pub fn performance_counters_sampling(
         mut self,
         performance_counters_sampling: QueryPoolSamplingModeINTEL,
-    ) -> QueryPoolPerformanceQueryCreateInfoINTELBuilder<'a> {
+    ) -> Self {
         self.inner.performance_counters_sampling = performance_counters_sampling;
         self
     }
@@ -40052,7 +37163,7 @@ impl<'a> ::std::ops::DerefMut for PerformanceMarkerInfoINTELBuilder<'a> {
     }
 }
 impl<'a> PerformanceMarkerInfoINTELBuilder<'a> {
-    pub fn marker(mut self, marker: u64) -> PerformanceMarkerInfoINTELBuilder<'a> {
+    pub fn marker(mut self, marker: u64) -> Self {
         self.inner.marker = marker;
         self
     }
@@ -40061,10 +37172,7 @@ impl<'a> PerformanceMarkerInfoINTELBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPerformanceMarkerInfoINTEL>(
-        mut self,
-        next: &'a mut T,
-    ) -> PerformanceMarkerInfoINTELBuilder<'a> {
+    pub fn push_next<T: ExtendsPerformanceMarkerInfoINTEL>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -40123,7 +37231,7 @@ impl<'a> ::std::ops::DerefMut for PerformanceStreamMarkerInfoINTELBuilder<'a> {
     }
 }
 impl<'a> PerformanceStreamMarkerInfoINTELBuilder<'a> {
-    pub fn marker(mut self, marker: u32) -> PerformanceStreamMarkerInfoINTELBuilder<'a> {
+    pub fn marker(mut self, marker: u32) -> Self {
         self.inner.marker = marker;
         self
     }
@@ -40135,7 +37243,7 @@ impl<'a> PerformanceStreamMarkerInfoINTELBuilder<'a> {
     pub fn push_next<T: ExtendsPerformanceStreamMarkerInfoINTEL>(
         mut self,
         next: &'a mut T,
-    ) -> PerformanceStreamMarkerInfoINTELBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -40198,18 +37306,15 @@ impl<'a> ::std::ops::DerefMut for PerformanceOverrideInfoINTELBuilder<'a> {
     }
 }
 impl<'a> PerformanceOverrideInfoINTELBuilder<'a> {
-    pub fn ty(
-        mut self,
-        ty: PerformanceOverrideTypeINTEL,
-    ) -> PerformanceOverrideInfoINTELBuilder<'a> {
+    pub fn ty(mut self, ty: PerformanceOverrideTypeINTEL) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn enable(mut self, enable: bool) -> PerformanceOverrideInfoINTELBuilder<'a> {
+    pub fn enable(mut self, enable: bool) -> Self {
         self.inner.enable = enable.into();
         self
     }
-    pub fn parameter(mut self, parameter: u64) -> PerformanceOverrideInfoINTELBuilder<'a> {
+    pub fn parameter(mut self, parameter: u64) -> Self {
         self.inner.parameter = parameter;
         self
     }
@@ -40218,10 +37323,7 @@ impl<'a> PerformanceOverrideInfoINTELBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPerformanceOverrideInfoINTEL>(
-        mut self,
-        next: &'a mut T,
-    ) -> PerformanceOverrideInfoINTELBuilder<'a> {
+    pub fn push_next<T: ExtendsPerformanceOverrideInfoINTEL>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -40280,10 +37382,7 @@ impl<'a> ::std::ops::DerefMut for PerformanceConfigurationAcquireInfoINTELBuilde
     }
 }
 impl<'a> PerformanceConfigurationAcquireInfoINTELBuilder<'a> {
-    pub fn ty(
-        mut self,
-        ty: PerformanceConfigurationTypeINTEL,
-    ) -> PerformanceConfigurationAcquireInfoINTELBuilder<'a> {
+    pub fn ty(mut self, ty: PerformanceConfigurationTypeINTEL) -> Self {
         self.inner.ty = ty;
         self
     }
@@ -40295,7 +37394,7 @@ impl<'a> PerformanceConfigurationAcquireInfoINTELBuilder<'a> {
     pub fn push_next<T: ExtendsPerformanceConfigurationAcquireInfoINTEL>(
         mut self,
         next: &'a mut T,
-    ) -> PerformanceConfigurationAcquireInfoINTELBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -40357,17 +37456,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderClockFeaturesKHRBuilder<'a
     }
 }
 impl<'a> PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
-    pub fn shader_subgroup_clock(
-        mut self,
-        shader_subgroup_clock: bool,
-    ) -> PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
+    pub fn shader_subgroup_clock(mut self, shader_subgroup_clock: bool) -> Self {
         self.inner.shader_subgroup_clock = shader_subgroup_clock.into();
         self
     }
-    pub fn shader_device_clock(
-        mut self,
-        shader_device_clock: bool,
-    ) -> PhysicalDeviceShaderClockFeaturesKHRBuilder<'a> {
+    pub fn shader_device_clock(mut self, shader_device_clock: bool) -> Self {
         self.inner.shader_device_clock = shader_device_clock.into();
         self
     }
@@ -40422,10 +37515,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceIndexTypeUint8FeaturesEXTBuilder
     }
 }
 impl<'a> PhysicalDeviceIndexTypeUint8FeaturesEXTBuilder<'a> {
-    pub fn index_type_uint8(
-        mut self,
-        index_type_uint8: bool,
-    ) -> PhysicalDeviceIndexTypeUint8FeaturesEXTBuilder<'a> {
+    pub fn index_type_uint8(mut self, index_type_uint8: bool) -> Self {
         self.inner.index_type_uint8 = index_type_uint8.into();
         self
     }
@@ -40485,17 +37575,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderSMBuiltinsPropertiesNVBuil
     }
 }
 impl<'a> PhysicalDeviceShaderSMBuiltinsPropertiesNVBuilder<'a> {
-    pub fn shader_sm_count(
-        mut self,
-        shader_sm_count: u32,
-    ) -> PhysicalDeviceShaderSMBuiltinsPropertiesNVBuilder<'a> {
+    pub fn shader_sm_count(mut self, shader_sm_count: u32) -> Self {
         self.inner.shader_sm_count = shader_sm_count;
         self
     }
-    pub fn shader_warps_per_sm(
-        mut self,
-        shader_warps_per_sm: u32,
-    ) -> PhysicalDeviceShaderSMBuiltinsPropertiesNVBuilder<'a> {
+    pub fn shader_warps_per_sm(mut self, shader_warps_per_sm: u32) -> Self {
         self.inner.shader_warps_per_sm = shader_warps_per_sm;
         self
     }
@@ -40550,10 +37634,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderSMBuiltinsFeaturesNVBuilde
     }
 }
 impl<'a> PhysicalDeviceShaderSMBuiltinsFeaturesNVBuilder<'a> {
-    pub fn shader_sm_builtins(
-        mut self,
-        shader_sm_builtins: bool,
-    ) -> PhysicalDeviceShaderSMBuiltinsFeaturesNVBuilder<'a> {
+    pub fn shader_sm_builtins(mut self, shader_sm_builtins: bool) -> Self {
         self.inner.shader_sm_builtins = shader_sm_builtins.into();
         self
     }
@@ -40618,21 +37699,21 @@ impl<'a> PhysicalDeviceFragmentShaderInterlockFeaturesEXTBuilder<'a> {
     pub fn fragment_shader_sample_interlock(
         mut self,
         fragment_shader_sample_interlock: bool,
-    ) -> PhysicalDeviceFragmentShaderInterlockFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.fragment_shader_sample_interlock = fragment_shader_sample_interlock.into();
         self
     }
     pub fn fragment_shader_pixel_interlock(
         mut self,
         fragment_shader_pixel_interlock: bool,
-    ) -> PhysicalDeviceFragmentShaderInterlockFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.fragment_shader_pixel_interlock = fragment_shader_pixel_interlock.into();
         self
     }
     pub fn fragment_shader_shading_rate_interlock(
         mut self,
         fragment_shader_shading_rate_interlock: bool,
-    ) -> PhysicalDeviceFragmentShaderInterlockFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.fragment_shader_shading_rate_interlock =
             fragment_shader_shading_rate_interlock.into();
         self
@@ -40691,10 +37772,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceSeparateDepthStencilLayoutsFeatu
     }
 }
 impl<'a> PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'a> {
-    pub fn separate_depth_stencil_layouts(
-        mut self,
-        separate_depth_stencil_layouts: bool,
-    ) -> PhysicalDeviceSeparateDepthStencilLayoutsFeaturesBuilder<'a> {
+    pub fn separate_depth_stencil_layouts(mut self, separate_depth_stencil_layouts: bool) -> Self {
         self.inner.separate_depth_stencil_layouts = separate_depth_stencil_layouts.into();
         self
     }
@@ -40749,10 +37827,7 @@ impl<'a> ::std::ops::DerefMut for AttachmentReferenceStencilLayoutBuilder<'a> {
     }
 }
 impl<'a> AttachmentReferenceStencilLayoutBuilder<'a> {
-    pub fn stencil_layout(
-        mut self,
-        stencil_layout: ImageLayout,
-    ) -> AttachmentReferenceStencilLayoutBuilder<'a> {
+    pub fn stencil_layout(mut self, stencil_layout: ImageLayout) -> Self {
         self.inner.stencil_layout = stencil_layout;
         self
     }
@@ -40809,17 +37884,11 @@ impl<'a> ::std::ops::DerefMut for AttachmentDescriptionStencilLayoutBuilder<'a> 
     }
 }
 impl<'a> AttachmentDescriptionStencilLayoutBuilder<'a> {
-    pub fn stencil_initial_layout(
-        mut self,
-        stencil_initial_layout: ImageLayout,
-    ) -> AttachmentDescriptionStencilLayoutBuilder<'a> {
+    pub fn stencil_initial_layout(mut self, stencil_initial_layout: ImageLayout) -> Self {
         self.inner.stencil_initial_layout = stencil_initial_layout;
         self
     }
-    pub fn stencil_final_layout(
-        mut self,
-        stencil_final_layout: ImageLayout,
-    ) -> AttachmentDescriptionStencilLayoutBuilder<'a> {
+    pub fn stencil_final_layout(mut self, stencil_final_layout: ImageLayout) -> Self {
         self.inner.stencil_final_layout = stencil_final_layout;
         self
     }
@@ -40877,10 +37946,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDevicePipelineExecutablePropertiesFeat
     }
 }
 impl<'a> PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'a> {
-    pub fn pipeline_executable_info(
-        mut self,
-        pipeline_executable_info: bool,
-    ) -> PhysicalDevicePipelineExecutablePropertiesFeaturesKHRBuilder<'a> {
+    pub fn pipeline_executable_info(mut self, pipeline_executable_info: bool) -> Self {
         self.inner.pipeline_executable_info = pipeline_executable_info.into();
         self
     }
@@ -40934,7 +38000,7 @@ impl<'a> ::std::ops::DerefMut for PipelineInfoKHRBuilder<'a> {
     }
 }
 impl<'a> PipelineInfoKHRBuilder<'a> {
-    pub fn pipeline(mut self, pipeline: Pipeline) -> PipelineInfoKHRBuilder<'a> {
+    pub fn pipeline(mut self, pipeline: Pipeline) -> Self {
         self.inner.pipeline = pipeline;
         self
     }
@@ -40943,10 +38009,7 @@ impl<'a> PipelineInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -41027,31 +38090,19 @@ impl<'a> ::std::ops::DerefMut for PipelineExecutablePropertiesKHRBuilder<'a> {
     }
 }
 impl<'a> PipelineExecutablePropertiesKHRBuilder<'a> {
-    pub fn stages(
-        mut self,
-        stages: ShaderStageFlags,
-    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+    pub fn stages(mut self, stages: ShaderStageFlags) -> Self {
         self.inner.stages = stages;
         self
     }
-    pub fn name(
-        mut self,
-        name: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+    pub fn name(mut self, name: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.name = name;
         self
     }
-    pub fn description(
-        mut self,
-        description: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+    pub fn description(mut self, description: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.description = description;
         self
     }
-    pub fn subgroup_size(
-        mut self,
-        subgroup_size: u32,
-    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+    pub fn subgroup_size(mut self, subgroup_size: u32) -> Self {
         self.inner.subgroup_size = subgroup_size;
         self
     }
@@ -41060,10 +38111,7 @@ impl<'a> PipelineExecutablePropertiesKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineExecutablePropertiesKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineExecutablePropertiesKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineExecutablePropertiesKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -41124,14 +38172,11 @@ impl<'a> ::std::ops::DerefMut for PipelineExecutableInfoKHRBuilder<'a> {
     }
 }
 impl<'a> PipelineExecutableInfoKHRBuilder<'a> {
-    pub fn pipeline(mut self, pipeline: Pipeline) -> PipelineExecutableInfoKHRBuilder<'a> {
+    pub fn pipeline(mut self, pipeline: Pipeline) -> Self {
         self.inner.pipeline = pipeline;
         self
     }
-    pub fn executable_index(
-        mut self,
-        executable_index: u32,
-    ) -> PipelineExecutableInfoKHRBuilder<'a> {
+    pub fn executable_index(mut self, executable_index: u32) -> Self {
         self.inner.executable_index = executable_index;
         self
     }
@@ -41140,10 +38185,7 @@ impl<'a> PipelineExecutableInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineExecutableInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineExecutableInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineExecutableInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -41238,31 +38280,19 @@ impl<'a> ::std::ops::DerefMut for PipelineExecutableStatisticKHRBuilder<'a> {
     }
 }
 impl<'a> PipelineExecutableStatisticKHRBuilder<'a> {
-    pub fn name(
-        mut self,
-        name: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+    pub fn name(mut self, name: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.name = name;
         self
     }
-    pub fn description(
-        mut self,
-        description: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+    pub fn description(mut self, description: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.description = description;
         self
     }
-    pub fn format(
-        mut self,
-        format: PipelineExecutableStatisticFormatKHR,
-    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+    pub fn format(mut self, format: PipelineExecutableStatisticFormatKHR) -> Self {
         self.inner.format = format;
         self
     }
-    pub fn value(
-        mut self,
-        value: PipelineExecutableStatisticValueKHR,
-    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+    pub fn value(mut self, value: PipelineExecutableStatisticValueKHR) -> Self {
         self.inner.value = value;
         self
     }
@@ -41271,10 +38301,7 @@ impl<'a> PipelineExecutableStatisticKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineExecutableStatisticKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineExecutableStatisticKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineExecutableStatisticKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -41358,31 +38385,19 @@ impl<'a> ::std::ops::DerefMut for PipelineExecutableInternalRepresentationKHRBui
     }
 }
 impl<'a> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
-    pub fn name(
-        mut self,
-        name: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+    pub fn name(mut self, name: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.name = name;
         self
     }
-    pub fn description(
-        mut self,
-        description: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+    pub fn description(mut self, description: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.description = description;
         self
     }
-    pub fn is_text(
-        mut self,
-        is_text: bool,
-    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+    pub fn is_text(mut self, is_text: bool) -> Self {
         self.inner.is_text = is_text.into();
         self
     }
-    pub fn data(
-        mut self,
-        data: &'a mut [u8],
-    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+    pub fn data(mut self, data: &'a mut [u8]) -> Self {
         self.inner.data_size = data.len() as _;
         self.inner.p_data = data.as_mut_ptr() as *mut c_void;
         self
@@ -41395,7 +38410,7 @@ impl<'a> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
     pub fn push_next<T: ExtendsPipelineExecutableInternalRepresentationKHR>(
         mut self,
         next: &'a mut T,
-    ) -> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -41463,7 +38478,7 @@ impl<'a> PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'a> {
     pub fn shader_demote_to_helper_invocation(
         mut self,
         shader_demote_to_helper_invocation: bool,
-    ) -> PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.shader_demote_to_helper_invocation = shader_demote_to_helper_invocation.into();
         self
     }
@@ -41518,10 +38533,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceTexelBufferAlignmentFeaturesEXTB
     }
 }
 impl<'a> PhysicalDeviceTexelBufferAlignmentFeaturesEXTBuilder<'a> {
-    pub fn texel_buffer_alignment(
-        mut self,
-        texel_buffer_alignment: bool,
-    ) -> PhysicalDeviceTexelBufferAlignmentFeaturesEXTBuilder<'a> {
+    pub fn texel_buffer_alignment(mut self, texel_buffer_alignment: bool) -> Self {
         self.inner.texel_buffer_alignment = texel_buffer_alignment.into();
         self
     }
@@ -41588,7 +38600,7 @@ impl<'a> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
     pub fn storage_texel_buffer_offset_alignment_bytes(
         mut self,
         storage_texel_buffer_offset_alignment_bytes: DeviceSize,
-    ) -> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.storage_texel_buffer_offset_alignment_bytes =
             storage_texel_buffer_offset_alignment_bytes;
         self
@@ -41596,7 +38608,7 @@ impl<'a> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
     pub fn storage_texel_buffer_offset_single_texel_alignment(
         mut self,
         storage_texel_buffer_offset_single_texel_alignment: bool,
-    ) -> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner
             .storage_texel_buffer_offset_single_texel_alignment =
             storage_texel_buffer_offset_single_texel_alignment.into();
@@ -41605,7 +38617,7 @@ impl<'a> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
     pub fn uniform_texel_buffer_offset_alignment_bytes(
         mut self,
         uniform_texel_buffer_offset_alignment_bytes: DeviceSize,
-    ) -> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.uniform_texel_buffer_offset_alignment_bytes =
             uniform_texel_buffer_offset_alignment_bytes;
         self
@@ -41613,7 +38625,7 @@ impl<'a> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
     pub fn uniform_texel_buffer_offset_single_texel_alignment(
         mut self,
         uniform_texel_buffer_offset_single_texel_alignment: bool,
-    ) -> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner
             .uniform_texel_buffer_offset_single_texel_alignment =
             uniform_texel_buffer_offset_single_texel_alignment.into();
@@ -41672,17 +38684,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceSubgroupSizeControlFeaturesEXTBu
     }
 }
 impl<'a> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
-    pub fn subgroup_size_control(
-        mut self,
-        subgroup_size_control: bool,
-    ) -> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+    pub fn subgroup_size_control(mut self, subgroup_size_control: bool) -> Self {
         self.inner.subgroup_size_control = subgroup_size_control.into();
         self
     }
-    pub fn compute_full_subgroups(
-        mut self,
-        compute_full_subgroups: bool,
-    ) -> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+    pub fn compute_full_subgroups(mut self, compute_full_subgroups: bool) -> Self {
         self.inner.compute_full_subgroups = compute_full_subgroups.into();
         self
     }
@@ -41746,31 +38752,22 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceSubgroupSizeControlPropertiesEXT
     }
 }
 impl<'a> PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
-    pub fn min_subgroup_size(
-        mut self,
-        min_subgroup_size: u32,
-    ) -> PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
+    pub fn min_subgroup_size(mut self, min_subgroup_size: u32) -> Self {
         self.inner.min_subgroup_size = min_subgroup_size;
         self
     }
-    pub fn max_subgroup_size(
-        mut self,
-        max_subgroup_size: u32,
-    ) -> PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
+    pub fn max_subgroup_size(mut self, max_subgroup_size: u32) -> Self {
         self.inner.max_subgroup_size = max_subgroup_size;
         self
     }
-    pub fn max_compute_workgroup_subgroups(
-        mut self,
-        max_compute_workgroup_subgroups: u32,
-    ) -> PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
+    pub fn max_compute_workgroup_subgroups(mut self, max_compute_workgroup_subgroups: u32) -> Self {
         self.inner.max_compute_workgroup_subgroups = max_compute_workgroup_subgroups;
         self
     }
     pub fn required_subgroup_size_stages(
         mut self,
         required_subgroup_size_stages: ShaderStageFlags,
-    ) -> PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.required_subgroup_size_stages = required_subgroup_size_stages;
         self
     }
@@ -41831,10 +38828,7 @@ impl<'a> ::std::ops::DerefMut for PipelineShaderStageRequiredSubgroupSizeCreateI
     }
 }
 impl<'a> PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
-    pub fn required_subgroup_size(
-        mut self,
-        required_subgroup_size: u32,
-    ) -> PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
+    pub fn required_subgroup_size(mut self, required_subgroup_size: u32) -> Self {
         self.inner.required_subgroup_size = required_subgroup_size;
         self
     }
@@ -41889,10 +38883,7 @@ impl<'a> ::std::ops::DerefMut for MemoryOpaqueCaptureAddressAllocateInfoBuilder<
     }
 }
 impl<'a> MemoryOpaqueCaptureAddressAllocateInfoBuilder<'a> {
-    pub fn opaque_capture_address(
-        mut self,
-        opaque_capture_address: u64,
-    ) -> MemoryOpaqueCaptureAddressAllocateInfoBuilder<'a> {
+    pub fn opaque_capture_address(mut self, opaque_capture_address: u64) -> Self {
         self.inner.opaque_capture_address = opaque_capture_address;
         self
     }
@@ -41946,10 +38937,7 @@ impl<'a> ::std::ops::DerefMut for DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a
     }
 }
 impl<'a> DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
-    pub fn memory(
-        mut self,
-        memory: DeviceMemory,
-    ) -> DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
+    pub fn memory(mut self, memory: DeviceMemory) -> Self {
         self.inner.memory = memory;
         self
     }
@@ -41961,7 +38949,7 @@ impl<'a> DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
     pub fn push_next<T: ExtendsDeviceMemoryOpaqueCaptureAddressInfo>(
         mut self,
         next: &'a mut T,
-    ) -> DeviceMemoryOpaqueCaptureAddressInfoBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -42031,45 +39019,27 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceLineRasterizationFeaturesEXTBuil
     }
 }
 impl<'a> PhysicalDeviceLineRasterizationFeaturesEXTBuilder<'a> {
-    pub fn rectangular_lines(
-        mut self,
-        rectangular_lines: bool,
-    ) -> PhysicalDeviceLineRasterizationFeaturesEXTBuilder<'a> {
+    pub fn rectangular_lines(mut self, rectangular_lines: bool) -> Self {
         self.inner.rectangular_lines = rectangular_lines.into();
         self
     }
-    pub fn bresenham_lines(
-        mut self,
-        bresenham_lines: bool,
-    ) -> PhysicalDeviceLineRasterizationFeaturesEXTBuilder<'a> {
+    pub fn bresenham_lines(mut self, bresenham_lines: bool) -> Self {
         self.inner.bresenham_lines = bresenham_lines.into();
         self
     }
-    pub fn smooth_lines(
-        mut self,
-        smooth_lines: bool,
-    ) -> PhysicalDeviceLineRasterizationFeaturesEXTBuilder<'a> {
+    pub fn smooth_lines(mut self, smooth_lines: bool) -> Self {
         self.inner.smooth_lines = smooth_lines.into();
         self
     }
-    pub fn stippled_rectangular_lines(
-        mut self,
-        stippled_rectangular_lines: bool,
-    ) -> PhysicalDeviceLineRasterizationFeaturesEXTBuilder<'a> {
+    pub fn stippled_rectangular_lines(mut self, stippled_rectangular_lines: bool) -> Self {
         self.inner.stippled_rectangular_lines = stippled_rectangular_lines.into();
         self
     }
-    pub fn stippled_bresenham_lines(
-        mut self,
-        stippled_bresenham_lines: bool,
-    ) -> PhysicalDeviceLineRasterizationFeaturesEXTBuilder<'a> {
+    pub fn stippled_bresenham_lines(mut self, stippled_bresenham_lines: bool) -> Self {
         self.inner.stippled_bresenham_lines = stippled_bresenham_lines.into();
         self
     }
-    pub fn stippled_smooth_lines(
-        mut self,
-        stippled_smooth_lines: bool,
-    ) -> PhysicalDeviceLineRasterizationFeaturesEXTBuilder<'a> {
+    pub fn stippled_smooth_lines(mut self, stippled_smooth_lines: bool) -> Self {
         self.inner.stippled_smooth_lines = stippled_smooth_lines.into();
         self
     }
@@ -42127,10 +39097,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceLineRasterizationPropertiesEXTBu
     }
 }
 impl<'a> PhysicalDeviceLineRasterizationPropertiesEXTBuilder<'a> {
-    pub fn line_sub_pixel_precision_bits(
-        mut self,
-        line_sub_pixel_precision_bits: u32,
-    ) -> PhysicalDeviceLineRasterizationPropertiesEXTBuilder<'a> {
+    pub fn line_sub_pixel_precision_bits(mut self, line_sub_pixel_precision_bits: u32) -> Self {
         self.inner.line_sub_pixel_precision_bits = line_sub_pixel_precision_bits;
         self
     }
@@ -42200,28 +39167,19 @@ impl<'a> PipelineRasterizationLineStateCreateInfoEXTBuilder<'a> {
     pub fn line_rasterization_mode(
         mut self,
         line_rasterization_mode: LineRasterizationModeEXT,
-    ) -> PipelineRasterizationLineStateCreateInfoEXTBuilder<'a> {
+    ) -> Self {
         self.inner.line_rasterization_mode = line_rasterization_mode;
         self
     }
-    pub fn stippled_line_enable(
-        mut self,
-        stippled_line_enable: bool,
-    ) -> PipelineRasterizationLineStateCreateInfoEXTBuilder<'a> {
+    pub fn stippled_line_enable(mut self, stippled_line_enable: bool) -> Self {
         self.inner.stippled_line_enable = stippled_line_enable.into();
         self
     }
-    pub fn line_stipple_factor(
-        mut self,
-        line_stipple_factor: u32,
-    ) -> PipelineRasterizationLineStateCreateInfoEXTBuilder<'a> {
+    pub fn line_stipple_factor(mut self, line_stipple_factor: u32) -> Self {
         self.inner.line_stipple_factor = line_stipple_factor;
         self
     }
-    pub fn line_stipple_pattern(
-        mut self,
-        line_stipple_pattern: u16,
-    ) -> PipelineRasterizationLineStateCreateInfoEXTBuilder<'a> {
+    pub fn line_stipple_pattern(mut self, line_stipple_pattern: u16) -> Self {
         self.inner.line_stipple_pattern = line_stipple_pattern;
         self
     }
@@ -42282,7 +39240,7 @@ impl<'a> PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'a> {
     pub fn pipeline_creation_cache_control(
         mut self,
         pipeline_creation_cache_control: bool,
-    ) -> PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.pipeline_creation_cache_control = pipeline_creation_cache_control.into();
         self
     }
@@ -42359,85 +39317,58 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan11FeaturesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
-    pub fn storage_buffer16_bit_access(
-        mut self,
-        storage_buffer16_bit_access: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn storage_buffer16_bit_access(mut self, storage_buffer16_bit_access: bool) -> Self {
         self.inner.storage_buffer16_bit_access = storage_buffer16_bit_access.into();
         self
     }
     pub fn uniform_and_storage_buffer16_bit_access(
         mut self,
         uniform_and_storage_buffer16_bit_access: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.uniform_and_storage_buffer16_bit_access =
             uniform_and_storage_buffer16_bit_access.into();
         self
     }
-    pub fn storage_push_constant16(
-        mut self,
-        storage_push_constant16: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn storage_push_constant16(mut self, storage_push_constant16: bool) -> Self {
         self.inner.storage_push_constant16 = storage_push_constant16.into();
         self
     }
-    pub fn storage_input_output16(
-        mut self,
-        storage_input_output16: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn storage_input_output16(mut self, storage_input_output16: bool) -> Self {
         self.inner.storage_input_output16 = storage_input_output16.into();
         self
     }
-    pub fn multiview(mut self, multiview: bool) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn multiview(mut self, multiview: bool) -> Self {
         self.inner.multiview = multiview.into();
         self
     }
-    pub fn multiview_geometry_shader(
-        mut self,
-        multiview_geometry_shader: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn multiview_geometry_shader(mut self, multiview_geometry_shader: bool) -> Self {
         self.inner.multiview_geometry_shader = multiview_geometry_shader.into();
         self
     }
-    pub fn multiview_tessellation_shader(
-        mut self,
-        multiview_tessellation_shader: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn multiview_tessellation_shader(mut self, multiview_tessellation_shader: bool) -> Self {
         self.inner.multiview_tessellation_shader = multiview_tessellation_shader.into();
         self
     }
     pub fn variable_pointers_storage_buffer(
         mut self,
         variable_pointers_storage_buffer: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.variable_pointers_storage_buffer = variable_pointers_storage_buffer.into();
         self
     }
-    pub fn variable_pointers(
-        mut self,
-        variable_pointers: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn variable_pointers(mut self, variable_pointers: bool) -> Self {
         self.inner.variable_pointers = variable_pointers.into();
         self
     }
-    pub fn protected_memory(
-        mut self,
-        protected_memory: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn protected_memory(mut self, protected_memory: bool) -> Self {
         self.inner.protected_memory = protected_memory.into();
         self
     }
-    pub fn sampler_ycbcr_conversion(
-        mut self,
-        sampler_ycbcr_conversion: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn sampler_ycbcr_conversion(mut self, sampler_ycbcr_conversion: bool) -> Self {
         self.inner.sampler_ycbcr_conversion = sampler_ycbcr_conversion.into();
         self
     }
-    pub fn shader_draw_parameters(
-        mut self,
-        shader_draw_parameters: bool,
-    ) -> PhysicalDeviceVulkan11FeaturesBuilder<'a> {
+    pub fn shader_draw_parameters(mut self, shader_draw_parameters: bool) -> Self {
         self.inner.shader_draw_parameters = shader_draw_parameters.into();
         self
     }
@@ -42520,66 +39451,48 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan11PropertiesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
-    pub fn device_uuid(
-        mut self,
-        device_uuid: [u8; UUID_SIZE],
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn device_uuid(mut self, device_uuid: [u8; UUID_SIZE]) -> Self {
         self.inner.device_uuid = device_uuid;
         self
     }
-    pub fn driver_uuid(
-        mut self,
-        driver_uuid: [u8; UUID_SIZE],
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn driver_uuid(mut self, driver_uuid: [u8; UUID_SIZE]) -> Self {
         self.inner.driver_uuid = driver_uuid;
         self
     }
-    pub fn device_luid(
-        mut self,
-        device_luid: [u8; LUID_SIZE],
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn device_luid(mut self, device_luid: [u8; LUID_SIZE]) -> Self {
         self.inner.device_luid = device_luid;
         self
     }
-    pub fn device_node_mask(
-        mut self,
-        device_node_mask: u32,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn device_node_mask(mut self, device_node_mask: u32) -> Self {
         self.inner.device_node_mask = device_node_mask;
         self
     }
-    pub fn device_luid_valid(
-        mut self,
-        device_luid_valid: bool,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn device_luid_valid(mut self, device_luid_valid: bool) -> Self {
         self.inner.device_luid_valid = device_luid_valid.into();
         self
     }
-    pub fn subgroup_size(
-        mut self,
-        subgroup_size: u32,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn subgroup_size(mut self, subgroup_size: u32) -> Self {
         self.inner.subgroup_size = subgroup_size;
         self
     }
     pub fn subgroup_supported_stages(
         mut self,
         subgroup_supported_stages: ShaderStageFlags,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.subgroup_supported_stages = subgroup_supported_stages;
         self
     }
     pub fn subgroup_supported_operations(
         mut self,
         subgroup_supported_operations: SubgroupFeatureFlags,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.subgroup_supported_operations = subgroup_supported_operations;
         self
     }
     pub fn subgroup_quad_operations_in_all_stages(
         mut self,
         subgroup_quad_operations_in_all_stages: bool,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.subgroup_quad_operations_in_all_stages =
             subgroup_quad_operations_in_all_stages.into();
         self
@@ -42587,42 +39500,27 @@ impl<'a> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
     pub fn point_clipping_behavior(
         mut self,
         point_clipping_behavior: PointClippingBehavior,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.point_clipping_behavior = point_clipping_behavior;
         self
     }
-    pub fn max_multiview_view_count(
-        mut self,
-        max_multiview_view_count: u32,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn max_multiview_view_count(mut self, max_multiview_view_count: u32) -> Self {
         self.inner.max_multiview_view_count = max_multiview_view_count;
         self
     }
-    pub fn max_multiview_instance_index(
-        mut self,
-        max_multiview_instance_index: u32,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn max_multiview_instance_index(mut self, max_multiview_instance_index: u32) -> Self {
         self.inner.max_multiview_instance_index = max_multiview_instance_index;
         self
     }
-    pub fn protected_no_fault(
-        mut self,
-        protected_no_fault: bool,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn protected_no_fault(mut self, protected_no_fault: bool) -> Self {
         self.inner.protected_no_fault = protected_no_fault.into();
         self
     }
-    pub fn max_per_set_descriptors(
-        mut self,
-        max_per_set_descriptors: u32,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn max_per_set_descriptors(mut self, max_per_set_descriptors: u32) -> Self {
         self.inner.max_per_set_descriptors = max_per_set_descriptors;
         self
     }
-    pub fn max_memory_allocation_size(
-        mut self,
-        max_memory_allocation_size: DeviceSize,
-    ) -> PhysicalDeviceVulkan11PropertiesBuilder<'a> {
+    pub fn max_memory_allocation_size(mut self, max_memory_allocation_size: DeviceSize) -> Self {
         self.inner.max_memory_allocation_size = max_memory_allocation_size;
         self
     }
@@ -42769,78 +39667,54 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
-    pub fn sampler_mirror_clamp_to_edge(
-        mut self,
-        sampler_mirror_clamp_to_edge: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn sampler_mirror_clamp_to_edge(mut self, sampler_mirror_clamp_to_edge: bool) -> Self {
         self.inner.sampler_mirror_clamp_to_edge = sampler_mirror_clamp_to_edge.into();
         self
     }
-    pub fn draw_indirect_count(
-        mut self,
-        draw_indirect_count: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn draw_indirect_count(mut self, draw_indirect_count: bool) -> Self {
         self.inner.draw_indirect_count = draw_indirect_count.into();
         self
     }
-    pub fn storage_buffer8_bit_access(
-        mut self,
-        storage_buffer8_bit_access: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn storage_buffer8_bit_access(mut self, storage_buffer8_bit_access: bool) -> Self {
         self.inner.storage_buffer8_bit_access = storage_buffer8_bit_access.into();
         self
     }
     pub fn uniform_and_storage_buffer8_bit_access(
         mut self,
         uniform_and_storage_buffer8_bit_access: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.uniform_and_storage_buffer8_bit_access =
             uniform_and_storage_buffer8_bit_access.into();
         self
     }
-    pub fn storage_push_constant8(
-        mut self,
-        storage_push_constant8: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn storage_push_constant8(mut self, storage_push_constant8: bool) -> Self {
         self.inner.storage_push_constant8 = storage_push_constant8.into();
         self
     }
-    pub fn shader_buffer_int64_atomics(
-        mut self,
-        shader_buffer_int64_atomics: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn shader_buffer_int64_atomics(mut self, shader_buffer_int64_atomics: bool) -> Self {
         self.inner.shader_buffer_int64_atomics = shader_buffer_int64_atomics.into();
         self
     }
-    pub fn shader_shared_int64_atomics(
-        mut self,
-        shader_shared_int64_atomics: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn shader_shared_int64_atomics(mut self, shader_shared_int64_atomics: bool) -> Self {
         self.inner.shader_shared_int64_atomics = shader_shared_int64_atomics.into();
         self
     }
-    pub fn shader_float16(
-        mut self,
-        shader_float16: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn shader_float16(mut self, shader_float16: bool) -> Self {
         self.inner.shader_float16 = shader_float16.into();
         self
     }
-    pub fn shader_int8(mut self, shader_int8: bool) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn shader_int8(mut self, shader_int8: bool) -> Self {
         self.inner.shader_int8 = shader_int8.into();
         self
     }
-    pub fn descriptor_indexing(
-        mut self,
-        descriptor_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn descriptor_indexing(mut self, descriptor_indexing: bool) -> Self {
         self.inner.descriptor_indexing = descriptor_indexing.into();
         self
     }
     pub fn shader_input_attachment_array_dynamic_indexing(
         mut self,
         shader_input_attachment_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_input_attachment_array_dynamic_indexing =
             shader_input_attachment_array_dynamic_indexing.into();
         self
@@ -42848,7 +39722,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn shader_uniform_texel_buffer_array_dynamic_indexing(
         mut self,
         shader_uniform_texel_buffer_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_uniform_texel_buffer_array_dynamic_indexing =
             shader_uniform_texel_buffer_array_dynamic_indexing.into();
@@ -42857,7 +39731,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn shader_storage_texel_buffer_array_dynamic_indexing(
         mut self,
         shader_storage_texel_buffer_array_dynamic_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_storage_texel_buffer_array_dynamic_indexing =
             shader_storage_texel_buffer_array_dynamic_indexing.into();
@@ -42866,7 +39740,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn shader_uniform_buffer_array_non_uniform_indexing(
         mut self,
         shader_uniform_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_uniform_buffer_array_non_uniform_indexing =
             shader_uniform_buffer_array_non_uniform_indexing.into();
         self
@@ -42874,7 +39748,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn shader_sampled_image_array_non_uniform_indexing(
         mut self,
         shader_sampled_image_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_sampled_image_array_non_uniform_indexing =
             shader_sampled_image_array_non_uniform_indexing.into();
         self
@@ -42882,7 +39756,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn shader_storage_buffer_array_non_uniform_indexing(
         mut self,
         shader_storage_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_buffer_array_non_uniform_indexing =
             shader_storage_buffer_array_non_uniform_indexing.into();
         self
@@ -42890,7 +39764,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn shader_storage_image_array_non_uniform_indexing(
         mut self,
         shader_storage_image_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_storage_image_array_non_uniform_indexing =
             shader_storage_image_array_non_uniform_indexing.into();
         self
@@ -42898,7 +39772,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn shader_input_attachment_array_non_uniform_indexing(
         mut self,
         shader_input_attachment_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_input_attachment_array_non_uniform_indexing =
             shader_input_attachment_array_non_uniform_indexing.into();
@@ -42907,7 +39781,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn shader_uniform_texel_buffer_array_non_uniform_indexing(
         mut self,
         shader_uniform_texel_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_uniform_texel_buffer_array_non_uniform_indexing =
             shader_uniform_texel_buffer_array_non_uniform_indexing.into();
@@ -42916,7 +39790,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn shader_storage_texel_buffer_array_non_uniform_indexing(
         mut self,
         shader_storage_texel_buffer_array_non_uniform_indexing: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_storage_texel_buffer_array_non_uniform_indexing =
             shader_storage_texel_buffer_array_non_uniform_indexing.into();
@@ -42925,7 +39799,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn descriptor_binding_uniform_buffer_update_after_bind(
         mut self,
         descriptor_binding_uniform_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_uniform_buffer_update_after_bind =
             descriptor_binding_uniform_buffer_update_after_bind.into();
@@ -42934,7 +39808,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn descriptor_binding_sampled_image_update_after_bind(
         mut self,
         descriptor_binding_sampled_image_update_after_bind: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_sampled_image_update_after_bind =
             descriptor_binding_sampled_image_update_after_bind.into();
@@ -42943,7 +39817,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn descriptor_binding_storage_image_update_after_bind(
         mut self,
         descriptor_binding_storage_image_update_after_bind: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_storage_image_update_after_bind =
             descriptor_binding_storage_image_update_after_bind.into();
@@ -42952,7 +39826,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn descriptor_binding_storage_buffer_update_after_bind(
         mut self,
         descriptor_binding_storage_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_storage_buffer_update_after_bind =
             descriptor_binding_storage_buffer_update_after_bind.into();
@@ -42961,7 +39835,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn descriptor_binding_uniform_texel_buffer_update_after_bind(
         mut self,
         descriptor_binding_uniform_texel_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_uniform_texel_buffer_update_after_bind =
             descriptor_binding_uniform_texel_buffer_update_after_bind.into();
@@ -42970,7 +39844,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn descriptor_binding_storage_texel_buffer_update_after_bind(
         mut self,
         descriptor_binding_storage_texel_buffer_update_after_bind: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .descriptor_binding_storage_texel_buffer_update_after_bind =
             descriptor_binding_storage_texel_buffer_update_after_bind.into();
@@ -42979,7 +39853,7 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn descriptor_binding_update_unused_while_pending(
         mut self,
         descriptor_binding_update_unused_while_pending: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.descriptor_binding_update_unused_while_pending =
             descriptor_binding_update_unused_while_pending.into();
         self
@@ -42987,92 +39861,62 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn descriptor_binding_partially_bound(
         mut self,
         descriptor_binding_partially_bound: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.descriptor_binding_partially_bound = descriptor_binding_partially_bound.into();
         self
     }
     pub fn descriptor_binding_variable_descriptor_count(
         mut self,
         descriptor_binding_variable_descriptor_count: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.descriptor_binding_variable_descriptor_count =
             descriptor_binding_variable_descriptor_count.into();
         self
     }
-    pub fn runtime_descriptor_array(
-        mut self,
-        runtime_descriptor_array: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn runtime_descriptor_array(mut self, runtime_descriptor_array: bool) -> Self {
         self.inner.runtime_descriptor_array = runtime_descriptor_array.into();
         self
     }
-    pub fn sampler_filter_minmax(
-        mut self,
-        sampler_filter_minmax: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn sampler_filter_minmax(mut self, sampler_filter_minmax: bool) -> Self {
         self.inner.sampler_filter_minmax = sampler_filter_minmax.into();
         self
     }
-    pub fn scalar_block_layout(
-        mut self,
-        scalar_block_layout: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn scalar_block_layout(mut self, scalar_block_layout: bool) -> Self {
         self.inner.scalar_block_layout = scalar_block_layout.into();
         self
     }
-    pub fn imageless_framebuffer(
-        mut self,
-        imageless_framebuffer: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn imageless_framebuffer(mut self, imageless_framebuffer: bool) -> Self {
         self.inner.imageless_framebuffer = imageless_framebuffer.into();
         self
     }
-    pub fn uniform_buffer_standard_layout(
-        mut self,
-        uniform_buffer_standard_layout: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn uniform_buffer_standard_layout(mut self, uniform_buffer_standard_layout: bool) -> Self {
         self.inner.uniform_buffer_standard_layout = uniform_buffer_standard_layout.into();
         self
     }
-    pub fn shader_subgroup_extended_types(
-        mut self,
-        shader_subgroup_extended_types: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn shader_subgroup_extended_types(mut self, shader_subgroup_extended_types: bool) -> Self {
         self.inner.shader_subgroup_extended_types = shader_subgroup_extended_types.into();
         self
     }
-    pub fn separate_depth_stencil_layouts(
-        mut self,
-        separate_depth_stencil_layouts: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn separate_depth_stencil_layouts(mut self, separate_depth_stencil_layouts: bool) -> Self {
         self.inner.separate_depth_stencil_layouts = separate_depth_stencil_layouts.into();
         self
     }
-    pub fn host_query_reset(
-        mut self,
-        host_query_reset: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn host_query_reset(mut self, host_query_reset: bool) -> Self {
         self.inner.host_query_reset = host_query_reset.into();
         self
     }
-    pub fn timeline_semaphore(
-        mut self,
-        timeline_semaphore: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn timeline_semaphore(mut self, timeline_semaphore: bool) -> Self {
         self.inner.timeline_semaphore = timeline_semaphore.into();
         self
     }
-    pub fn buffer_device_address(
-        mut self,
-        buffer_device_address: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn buffer_device_address(mut self, buffer_device_address: bool) -> Self {
         self.inner.buffer_device_address = buffer_device_address.into();
         self
     }
     pub fn buffer_device_address_capture_replay(
         mut self,
         buffer_device_address_capture_replay: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.buffer_device_address_capture_replay =
             buffer_device_address_capture_replay.into();
         self
@@ -43080,51 +39924,39 @@ impl<'a> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
     pub fn buffer_device_address_multi_device(
         mut self,
         buffer_device_address_multi_device: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.buffer_device_address_multi_device = buffer_device_address_multi_device.into();
         self
     }
-    pub fn vulkan_memory_model(
-        mut self,
-        vulkan_memory_model: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn vulkan_memory_model(mut self, vulkan_memory_model: bool) -> Self {
         self.inner.vulkan_memory_model = vulkan_memory_model.into();
         self
     }
     pub fn vulkan_memory_model_device_scope(
         mut self,
         vulkan_memory_model_device_scope: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner.vulkan_memory_model_device_scope = vulkan_memory_model_device_scope.into();
         self
     }
     pub fn vulkan_memory_model_availability_visibility_chains(
         mut self,
         vulkan_memory_model_availability_visibility_chains: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    ) -> Self {
         self.inner
             .vulkan_memory_model_availability_visibility_chains =
             vulkan_memory_model_availability_visibility_chains.into();
         self
     }
-    pub fn shader_output_viewport_index(
-        mut self,
-        shader_output_viewport_index: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn shader_output_viewport_index(mut self, shader_output_viewport_index: bool) -> Self {
         self.inner.shader_output_viewport_index = shader_output_viewport_index.into();
         self
     }
-    pub fn shader_output_layer(
-        mut self,
-        shader_output_layer: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn shader_output_layer(mut self, shader_output_layer: bool) -> Self {
         self.inner.shader_output_layer = shader_output_layer.into();
         self
     }
-    pub fn subgroup_broadcast_dynamic_id(
-        mut self,
-        subgroup_broadcast_dynamic_id: bool,
-    ) -> PhysicalDeviceVulkan12FeaturesBuilder<'a> {
+    pub fn subgroup_broadcast_dynamic_id(mut self, subgroup_broadcast_dynamic_id: bool) -> Self {
         self.inner.subgroup_broadcast_dynamic_id = subgroup_broadcast_dynamic_id.into();
         self
     }
@@ -43483,49 +40315,40 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
-    pub fn driver_id(mut self, driver_id: DriverId) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn driver_id(mut self, driver_id: DriverId) -> Self {
         self.inner.driver_id = driver_id;
         self
     }
-    pub fn driver_name(
-        mut self,
-        driver_name: [c_char; MAX_DRIVER_NAME_SIZE],
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn driver_name(mut self, driver_name: [c_char; MAX_DRIVER_NAME_SIZE]) -> Self {
         self.inner.driver_name = driver_name;
         self
     }
-    pub fn driver_info(
-        mut self,
-        driver_info: [c_char; MAX_DRIVER_INFO_SIZE],
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn driver_info(mut self, driver_info: [c_char; MAX_DRIVER_INFO_SIZE]) -> Self {
         self.inner.driver_info = driver_info;
         self
     }
-    pub fn conformance_version(
-        mut self,
-        conformance_version: ConformanceVersion,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn conformance_version(mut self, conformance_version: ConformanceVersion) -> Self {
         self.inner.conformance_version = conformance_version;
         self
     }
     pub fn denorm_behavior_independence(
         mut self,
         denorm_behavior_independence: ShaderFloatControlsIndependence,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.denorm_behavior_independence = denorm_behavior_independence;
         self
     }
     pub fn rounding_mode_independence(
         mut self,
         rounding_mode_independence: ShaderFloatControlsIndependence,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.rounding_mode_independence = rounding_mode_independence;
         self
     }
     pub fn shader_signed_zero_inf_nan_preserve_float16(
         mut self,
         shader_signed_zero_inf_nan_preserve_float16: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_signed_zero_inf_nan_preserve_float16 =
             shader_signed_zero_inf_nan_preserve_float16.into();
         self
@@ -43533,7 +40356,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn shader_signed_zero_inf_nan_preserve_float32(
         mut self,
         shader_signed_zero_inf_nan_preserve_float32: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_signed_zero_inf_nan_preserve_float32 =
             shader_signed_zero_inf_nan_preserve_float32.into();
         self
@@ -43541,99 +40364,90 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn shader_signed_zero_inf_nan_preserve_float64(
         mut self,
         shader_signed_zero_inf_nan_preserve_float64: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_signed_zero_inf_nan_preserve_float64 =
             shader_signed_zero_inf_nan_preserve_float64.into();
         self
     }
-    pub fn shader_denorm_preserve_float16(
-        mut self,
-        shader_denorm_preserve_float16: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn shader_denorm_preserve_float16(mut self, shader_denorm_preserve_float16: bool) -> Self {
         self.inner.shader_denorm_preserve_float16 = shader_denorm_preserve_float16.into();
         self
     }
-    pub fn shader_denorm_preserve_float32(
-        mut self,
-        shader_denorm_preserve_float32: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn shader_denorm_preserve_float32(mut self, shader_denorm_preserve_float32: bool) -> Self {
         self.inner.shader_denorm_preserve_float32 = shader_denorm_preserve_float32.into();
         self
     }
-    pub fn shader_denorm_preserve_float64(
-        mut self,
-        shader_denorm_preserve_float64: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn shader_denorm_preserve_float64(mut self, shader_denorm_preserve_float64: bool) -> Self {
         self.inner.shader_denorm_preserve_float64 = shader_denorm_preserve_float64.into();
         self
     }
     pub fn shader_denorm_flush_to_zero_float16(
         mut self,
         shader_denorm_flush_to_zero_float16: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_denorm_flush_to_zero_float16 = shader_denorm_flush_to_zero_float16.into();
         self
     }
     pub fn shader_denorm_flush_to_zero_float32(
         mut self,
         shader_denorm_flush_to_zero_float32: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_denorm_flush_to_zero_float32 = shader_denorm_flush_to_zero_float32.into();
         self
     }
     pub fn shader_denorm_flush_to_zero_float64(
         mut self,
         shader_denorm_flush_to_zero_float64: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_denorm_flush_to_zero_float64 = shader_denorm_flush_to_zero_float64.into();
         self
     }
     pub fn shader_rounding_mode_rte_float16(
         mut self,
         shader_rounding_mode_rte_float16: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rte_float16 = shader_rounding_mode_rte_float16.into();
         self
     }
     pub fn shader_rounding_mode_rte_float32(
         mut self,
         shader_rounding_mode_rte_float32: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rte_float32 = shader_rounding_mode_rte_float32.into();
         self
     }
     pub fn shader_rounding_mode_rte_float64(
         mut self,
         shader_rounding_mode_rte_float64: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rte_float64 = shader_rounding_mode_rte_float64.into();
         self
     }
     pub fn shader_rounding_mode_rtz_float16(
         mut self,
         shader_rounding_mode_rtz_float16: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rtz_float16 = shader_rounding_mode_rtz_float16.into();
         self
     }
     pub fn shader_rounding_mode_rtz_float32(
         mut self,
         shader_rounding_mode_rtz_float32: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rtz_float32 = shader_rounding_mode_rtz_float32.into();
         self
     }
     pub fn shader_rounding_mode_rtz_float64(
         mut self,
         shader_rounding_mode_rtz_float64: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.shader_rounding_mode_rtz_float64 = shader_rounding_mode_rtz_float64.into();
         self
     }
     pub fn max_update_after_bind_descriptors_in_all_pools(
         mut self,
         max_update_after_bind_descriptors_in_all_pools: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.max_update_after_bind_descriptors_in_all_pools =
             max_update_after_bind_descriptors_in_all_pools;
         self
@@ -43641,7 +40455,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn shader_uniform_buffer_array_non_uniform_indexing_native(
         mut self,
         shader_uniform_buffer_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_uniform_buffer_array_non_uniform_indexing_native =
             shader_uniform_buffer_array_non_uniform_indexing_native.into();
@@ -43650,7 +40464,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn shader_sampled_image_array_non_uniform_indexing_native(
         mut self,
         shader_sampled_image_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_sampled_image_array_non_uniform_indexing_native =
             shader_sampled_image_array_non_uniform_indexing_native.into();
@@ -43659,7 +40473,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn shader_storage_buffer_array_non_uniform_indexing_native(
         mut self,
         shader_storage_buffer_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_storage_buffer_array_non_uniform_indexing_native =
             shader_storage_buffer_array_non_uniform_indexing_native.into();
@@ -43668,7 +40482,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn shader_storage_image_array_non_uniform_indexing_native(
         mut self,
         shader_storage_image_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_storage_image_array_non_uniform_indexing_native =
             shader_storage_image_array_non_uniform_indexing_native.into();
@@ -43677,7 +40491,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn shader_input_attachment_array_non_uniform_indexing_native(
         mut self,
         shader_input_attachment_array_non_uniform_indexing_native: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .shader_input_attachment_array_non_uniform_indexing_native =
             shader_input_attachment_array_non_uniform_indexing_native.into();
@@ -43686,22 +40500,19 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn robust_buffer_access_update_after_bind(
         mut self,
         robust_buffer_access_update_after_bind: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.robust_buffer_access_update_after_bind =
             robust_buffer_access_update_after_bind.into();
         self
     }
-    pub fn quad_divergent_implicit_lod(
-        mut self,
-        quad_divergent_implicit_lod: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn quad_divergent_implicit_lod(mut self, quad_divergent_implicit_lod: bool) -> Self {
         self.inner.quad_divergent_implicit_lod = quad_divergent_implicit_lod.into();
         self
     }
     pub fn max_per_stage_descriptor_update_after_bind_samplers(
         mut self,
         max_per_stage_descriptor_update_after_bind_samplers: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_samplers =
             max_per_stage_descriptor_update_after_bind_samplers;
@@ -43710,7 +40521,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_uniform_buffers(
         mut self,
         max_per_stage_descriptor_update_after_bind_uniform_buffers: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_uniform_buffers =
             max_per_stage_descriptor_update_after_bind_uniform_buffers;
@@ -43719,7 +40530,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_storage_buffers(
         mut self,
         max_per_stage_descriptor_update_after_bind_storage_buffers: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_storage_buffers =
             max_per_stage_descriptor_update_after_bind_storage_buffers;
@@ -43728,7 +40539,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_sampled_images(
         mut self,
         max_per_stage_descriptor_update_after_bind_sampled_images: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_sampled_images =
             max_per_stage_descriptor_update_after_bind_sampled_images;
@@ -43737,7 +40548,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_storage_images(
         mut self,
         max_per_stage_descriptor_update_after_bind_storage_images: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_storage_images =
             max_per_stage_descriptor_update_after_bind_storage_images;
@@ -43746,7 +40557,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_per_stage_descriptor_update_after_bind_input_attachments(
         mut self,
         max_per_stage_descriptor_update_after_bind_input_attachments: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_per_stage_descriptor_update_after_bind_input_attachments =
             max_per_stage_descriptor_update_after_bind_input_attachments;
@@ -43755,7 +40566,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_per_stage_update_after_bind_resources(
         mut self,
         max_per_stage_update_after_bind_resources: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.max_per_stage_update_after_bind_resources =
             max_per_stage_update_after_bind_resources;
         self
@@ -43763,7 +40574,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_samplers(
         mut self,
         max_descriptor_set_update_after_bind_samplers: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.max_descriptor_set_update_after_bind_samplers =
             max_descriptor_set_update_after_bind_samplers;
         self
@@ -43771,7 +40582,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_uniform_buffers(
         mut self,
         max_descriptor_set_update_after_bind_uniform_buffers: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_uniform_buffers =
             max_descriptor_set_update_after_bind_uniform_buffers;
@@ -43780,7 +40591,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_uniform_buffers_dynamic(
         mut self,
         max_descriptor_set_update_after_bind_uniform_buffers_dynamic: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_uniform_buffers_dynamic =
             max_descriptor_set_update_after_bind_uniform_buffers_dynamic;
@@ -43789,7 +40600,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_storage_buffers(
         mut self,
         max_descriptor_set_update_after_bind_storage_buffers: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_storage_buffers =
             max_descriptor_set_update_after_bind_storage_buffers;
@@ -43798,7 +40609,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_storage_buffers_dynamic(
         mut self,
         max_descriptor_set_update_after_bind_storage_buffers_dynamic: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_storage_buffers_dynamic =
             max_descriptor_set_update_after_bind_storage_buffers_dynamic;
@@ -43807,7 +40618,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_sampled_images(
         mut self,
         max_descriptor_set_update_after_bind_sampled_images: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_sampled_images =
             max_descriptor_set_update_after_bind_sampled_images;
@@ -43816,7 +40627,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_storage_images(
         mut self,
         max_descriptor_set_update_after_bind_storage_images: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_storage_images =
             max_descriptor_set_update_after_bind_storage_images;
@@ -43825,7 +40636,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_descriptor_set_update_after_bind_input_attachments(
         mut self,
         max_descriptor_set_update_after_bind_input_attachments: u32,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_descriptor_set_update_after_bind_input_attachments =
             max_descriptor_set_update_after_bind_input_attachments;
@@ -43834,35 +40645,29 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn supported_depth_resolve_modes(
         mut self,
         supported_depth_resolve_modes: ResolveModeFlags,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.supported_depth_resolve_modes = supported_depth_resolve_modes;
         self
     }
     pub fn supported_stencil_resolve_modes(
         mut self,
         supported_stencil_resolve_modes: ResolveModeFlags,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.supported_stencil_resolve_modes = supported_stencil_resolve_modes;
         self
     }
-    pub fn independent_resolve_none(
-        mut self,
-        independent_resolve_none: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn independent_resolve_none(mut self, independent_resolve_none: bool) -> Self {
         self.inner.independent_resolve_none = independent_resolve_none.into();
         self
     }
-    pub fn independent_resolve(
-        mut self,
-        independent_resolve: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    pub fn independent_resolve(mut self, independent_resolve: bool) -> Self {
         self.inner.independent_resolve = independent_resolve.into();
         self
     }
     pub fn filter_minmax_single_component_formats(
         mut self,
         filter_minmax_single_component_formats: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.filter_minmax_single_component_formats =
             filter_minmax_single_component_formats.into();
         self
@@ -43870,7 +40675,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn filter_minmax_image_component_mapping(
         mut self,
         filter_minmax_image_component_mapping: bool,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.filter_minmax_image_component_mapping =
             filter_minmax_image_component_mapping.into();
         self
@@ -43878,7 +40683,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn max_timeline_semaphore_value_difference(
         mut self,
         max_timeline_semaphore_value_difference: u64,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.max_timeline_semaphore_value_difference =
             max_timeline_semaphore_value_difference;
         self
@@ -43886,7 +40691,7 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
     pub fn framebuffer_integer_color_sample_counts(
         mut self,
         framebuffer_integer_color_sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
+    ) -> Self {
         self.inner.framebuffer_integer_color_sample_counts =
             framebuffer_integer_color_sample_counts;
         self
@@ -43947,7 +40752,7 @@ impl<'a> PipelineCompilerControlCreateInfoAMDBuilder<'a> {
     pub fn compiler_control_flags(
         mut self,
         compiler_control_flags: PipelineCompilerControlFlagsAMD,
-    ) -> PipelineCompilerControlCreateInfoAMDBuilder<'a> {
+    ) -> Self {
         self.inner.compiler_control_flags = compiler_control_flags;
         self
     }
@@ -44002,10 +40807,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceCoherentMemoryFeaturesAMDBuilder
     }
 }
 impl<'a> PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
-    pub fn device_coherent_memory(
-        mut self,
-        device_coherent_memory: bool,
-    ) -> PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
+    pub fn device_coherent_memory(mut self, device_coherent_memory: bool) -> Self {
         self.inner.device_coherent_memory = device_coherent_memory.into();
         self
     }
@@ -44088,38 +40890,23 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceToolPropertiesEXTBuilder<'a> {
     }
 }
 impl<'a> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
-    pub fn name(
-        mut self,
-        name: [c_char; MAX_EXTENSION_NAME_SIZE],
-    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    pub fn name(mut self, name: [c_char; MAX_EXTENSION_NAME_SIZE]) -> Self {
         self.inner.name = name;
         self
     }
-    pub fn version(
-        mut self,
-        version: [c_char; MAX_EXTENSION_NAME_SIZE],
-    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    pub fn version(mut self, version: [c_char; MAX_EXTENSION_NAME_SIZE]) -> Self {
         self.inner.version = version;
         self
     }
-    pub fn purposes(
-        mut self,
-        purposes: ToolPurposeFlagsEXT,
-    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    pub fn purposes(mut self, purposes: ToolPurposeFlagsEXT) -> Self {
         self.inner.purposes = purposes;
         self
     }
-    pub fn description(
-        mut self,
-        description: [c_char; MAX_DESCRIPTION_SIZE],
-    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    pub fn description(mut self, description: [c_char; MAX_DESCRIPTION_SIZE]) -> Self {
         self.inner.description = description;
         self
     }
-    pub fn layer(
-        mut self,
-        layer: [c_char; MAX_EXTENSION_NAME_SIZE],
-    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    pub fn layer(mut self, layer: [c_char; MAX_EXTENSION_NAME_SIZE]) -> Self {
         self.inner.layer = layer;
         self
     }
@@ -44128,10 +40915,7 @@ impl<'a> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPhysicalDeviceToolPropertiesEXT>(
-        mut self,
-        next: &'a mut T,
-    ) -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+    pub fn push_next<T: ExtendsPhysicalDeviceToolPropertiesEXT>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -44203,14 +40987,11 @@ impl<'a> ::std::ops::DerefMut for SamplerCustomBorderColorCreateInfoEXTBuilder<'
     }
 }
 impl<'a> SamplerCustomBorderColorCreateInfoEXTBuilder<'a> {
-    pub fn custom_border_color(
-        mut self,
-        custom_border_color: ClearColorValue,
-    ) -> SamplerCustomBorderColorCreateInfoEXTBuilder<'a> {
+    pub fn custom_border_color(mut self, custom_border_color: ClearColorValue) -> Self {
         self.inner.custom_border_color = custom_border_color;
         self
     }
-    pub fn format(mut self, format: Format) -> SamplerCustomBorderColorCreateInfoEXTBuilder<'a> {
+    pub fn format(mut self, format: Format) -> Self {
         self.inner.format = format;
         self
     }
@@ -44271,7 +41052,7 @@ impl<'a> PhysicalDeviceCustomBorderColorPropertiesEXTBuilder<'a> {
     pub fn max_custom_border_color_samplers(
         mut self,
         max_custom_border_color_samplers: u32,
-    ) -> PhysicalDeviceCustomBorderColorPropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.max_custom_border_color_samplers = max_custom_border_color_samplers;
         self
     }
@@ -44328,17 +41109,14 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceCustomBorderColorFeaturesEXTBuil
     }
 }
 impl<'a> PhysicalDeviceCustomBorderColorFeaturesEXTBuilder<'a> {
-    pub fn custom_border_colors(
-        mut self,
-        custom_border_colors: bool,
-    ) -> PhysicalDeviceCustomBorderColorFeaturesEXTBuilder<'a> {
+    pub fn custom_border_colors(mut self, custom_border_colors: bool) -> Self {
         self.inner.custom_border_colors = custom_border_colors.into();
         self
     }
     pub fn custom_border_color_without_format(
         mut self,
         custom_border_color_without_format: bool,
-    ) -> PhysicalDeviceCustomBorderColorFeaturesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.custom_border_color_without_format = custom_border_color_without_format.into();
         self
     }
@@ -44443,52 +41221,31 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureGeometryTrianglesDataKHRB
     }
 }
 impl<'a> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
-    pub fn vertex_format(
-        mut self,
-        vertex_format: Format,
-    ) -> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
+    pub fn vertex_format(mut self, vertex_format: Format) -> Self {
         self.inner.vertex_format = vertex_format;
         self
     }
-    pub fn vertex_data(
-        mut self,
-        vertex_data: DeviceOrHostAddressConstKHR,
-    ) -> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
+    pub fn vertex_data(mut self, vertex_data: DeviceOrHostAddressConstKHR) -> Self {
         self.inner.vertex_data = vertex_data;
         self
     }
-    pub fn vertex_stride(
-        mut self,
-        vertex_stride: DeviceSize,
-    ) -> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
+    pub fn vertex_stride(mut self, vertex_stride: DeviceSize) -> Self {
         self.inner.vertex_stride = vertex_stride;
         self
     }
-    pub fn max_vertex(
-        mut self,
-        max_vertex: u32,
-    ) -> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
+    pub fn max_vertex(mut self, max_vertex: u32) -> Self {
         self.inner.max_vertex = max_vertex;
         self
     }
-    pub fn index_type(
-        mut self,
-        index_type: IndexType,
-    ) -> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
+    pub fn index_type(mut self, index_type: IndexType) -> Self {
         self.inner.index_type = index_type;
         self
     }
-    pub fn index_data(
-        mut self,
-        index_data: DeviceOrHostAddressConstKHR,
-    ) -> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
+    pub fn index_data(mut self, index_data: DeviceOrHostAddressConstKHR) -> Self {
         self.inner.index_data = index_data;
         self
     }
-    pub fn transform_data(
-        mut self,
-        transform_data: DeviceOrHostAddressConstKHR,
-    ) -> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
+    pub fn transform_data(mut self, transform_data: DeviceOrHostAddressConstKHR) -> Self {
         self.inner.transform_data = transform_data;
         self
     }
@@ -44500,7 +41257,7 @@ impl<'a> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureGeometryTrianglesDataKHR>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureGeometryTrianglesDataKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -44571,17 +41328,11 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureGeometryAabbsDataKHRBuild
     }
 }
 impl<'a> AccelerationStructureGeometryAabbsDataKHRBuilder<'a> {
-    pub fn data(
-        mut self,
-        data: DeviceOrHostAddressConstKHR,
-    ) -> AccelerationStructureGeometryAabbsDataKHRBuilder<'a> {
+    pub fn data(mut self, data: DeviceOrHostAddressConstKHR) -> Self {
         self.inner.data = data;
         self
     }
-    pub fn stride(
-        mut self,
-        stride: DeviceSize,
-    ) -> AccelerationStructureGeometryAabbsDataKHRBuilder<'a> {
+    pub fn stride(mut self, stride: DeviceSize) -> Self {
         self.inner.stride = stride;
         self
     }
@@ -44593,7 +41344,7 @@ impl<'a> AccelerationStructureGeometryAabbsDataKHRBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureGeometryAabbsDataKHR>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureGeometryAabbsDataKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -44664,17 +41415,11 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureGeometryInstancesDataKHRB
     }
 }
 impl<'a> AccelerationStructureGeometryInstancesDataKHRBuilder<'a> {
-    pub fn array_of_pointers(
-        mut self,
-        array_of_pointers: bool,
-    ) -> AccelerationStructureGeometryInstancesDataKHRBuilder<'a> {
+    pub fn array_of_pointers(mut self, array_of_pointers: bool) -> Self {
         self.inner.array_of_pointers = array_of_pointers.into();
         self
     }
-    pub fn data(
-        mut self,
-        data: DeviceOrHostAddressConstKHR,
-    ) -> AccelerationStructureGeometryInstancesDataKHRBuilder<'a> {
+    pub fn data(mut self, data: DeviceOrHostAddressConstKHR) -> Self {
         self.inner.data = data;
         self
     }
@@ -44686,7 +41431,7 @@ impl<'a> AccelerationStructureGeometryInstancesDataKHRBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureGeometryInstancesDataKHR>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureGeometryInstancesDataKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -44773,21 +41518,15 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureGeometryKHRBuilder<'a> {
     }
 }
 impl<'a> AccelerationStructureGeometryKHRBuilder<'a> {
-    pub fn geometry_type(
-        mut self,
-        geometry_type: GeometryTypeKHR,
-    ) -> AccelerationStructureGeometryKHRBuilder<'a> {
+    pub fn geometry_type(mut self, geometry_type: GeometryTypeKHR) -> Self {
         self.inner.geometry_type = geometry_type;
         self
     }
-    pub fn geometry(
-        mut self,
-        geometry: AccelerationStructureGeometryDataKHR,
-    ) -> AccelerationStructureGeometryKHRBuilder<'a> {
+    pub fn geometry(mut self, geometry: AccelerationStructureGeometryDataKHR) -> Self {
         self.inner.geometry = geometry;
         self
     }
-    pub fn flags(mut self, flags: GeometryFlagsKHR) -> AccelerationStructureGeometryKHRBuilder<'a> {
+    pub fn flags(mut self, flags: GeometryFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -44799,7 +41538,7 @@ impl<'a> AccelerationStructureGeometryKHRBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureGeometryKHR>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureGeometryKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -44897,45 +41636,33 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureBuildGeometryInfoKHRBuild
     }
 }
 impl<'a> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
-    pub fn ty(
-        mut self,
-        ty: AccelerationStructureTypeKHR,
-    ) -> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
+    pub fn ty(mut self, ty: AccelerationStructureTypeKHR) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn flags(
-        mut self,
-        flags: BuildAccelerationStructureFlagsKHR,
-    ) -> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
+    pub fn flags(mut self, flags: BuildAccelerationStructureFlagsKHR) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn mode(
-        mut self,
-        mode: BuildAccelerationStructureModeKHR,
-    ) -> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
+    pub fn mode(mut self, mode: BuildAccelerationStructureModeKHR) -> Self {
         self.inner.mode = mode;
         self
     }
     pub fn src_acceleration_structure(
         mut self,
         src_acceleration_structure: AccelerationStructureKHR,
-    ) -> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.src_acceleration_structure = src_acceleration_structure;
         self
     }
     pub fn dst_acceleration_structure(
         mut self,
         dst_acceleration_structure: AccelerationStructureKHR,
-    ) -> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.dst_acceleration_structure = dst_acceleration_structure;
         self
     }
-    pub fn geometries(
-        mut self,
-        geometries: &'a [AccelerationStructureGeometryKHR],
-    ) -> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
+    pub fn geometries(mut self, geometries: &'a [AccelerationStructureGeometryKHR]) -> Self {
         self.inner.geometry_count = geometries.len() as _;
         self.inner.p_geometries = geometries.as_ptr();
         self
@@ -44943,15 +41670,12 @@ impl<'a> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
     pub fn geometries_ptrs(
         mut self,
         geometries: &'a [*const AccelerationStructureGeometryKHR],
-    ) -> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.geometry_count = geometries.len() as _;
         self.inner.pp_geometries = geometries.as_ptr();
         self
     }
-    pub fn scratch_data(
-        mut self,
-        scratch_data: DeviceOrHostAddressKHR,
-    ) -> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
+    pub fn scratch_data(mut self, scratch_data: DeviceOrHostAddressKHR) -> Self {
         self.inner.scratch_data = scratch_data;
         self
     }
@@ -44963,7 +41687,7 @@ impl<'a> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureBuildGeometryInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureBuildGeometryInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -45013,31 +41737,19 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureBuildRangeInfoKHRBuilder<
     }
 }
 impl<'a> AccelerationStructureBuildRangeInfoKHRBuilder<'a> {
-    pub fn primitive_count(
-        mut self,
-        primitive_count: u32,
-    ) -> AccelerationStructureBuildRangeInfoKHRBuilder<'a> {
+    pub fn primitive_count(mut self, primitive_count: u32) -> Self {
         self.inner.primitive_count = primitive_count;
         self
     }
-    pub fn primitive_offset(
-        mut self,
-        primitive_offset: u32,
-    ) -> AccelerationStructureBuildRangeInfoKHRBuilder<'a> {
+    pub fn primitive_offset(mut self, primitive_offset: u32) -> Self {
         self.inner.primitive_offset = primitive_offset;
         self
     }
-    pub fn first_vertex(
-        mut self,
-        first_vertex: u32,
-    ) -> AccelerationStructureBuildRangeInfoKHRBuilder<'a> {
+    pub fn first_vertex(mut self, first_vertex: u32) -> Self {
         self.inner.first_vertex = first_vertex;
         self
     }
-    pub fn transform_offset(
-        mut self,
-        transform_offset: u32,
-    ) -> AccelerationStructureBuildRangeInfoKHRBuilder<'a> {
+    pub fn transform_offset(mut self, transform_offset: u32) -> Self {
         self.inner.transform_offset = transform_offset;
         self
     }
@@ -45101,36 +41813,27 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureCreateInfoKHRBuilder<'a> 
     }
 }
 impl<'a> AccelerationStructureCreateInfoKHRBuilder<'a> {
-    pub fn create_flags(
-        mut self,
-        create_flags: AccelerationStructureCreateFlagsKHR,
-    ) -> AccelerationStructureCreateInfoKHRBuilder<'a> {
+    pub fn create_flags(mut self, create_flags: AccelerationStructureCreateFlagsKHR) -> Self {
         self.inner.create_flags = create_flags;
         self
     }
-    pub fn buffer(mut self, buffer: Buffer) -> AccelerationStructureCreateInfoKHRBuilder<'a> {
+    pub fn buffer(mut self, buffer: Buffer) -> Self {
         self.inner.buffer = buffer;
         self
     }
-    pub fn offset(mut self, offset: DeviceSize) -> AccelerationStructureCreateInfoKHRBuilder<'a> {
+    pub fn offset(mut self, offset: DeviceSize) -> Self {
         self.inner.offset = offset;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> AccelerationStructureCreateInfoKHRBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
-    pub fn ty(
-        mut self,
-        ty: AccelerationStructureTypeKHR,
-    ) -> AccelerationStructureCreateInfoKHRBuilder<'a> {
+    pub fn ty(mut self, ty: AccelerationStructureTypeKHR) -> Self {
         self.inner.ty = ty;
         self
     }
-    pub fn device_address(
-        mut self,
-        device_address: DeviceAddress,
-    ) -> AccelerationStructureCreateInfoKHRBuilder<'a> {
+    pub fn device_address(mut self, device_address: DeviceAddress) -> Self {
         self.inner.device_address = device_address;
         self
     }
@@ -45142,7 +41845,7 @@ impl<'a> AccelerationStructureCreateInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureCreateInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureCreateInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -45194,27 +41897,27 @@ impl<'a> ::std::ops::DerefMut for AabbPositionsKHRBuilder<'a> {
     }
 }
 impl<'a> AabbPositionsKHRBuilder<'a> {
-    pub fn min_x(mut self, min_x: f32) -> AabbPositionsKHRBuilder<'a> {
+    pub fn min_x(mut self, min_x: f32) -> Self {
         self.inner.min_x = min_x;
         self
     }
-    pub fn min_y(mut self, min_y: f32) -> AabbPositionsKHRBuilder<'a> {
+    pub fn min_y(mut self, min_y: f32) -> Self {
         self.inner.min_y = min_y;
         self
     }
-    pub fn min_z(mut self, min_z: f32) -> AabbPositionsKHRBuilder<'a> {
+    pub fn min_z(mut self, min_z: f32) -> Self {
         self.inner.min_z = min_z;
         self
     }
-    pub fn max_x(mut self, max_x: f32) -> AabbPositionsKHRBuilder<'a> {
+    pub fn max_x(mut self, max_x: f32) -> Self {
         self.inner.max_x = max_x;
         self
     }
-    pub fn max_y(mut self, max_y: f32) -> AabbPositionsKHRBuilder<'a> {
+    pub fn max_y(mut self, max_y: f32) -> Self {
         self.inner.max_y = max_y;
         self
     }
-    pub fn max_z(mut self, max_z: f32) -> AabbPositionsKHRBuilder<'a> {
+    pub fn max_z(mut self, max_z: f32) -> Self {
         self.inner.max_z = max_z;
         self
     }
@@ -45290,7 +41993,7 @@ impl<'a> AccelerationStructureDeviceAddressInfoKHRBuilder<'a> {
     pub fn acceleration_structure(
         mut self,
         acceleration_structure: AccelerationStructureKHR,
-    ) -> AccelerationStructureDeviceAddressInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.acceleration_structure = acceleration_structure;
         self
     }
@@ -45302,7 +42005,7 @@ impl<'a> AccelerationStructureDeviceAddressInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureDeviceAddressInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureDeviceAddressInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -45361,10 +42064,7 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureVersionInfoKHRBuilder<'a>
     }
 }
 impl<'a> AccelerationStructureVersionInfoKHRBuilder<'a> {
-    pub fn version_data(
-        mut self,
-        version_data: &'a [u8; 2 * UUID_SIZE],
-    ) -> AccelerationStructureVersionInfoKHRBuilder<'a> {
+    pub fn version_data(mut self, version_data: &'a [u8; 2 * UUID_SIZE]) -> Self {
         self.inner.p_version_data = version_data.as_ptr();
         self
     }
@@ -45376,7 +42076,7 @@ impl<'a> AccelerationStructureVersionInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureVersionInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureVersionInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -45439,24 +42139,15 @@ impl<'a> ::std::ops::DerefMut for CopyAccelerationStructureInfoKHRBuilder<'a> {
     }
 }
 impl<'a> CopyAccelerationStructureInfoKHRBuilder<'a> {
-    pub fn src(
-        mut self,
-        src: AccelerationStructureKHR,
-    ) -> CopyAccelerationStructureInfoKHRBuilder<'a> {
+    pub fn src(mut self, src: AccelerationStructureKHR) -> Self {
         self.inner.src = src;
         self
     }
-    pub fn dst(
-        mut self,
-        dst: AccelerationStructureKHR,
-    ) -> CopyAccelerationStructureInfoKHRBuilder<'a> {
+    pub fn dst(mut self, dst: AccelerationStructureKHR) -> Self {
         self.inner.dst = dst;
         self
     }
-    pub fn mode(
-        mut self,
-        mode: CopyAccelerationStructureModeKHR,
-    ) -> CopyAccelerationStructureInfoKHRBuilder<'a> {
+    pub fn mode(mut self, mode: CopyAccelerationStructureModeKHR) -> Self {
         self.inner.mode = mode;
         self
     }
@@ -45468,7 +42159,7 @@ impl<'a> CopyAccelerationStructureInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsCopyAccelerationStructureInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> CopyAccelerationStructureInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -45542,24 +42233,15 @@ impl<'a> ::std::ops::DerefMut for CopyAccelerationStructureToMemoryInfoKHRBuilde
     }
 }
 impl<'a> CopyAccelerationStructureToMemoryInfoKHRBuilder<'a> {
-    pub fn src(
-        mut self,
-        src: AccelerationStructureKHR,
-    ) -> CopyAccelerationStructureToMemoryInfoKHRBuilder<'a> {
+    pub fn src(mut self, src: AccelerationStructureKHR) -> Self {
         self.inner.src = src;
         self
     }
-    pub fn dst(
-        mut self,
-        dst: DeviceOrHostAddressKHR,
-    ) -> CopyAccelerationStructureToMemoryInfoKHRBuilder<'a> {
+    pub fn dst(mut self, dst: DeviceOrHostAddressKHR) -> Self {
         self.inner.dst = dst;
         self
     }
-    pub fn mode(
-        mut self,
-        mode: CopyAccelerationStructureModeKHR,
-    ) -> CopyAccelerationStructureToMemoryInfoKHRBuilder<'a> {
+    pub fn mode(mut self, mode: CopyAccelerationStructureModeKHR) -> Self {
         self.inner.mode = mode;
         self
     }
@@ -45571,7 +42253,7 @@ impl<'a> CopyAccelerationStructureToMemoryInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsCopyAccelerationStructureToMemoryInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> CopyAccelerationStructureToMemoryInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -45645,24 +42327,15 @@ impl<'a> ::std::ops::DerefMut for CopyMemoryToAccelerationStructureInfoKHRBuilde
     }
 }
 impl<'a> CopyMemoryToAccelerationStructureInfoKHRBuilder<'a> {
-    pub fn src(
-        mut self,
-        src: DeviceOrHostAddressConstKHR,
-    ) -> CopyMemoryToAccelerationStructureInfoKHRBuilder<'a> {
+    pub fn src(mut self, src: DeviceOrHostAddressConstKHR) -> Self {
         self.inner.src = src;
         self
     }
-    pub fn dst(
-        mut self,
-        dst: AccelerationStructureKHR,
-    ) -> CopyMemoryToAccelerationStructureInfoKHRBuilder<'a> {
+    pub fn dst(mut self, dst: AccelerationStructureKHR) -> Self {
         self.inner.dst = dst;
         self
     }
-    pub fn mode(
-        mut self,
-        mode: CopyAccelerationStructureModeKHR,
-    ) -> CopyMemoryToAccelerationStructureInfoKHRBuilder<'a> {
+    pub fn mode(mut self, mode: CopyAccelerationStructureModeKHR) -> Self {
         self.inner.mode = mode;
         self
     }
@@ -45674,7 +42347,7 @@ impl<'a> CopyMemoryToAccelerationStructureInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsCopyMemoryToAccelerationStructureInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> CopyMemoryToAccelerationStructureInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -45735,17 +42408,14 @@ impl<'a> ::std::ops::DerefMut for RayTracingPipelineInterfaceCreateInfoKHRBuilde
     }
 }
 impl<'a> RayTracingPipelineInterfaceCreateInfoKHRBuilder<'a> {
-    pub fn max_pipeline_ray_payload_size(
-        mut self,
-        max_pipeline_ray_payload_size: u32,
-    ) -> RayTracingPipelineInterfaceCreateInfoKHRBuilder<'a> {
+    pub fn max_pipeline_ray_payload_size(mut self, max_pipeline_ray_payload_size: u32) -> Self {
         self.inner.max_pipeline_ray_payload_size = max_pipeline_ray_payload_size;
         self
     }
     pub fn max_pipeline_ray_hit_attribute_size(
         mut self,
         max_pipeline_ray_hit_attribute_size: u32,
-    ) -> RayTracingPipelineInterfaceCreateInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.max_pipeline_ray_hit_attribute_size = max_pipeline_ray_hit_attribute_size;
         self
     }
@@ -45757,7 +42427,7 @@ impl<'a> RayTracingPipelineInterfaceCreateInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsRayTracingPipelineInterfaceCreateInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> RayTracingPipelineInterfaceCreateInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -45818,10 +42488,7 @@ impl<'a> ::std::ops::DerefMut for PipelineLibraryCreateInfoKHRBuilder<'a> {
     }
 }
 impl<'a> PipelineLibraryCreateInfoKHRBuilder<'a> {
-    pub fn libraries(
-        mut self,
-        libraries: &'a [Pipeline],
-    ) -> PipelineLibraryCreateInfoKHRBuilder<'a> {
+    pub fn libraries(mut self, libraries: &'a [Pipeline]) -> Self {
         self.inner.library_count = libraries.len() as _;
         self.inner.p_libraries = libraries.as_ptr();
         self
@@ -45831,10 +42498,7 @@ impl<'a> PipelineLibraryCreateInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsPipelineLibraryCreateInfoKHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> PipelineLibraryCreateInfoKHRBuilder<'a> {
+    pub fn push_next<T: ExtendsPipelineLibraryCreateInfoKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -45894,10 +42558,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceExtendedDynamicStateFeaturesEXTB
     }
 }
 impl<'a> PhysicalDeviceExtendedDynamicStateFeaturesEXTBuilder<'a> {
-    pub fn extended_dynamic_state(
-        mut self,
-        extended_dynamic_state: bool,
-    ) -> PhysicalDeviceExtendedDynamicStateFeaturesEXTBuilder<'a> {
+    pub fn extended_dynamic_state(mut self, extended_dynamic_state: bool) -> Self {
         self.inner.extended_dynamic_state = extended_dynamic_state.into();
         self
     }
@@ -45952,10 +42613,7 @@ impl<'a> ::std::ops::DerefMut for RenderPassTransformBeginInfoQCOMBuilder<'a> {
     }
 }
 impl<'a> RenderPassTransformBeginInfoQCOMBuilder<'a> {
-    pub fn transform(
-        mut self,
-        transform: SurfaceTransformFlagsKHR,
-    ) -> RenderPassTransformBeginInfoQCOMBuilder<'a> {
+    pub fn transform(mut self, transform: SurfaceTransformFlagsKHR) -> Self {
         self.inner.transform = transform;
         self
     }
@@ -46012,10 +42670,7 @@ impl<'a> ::std::ops::DerefMut for CopyCommandTransformInfoQCOMBuilder<'a> {
     }
 }
 impl<'a> CopyCommandTransformInfoQCOMBuilder<'a> {
-    pub fn transform(
-        mut self,
-        transform: SurfaceTransformFlagsKHR,
-    ) -> CopyCommandTransformInfoQCOMBuilder<'a> {
+    pub fn transform(mut self, transform: SurfaceTransformFlagsKHR) -> Self {
         self.inner.transform = transform;
         self
     }
@@ -46078,17 +42733,11 @@ impl<'a> ::std::ops::DerefMut for CommandBufferInheritanceRenderPassTransformInf
     }
 }
 impl<'a> CommandBufferInheritanceRenderPassTransformInfoQCOMBuilder<'a> {
-    pub fn transform(
-        mut self,
-        transform: SurfaceTransformFlagsKHR,
-    ) -> CommandBufferInheritanceRenderPassTransformInfoQCOMBuilder<'a> {
+    pub fn transform(mut self, transform: SurfaceTransformFlagsKHR) -> Self {
         self.inner.transform = transform;
         self
     }
-    pub fn render_area(
-        mut self,
-        render_area: Rect2D,
-    ) -> CommandBufferInheritanceRenderPassTransformInfoQCOMBuilder<'a> {
+    pub fn render_area(mut self, render_area: Rect2D) -> Self {
         self.inner.render_area = render_area;
         self
     }
@@ -46143,10 +42792,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceDiagnosticsConfigFeaturesNVBuild
     }
 }
 impl<'a> PhysicalDeviceDiagnosticsConfigFeaturesNVBuilder<'a> {
-    pub fn diagnostics_config(
-        mut self,
-        diagnostics_config: bool,
-    ) -> PhysicalDeviceDiagnosticsConfigFeaturesNVBuilder<'a> {
+    pub fn diagnostics_config(mut self, diagnostics_config: bool) -> Self {
         self.inner.diagnostics_config = diagnostics_config.into();
         self
     }
@@ -46201,10 +42847,7 @@ impl<'a> ::std::ops::DerefMut for DeviceDiagnosticsConfigCreateInfoNVBuilder<'a>
     }
 }
 impl<'a> DeviceDiagnosticsConfigCreateInfoNVBuilder<'a> {
-    pub fn flags(
-        mut self,
-        flags: DeviceDiagnosticsConfigFlagsNV,
-    ) -> DeviceDiagnosticsConfigCreateInfoNVBuilder<'a> {
+    pub fn flags(mut self, flags: DeviceDiagnosticsConfigFlagsNV) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -46267,7 +42910,7 @@ impl<'a> PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'a> {
     pub fn shader_zero_initialize_workgroup_memory(
         mut self,
         shader_zero_initialize_workgroup_memory: bool,
-    ) -> PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.shader_zero_initialize_workgroup_memory =
             shader_zero_initialize_workgroup_memory.into();
         self
@@ -46327,24 +42970,15 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceRobustness2FeaturesEXTBuilder<'a
     }
 }
 impl<'a> PhysicalDeviceRobustness2FeaturesEXTBuilder<'a> {
-    pub fn robust_buffer_access2(
-        mut self,
-        robust_buffer_access2: bool,
-    ) -> PhysicalDeviceRobustness2FeaturesEXTBuilder<'a> {
+    pub fn robust_buffer_access2(mut self, robust_buffer_access2: bool) -> Self {
         self.inner.robust_buffer_access2 = robust_buffer_access2.into();
         self
     }
-    pub fn robust_image_access2(
-        mut self,
-        robust_image_access2: bool,
-    ) -> PhysicalDeviceRobustness2FeaturesEXTBuilder<'a> {
+    pub fn robust_image_access2(mut self, robust_image_access2: bool) -> Self {
         self.inner.robust_image_access2 = robust_image_access2.into();
         self
     }
-    pub fn null_descriptor(
-        mut self,
-        null_descriptor: bool,
-    ) -> PhysicalDeviceRobustness2FeaturesEXTBuilder<'a> {
+    pub fn null_descriptor(mut self, null_descriptor: bool) -> Self {
         self.inner.null_descriptor = null_descriptor.into();
         self
     }
@@ -46404,7 +43038,7 @@ impl<'a> PhysicalDeviceRobustness2PropertiesEXTBuilder<'a> {
     pub fn robust_storage_buffer_access_size_alignment(
         mut self,
         robust_storage_buffer_access_size_alignment: DeviceSize,
-    ) -> PhysicalDeviceRobustness2PropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.robust_storage_buffer_access_size_alignment =
             robust_storage_buffer_access_size_alignment;
         self
@@ -46412,7 +43046,7 @@ impl<'a> PhysicalDeviceRobustness2PropertiesEXTBuilder<'a> {
     pub fn robust_uniform_buffer_access_size_alignment(
         mut self,
         robust_uniform_buffer_access_size_alignment: DeviceSize,
-    ) -> PhysicalDeviceRobustness2PropertiesEXTBuilder<'a> {
+    ) -> Self {
         self.inner.robust_uniform_buffer_access_size_alignment =
             robust_uniform_buffer_access_size_alignment;
         self
@@ -46468,10 +43102,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceImageRobustnessFeaturesEXTBuilde
     }
 }
 impl<'a> PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'a> {
-    pub fn robust_image_access(
-        mut self,
-        robust_image_access: bool,
-    ) -> PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'a> {
+    pub fn robust_image_access(mut self, robust_image_access: bool) -> Self {
         self.inner.robust_image_access = robust_image_access.into();
         self
     }
@@ -46540,14 +43171,14 @@ impl<'a> PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHRBuilder<'a> {
     pub fn workgroup_memory_explicit_layout(
         mut self,
         workgroup_memory_explicit_layout: bool,
-    ) -> PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.workgroup_memory_explicit_layout = workgroup_memory_explicit_layout.into();
         self
     }
     pub fn workgroup_memory_explicit_layout_scalar_block_layout(
         mut self,
         workgroup_memory_explicit_layout_scalar_block_layout: bool,
-    ) -> PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .workgroup_memory_explicit_layout_scalar_block_layout =
             workgroup_memory_explicit_layout_scalar_block_layout.into();
@@ -46556,7 +43187,7 @@ impl<'a> PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHRBuilder<'a> {
     pub fn workgroup_memory_explicit_layout8_bit_access(
         mut self,
         workgroup_memory_explicit_layout8_bit_access: bool,
-    ) -> PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.workgroup_memory_explicit_layout8_bit_access =
             workgroup_memory_explicit_layout8_bit_access.into();
         self
@@ -46564,7 +43195,7 @@ impl<'a> PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHRBuilder<'a> {
     pub fn workgroup_memory_explicit_layout16_bit_access(
         mut self,
         workgroup_memory_explicit_layout16_bit_access: bool,
-    ) -> PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.workgroup_memory_explicit_layout16_bit_access =
             workgroup_memory_explicit_layout16_bit_access.into();
         self
@@ -46651,103 +43282,73 @@ impl<'a> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
     pub fn constant_alpha_color_blend_factors(
         mut self,
         constant_alpha_color_blend_factors: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.constant_alpha_color_blend_factors = constant_alpha_color_blend_factors.into();
         self
     }
-    pub fn events(mut self, events: bool) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn events(mut self, events: bool) -> Self {
         self.inner.events = events.into();
         self
     }
     pub fn image_view_format_reinterpretation(
         mut self,
         image_view_format_reinterpretation: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.image_view_format_reinterpretation = image_view_format_reinterpretation.into();
         self
     }
-    pub fn image_view_format_swizzle(
-        mut self,
-        image_view_format_swizzle: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn image_view_format_swizzle(mut self, image_view_format_swizzle: bool) -> Self {
         self.inner.image_view_format_swizzle = image_view_format_swizzle.into();
         self
     }
-    pub fn image_view2_d_on3_d_image(
-        mut self,
-        image_view2_d_on3_d_image: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn image_view2_d_on3_d_image(mut self, image_view2_d_on3_d_image: bool) -> Self {
         self.inner.image_view2_d_on3_d_image = image_view2_d_on3_d_image.into();
         self
     }
-    pub fn multisample_array_image(
-        mut self,
-        multisample_array_image: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn multisample_array_image(mut self, multisample_array_image: bool) -> Self {
         self.inner.multisample_array_image = multisample_array_image.into();
         self
     }
-    pub fn mutable_comparison_samplers(
-        mut self,
-        mutable_comparison_samplers: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn mutable_comparison_samplers(mut self, mutable_comparison_samplers: bool) -> Self {
         self.inner.mutable_comparison_samplers = mutable_comparison_samplers.into();
         self
     }
-    pub fn point_polygons(
-        mut self,
-        point_polygons: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn point_polygons(mut self, point_polygons: bool) -> Self {
         self.inner.point_polygons = point_polygons.into();
         self
     }
-    pub fn sampler_mip_lod_bias(
-        mut self,
-        sampler_mip_lod_bias: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn sampler_mip_lod_bias(mut self, sampler_mip_lod_bias: bool) -> Self {
         self.inner.sampler_mip_lod_bias = sampler_mip_lod_bias.into();
         self
     }
-    pub fn separate_stencil_mask_ref(
-        mut self,
-        separate_stencil_mask_ref: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn separate_stencil_mask_ref(mut self, separate_stencil_mask_ref: bool) -> Self {
         self.inner.separate_stencil_mask_ref = separate_stencil_mask_ref.into();
         self
     }
     pub fn shader_sample_rate_interpolation_functions(
         mut self,
         shader_sample_rate_interpolation_functions: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.shader_sample_rate_interpolation_functions =
             shader_sample_rate_interpolation_functions.into();
         self
     }
-    pub fn tessellation_isolines(
-        mut self,
-        tessellation_isolines: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn tessellation_isolines(mut self, tessellation_isolines: bool) -> Self {
         self.inner.tessellation_isolines = tessellation_isolines.into();
         self
     }
-    pub fn tessellation_point_mode(
-        mut self,
-        tessellation_point_mode: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn tessellation_point_mode(mut self, tessellation_point_mode: bool) -> Self {
         self.inner.tessellation_point_mode = tessellation_point_mode.into();
         self
     }
-    pub fn triangle_fans(
-        mut self,
-        triangle_fans: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    pub fn triangle_fans(mut self, triangle_fans: bool) -> Self {
         self.inner.triangle_fans = triangle_fans.into();
         self
     }
     pub fn vertex_attribute_access_beyond_stride(
         mut self,
         vertex_attribute_access_beyond_stride: bool,
-    ) -> PhysicalDevicePortabilitySubsetFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.vertex_attribute_access_beyond_stride =
             vertex_attribute_access_beyond_stride.into();
         self
@@ -46809,7 +43410,7 @@ impl<'a> PhysicalDevicePortabilitySubsetPropertiesKHRBuilder<'a> {
     pub fn min_vertex_input_binding_stride_alignment(
         mut self,
         min_vertex_input_binding_stride_alignment: u32,
-    ) -> PhysicalDevicePortabilitySubsetPropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.min_vertex_input_binding_stride_alignment =
             min_vertex_input_binding_stride_alignment;
         self
@@ -46867,17 +43468,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDevice4444FormatsFeaturesEXTBuilder<'a
     }
 }
 impl<'a> PhysicalDevice4444FormatsFeaturesEXTBuilder<'a> {
-    pub fn format_a4r4g4b4(
-        mut self,
-        format_a4r4g4b4: bool,
-    ) -> PhysicalDevice4444FormatsFeaturesEXTBuilder<'a> {
+    pub fn format_a4r4g4b4(mut self, format_a4r4g4b4: bool) -> Self {
         self.inner.format_a4r4g4b4 = format_a4r4g4b4.into();
         self
     }
-    pub fn format_a4b4g4r4(
-        mut self,
-        format_a4b4g4r4: bool,
-    ) -> PhysicalDevice4444FormatsFeaturesEXTBuilder<'a> {
+    pub fn format_a4b4g4r4(mut self, format_a4b4g4r4: bool) -> Self {
         self.inner.format_a4b4g4r4 = format_a4b4g4r4.into();
         self
     }
@@ -46935,15 +43530,15 @@ impl<'a> ::std::ops::DerefMut for BufferCopy2KHRBuilder<'a> {
     }
 }
 impl<'a> BufferCopy2KHRBuilder<'a> {
-    pub fn src_offset(mut self, src_offset: DeviceSize) -> BufferCopy2KHRBuilder<'a> {
+    pub fn src_offset(mut self, src_offset: DeviceSize) -> Self {
         self.inner.src_offset = src_offset;
         self
     }
-    pub fn dst_offset(mut self, dst_offset: DeviceSize) -> BufferCopy2KHRBuilder<'a> {
+    pub fn dst_offset(mut self, dst_offset: DeviceSize) -> Self {
         self.inner.dst_offset = dst_offset;
         self
     }
-    pub fn size(mut self, size: DeviceSize) -> BufferCopy2KHRBuilder<'a> {
+    pub fn size(mut self, size: DeviceSize) -> Self {
         self.inner.size = size;
         self
     }
@@ -46952,10 +43547,7 @@ impl<'a> BufferCopy2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBufferCopy2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> BufferCopy2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsBufferCopy2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47022,29 +43614,23 @@ impl<'a> ::std::ops::DerefMut for ImageCopy2KHRBuilder<'a> {
     }
 }
 impl<'a> ImageCopy2KHRBuilder<'a> {
-    pub fn src_subresource(
-        mut self,
-        src_subresource: ImageSubresourceLayers,
-    ) -> ImageCopy2KHRBuilder<'a> {
+    pub fn src_subresource(mut self, src_subresource: ImageSubresourceLayers) -> Self {
         self.inner.src_subresource = src_subresource;
         self
     }
-    pub fn src_offset(mut self, src_offset: Offset3D) -> ImageCopy2KHRBuilder<'a> {
+    pub fn src_offset(mut self, src_offset: Offset3D) -> Self {
         self.inner.src_offset = src_offset;
         self
     }
-    pub fn dst_subresource(
-        mut self,
-        dst_subresource: ImageSubresourceLayers,
-    ) -> ImageCopy2KHRBuilder<'a> {
+    pub fn dst_subresource(mut self, dst_subresource: ImageSubresourceLayers) -> Self {
         self.inner.dst_subresource = dst_subresource;
         self
     }
-    pub fn dst_offset(mut self, dst_offset: Offset3D) -> ImageCopy2KHRBuilder<'a> {
+    pub fn dst_offset(mut self, dst_offset: Offset3D) -> Self {
         self.inner.dst_offset = dst_offset;
         self
     }
-    pub fn extent(mut self, extent: Extent3D) -> ImageCopy2KHRBuilder<'a> {
+    pub fn extent(mut self, extent: Extent3D) -> Self {
         self.inner.extent = extent;
         self
     }
@@ -47053,10 +43639,7 @@ impl<'a> ImageCopy2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageCopy2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageCopy2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsImageCopy2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47121,25 +43704,19 @@ impl<'a> ::std::ops::DerefMut for ImageBlit2KHRBuilder<'a> {
     }
 }
 impl<'a> ImageBlit2KHRBuilder<'a> {
-    pub fn src_subresource(
-        mut self,
-        src_subresource: ImageSubresourceLayers,
-    ) -> ImageBlit2KHRBuilder<'a> {
+    pub fn src_subresource(mut self, src_subresource: ImageSubresourceLayers) -> Self {
         self.inner.src_subresource = src_subresource;
         self
     }
-    pub fn src_offsets(mut self, src_offsets: [Offset3D; 2]) -> ImageBlit2KHRBuilder<'a> {
+    pub fn src_offsets(mut self, src_offsets: [Offset3D; 2]) -> Self {
         self.inner.src_offsets = src_offsets;
         self
     }
-    pub fn dst_subresource(
-        mut self,
-        dst_subresource: ImageSubresourceLayers,
-    ) -> ImageBlit2KHRBuilder<'a> {
+    pub fn dst_subresource(mut self, dst_subresource: ImageSubresourceLayers) -> Self {
         self.inner.dst_subresource = dst_subresource;
         self
     }
-    pub fn dst_offsets(mut self, dst_offsets: [Offset3D; 2]) -> ImageBlit2KHRBuilder<'a> {
+    pub fn dst_offsets(mut self, dst_offsets: [Offset3D; 2]) -> Self {
         self.inner.dst_offsets = dst_offsets;
         self
     }
@@ -47148,10 +43725,7 @@ impl<'a> ImageBlit2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageBlit2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageBlit2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsImageBlit2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47220,33 +43794,27 @@ impl<'a> ::std::ops::DerefMut for BufferImageCopy2KHRBuilder<'a> {
     }
 }
 impl<'a> BufferImageCopy2KHRBuilder<'a> {
-    pub fn buffer_offset(mut self, buffer_offset: DeviceSize) -> BufferImageCopy2KHRBuilder<'a> {
+    pub fn buffer_offset(mut self, buffer_offset: DeviceSize) -> Self {
         self.inner.buffer_offset = buffer_offset;
         self
     }
-    pub fn buffer_row_length(mut self, buffer_row_length: u32) -> BufferImageCopy2KHRBuilder<'a> {
+    pub fn buffer_row_length(mut self, buffer_row_length: u32) -> Self {
         self.inner.buffer_row_length = buffer_row_length;
         self
     }
-    pub fn buffer_image_height(
-        mut self,
-        buffer_image_height: u32,
-    ) -> BufferImageCopy2KHRBuilder<'a> {
+    pub fn buffer_image_height(mut self, buffer_image_height: u32) -> Self {
         self.inner.buffer_image_height = buffer_image_height;
         self
     }
-    pub fn image_subresource(
-        mut self,
-        image_subresource: ImageSubresourceLayers,
-    ) -> BufferImageCopy2KHRBuilder<'a> {
+    pub fn image_subresource(mut self, image_subresource: ImageSubresourceLayers) -> Self {
         self.inner.image_subresource = image_subresource;
         self
     }
-    pub fn image_offset(mut self, image_offset: Offset3D) -> BufferImageCopy2KHRBuilder<'a> {
+    pub fn image_offset(mut self, image_offset: Offset3D) -> Self {
         self.inner.image_offset = image_offset;
         self
     }
-    pub fn image_extent(mut self, image_extent: Extent3D) -> BufferImageCopy2KHRBuilder<'a> {
+    pub fn image_extent(mut self, image_extent: Extent3D) -> Self {
         self.inner.image_extent = image_extent;
         self
     }
@@ -47255,10 +43823,7 @@ impl<'a> BufferImageCopy2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBufferImageCopy2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> BufferImageCopy2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsBufferImageCopy2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47325,29 +43890,23 @@ impl<'a> ::std::ops::DerefMut for ImageResolve2KHRBuilder<'a> {
     }
 }
 impl<'a> ImageResolve2KHRBuilder<'a> {
-    pub fn src_subresource(
-        mut self,
-        src_subresource: ImageSubresourceLayers,
-    ) -> ImageResolve2KHRBuilder<'a> {
+    pub fn src_subresource(mut self, src_subresource: ImageSubresourceLayers) -> Self {
         self.inner.src_subresource = src_subresource;
         self
     }
-    pub fn src_offset(mut self, src_offset: Offset3D) -> ImageResolve2KHRBuilder<'a> {
+    pub fn src_offset(mut self, src_offset: Offset3D) -> Self {
         self.inner.src_offset = src_offset;
         self
     }
-    pub fn dst_subresource(
-        mut self,
-        dst_subresource: ImageSubresourceLayers,
-    ) -> ImageResolve2KHRBuilder<'a> {
+    pub fn dst_subresource(mut self, dst_subresource: ImageSubresourceLayers) -> Self {
         self.inner.dst_subresource = dst_subresource;
         self
     }
-    pub fn dst_offset(mut self, dst_offset: Offset3D) -> ImageResolve2KHRBuilder<'a> {
+    pub fn dst_offset(mut self, dst_offset: Offset3D) -> Self {
         self.inner.dst_offset = dst_offset;
         self
     }
-    pub fn extent(mut self, extent: Extent3D) -> ImageResolve2KHRBuilder<'a> {
+    pub fn extent(mut self, extent: Extent3D) -> Self {
         self.inner.extent = extent;
         self
     }
@@ -47356,10 +43915,7 @@ impl<'a> ImageResolve2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageResolve2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> ImageResolve2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsImageResolve2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47424,15 +43980,15 @@ impl<'a> ::std::ops::DerefMut for CopyBufferInfo2KHRBuilder<'a> {
     }
 }
 impl<'a> CopyBufferInfo2KHRBuilder<'a> {
-    pub fn src_buffer(mut self, src_buffer: Buffer) -> CopyBufferInfo2KHRBuilder<'a> {
+    pub fn src_buffer(mut self, src_buffer: Buffer) -> Self {
         self.inner.src_buffer = src_buffer;
         self
     }
-    pub fn dst_buffer(mut self, dst_buffer: Buffer) -> CopyBufferInfo2KHRBuilder<'a> {
+    pub fn dst_buffer(mut self, dst_buffer: Buffer) -> Self {
         self.inner.dst_buffer = dst_buffer;
         self
     }
-    pub fn regions(mut self, regions: &'a [BufferCopy2KHR]) -> CopyBufferInfo2KHRBuilder<'a> {
+    pub fn regions(mut self, regions: &'a [BufferCopy2KHR]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -47442,10 +43998,7 @@ impl<'a> CopyBufferInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCopyBufferInfo2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> CopyBufferInfo2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsCopyBufferInfo2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47514,29 +44067,23 @@ impl<'a> ::std::ops::DerefMut for CopyImageInfo2KHRBuilder<'a> {
     }
 }
 impl<'a> CopyImageInfo2KHRBuilder<'a> {
-    pub fn src_image(mut self, src_image: Image) -> CopyImageInfo2KHRBuilder<'a> {
+    pub fn src_image(mut self, src_image: Image) -> Self {
         self.inner.src_image = src_image;
         self
     }
-    pub fn src_image_layout(
-        mut self,
-        src_image_layout: ImageLayout,
-    ) -> CopyImageInfo2KHRBuilder<'a> {
+    pub fn src_image_layout(mut self, src_image_layout: ImageLayout) -> Self {
         self.inner.src_image_layout = src_image_layout;
         self
     }
-    pub fn dst_image(mut self, dst_image: Image) -> CopyImageInfo2KHRBuilder<'a> {
+    pub fn dst_image(mut self, dst_image: Image) -> Self {
         self.inner.dst_image = dst_image;
         self
     }
-    pub fn dst_image_layout(
-        mut self,
-        dst_image_layout: ImageLayout,
-    ) -> CopyImageInfo2KHRBuilder<'a> {
+    pub fn dst_image_layout(mut self, dst_image_layout: ImageLayout) -> Self {
         self.inner.dst_image_layout = dst_image_layout;
         self
     }
-    pub fn regions(mut self, regions: &'a [ImageCopy2KHR]) -> CopyImageInfo2KHRBuilder<'a> {
+    pub fn regions(mut self, regions: &'a [ImageCopy2KHR]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -47546,10 +44093,7 @@ impl<'a> CopyImageInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCopyImageInfo2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> CopyImageInfo2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsCopyImageInfo2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47620,34 +44164,28 @@ impl<'a> ::std::ops::DerefMut for BlitImageInfo2KHRBuilder<'a> {
     }
 }
 impl<'a> BlitImageInfo2KHRBuilder<'a> {
-    pub fn src_image(mut self, src_image: Image) -> BlitImageInfo2KHRBuilder<'a> {
+    pub fn src_image(mut self, src_image: Image) -> Self {
         self.inner.src_image = src_image;
         self
     }
-    pub fn src_image_layout(
-        mut self,
-        src_image_layout: ImageLayout,
-    ) -> BlitImageInfo2KHRBuilder<'a> {
+    pub fn src_image_layout(mut self, src_image_layout: ImageLayout) -> Self {
         self.inner.src_image_layout = src_image_layout;
         self
     }
-    pub fn dst_image(mut self, dst_image: Image) -> BlitImageInfo2KHRBuilder<'a> {
+    pub fn dst_image(mut self, dst_image: Image) -> Self {
         self.inner.dst_image = dst_image;
         self
     }
-    pub fn dst_image_layout(
-        mut self,
-        dst_image_layout: ImageLayout,
-    ) -> BlitImageInfo2KHRBuilder<'a> {
+    pub fn dst_image_layout(mut self, dst_image_layout: ImageLayout) -> Self {
         self.inner.dst_image_layout = dst_image_layout;
         self
     }
-    pub fn regions(mut self, regions: &'a [ImageBlit2KHR]) -> BlitImageInfo2KHRBuilder<'a> {
+    pub fn regions(mut self, regions: &'a [ImageBlit2KHR]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
     }
-    pub fn filter(mut self, filter: Filter) -> BlitImageInfo2KHRBuilder<'a> {
+    pub fn filter(mut self, filter: Filter) -> Self {
         self.inner.filter = filter;
         self
     }
@@ -47656,10 +44194,7 @@ impl<'a> BlitImageInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBlitImageInfo2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> BlitImageInfo2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsBlitImageInfo2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47726,25 +44261,19 @@ impl<'a> ::std::ops::DerefMut for CopyBufferToImageInfo2KHRBuilder<'a> {
     }
 }
 impl<'a> CopyBufferToImageInfo2KHRBuilder<'a> {
-    pub fn src_buffer(mut self, src_buffer: Buffer) -> CopyBufferToImageInfo2KHRBuilder<'a> {
+    pub fn src_buffer(mut self, src_buffer: Buffer) -> Self {
         self.inner.src_buffer = src_buffer;
         self
     }
-    pub fn dst_image(mut self, dst_image: Image) -> CopyBufferToImageInfo2KHRBuilder<'a> {
+    pub fn dst_image(mut self, dst_image: Image) -> Self {
         self.inner.dst_image = dst_image;
         self
     }
-    pub fn dst_image_layout(
-        mut self,
-        dst_image_layout: ImageLayout,
-    ) -> CopyBufferToImageInfo2KHRBuilder<'a> {
+    pub fn dst_image_layout(mut self, dst_image_layout: ImageLayout) -> Self {
         self.inner.dst_image_layout = dst_image_layout;
         self
     }
-    pub fn regions(
-        mut self,
-        regions: &'a [BufferImageCopy2KHR],
-    ) -> CopyBufferToImageInfo2KHRBuilder<'a> {
+    pub fn regions(mut self, regions: &'a [BufferImageCopy2KHR]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -47754,10 +44283,7 @@ impl<'a> CopyBufferToImageInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCopyBufferToImageInfo2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> CopyBufferToImageInfo2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsCopyBufferToImageInfo2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47824,25 +44350,19 @@ impl<'a> ::std::ops::DerefMut for CopyImageToBufferInfo2KHRBuilder<'a> {
     }
 }
 impl<'a> CopyImageToBufferInfo2KHRBuilder<'a> {
-    pub fn src_image(mut self, src_image: Image) -> CopyImageToBufferInfo2KHRBuilder<'a> {
+    pub fn src_image(mut self, src_image: Image) -> Self {
         self.inner.src_image = src_image;
         self
     }
-    pub fn src_image_layout(
-        mut self,
-        src_image_layout: ImageLayout,
-    ) -> CopyImageToBufferInfo2KHRBuilder<'a> {
+    pub fn src_image_layout(mut self, src_image_layout: ImageLayout) -> Self {
         self.inner.src_image_layout = src_image_layout;
         self
     }
-    pub fn dst_buffer(mut self, dst_buffer: Buffer) -> CopyImageToBufferInfo2KHRBuilder<'a> {
+    pub fn dst_buffer(mut self, dst_buffer: Buffer) -> Self {
         self.inner.dst_buffer = dst_buffer;
         self
     }
-    pub fn regions(
-        mut self,
-        regions: &'a [BufferImageCopy2KHR],
-    ) -> CopyImageToBufferInfo2KHRBuilder<'a> {
+    pub fn regions(mut self, regions: &'a [BufferImageCopy2KHR]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -47852,10 +44372,7 @@ impl<'a> CopyImageToBufferInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsCopyImageToBufferInfo2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> CopyImageToBufferInfo2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsCopyImageToBufferInfo2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47924,29 +44441,23 @@ impl<'a> ::std::ops::DerefMut for ResolveImageInfo2KHRBuilder<'a> {
     }
 }
 impl<'a> ResolveImageInfo2KHRBuilder<'a> {
-    pub fn src_image(mut self, src_image: Image) -> ResolveImageInfo2KHRBuilder<'a> {
+    pub fn src_image(mut self, src_image: Image) -> Self {
         self.inner.src_image = src_image;
         self
     }
-    pub fn src_image_layout(
-        mut self,
-        src_image_layout: ImageLayout,
-    ) -> ResolveImageInfo2KHRBuilder<'a> {
+    pub fn src_image_layout(mut self, src_image_layout: ImageLayout) -> Self {
         self.inner.src_image_layout = src_image_layout;
         self
     }
-    pub fn dst_image(mut self, dst_image: Image) -> ResolveImageInfo2KHRBuilder<'a> {
+    pub fn dst_image(mut self, dst_image: Image) -> Self {
         self.inner.dst_image = dst_image;
         self
     }
-    pub fn dst_image_layout(
-        mut self,
-        dst_image_layout: ImageLayout,
-    ) -> ResolveImageInfo2KHRBuilder<'a> {
+    pub fn dst_image_layout(mut self, dst_image_layout: ImageLayout) -> Self {
         self.inner.dst_image_layout = dst_image_layout;
         self
     }
-    pub fn regions(mut self, regions: &'a [ImageResolve2KHR]) -> ResolveImageInfo2KHRBuilder<'a> {
+    pub fn regions(mut self, regions: &'a [ImageResolve2KHR]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -47956,10 +44467,7 @@ impl<'a> ResolveImageInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsResolveImageInfo2KHR>(
-        mut self,
-        next: &'a mut T,
-    ) -> ResolveImageInfo2KHRBuilder<'a> {
+    pub fn push_next<T: ExtendsResolveImageInfo2KHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -48021,17 +44529,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderImageAtomicInt64FeaturesEX
     }
 }
 impl<'a> PhysicalDeviceShaderImageAtomicInt64FeaturesEXTBuilder<'a> {
-    pub fn shader_image_int64_atomics(
-        mut self,
-        shader_image_int64_atomics: bool,
-    ) -> PhysicalDeviceShaderImageAtomicInt64FeaturesEXTBuilder<'a> {
+    pub fn shader_image_int64_atomics(mut self, shader_image_int64_atomics: bool) -> Self {
         self.inner.shader_image_int64_atomics = shader_image_int64_atomics.into();
         self
     }
-    pub fn sparse_image_int64_atomics(
-        mut self,
-        sparse_image_int64_atomics: bool,
-    ) -> PhysicalDeviceShaderImageAtomicInt64FeaturesEXTBuilder<'a> {
+    pub fn sparse_image_int64_atomics(mut self, sparse_image_int64_atomics: bool) -> Self {
         self.inner.sparse_image_int64_atomics = sparse_image_int64_atomics.into();
         self
     }
@@ -48091,14 +44593,14 @@ impl<'a> FragmentShadingRateAttachmentInfoKHRBuilder<'a> {
     pub fn fragment_shading_rate_attachment(
         mut self,
         fragment_shading_rate_attachment: &'a AttachmentReference2,
-    ) -> FragmentShadingRateAttachmentInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.p_fragment_shading_rate_attachment = fragment_shading_rate_attachment;
         self
     }
     pub fn shading_rate_attachment_texel_size(
         mut self,
         shading_rate_attachment_texel_size: Extent2D,
-    ) -> FragmentShadingRateAttachmentInfoKHRBuilder<'a> {
+    ) -> Self {
         self.inner.shading_rate_attachment_texel_size = shading_rate_attachment_texel_size;
         self
     }
@@ -48158,17 +44660,11 @@ impl<'a> ::std::ops::DerefMut for PipelineFragmentShadingRateStateCreateInfoKHRB
     }
 }
 impl<'a> PipelineFragmentShadingRateStateCreateInfoKHRBuilder<'a> {
-    pub fn fragment_size(
-        mut self,
-        fragment_size: Extent2D,
-    ) -> PipelineFragmentShadingRateStateCreateInfoKHRBuilder<'a> {
+    pub fn fragment_size(mut self, fragment_size: Extent2D) -> Self {
         self.inner.fragment_size = fragment_size;
         self
     }
-    pub fn combiner_ops(
-        mut self,
-        combiner_ops: [FragmentShadingRateCombinerOpKHR; 2],
-    ) -> PipelineFragmentShadingRateStateCreateInfoKHRBuilder<'a> {
+    pub fn combiner_ops(mut self, combiner_ops: [FragmentShadingRateCombinerOpKHR; 2]) -> Self {
         self.inner.combiner_ops = combiner_ops;
         self
     }
@@ -48227,24 +44723,21 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceFragmentShadingRateFeaturesKHRBu
     }
 }
 impl<'a> PhysicalDeviceFragmentShadingRateFeaturesKHRBuilder<'a> {
-    pub fn pipeline_fragment_shading_rate(
-        mut self,
-        pipeline_fragment_shading_rate: bool,
-    ) -> PhysicalDeviceFragmentShadingRateFeaturesKHRBuilder<'a> {
+    pub fn pipeline_fragment_shading_rate(mut self, pipeline_fragment_shading_rate: bool) -> Self {
         self.inner.pipeline_fragment_shading_rate = pipeline_fragment_shading_rate.into();
         self
     }
     pub fn primitive_fragment_shading_rate(
         mut self,
         primitive_fragment_shading_rate: bool,
-    ) -> PhysicalDeviceFragmentShadingRateFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.primitive_fragment_shading_rate = primitive_fragment_shading_rate.into();
         self
     }
     pub fn attachment_fragment_shading_rate(
         mut self,
         attachment_fragment_shading_rate: bool,
-    ) -> PhysicalDeviceFragmentShadingRateFeaturesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.attachment_fragment_shading_rate = attachment_fragment_shading_rate.into();
         self
     }
@@ -48337,7 +44830,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn min_fragment_shading_rate_attachment_texel_size(
         mut self,
         min_fragment_shading_rate_attachment_texel_size: Extent2D,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.min_fragment_shading_rate_attachment_texel_size =
             min_fragment_shading_rate_attachment_texel_size;
         self
@@ -48345,7 +44838,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn max_fragment_shading_rate_attachment_texel_size(
         mut self,
         max_fragment_shading_rate_attachment_texel_size: Extent2D,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.max_fragment_shading_rate_attachment_texel_size =
             max_fragment_shading_rate_attachment_texel_size;
         self
@@ -48353,7 +44846,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn max_fragment_shading_rate_attachment_texel_size_aspect_ratio(
         mut self,
         max_fragment_shading_rate_attachment_texel_size_aspect_ratio: u32,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .max_fragment_shading_rate_attachment_texel_size_aspect_ratio =
             max_fragment_shading_rate_attachment_texel_size_aspect_ratio;
@@ -48362,7 +44855,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn primitive_fragment_shading_rate_with_multiple_viewports(
         mut self,
         primitive_fragment_shading_rate_with_multiple_viewports: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .primitive_fragment_shading_rate_with_multiple_viewports =
             primitive_fragment_shading_rate_with_multiple_viewports.into();
@@ -48371,36 +44864,30 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn layered_shading_rate_attachments(
         mut self,
         layered_shading_rate_attachments: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.layered_shading_rate_attachments = layered_shading_rate_attachments.into();
         self
     }
     pub fn fragment_shading_rate_non_trivial_combiner_ops(
         mut self,
         fragment_shading_rate_non_trivial_combiner_ops: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.fragment_shading_rate_non_trivial_combiner_ops =
             fragment_shading_rate_non_trivial_combiner_ops.into();
         self
     }
-    pub fn max_fragment_size(
-        mut self,
-        max_fragment_size: Extent2D,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    pub fn max_fragment_size(mut self, max_fragment_size: Extent2D) -> Self {
         self.inner.max_fragment_size = max_fragment_size;
         self
     }
-    pub fn max_fragment_size_aspect_ratio(
-        mut self,
-        max_fragment_size_aspect_ratio: u32,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    pub fn max_fragment_size_aspect_ratio(mut self, max_fragment_size_aspect_ratio: u32) -> Self {
         self.inner.max_fragment_size_aspect_ratio = max_fragment_size_aspect_ratio;
         self
     }
     pub fn max_fragment_shading_rate_coverage_samples(
         mut self,
         max_fragment_shading_rate_coverage_samples: u32,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.max_fragment_shading_rate_coverage_samples =
             max_fragment_shading_rate_coverage_samples;
         self
@@ -48408,7 +44895,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn max_fragment_shading_rate_rasterization_samples(
         mut self,
         max_fragment_shading_rate_rasterization_samples: SampleCountFlags,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.max_fragment_shading_rate_rasterization_samples =
             max_fragment_shading_rate_rasterization_samples;
         self
@@ -48416,7 +44903,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn fragment_shading_rate_with_shader_depth_stencil_writes(
         mut self,
         fragment_shading_rate_with_shader_depth_stencil_writes: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .fragment_shading_rate_with_shader_depth_stencil_writes =
             fragment_shading_rate_with_shader_depth_stencil_writes.into();
@@ -48425,7 +44912,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn fragment_shading_rate_with_sample_mask(
         mut self,
         fragment_shading_rate_with_sample_mask: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.fragment_shading_rate_with_sample_mask =
             fragment_shading_rate_with_sample_mask.into();
         self
@@ -48433,7 +44920,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn fragment_shading_rate_with_shader_sample_mask(
         mut self,
         fragment_shading_rate_with_shader_sample_mask: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.fragment_shading_rate_with_shader_sample_mask =
             fragment_shading_rate_with_shader_sample_mask.into();
         self
@@ -48441,7 +44928,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn fragment_shading_rate_with_conservative_rasterization(
         mut self,
         fragment_shading_rate_with_conservative_rasterization: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .fragment_shading_rate_with_conservative_rasterization =
             fragment_shading_rate_with_conservative_rasterization.into();
@@ -48450,7 +44937,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn fragment_shading_rate_with_fragment_shader_interlock(
         mut self,
         fragment_shading_rate_with_fragment_shader_interlock: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .fragment_shading_rate_with_fragment_shader_interlock =
             fragment_shading_rate_with_fragment_shader_interlock.into();
@@ -48459,7 +44946,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn fragment_shading_rate_with_custom_sample_locations(
         mut self,
         fragment_shading_rate_with_custom_sample_locations: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner
             .fragment_shading_rate_with_custom_sample_locations =
             fragment_shading_rate_with_custom_sample_locations.into();
@@ -48468,7 +44955,7 @@ impl<'a> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
     pub fn fragment_shading_rate_strict_multiply_combiner(
         mut self,
         fragment_shading_rate_strict_multiply_combiner: bool,
-    ) -> PhysicalDeviceFragmentShadingRatePropertiesKHRBuilder<'a> {
+    ) -> Self {
         self.inner.fragment_shading_rate_strict_multiply_combiner =
             fragment_shading_rate_strict_multiply_combiner.into();
         self
@@ -48525,17 +45012,11 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceFragmentShadingRateKHRBuilder<'a
     }
 }
 impl<'a> PhysicalDeviceFragmentShadingRateKHRBuilder<'a> {
-    pub fn sample_counts(
-        mut self,
-        sample_counts: SampleCountFlags,
-    ) -> PhysicalDeviceFragmentShadingRateKHRBuilder<'a> {
+    pub fn sample_counts(mut self, sample_counts: SampleCountFlags) -> Self {
         self.inner.sample_counts = sample_counts;
         self
     }
-    pub fn fragment_size(
-        mut self,
-        fragment_size: Extent2D,
-    ) -> PhysicalDeviceFragmentShadingRateKHRBuilder<'a> {
+    pub fn fragment_size(mut self, fragment_size: Extent2D) -> Self {
         self.inner.fragment_size = fragment_size;
         self
     }
@@ -48547,7 +45028,7 @@ impl<'a> PhysicalDeviceFragmentShadingRateKHRBuilder<'a> {
     pub fn push_next<T: ExtendsPhysicalDeviceFragmentShadingRateKHR>(
         mut self,
         next: &'a mut T,
-    ) -> PhysicalDeviceFragmentShadingRateKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -48610,10 +45091,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderTerminateInvocationFeature
     }
 }
 impl<'a> PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'a> {
-    pub fn shader_terminate_invocation(
-        mut self,
-        shader_terminate_invocation: bool,
-    ) -> PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'a> {
+    pub fn shader_terminate_invocation(mut self, shader_terminate_invocation: bool) -> Self {
         self.inner.shader_terminate_invocation = shader_terminate_invocation.into();
         self
     }
@@ -48675,24 +45153,21 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceFragmentShadingRateEnumsFeatures
     }
 }
 impl<'a> PhysicalDeviceFragmentShadingRateEnumsFeaturesNVBuilder<'a> {
-    pub fn fragment_shading_rate_enums(
-        mut self,
-        fragment_shading_rate_enums: bool,
-    ) -> PhysicalDeviceFragmentShadingRateEnumsFeaturesNVBuilder<'a> {
+    pub fn fragment_shading_rate_enums(mut self, fragment_shading_rate_enums: bool) -> Self {
         self.inner.fragment_shading_rate_enums = fragment_shading_rate_enums.into();
         self
     }
     pub fn supersample_fragment_shading_rates(
         mut self,
         supersample_fragment_shading_rates: bool,
-    ) -> PhysicalDeviceFragmentShadingRateEnumsFeaturesNVBuilder<'a> {
+    ) -> Self {
         self.inner.supersample_fragment_shading_rates = supersample_fragment_shading_rates.into();
         self
     }
     pub fn no_invocation_fragment_shading_rates(
         mut self,
         no_invocation_fragment_shading_rates: bool,
-    ) -> PhysicalDeviceFragmentShadingRateEnumsFeaturesNVBuilder<'a> {
+    ) -> Self {
         self.inner.no_invocation_fragment_shading_rates =
             no_invocation_fragment_shading_rates.into();
         self
@@ -48757,7 +45232,7 @@ impl<'a> PhysicalDeviceFragmentShadingRateEnumsPropertiesNVBuilder<'a> {
     pub fn max_fragment_shading_rate_invocation_count(
         mut self,
         max_fragment_shading_rate_invocation_count: SampleCountFlags,
-    ) -> PhysicalDeviceFragmentShadingRateEnumsPropertiesNVBuilder<'a> {
+    ) -> Self {
         self.inner.max_fragment_shading_rate_invocation_count =
             max_fragment_shading_rate_invocation_count;
         self
@@ -48820,24 +45295,15 @@ impl<'a> ::std::ops::DerefMut for PipelineFragmentShadingRateEnumStateCreateInfo
     }
 }
 impl<'a> PipelineFragmentShadingRateEnumStateCreateInfoNVBuilder<'a> {
-    pub fn shading_rate_type(
-        mut self,
-        shading_rate_type: FragmentShadingRateTypeNV,
-    ) -> PipelineFragmentShadingRateEnumStateCreateInfoNVBuilder<'a> {
+    pub fn shading_rate_type(mut self, shading_rate_type: FragmentShadingRateTypeNV) -> Self {
         self.inner.shading_rate_type = shading_rate_type;
         self
     }
-    pub fn shading_rate(
-        mut self,
-        shading_rate: FragmentShadingRateNV,
-    ) -> PipelineFragmentShadingRateEnumStateCreateInfoNVBuilder<'a> {
+    pub fn shading_rate(mut self, shading_rate: FragmentShadingRateNV) -> Self {
         self.inner.shading_rate = shading_rate;
         self
     }
-    pub fn combiner_ops(
-        mut self,
-        combiner_ops: [FragmentShadingRateCombinerOpKHR; 2],
-    ) -> PipelineFragmentShadingRateEnumStateCreateInfoNVBuilder<'a> {
+    pub fn combiner_ops(mut self, combiner_ops: [FragmentShadingRateCombinerOpKHR; 2]) -> Self {
         self.inner.combiner_ops = combiner_ops;
         self
     }
@@ -48895,24 +45361,15 @@ impl<'a> ::std::ops::DerefMut for AccelerationStructureBuildSizesInfoKHRBuilder<
     }
 }
 impl<'a> AccelerationStructureBuildSizesInfoKHRBuilder<'a> {
-    pub fn acceleration_structure_size(
-        mut self,
-        acceleration_structure_size: DeviceSize,
-    ) -> AccelerationStructureBuildSizesInfoKHRBuilder<'a> {
+    pub fn acceleration_structure_size(mut self, acceleration_structure_size: DeviceSize) -> Self {
         self.inner.acceleration_structure_size = acceleration_structure_size;
         self
     }
-    pub fn update_scratch_size(
-        mut self,
-        update_scratch_size: DeviceSize,
-    ) -> AccelerationStructureBuildSizesInfoKHRBuilder<'a> {
+    pub fn update_scratch_size(mut self, update_scratch_size: DeviceSize) -> Self {
         self.inner.update_scratch_size = update_scratch_size;
         self
     }
-    pub fn build_scratch_size(
-        mut self,
-        build_scratch_size: DeviceSize,
-    ) -> AccelerationStructureBuildSizesInfoKHRBuilder<'a> {
+    pub fn build_scratch_size(mut self, build_scratch_size: DeviceSize) -> Self {
         self.inner.build_scratch_size = build_scratch_size;
         self
     }
@@ -48924,7 +45381,7 @@ impl<'a> AccelerationStructureBuildSizesInfoKHRBuilder<'a> {
     pub fn push_next<T: ExtendsAccelerationStructureBuildSizesInfoKHR>(
         mut self,
         next: &'a mut T,
-    ) -> AccelerationStructureBuildSizesInfoKHRBuilder<'a> {
+    ) -> Self {
         unsafe {
             let next_ptr = next as *mut T as *mut BaseOutStructure;
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -48987,10 +45444,7 @@ impl<'a> ::std::ops::DerefMut for PhysicalDeviceMutableDescriptorTypeFeaturesVAL
     }
 }
 impl<'a> PhysicalDeviceMutableDescriptorTypeFeaturesVALVEBuilder<'a> {
-    pub fn mutable_descriptor_type(
-        mut self,
-        mutable_descriptor_type: bool,
-    ) -> PhysicalDeviceMutableDescriptorTypeFeaturesVALVEBuilder<'a> {
+    pub fn mutable_descriptor_type(mut self, mutable_descriptor_type: bool) -> Self {
         self.inner.mutable_descriptor_type = mutable_descriptor_type.into();
         self
     }
@@ -49041,10 +45495,7 @@ impl<'a> ::std::ops::DerefMut for MutableDescriptorTypeListVALVEBuilder<'a> {
     }
 }
 impl<'a> MutableDescriptorTypeListVALVEBuilder<'a> {
-    pub fn descriptor_types(
-        mut self,
-        descriptor_types: &'a [DescriptorType],
-    ) -> MutableDescriptorTypeListVALVEBuilder<'a> {
+    pub fn descriptor_types(mut self, descriptor_types: &'a [DescriptorType]) -> Self {
         self.inner.descriptor_type_count = descriptor_types.len() as _;
         self.inner.p_descriptor_types = descriptor_types.as_ptr();
         self
@@ -49110,7 +45561,7 @@ impl<'a> MutableDescriptorTypeCreateInfoVALVEBuilder<'a> {
     pub fn mutable_descriptor_type_lists(
         mut self,
         mutable_descriptor_type_lists: &'a [MutableDescriptorTypeListVALVE],
-    ) -> MutableDescriptorTypeCreateInfoVALVEBuilder<'a> {
+    ) -> Self {
         self.inner.mutable_descriptor_type_list_count = mutable_descriptor_type_lists.len() as _;
         self.inner.p_mutable_descriptor_type_lists = mutable_descriptor_type_lists.as_ptr();
         self

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1733,7 +1733,7 @@ pub fn derive_setters(
             // Unique cases
             if name == "pCode" {
                 return Some(quote!{
-                    pub fn code(mut self, code: &'a [u32]) -> #name_builder<'a> {
+                    pub fn code(mut self, code: &'a [u32]) -> Self {
                         self.inner.code_size = code.len() * 4;
                         self.inner.p_code = code.as_ptr() as *const u32;
                         self
@@ -1743,7 +1743,7 @@ pub fn derive_setters(
 
             if name == "pSampleMask" {
                 return Some(quote!{
-                    pub fn sample_mask(mut self, sample_mask: &'a [SampleMask]) -> #name_builder<'a> {
+                    pub fn sample_mask(mut self, sample_mask: &'a [SampleMask]) -> Self {
                         self.inner.p_sample_mask = sample_mask.as_ptr() as *const SampleMask;
                         self
                     }
@@ -1752,7 +1752,7 @@ pub fn derive_setters(
 
             if name == "ppGeometries" {
                 return Some(quote!{
-                    pub fn geometries_ptrs(mut self, geometries: &'a [*const AccelerationStructureGeometryKHR]) -> #name_builder<'a> {
+                    pub fn geometries_ptrs(mut self, geometries: &'a [*const AccelerationStructureGeometryKHR]) -> Self {
                         self.inner.geometry_count = geometries.len() as _;
                         self.inner.pp_geometries = geometries.as_ptr();
                         self
@@ -1767,7 +1767,7 @@ pub fn derive_setters(
                 assert!(field.null_terminate);
                 assert_eq!(field.size, None);
                 return Some(quote!{
-                    pub fn #param_ident_short(mut self, #param_ident_short: &'a ::std::ffi::CStr) -> #name_builder<'a> {
+                    pub fn #param_ident_short(mut self, #param_ident_short: &'a ::std::ffi::CStr) -> Self {
                         self.inner.#param_ident = #param_ident_short.as_ptr();
                         self
                     }
@@ -1812,7 +1812,7 @@ pub fn derive_setters(
                         };
 
                         return Some(quote! {
-                            pub fn #param_ident_short(mut self, #param_ident_short: &'a #mutable #slice_param_ty_tokens) -> #name_builder<'a> {
+                            pub fn #param_ident_short(mut self, #param_ident_short: &'a #mutable #slice_param_ty_tokens) -> Self {
                                 #set_size_stmt
                                 self.inner.#param_ident = #param_ident_short#ptr;
                                 self
@@ -1825,7 +1825,7 @@ pub fn derive_setters(
 
         if field.basetype == "VkBool32" {
             return Some(quote!{
-                pub fn #param_ident_short(mut self, #param_ident_short: bool) -> #name_builder<'a> {
+                pub fn #param_ident_short(mut self, #param_ident_short: bool) -> Self {
                     self.inner.#param_ident = #param_ident_short.into();
                     self
                 }
@@ -1840,7 +1840,7 @@ pub fn derive_setters(
         };
 
         Some(quote!{
-            pub fn #param_ident_short(mut self, #param_ident_short: #param_ty_tokens) -> #name_builder<'a> {
+            pub fn #param_ident_short(mut self, #param_ident_short: #param_ty_tokens) -> Self {
                 self.inner.#param_ident = #param_ident_short;
                 self
             }
@@ -1869,7 +1869,7 @@ pub fn derive_setters(
             /// valid extension structs can be pushed into the chain.
             /// If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the
             /// chain will look like `A -> D -> B -> C`.
-            pub fn push_next<T: #extends_name>(mut self, next: &'a mut T) -> #name_builder<'a> {
+            pub fn push_next<T: #extends_name>(mut self, next: &'a mut T) -> Self {
                 unsafe{
                     let next_ptr = next as *mut T as *mut BaseOutStructure;
                     // `next` here can contain a pointer chain. This means that we must correctly


### PR DESCRIPTION
Do not Repeat Yourself in `impl` blocks, especially with the extra lifetime these are unnecessarily verbose.
