### PR TITLE
generator: Fortify enum-variant type prefix stripping

### DIFF
--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -2350,7 +2350,12 @@ impl fmt::Debug for PeerMemoryFeatureFlags {
 }
 impl fmt::Debug for PerformanceConfigurationTypeINTEL {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let name = match * self { Self :: PERFORMANCE_CONFIGURATION_TYPE_COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED_INTEL => Some ("PERFORMANCE_CONFIGURATION_TYPE_COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED_INTEL") , _ => None , } ;
+        let name = match *self {
+            Self::COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED => {
+                Some("COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED")
+            }
+            _ => None,
+        };
         if let Some(x) = name {
             f.write_str(x)
         } else {
@@ -2432,12 +2437,8 @@ impl fmt::Debug for PerformanceCounterUnitKHR {
 impl fmt::Debug for PerformanceOverrideTypeINTEL {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
-            Self::PERFORMANCE_OVERRIDE_TYPE_NULL_HARDWARE_INTEL => {
-                Some("PERFORMANCE_OVERRIDE_TYPE_NULL_HARDWARE_INTEL")
-            }
-            Self::PERFORMANCE_OVERRIDE_TYPE_FLUSH_GPU_CACHES_INTEL => {
-                Some("PERFORMANCE_OVERRIDE_TYPE_FLUSH_GPU_CACHES_INTEL")
-            }
+            Self::NULL_HARDWARE => Some("NULL_HARDWARE"),
+            Self::FLUSH_GPU_CACHES => Some("FLUSH_GPU_CACHES"),
             _ => None,
         };
         if let Some(x) = name {
@@ -2450,12 +2451,8 @@ impl fmt::Debug for PerformanceOverrideTypeINTEL {
 impl fmt::Debug for PerformanceParameterTypeINTEL {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
-            Self::PERFORMANCE_PARAMETER_TYPE_HW_COUNTERS_SUPPORTED_INTEL => {
-                Some("PERFORMANCE_PARAMETER_TYPE_HW_COUNTERS_SUPPORTED_INTEL")
-            }
-            Self::PERFORMANCE_PARAMETER_TYPE_STREAM_MARKER_VALIDS_INTEL => {
-                Some("PERFORMANCE_PARAMETER_TYPE_STREAM_MARKER_VALIDS_INTEL")
-            }
+            Self::HW_COUNTERS_SUPPORTED => Some("HW_COUNTERS_SUPPORTED"),
+            Self::STREAM_MARKER_VALIDS => Some("STREAM_MARKER_VALIDS"),
             _ => None,
         };
         if let Some(x) = name {
@@ -2468,17 +2465,11 @@ impl fmt::Debug for PerformanceParameterTypeINTEL {
 impl fmt::Debug for PerformanceValueTypeINTEL {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
-            Self::PERFORMANCE_VALUE_TYPE_UINT32_INTEL => {
-                Some("PERFORMANCE_VALUE_TYPE_UINT32_INTEL")
-            }
-            Self::PERFORMANCE_VALUE_TYPE_UINT64_INTEL => {
-                Some("PERFORMANCE_VALUE_TYPE_UINT64_INTEL")
-            }
-            Self::PERFORMANCE_VALUE_TYPE_FLOAT_INTEL => Some("PERFORMANCE_VALUE_TYPE_FLOAT_INTEL"),
-            Self::PERFORMANCE_VALUE_TYPE_BOOL_INTEL => Some("PERFORMANCE_VALUE_TYPE_BOOL_INTEL"),
-            Self::PERFORMANCE_VALUE_TYPE_STRING_INTEL => {
-                Some("PERFORMANCE_VALUE_TYPE_STRING_INTEL")
-            }
+            Self::UINT32 => Some("UINT32"),
+            Self::UINT64 => Some("UINT64"),
+            Self::FLOAT => Some("FLOAT"),
+            Self::BOOL => Some("BOOL"),
+            Self::STRING => Some("STRING"),
             _ => None,
         };
         if let Some(x) = name {
@@ -3000,9 +2991,7 @@ impl fmt::Debug for QueryPoolCreateFlags {
 impl fmt::Debug for QueryPoolSamplingModeINTEL {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
-            Self::QUERY_POOL_SAMPLING_MODE_MANUAL_INTEL => {
-                Some("QUERY_POOL_SAMPLING_MODE_MANUAL_INTEL")
-            }
+            Self::MANUAL => Some("MANUAL"),
             _ => None,
         };
         if let Some(x) = name {

--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -2042,8 +2042,7 @@ impl PerformanceConfigurationTypeINTEL {
     }
 }
 impl PerformanceConfigurationTypeINTEL {
-    pub const PERFORMANCE_CONFIGURATION_TYPE_COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED_INTEL: Self =
-        Self(0);
+    pub const COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED: Self = Self(0);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -2058,7 +2057,7 @@ impl QueryPoolSamplingModeINTEL {
     }
 }
 impl QueryPoolSamplingModeINTEL {
-    pub const QUERY_POOL_SAMPLING_MODE_MANUAL_INTEL: Self = Self(0);
+    pub const MANUAL: Self = Self(0);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -2073,8 +2072,8 @@ impl PerformanceOverrideTypeINTEL {
     }
 }
 impl PerformanceOverrideTypeINTEL {
-    pub const PERFORMANCE_OVERRIDE_TYPE_NULL_HARDWARE_INTEL: Self = Self(0);
-    pub const PERFORMANCE_OVERRIDE_TYPE_FLUSH_GPU_CACHES_INTEL: Self = Self(1);
+    pub const NULL_HARDWARE: Self = Self(0);
+    pub const FLUSH_GPU_CACHES: Self = Self(1);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -2089,8 +2088,8 @@ impl PerformanceParameterTypeINTEL {
     }
 }
 impl PerformanceParameterTypeINTEL {
-    pub const PERFORMANCE_PARAMETER_TYPE_HW_COUNTERS_SUPPORTED_INTEL: Self = Self(0);
-    pub const PERFORMANCE_PARAMETER_TYPE_STREAM_MARKER_VALIDS_INTEL: Self = Self(1);
+    pub const HW_COUNTERS_SUPPORTED: Self = Self(0);
+    pub const STREAM_MARKER_VALIDS: Self = Self(1);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -2105,11 +2104,11 @@ impl PerformanceValueTypeINTEL {
     }
 }
 impl PerformanceValueTypeINTEL {
-    pub const PERFORMANCE_VALUE_TYPE_UINT32_INTEL: Self = Self(0);
-    pub const PERFORMANCE_VALUE_TYPE_UINT64_INTEL: Self = Self(1);
-    pub const PERFORMANCE_VALUE_TYPE_FLOAT_INTEL: Self = Self(2);
-    pub const PERFORMANCE_VALUE_TYPE_BOOL_INTEL: Self = Self(3);
-    pub const PERFORMANCE_VALUE_TYPE_STRING_INTEL: Self = Self(4);
+    pub const UINT32: Self = Self(0);
+    pub const UINT64: Self = Self(1);
+    pub const FLOAT: Self = Self(2);
+    pub const BOOL: Self = Self(3);
+    pub const STRING: Self = Self(4);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1324,7 +1324,9 @@ pub fn variant_ident(enum_name: &str, variant_name: &str) -> Ident {
     // TODO: Should be read from vk.xml id:2
     // TODO: Also needs to be more robust, vendor names can be substrings from itself, id:4
     // like NVX and NV
-    let vendors = ["_NVX", "_KHR", "_EXT", "_NV", "_AMD", "_ANDROID", "_GOOGLE"];
+    let vendors = [
+        "_NVX", "_KHR", "_EXT", "_NV", "_AMD", "_ANDROID", "_GOOGLE", "_INTEL",
+    ];
     let struct_name = _name.to_shouty_snake_case();
     let vendor = vendors
         .iter()


### PR DESCRIPTION
As brought up in [1] a new enum variant "pattern" not dealth with by our type-prefix stripper went silently unnoticed.  Explicitly listing the few misnamed enum variants and panicking otherwise makes sure this won't happen again.

[1]: https://github.com/MaikKlein/ash/pull/411#issuecomment-826013950

Also add `_INTEL` to the list of vendor suffixes to strip, cleaning more misnamed variants.
