### PR TITLE
vk/platform_types: Mark SECURITY_ATTRIBUTES as a true ffi::c_void

### DIFF
--- a/ash/src/vk/platform_types.rs
+++ b/ash/src/vk/platform_types.rs
@@ -27,10 +27,8 @@ pub type zx_handle_t = u32;
 pub type _screen_context = c_void;
 #[allow(non_camel_case_types)]
 pub type _screen_window = c_void;
-// FIXME: Platform specific types that should come from a library id:0
-// typedefs are only here so that the code compiles for now
 #[allow(non_camel_case_types)]
-pub type SECURITY_ATTRIBUTES = ();
+pub type SECURITY_ATTRIBUTES = c_void;
 // Opaque types
 pub type ANativeWindow = c_void;
 pub type AHardwareBuffer = c_void;


### PR DESCRIPTION
Depends on #429

`()` is an empty tuple which can be constructed, while `ffi::c_void` cannot.  This is only ever used as an opaque pointer anyway and not used by Ash; those wishing to access members directly should cast it to a struct representation of choice (`winapi`, `windows-rs` or something custom).

Fixes #156
