### PR TITLE
generator: pSampleMask setter should write NULL if slice is empty

### DIFF
--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -5672,8 +5672,17 @@ impl<'a> PipelineMultisampleStateCreateInfoBuilder<'a> {
         self.inner.min_sample_shading = min_sample_shading;
         self
     }
+    #[doc = r" Sets `p_sample_mask` to `null` if the slice is empty. The mask will"]
+    #[doc = r" be treated as if it has all bits set to `1`."]
+    #[doc = r""]
+    #[doc = r" See <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineMultisampleStateCreateInfo.html#_description>"]
+    #[doc = r" for more details."]
     pub fn sample_mask(mut self, sample_mask: &'a [SampleMask]) -> Self {
-        self.inner.p_sample_mask = sample_mask.as_ptr() as *const SampleMask;
+        self.inner.p_sample_mask = if sample_mask.is_empty() {
+            std::ptr::null()
+        } else {
+            sample_mask.as_ptr() as *const SampleMask
+        };
         self
     }
     pub fn alpha_to_coverage_enable(mut self, alpha_to_coverage_enable: bool) -> Self {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1788,8 +1788,17 @@ pub fn derive_setters(
 
             if name == "pSampleMask" {
                 return Some(quote!{
+                    /// Sets `p_sample_mask` to `null` if the slice is empty. The mask will
+                    /// be treated as if it has all bits set to `1`.
+                    ///
+                    /// See <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineMultisampleStateCreateInfo.html#_description>
+                    /// for more details.
                     pub fn sample_mask(mut self, sample_mask: &'a [SampleMask]) -> Self {
-                        self.inner.p_sample_mask = sample_mask.as_ptr() as *const SampleMask;
+                        self.inner.p_sample_mask = if sample_mask.is_empty() {
+                            std::ptr::null()
+                        } else {
+                            sample_mask.as_ptr() as *const SampleMask
+                        };
                         self
                     }
                 });


### PR DESCRIPTION
Fixes #256

As per #256 no explicit length field is available for `pSampleMask`, this is based on `ceil(rasterizationSamples/32)` instead.  It is valid to not set an array for `pSampleMask` (under normal circumestances this is signaled by setting the length to zero, and the array pointer is ignored) but this has to happen by setting the pointer to `NULL`.

EDIT: And so Erupt followed suit 😬 https://gitlab.com/Friz64/erupt/-/commit/5a0574a0f0c29330f15803dc0475c06bd88438c7 👀 