### PR TITLE
Improve Result's Display impl for extension values

### DIFF
--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -997,7 +997,7 @@ impl fmt::Display for Result {
         if let Some(x) = name {
             fmt.write_str(x)
         } else {
-            self.0.fmt(fmt)
+            <Self as fmt::Debug>::fmt(&self, fmt)
         }
     }
 }

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1535,7 +1535,9 @@ pub fn generate_result(ident: Ident, enum_: &vk_parse::Enums) -> TokenStream {
                 if let Some(x) = name {
                     fmt.write_str(x)
                 } else {
-                    self.0.fmt(fmt)
+                    // If we don't have a nice message to show, call the generated `Debug` impl
+                    // which includes *all* enum variants, including those from extensions.
+                    <Self as fmt::Debug>::fmt(&self, fmt)
                 }
             }
         }


### PR DESCRIPTION
Previously, the `Display` impl for `vk::Result` did not include handling for extension values. For example, VK_ERROR_OUT_OF_DATE_KHR would display simply as "-1000001004".

With this change, we fall back to the `Debug` impl of the `Result` if the value is unknown (i.e. from an extension). This preserves the current nice messages for non-extension values, and the numeric output for truly unknown values, but displays the enum variant name (e.g. "ERROR_OUT_OF_DATE_KHR")  for extension-provided enum variants.