### PR TITLE
generator: Remove deprecated `description()` impl for `Error`

### DIFF
--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -919,45 +919,7 @@ impl Result {
     #[doc = "An unknown error has occurred, due to an implementation or application bug"]
     pub const ERROR_UNKNOWN: Self = Self(-13);
 }
-impl ::std::error::Error for Result {
-    fn description(&self) -> &str {
-        let name = match *self {
-            Result::SUCCESS => Some("Command completed successfully"),
-            Result::NOT_READY => Some("A fence or query has not yet completed"),
-            Result::TIMEOUT => Some("A wait operation has not completed in the specified time"),
-            Result::EVENT_SET => Some("An event is signaled"),
-            Result::EVENT_RESET => Some("An event is unsignaled"),
-            Result::INCOMPLETE => Some("A return array was too small for the result"),
-            Result::ERROR_OUT_OF_HOST_MEMORY => Some("A host memory allocation has failed"),
-            Result::ERROR_OUT_OF_DEVICE_MEMORY => Some("A device memory allocation has failed"),
-            Result::ERROR_INITIALIZATION_FAILED => Some("Initialization of a object has failed"),
-            Result::ERROR_DEVICE_LOST => {
-                Some("The logical device has been lost. See <<devsandqueues-lost-device>>")
-            }
-            Result::ERROR_MEMORY_MAP_FAILED => Some("Mapping of a memory object has failed"),
-            Result::ERROR_LAYER_NOT_PRESENT => Some("Layer specified does not exist"),
-            Result::ERROR_EXTENSION_NOT_PRESENT => Some("Extension specified does not exist"),
-            Result::ERROR_FEATURE_NOT_PRESENT => {
-                Some("Requested feature is not available on this device")
-            }
-            Result::ERROR_INCOMPATIBLE_DRIVER => Some("Unable to find a Vulkan driver"),
-            Result::ERROR_TOO_MANY_OBJECTS => {
-                Some("Too many objects of the type have already been created")
-            }
-            Result::ERROR_FORMAT_NOT_SUPPORTED => {
-                Some("Requested format is not supported on this device")
-            }
-            Result::ERROR_FRAGMENTED_POOL => Some(
-                "A requested pool allocation has failed due to fragmentation of the pool's memory",
-            ),
-            Result::ERROR_UNKNOWN => {
-                Some("An unknown error has occurred, due to an implementation or application bug")
-            }
-            _ => None,
-        };
-        name.unwrap_or("unknown error")
-    }
-}
+impl ::std::error::Error for Result {}
 impl fmt::Display for Result {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1515,21 +1515,12 @@ pub fn generate_result(ident: Ident, enum_: &vk_parse::Enums) -> TokenStream {
         })
     });
 
-    let notation2 = notation.clone();
     quote! {
-        impl ::std::error::Error for #ident {
-            fn description(&self) -> &str {
-                let name = match *self {
-                    #(#notation),*,
-                    _ => None,
-                };
-                name.unwrap_or("unknown error")
-            }
-        }
+        impl ::std::error::Error for #ident {}
         impl fmt::Display for #ident {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
                 let name = match *self {
-                    #(#notation2),*,
+                    #(#notation),*,
                     _ => None,
                 };
                 if let Some(x) = name {


### PR DESCRIPTION
The docs clearly state:

```rust
#[rustc_deprecated(since = "1.42.0", reason = "use the Display impl or to_string()")]
fn description(&self) -> &str {
    "description() is deprecated; use Display"
}
```

We already have a `Display` implementation containing an identical `match` block and has further improvements on the way in [1].

[1]: https://github.com/MaikKlein/ash/pull/424
