### PR TITLE
Do not initialize simple integer types with mem::zeroed()

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -301,7 +301,7 @@ impl Device {
         &self,
         info: &vk::ImageSparseMemoryRequirementsInfo2,
     ) -> usize {
-        let mut count = mem::zeroed();
+        let mut count = 0;
         self.device_fn_1_1.get_image_sparse_memory_requirements2(
             self.handle(),
             info,

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -103,7 +103,7 @@ impl<L> EntryCustom<L> {
         create_info: &vk::InstanceCreateInfo,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> Result<Instance, InstanceError> {
-        let mut instance: vk::Instance = mem::zeroed();
+        let mut instance = mem::zeroed();
         self.entry_fn_1_0
             .create_instance(
                 create_info,
@@ -118,15 +118,15 @@ impl<L> EntryCustom<L> {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateInstanceLayerProperties.html>"]
     pub fn enumerate_instance_layer_properties(&self) -> VkResult<Vec<vk::LayerProperties>> {
         unsafe {
-            let mut num = 0;
+            let mut count = 0;
             self.entry_fn_1_0
-                .enumerate_instance_layer_properties(&mut num, ptr::null_mut())
+                .enumerate_instance_layer_properties(&mut count, ptr::null_mut())
                 .result()?;
-            let mut v = Vec::with_capacity(num as usize);
+            let mut v = Vec::with_capacity(count as usize);
             let err_code = self
                 .entry_fn_1_0
-                .enumerate_instance_layer_properties(&mut num, v.as_mut_ptr());
-            v.set_len(num as usize);
+                .enumerate_instance_layer_properties(&mut count, v.as_mut_ptr());
+            v.set_len(count as usize);
             err_code.result_with_success(v)
         }
     }
@@ -136,17 +136,17 @@ impl<L> EntryCustom<L> {
         &self,
     ) -> VkResult<Vec<vk::ExtensionProperties>> {
         unsafe {
-            let mut num = 0;
+            let mut count = 0;
             self.entry_fn_1_0
-                .enumerate_instance_extension_properties(ptr::null(), &mut num, ptr::null_mut())
+                .enumerate_instance_extension_properties(ptr::null(), &mut count, ptr::null_mut())
                 .result()?;
-            let mut data = Vec::with_capacity(num as usize);
+            let mut data = Vec::with_capacity(count as usize);
             let err_code = self.entry_fn_1_0.enumerate_instance_extension_properties(
                 ptr::null(),
-                &mut num,
+                &mut count,
                 data.as_mut_ptr(),
             );
-            data.set_len(num as usize);
+            data.set_len(count as usize);
             err_code.result_with_success(data)
         }
     }

--- a/ash/src/extensions/ext/full_screen_exclusive.rs
+++ b/ash/src/extensions/ext/full_screen_exclusive.rs
@@ -43,7 +43,7 @@ impl FullScreenExclusive {
         physical_device: vk::PhysicalDevice,
         surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
-        let mut count = mem::zeroed();
+        let mut count = 0;
         self.full_screen_exclusive_fn
             .get_physical_device_surface_present_modes2_ext(
                 physical_device,

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -50,7 +50,7 @@ impl GetMemoryRequirements2 {
         &self,
         info: &vk::ImageSparseMemoryRequirementsInfo2KHR,
     ) -> usize {
-        let mut count = mem::zeroed();
+        let mut count = 0;
         self.get_memory_requirements2_fn
             .get_image_sparse_memory_requirements2_khr(
                 self.handle,

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -89,7 +89,7 @@ impl GetPhysicalDeviceProperties2 {
         &self,
         physical_device: vk::PhysicalDevice,
     ) -> usize {
-        let mut count = mem::zeroed();
+        let mut count = 0;
         self.get_physical_device_properties2_fn
             .get_physical_device_queue_family_properties2_khr(
                 physical_device,
@@ -119,7 +119,7 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
         format_info: &vk::PhysicalDeviceSparseImageFormatInfo2KHR,
     ) -> usize {
-        let mut count = mem::zeroed();
+        let mut count = 0;
         self.get_physical_device_properties2_fn
             .get_physical_device_sparse_image_format_properties2_khr(
                 physical_device,

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -35,7 +35,7 @@ impl Surface {
         queue_family_index: u32,
         surface: vk::SurfaceKHR,
     ) -> VkResult<bool> {
-        let mut b = mem::zeroed();
+        let mut b = 0;
         self.surface_fn
             .get_physical_device_surface_support_khr(
                 physical_device,

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -50,7 +50,7 @@ impl Swapchain {
         semaphore: vk::Semaphore,
         fence: vk::Fence,
     ) -> VkResult<(u32, bool)> {
-        let mut index = mem::zeroed();
+        let mut index = 0;
         let err_code = self.swapchain_fn.acquire_next_image_khr(
             self.handle,
             swapchain,

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -53,7 +53,7 @@ impl Instance {
     }
 
     pub unsafe fn enumerate_physical_device_groups_len(&self) -> VkResult<usize> {
-        let mut group_count = mem::zeroed();
+        let mut group_count = 0;
         self.instance_fn_1_1
             .enumerate_physical_device_groups(self.handle(), &mut group_count, ptr::null_mut())
             .result_with_success(group_count as usize)
@@ -256,7 +256,7 @@ impl Instance {
         create_info: &vk::DeviceCreateInfo,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Device> {
-        let mut device: vk::Device = mem::zeroed();
+        let mut device = mem::zeroed();
         self.instance_fn_1_0
             .create_device(
                 physical_device,
@@ -380,17 +380,17 @@ impl Instance {
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumeratePhysicalDevices.html>"]
     pub unsafe fn enumerate_physical_devices(&self) -> VkResult<Vec<vk::PhysicalDevice>> {
-        let mut num = mem::zeroed();
+        let mut count = 0;
         self.instance_fn_1_0
-            .enumerate_physical_devices(self.handle(), &mut num, ptr::null_mut())
+            .enumerate_physical_devices(self.handle(), &mut count, ptr::null_mut())
             .result()?;
-        let mut physical_devices = Vec::<vk::PhysicalDevice>::with_capacity(num as usize);
+        let mut physical_devices = Vec::<vk::PhysicalDevice>::with_capacity(count as usize);
         let err_code = self.instance_fn_1_0.enumerate_physical_devices(
             self.handle(),
-            &mut num,
+            &mut count,
             physical_devices.as_mut_ptr(),
         );
-        physical_devices.set_len(num as usize);
+        physical_devices.set_len(count as usize);
         err_code.result_with_success(physical_devices)
     }
 
@@ -399,18 +399,18 @@ impl Instance {
         &self,
         device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::ExtensionProperties>> {
-        let mut num = 0;
+        let mut count = 0;
         self.instance_fn_1_0
-            .enumerate_device_extension_properties(device, ptr::null(), &mut num, ptr::null_mut())
+            .enumerate_device_extension_properties(device, ptr::null(), &mut count, ptr::null_mut())
             .result()?;
-        let mut data = Vec::with_capacity(num as usize);
+        let mut data = Vec::with_capacity(count as usize);
         let err_code = self.instance_fn_1_0.enumerate_device_extension_properties(
             device,
             ptr::null(),
-            &mut num,
+            &mut count,
             data.as_mut_ptr(),
         );
-        data.set_len(num as usize);
+        data.set_len(count as usize);
         err_code.result_with_success(data)
     }
 


### PR DESCRIPTION
Following our little discussion in [1] to just use `0` instead.

This also renames the remaining few `num` variables to `count` to more closely match the rest of the codebase and the name of the parameter in Vulkan [2].

[1]: https://github.com/MaikKlein/ash/pull/416#discussion_r604260529
[2]: https://github.com/MaikKlein/ash/pull/416#discussion_r604258864
