### PR TITLE
generator: Use stable vk-parse 0.6 release

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -12,7 +12,7 @@ once_cell = "1.7"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.4"
-vk-parse = { git = "https://github.com/krolli/vk-parse", rev = "a133cbb330deeb5c8cea63574cb309075e43a231", features = ["vkxml-convert"] }
+vk-parse = { version = "0.6", features = ["vkxml-convert"] }
 vkxml = "0.3"
 
 [dependencies.syn]


### PR DESCRIPTION
Following [1] a stable release including the fixed commit has been made; we can now depend on the released crate version again.  This also includes support for all new fields up to Vulkan 1.2.176.

[1]: https://github.com/krolli/vk-parse/issues/18#issuecomment-837815599
