### PR TITLE
Mark all function pointer types as unsafe

### DIFF
--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -11,62 +11,62 @@ impl KhrSurfaceFn {
     pub const SPEC_VERSION: u32 = 25u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroySurfaceKHR = extern "system" fn(
+pub type PFN_vkDestroySurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
     surface: SurfaceKHR,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSurfaceSupportKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSurfaceSupportKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     queue_family_index: u32,
     surface: SurfaceKHR,
     p_supported: *mut Bool32,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     surface: SurfaceKHR,
     p_surface_capabilities: *mut SurfaceCapabilitiesKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSurfaceFormatsKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSurfaceFormatsKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     surface: SurfaceKHR,
     p_surface_format_count: *mut u32,
     p_surface_formats: *mut SurfaceFormatKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSurfacePresentModesKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSurfacePresentModesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     surface: SurfaceKHR,
     p_present_mode_count: *mut u32,
     p_present_modes: *mut PresentModeKHR,
 ) -> Result;
 pub struct KhrSurfaceFn {
-    pub destroy_surface_khr: extern "system" fn(
+    pub destroy_surface_khr: unsafe extern "system" fn(
         instance: Instance,
         surface: SurfaceKHR,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub get_physical_device_surface_support_khr: extern "system" fn(
+    pub get_physical_device_surface_support_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         queue_family_index: u32,
         surface: SurfaceKHR,
         p_supported: *mut Bool32,
     ) -> Result,
-    pub get_physical_device_surface_capabilities_khr: extern "system" fn(
+    pub get_physical_device_surface_capabilities_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         surface: SurfaceKHR,
         p_surface_capabilities: *mut SurfaceCapabilitiesKHR,
     ) -> Result,
-    pub get_physical_device_surface_formats_khr: extern "system" fn(
+    pub get_physical_device_surface_formats_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         surface: SurfaceKHR,
         p_surface_format_count: *mut u32,
         p_surface_formats: *mut SurfaceFormatKHR,
     ) -> Result,
-    pub get_physical_device_surface_present_modes_khr: extern "system" fn(
+    pub get_physical_device_surface_present_modes_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         surface: SurfaceKHR,
         p_present_mode_count: *mut u32,
@@ -95,7 +95,7 @@ impl KhrSurfaceFn {
     {
         KhrSurfaceFn {
             destroy_surface_khr: unsafe {
-                extern "system" fn destroy_surface_khr(
+                unsafe extern "system" fn destroy_surface_khr(
                     _instance: Instance,
                     _surface: SurfaceKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -112,7 +112,7 @@ impl KhrSurfaceFn {
                 }
             },
             get_physical_device_surface_support_khr: unsafe {
-                extern "system" fn get_physical_device_surface_support_khr(
+                unsafe extern "system" fn get_physical_device_surface_support_khr(
                     _physical_device: PhysicalDevice,
                     _queue_family_index: u32,
                     _surface: SurfaceKHR,
@@ -134,7 +134,7 @@ impl KhrSurfaceFn {
                 }
             },
             get_physical_device_surface_capabilities_khr: unsafe {
-                extern "system" fn get_physical_device_surface_capabilities_khr(
+                unsafe extern "system" fn get_physical_device_surface_capabilities_khr(
                     _physical_device: PhysicalDevice,
                     _surface: SurfaceKHR,
                     _p_surface_capabilities: *mut SurfaceCapabilitiesKHR,
@@ -155,7 +155,7 @@ impl KhrSurfaceFn {
                 }
             },
             get_physical_device_surface_formats_khr: unsafe {
-                extern "system" fn get_physical_device_surface_formats_khr(
+                unsafe extern "system" fn get_physical_device_surface_formats_khr(
                     _physical_device: PhysicalDevice,
                     _surface: SurfaceKHR,
                     _p_surface_format_count: *mut u32,
@@ -177,7 +177,7 @@ impl KhrSurfaceFn {
                 }
             },
             get_physical_device_surface_present_modes_khr: unsafe {
-                extern "system" fn get_physical_device_surface_present_modes_khr(
+                unsafe extern "system" fn get_physical_device_surface_present_modes_khr(
                     _physical_device: PhysicalDevice,
                     _surface: SurfaceKHR,
                     _p_present_mode_count: *mut u32,
@@ -288,27 +288,27 @@ impl KhrSwapchainFn {
     pub const SPEC_VERSION: u32 = 70u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateSwapchainKHR = extern "system" fn(
+pub type PFN_vkCreateSwapchainKHR = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const SwapchainCreateInfoKHR,
     p_allocator: *const AllocationCallbacks,
     p_swapchain: *mut SwapchainKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroySwapchainKHR = extern "system" fn(
+pub type PFN_vkDestroySwapchainKHR = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetSwapchainImagesKHR = extern "system" fn(
+pub type PFN_vkGetSwapchainImagesKHR = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
     p_swapchain_image_count: *mut u32,
     p_swapchain_images: *mut Image,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkAcquireNextImageKHR = extern "system" fn(
+pub type PFN_vkAcquireNextImageKHR = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
     timeout: u64,
@@ -318,50 +318,50 @@ pub type PFN_vkAcquireNextImageKHR = extern "system" fn(
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkQueuePresentKHR =
-    extern "system" fn(queue: Queue, p_present_info: *const PresentInfoKHR) -> Result;
+    unsafe extern "system" fn(queue: Queue, p_present_info: *const PresentInfoKHR) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceGroupPresentCapabilitiesKHR = extern "system" fn(
+pub type PFN_vkGetDeviceGroupPresentCapabilitiesKHR = unsafe extern "system" fn(
     device: Device,
     p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceGroupSurfacePresentModesKHR = extern "system" fn(
+pub type PFN_vkGetDeviceGroupSurfacePresentModesKHR = unsafe extern "system" fn(
     device: Device,
     surface: SurfaceKHR,
     p_modes: *mut DeviceGroupPresentModeFlagsKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDevicePresentRectanglesKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDevicePresentRectanglesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     surface: SurfaceKHR,
     p_rect_count: *mut u32,
     p_rects: *mut Rect2D,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkAcquireNextImage2KHR = extern "system" fn(
+pub type PFN_vkAcquireNextImage2KHR = unsafe extern "system" fn(
     device: Device,
     p_acquire_info: *const AcquireNextImageInfoKHR,
     p_image_index: *mut u32,
 ) -> Result;
 pub struct KhrSwapchainFn {
-    pub create_swapchain_khr: extern "system" fn(
+    pub create_swapchain_khr: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const SwapchainCreateInfoKHR,
         p_allocator: *const AllocationCallbacks,
         p_swapchain: *mut SwapchainKHR,
     ) -> Result,
-    pub destroy_swapchain_khr: extern "system" fn(
+    pub destroy_swapchain_khr: unsafe extern "system" fn(
         device: Device,
         swapchain: SwapchainKHR,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub get_swapchain_images_khr: extern "system" fn(
+    pub get_swapchain_images_khr: unsafe extern "system" fn(
         device: Device,
         swapchain: SwapchainKHR,
         p_swapchain_image_count: *mut u32,
         p_swapchain_images: *mut Image,
     ) -> Result,
-    pub acquire_next_image_khr: extern "system" fn(
+    pub acquire_next_image_khr: unsafe extern "system" fn(
         device: Device,
         swapchain: SwapchainKHR,
         timeout: u64,
@@ -370,23 +370,23 @@ pub struct KhrSwapchainFn {
         p_image_index: *mut u32,
     ) -> Result,
     pub queue_present_khr:
-        extern "system" fn(queue: Queue, p_present_info: *const PresentInfoKHR) -> Result,
-    pub get_device_group_present_capabilities_khr: extern "system" fn(
+        unsafe extern "system" fn(queue: Queue, p_present_info: *const PresentInfoKHR) -> Result,
+    pub get_device_group_present_capabilities_khr: unsafe extern "system" fn(
         device: Device,
         p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR,
     ) -> Result,
-    pub get_device_group_surface_present_modes_khr: extern "system" fn(
+    pub get_device_group_surface_present_modes_khr: unsafe extern "system" fn(
         device: Device,
         surface: SurfaceKHR,
         p_modes: *mut DeviceGroupPresentModeFlagsKHR,
     ) -> Result,
-    pub get_physical_device_present_rectangles_khr: extern "system" fn(
+    pub get_physical_device_present_rectangles_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         surface: SurfaceKHR,
         p_rect_count: *mut u32,
         p_rects: *mut Rect2D,
     ) -> Result,
-    pub acquire_next_image2_khr: extern "system" fn(
+    pub acquire_next_image2_khr: unsafe extern "system" fn(
         device: Device,
         p_acquire_info: *const AcquireNextImageInfoKHR,
         p_image_index: *mut u32,
@@ -419,7 +419,7 @@ impl KhrSwapchainFn {
     {
         KhrSwapchainFn {
             create_swapchain_khr: unsafe {
-                extern "system" fn create_swapchain_khr(
+                unsafe extern "system" fn create_swapchain_khr(
                     _device: Device,
                     _p_create_info: *const SwapchainCreateInfoKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -437,7 +437,7 @@ impl KhrSwapchainFn {
                 }
             },
             destroy_swapchain_khr: unsafe {
-                extern "system" fn destroy_swapchain_khr(
+                unsafe extern "system" fn destroy_swapchain_khr(
                     _device: Device,
                     _swapchain: SwapchainKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -457,7 +457,7 @@ impl KhrSwapchainFn {
                 }
             },
             get_swapchain_images_khr: unsafe {
-                extern "system" fn get_swapchain_images_khr(
+                unsafe extern "system" fn get_swapchain_images_khr(
                     _device: Device,
                     _swapchain: SwapchainKHR,
                     _p_swapchain_image_count: *mut u32,
@@ -478,7 +478,7 @@ impl KhrSwapchainFn {
                 }
             },
             acquire_next_image_khr: unsafe {
-                extern "system" fn acquire_next_image_khr(
+                unsafe extern "system" fn acquire_next_image_khr(
                     _device: Device,
                     _swapchain: SwapchainKHR,
                     _timeout: u64,
@@ -501,7 +501,7 @@ impl KhrSwapchainFn {
                 }
             },
             queue_present_khr: unsafe {
-                extern "system" fn queue_present_khr(
+                unsafe extern "system" fn queue_present_khr(
                     _queue: Queue,
                     _p_present_info: *const PresentInfoKHR,
                 ) -> Result {
@@ -516,7 +516,7 @@ impl KhrSwapchainFn {
                 }
             },
             get_device_group_present_capabilities_khr: unsafe {
-                extern "system" fn get_device_group_present_capabilities_khr(
+                unsafe extern "system" fn get_device_group_present_capabilities_khr(
                     _device: Device,
                     _p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR,
                 ) -> Result {
@@ -536,7 +536,7 @@ impl KhrSwapchainFn {
                 }
             },
             get_device_group_surface_present_modes_khr: unsafe {
-                extern "system" fn get_device_group_surface_present_modes_khr(
+                unsafe extern "system" fn get_device_group_surface_present_modes_khr(
                     _device: Device,
                     _surface: SurfaceKHR,
                     _p_modes: *mut DeviceGroupPresentModeFlagsKHR,
@@ -557,7 +557,7 @@ impl KhrSwapchainFn {
                 }
             },
             get_physical_device_present_rectangles_khr: unsafe {
-                extern "system" fn get_physical_device_present_rectangles_khr(
+                unsafe extern "system" fn get_physical_device_present_rectangles_khr(
                     _physical_device: PhysicalDevice,
                     _surface: SurfaceKHR,
                     _p_rect_count: *mut u32,
@@ -579,7 +579,7 @@ impl KhrSwapchainFn {
                 }
             },
             acquire_next_image2_khr: unsafe {
-                extern "system" fn acquire_next_image2_khr(
+                unsafe extern "system" fn acquire_next_image2_khr(
                     _device: Device,
                     _p_acquire_info: *const AcquireNextImageInfoKHR,
                     _p_image_index: *mut u32,
@@ -762,33 +762,33 @@ impl KhrDisplayFn {
     pub const SPEC_VERSION: u32 = 23u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceDisplayPropertiesKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceDisplayPropertiesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
     p_properties: *mut DisplayPropertiesKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
     p_properties: *mut DisplayPlanePropertiesKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDisplayPlaneSupportedDisplaysKHR = extern "system" fn(
+pub type PFN_vkGetDisplayPlaneSupportedDisplaysKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     plane_index: u32,
     p_display_count: *mut u32,
     p_displays: *mut DisplayKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDisplayModePropertiesKHR = extern "system" fn(
+pub type PFN_vkGetDisplayModePropertiesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     display: DisplayKHR,
     p_property_count: *mut u32,
     p_properties: *mut DisplayModePropertiesKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDisplayModeKHR = extern "system" fn(
+pub type PFN_vkCreateDisplayModeKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     display: DisplayKHR,
     p_create_info: *const DisplayModeCreateInfoKHR,
@@ -796,56 +796,56 @@ pub type PFN_vkCreateDisplayModeKHR = extern "system" fn(
     p_mode: *mut DisplayModeKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDisplayPlaneCapabilitiesKHR = extern "system" fn(
+pub type PFN_vkGetDisplayPlaneCapabilitiesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     mode: DisplayModeKHR,
     plane_index: u32,
     p_capabilities: *mut DisplayPlaneCapabilitiesKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDisplayPlaneSurfaceKHR = extern "system" fn(
+pub type PFN_vkCreateDisplayPlaneSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const DisplaySurfaceCreateInfoKHR,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub struct KhrDisplayFn {
-    pub get_physical_device_display_properties_khr: extern "system" fn(
+    pub get_physical_device_display_properties_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_property_count: *mut u32,
         p_properties: *mut DisplayPropertiesKHR,
     ) -> Result,
-    pub get_physical_device_display_plane_properties_khr: extern "system" fn(
+    pub get_physical_device_display_plane_properties_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_property_count: *mut u32,
         p_properties: *mut DisplayPlanePropertiesKHR,
     ) -> Result,
-    pub get_display_plane_supported_displays_khr: extern "system" fn(
+    pub get_display_plane_supported_displays_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         plane_index: u32,
         p_display_count: *mut u32,
         p_displays: *mut DisplayKHR,
     ) -> Result,
-    pub get_display_mode_properties_khr: extern "system" fn(
+    pub get_display_mode_properties_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         display: DisplayKHR,
         p_property_count: *mut u32,
         p_properties: *mut DisplayModePropertiesKHR,
     ) -> Result,
-    pub create_display_mode_khr: extern "system" fn(
+    pub create_display_mode_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         display: DisplayKHR,
         p_create_info: *const DisplayModeCreateInfoKHR,
         p_allocator: *const AllocationCallbacks,
         p_mode: *mut DisplayModeKHR,
     ) -> Result,
-    pub get_display_plane_capabilities_khr: extern "system" fn(
+    pub get_display_plane_capabilities_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         mode: DisplayModeKHR,
         plane_index: u32,
         p_capabilities: *mut DisplayPlaneCapabilitiesKHR,
     ) -> Result,
-    pub create_display_plane_surface_khr: extern "system" fn(
+    pub create_display_plane_surface_khr: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const DisplaySurfaceCreateInfoKHR,
         p_allocator: *const AllocationCallbacks,
@@ -876,7 +876,7 @@ impl KhrDisplayFn {
     {
         KhrDisplayFn {
             get_physical_device_display_properties_khr: unsafe {
-                extern "system" fn get_physical_device_display_properties_khr(
+                unsafe extern "system" fn get_physical_device_display_properties_khr(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
                     _p_properties: *mut DisplayPropertiesKHR,
@@ -897,7 +897,7 @@ impl KhrDisplayFn {
                 }
             },
             get_physical_device_display_plane_properties_khr: unsafe {
-                extern "system" fn get_physical_device_display_plane_properties_khr(
+                unsafe extern "system" fn get_physical_device_display_plane_properties_khr(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
                     _p_properties: *mut DisplayPlanePropertiesKHR,
@@ -918,7 +918,7 @@ impl KhrDisplayFn {
                 }
             },
             get_display_plane_supported_displays_khr: unsafe {
-                extern "system" fn get_display_plane_supported_displays_khr(
+                unsafe extern "system" fn get_display_plane_supported_displays_khr(
                     _physical_device: PhysicalDevice,
                     _plane_index: u32,
                     _p_display_count: *mut u32,
@@ -940,7 +940,7 @@ impl KhrDisplayFn {
                 }
             },
             get_display_mode_properties_khr: unsafe {
-                extern "system" fn get_display_mode_properties_khr(
+                unsafe extern "system" fn get_display_mode_properties_khr(
                     _physical_device: PhysicalDevice,
                     _display: DisplayKHR,
                     _p_property_count: *mut u32,
@@ -962,7 +962,7 @@ impl KhrDisplayFn {
                 }
             },
             create_display_mode_khr: unsafe {
-                extern "system" fn create_display_mode_khr(
+                unsafe extern "system" fn create_display_mode_khr(
                     _physical_device: PhysicalDevice,
                     _display: DisplayKHR,
                     _p_create_info: *const DisplayModeCreateInfoKHR,
@@ -984,7 +984,7 @@ impl KhrDisplayFn {
                 }
             },
             get_display_plane_capabilities_khr: unsafe {
-                extern "system" fn get_display_plane_capabilities_khr(
+                unsafe extern "system" fn get_display_plane_capabilities_khr(
                     _physical_device: PhysicalDevice,
                     _mode: DisplayModeKHR,
                     _plane_index: u32,
@@ -1006,7 +1006,7 @@ impl KhrDisplayFn {
                 }
             },
             create_display_plane_surface_khr: unsafe {
-                extern "system" fn create_display_plane_surface_khr(
+                unsafe extern "system" fn create_display_plane_surface_khr(
                     _instance: Instance,
                     _p_create_info: *const DisplaySurfaceCreateInfoKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -1146,7 +1146,7 @@ impl KhrDisplaySwapchainFn {
     pub const SPEC_VERSION: u32 = 10u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateSharedSwapchainsKHR = extern "system" fn(
+pub type PFN_vkCreateSharedSwapchainsKHR = unsafe extern "system" fn(
     device: Device,
     swapchain_count: u32,
     p_create_infos: *const SwapchainCreateInfoKHR,
@@ -1154,7 +1154,7 @@ pub type PFN_vkCreateSharedSwapchainsKHR = extern "system" fn(
     p_swapchains: *mut SwapchainKHR,
 ) -> Result;
 pub struct KhrDisplaySwapchainFn {
-    pub create_shared_swapchains_khr: extern "system" fn(
+    pub create_shared_swapchains_khr: unsafe extern "system" fn(
         device: Device,
         swapchain_count: u32,
         p_create_infos: *const SwapchainCreateInfoKHR,
@@ -1178,7 +1178,7 @@ impl KhrDisplaySwapchainFn {
     {
         KhrDisplaySwapchainFn {
             create_shared_swapchains_khr: unsafe {
-                extern "system" fn create_shared_swapchains_khr(
+                unsafe extern "system" fn create_shared_swapchains_khr(
                     _device: Device,
                     _swapchain_count: u32,
                     _p_create_infos: *const SwapchainCreateInfoKHR,
@@ -1236,27 +1236,27 @@ impl KhrXlibSurfaceFn {
     pub const SPEC_VERSION: u32 = 6u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateXlibSurfaceKHR = extern "system" fn(
+pub type PFN_vkCreateXlibSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const XlibSurfaceCreateInfoKHR,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     queue_family_index: u32,
     dpy: *mut Display,
     visual_id: VisualID,
 ) -> Bool32;
 pub struct KhrXlibSurfaceFn {
-    pub create_xlib_surface_khr: extern "system" fn(
+    pub create_xlib_surface_khr: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const XlibSurfaceCreateInfoKHR,
         p_allocator: *const AllocationCallbacks,
         p_surface: *mut SurfaceKHR,
     ) -> Result,
-    pub get_physical_device_xlib_presentation_support_khr: extern "system" fn(
+    pub get_physical_device_xlib_presentation_support_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         queue_family_index: u32,
         dpy: *mut Display,
@@ -1281,7 +1281,7 @@ impl KhrXlibSurfaceFn {
     {
         KhrXlibSurfaceFn {
             create_xlib_surface_khr: unsafe {
-                extern "system" fn create_xlib_surface_khr(
+                unsafe extern "system" fn create_xlib_surface_khr(
                     _instance: Instance,
                     _p_create_info: *const XlibSurfaceCreateInfoKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -1302,7 +1302,7 @@ impl KhrXlibSurfaceFn {
                 }
             },
             get_physical_device_xlib_presentation_support_khr: unsafe {
-                extern "system" fn get_physical_device_xlib_presentation_support_khr(
+                unsafe extern "system" fn get_physical_device_xlib_presentation_support_khr(
                     _physical_device: PhysicalDevice,
                     _queue_family_index: u32,
                     _dpy: *mut Display,
@@ -1363,27 +1363,27 @@ impl KhrXcbSurfaceFn {
     pub const SPEC_VERSION: u32 = 6u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateXcbSurfaceKHR = extern "system" fn(
+pub type PFN_vkCreateXcbSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const XcbSurfaceCreateInfoKHR,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     queue_family_index: u32,
     connection: *mut xcb_connection_t,
     visual_id: xcb_visualid_t,
 ) -> Bool32;
 pub struct KhrXcbSurfaceFn {
-    pub create_xcb_surface_khr: extern "system" fn(
+    pub create_xcb_surface_khr: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const XcbSurfaceCreateInfoKHR,
         p_allocator: *const AllocationCallbacks,
         p_surface: *mut SurfaceKHR,
     ) -> Result,
-    pub get_physical_device_xcb_presentation_support_khr: extern "system" fn(
+    pub get_physical_device_xcb_presentation_support_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         queue_family_index: u32,
         connection: *mut xcb_connection_t,
@@ -1408,7 +1408,7 @@ impl KhrXcbSurfaceFn {
     {
         KhrXcbSurfaceFn {
             create_xcb_surface_khr: unsafe {
-                extern "system" fn create_xcb_surface_khr(
+                unsafe extern "system" fn create_xcb_surface_khr(
                     _instance: Instance,
                     _p_create_info: *const XcbSurfaceCreateInfoKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -1429,7 +1429,7 @@ impl KhrXcbSurfaceFn {
                 }
             },
             get_physical_device_xcb_presentation_support_khr: unsafe {
-                extern "system" fn get_physical_device_xcb_presentation_support_khr(
+                unsafe extern "system" fn get_physical_device_xcb_presentation_support_khr(
                     _physical_device: PhysicalDevice,
                     _queue_family_index: u32,
                     _connection: *mut xcb_connection_t,
@@ -1490,30 +1490,32 @@ impl KhrWaylandSurfaceFn {
     pub const SPEC_VERSION: u32 = 6u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateWaylandSurfaceKHR = extern "system" fn(
+pub type PFN_vkCreateWaylandSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const WaylandSurfaceCreateInfoKHR,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     queue_family_index: u32,
     display: *mut wl_display,
-) -> Bool32;
+)
+    -> Bool32;
 pub struct KhrWaylandSurfaceFn {
-    pub create_wayland_surface_khr: extern "system" fn(
+    pub create_wayland_surface_khr: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const WaylandSurfaceCreateInfoKHR,
         p_allocator: *const AllocationCallbacks,
         p_surface: *mut SurfaceKHR,
     ) -> Result,
-    pub get_physical_device_wayland_presentation_support_khr: extern "system" fn(
+    pub get_physical_device_wayland_presentation_support_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         queue_family_index: u32,
         display: *mut wl_display,
-    ) -> Bool32,
+    )
+        -> Bool32,
 }
 unsafe impl Send for KhrWaylandSurfaceFn {}
 unsafe impl Sync for KhrWaylandSurfaceFn {}
@@ -1533,7 +1535,7 @@ impl KhrWaylandSurfaceFn {
     {
         KhrWaylandSurfaceFn {
             create_wayland_surface_khr: unsafe {
-                extern "system" fn create_wayland_surface_khr(
+                unsafe extern "system" fn create_wayland_surface_khr(
                     _instance: Instance,
                     _p_create_info: *const WaylandSurfaceCreateInfoKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -1554,7 +1556,7 @@ impl KhrWaylandSurfaceFn {
                 }
             },
             get_physical_device_wayland_presentation_support_khr: unsafe {
-                extern "system" fn get_physical_device_wayland_presentation_support_khr(
+                unsafe extern "system" fn get_physical_device_wayland_presentation_support_khr(
                     _physical_device: PhysicalDevice,
                     _queue_family_index: u32,
                     _display: *mut wl_display,
@@ -1635,14 +1637,14 @@ impl KhrAndroidSurfaceFn {
     pub const SPEC_VERSION: u32 = 6u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateAndroidSurfaceKHR = extern "system" fn(
+pub type PFN_vkCreateAndroidSurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const AndroidSurfaceCreateInfoKHR,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub struct KhrAndroidSurfaceFn {
-    pub create_android_surface_khr: extern "system" fn(
+    pub create_android_surface_khr: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const AndroidSurfaceCreateInfoKHR,
         p_allocator: *const AllocationCallbacks,
@@ -1665,7 +1667,7 @@ impl KhrAndroidSurfaceFn {
     {
         KhrAndroidSurfaceFn {
             create_android_surface_khr: unsafe {
-                extern "system" fn create_android_surface_khr(
+                unsafe extern "system" fn create_android_surface_khr(
                     _instance: Instance,
                     _p_create_info: *const AndroidSurfaceCreateInfoKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -1710,7 +1712,7 @@ impl KhrWin32SurfaceFn {
     pub const SPEC_VERSION: u32 = 6u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateWin32SurfaceKHR = extern "system" fn(
+pub type PFN_vkCreateWin32SurfaceKHR = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const Win32SurfaceCreateInfoKHR,
     p_allocator: *const AllocationCallbacks,
@@ -1718,16 +1720,19 @@ pub type PFN_vkCreateWin32SurfaceKHR = extern "system" fn(
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR =
-    extern "system" fn(physical_device: PhysicalDevice, queue_family_index: u32) -> Bool32;
+    unsafe extern "system" fn(physical_device: PhysicalDevice, queue_family_index: u32) -> Bool32;
 pub struct KhrWin32SurfaceFn {
-    pub create_win32_surface_khr: extern "system" fn(
+    pub create_win32_surface_khr: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const Win32SurfaceCreateInfoKHR,
         p_allocator: *const AllocationCallbacks,
         p_surface: *mut SurfaceKHR,
     ) -> Result,
-    pub get_physical_device_win32_presentation_support_khr:
-        extern "system" fn(physical_device: PhysicalDevice, queue_family_index: u32) -> Bool32,
+    pub get_physical_device_win32_presentation_support_khr: unsafe extern "system" fn(
+        physical_device: PhysicalDevice,
+        queue_family_index: u32,
+    )
+        -> Bool32,
 }
 unsafe impl Send for KhrWin32SurfaceFn {}
 unsafe impl Sync for KhrWin32SurfaceFn {}
@@ -1747,7 +1752,7 @@ impl KhrWin32SurfaceFn {
     {
         KhrWin32SurfaceFn {
             create_win32_surface_khr: unsafe {
-                extern "system" fn create_win32_surface_khr(
+                unsafe extern "system" fn create_win32_surface_khr(
                     _instance: Instance,
                     _p_create_info: *const Win32SurfaceCreateInfoKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -1768,7 +1773,7 @@ impl KhrWin32SurfaceFn {
                 }
             },
             get_physical_device_win32_presentation_support_khr: unsafe {
-                extern "system" fn get_physical_device_win32_presentation_support_khr(
+                unsafe extern "system" fn get_physical_device_win32_presentation_support_khr(
                     _physical_device: PhysicalDevice,
                     _queue_family_index: u32,
                 ) -> Bool32 {
@@ -1823,14 +1828,14 @@ impl AndroidNativeBufferFn {
     pub const SPEC_VERSION: u32 = 8u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetSwapchainGrallocUsageANDROID = extern "system" fn(
+pub type PFN_vkGetSwapchainGrallocUsageANDROID = unsafe extern "system" fn(
     device: Device,
     format: Format,
     image_usage: ImageUsageFlags,
     gralloc_usage: *mut c_int,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkAcquireImageANDROID = extern "system" fn(
+pub type PFN_vkAcquireImageANDROID = unsafe extern "system" fn(
     device: Device,
     image: Image,
     native_fence_fd: c_int,
@@ -1838,7 +1843,7 @@ pub type PFN_vkAcquireImageANDROID = extern "system" fn(
     fence: Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkQueueSignalReleaseImageANDROID = extern "system" fn(
+pub type PFN_vkQueueSignalReleaseImageANDROID = unsafe extern "system" fn(
     queue: Queue,
     wait_semaphore_count: u32,
     p_wait_semaphores: *const Semaphore,
@@ -1846,7 +1851,7 @@ pub type PFN_vkQueueSignalReleaseImageANDROID = extern "system" fn(
     p_native_fence_fd: *mut c_int,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetSwapchainGrallocUsage2ANDROID = extern "system" fn(
+pub type PFN_vkGetSwapchainGrallocUsage2ANDROID = unsafe extern "system" fn(
     device: Device,
     format: Format,
     image_usage: ImageUsageFlags,
@@ -1855,27 +1860,27 @@ pub type PFN_vkGetSwapchainGrallocUsage2ANDROID = extern "system" fn(
     gralloc_producer_usage: *mut u64,
 ) -> Result;
 pub struct AndroidNativeBufferFn {
-    pub get_swapchain_gralloc_usage_android: extern "system" fn(
+    pub get_swapchain_gralloc_usage_android: unsafe extern "system" fn(
         device: Device,
         format: Format,
         image_usage: ImageUsageFlags,
         gralloc_usage: *mut c_int,
     ) -> Result,
-    pub acquire_image_android: extern "system" fn(
+    pub acquire_image_android: unsafe extern "system" fn(
         device: Device,
         image: Image,
         native_fence_fd: c_int,
         semaphore: Semaphore,
         fence: Fence,
     ) -> Result,
-    pub queue_signal_release_image_android: extern "system" fn(
+    pub queue_signal_release_image_android: unsafe extern "system" fn(
         queue: Queue,
         wait_semaphore_count: u32,
         p_wait_semaphores: *const Semaphore,
         image: Image,
         p_native_fence_fd: *mut c_int,
     ) -> Result,
-    pub get_swapchain_gralloc_usage2_android: extern "system" fn(
+    pub get_swapchain_gralloc_usage2_android: unsafe extern "system" fn(
         device: Device,
         format: Format,
         image_usage: ImageUsageFlags,
@@ -1903,7 +1908,7 @@ impl AndroidNativeBufferFn {
     {
         AndroidNativeBufferFn {
             get_swapchain_gralloc_usage_android: unsafe {
-                extern "system" fn get_swapchain_gralloc_usage_android(
+                unsafe extern "system" fn get_swapchain_gralloc_usage_android(
                     _device: Device,
                     _format: Format,
                     _image_usage: ImageUsageFlags,
@@ -1925,7 +1930,7 @@ impl AndroidNativeBufferFn {
                 }
             },
             acquire_image_android: unsafe {
-                extern "system" fn acquire_image_android(
+                unsafe extern "system" fn acquire_image_android(
                     _device: Device,
                     _image: Image,
                     _native_fence_fd: c_int,
@@ -1947,7 +1952,7 @@ impl AndroidNativeBufferFn {
                 }
             },
             queue_signal_release_image_android: unsafe {
-                extern "system" fn queue_signal_release_image_android(
+                unsafe extern "system" fn queue_signal_release_image_android(
                     _queue: Queue,
                     _wait_semaphore_count: u32,
                     _p_wait_semaphores: *const Semaphore,
@@ -1970,7 +1975,7 @@ impl AndroidNativeBufferFn {
                 }
             },
             get_swapchain_gralloc_usage2_android: unsafe {
-                extern "system" fn get_swapchain_gralloc_usage2_android(
+                unsafe extern "system" fn get_swapchain_gralloc_usage2_android(
                     _device: Device,
                     _format: Format,
                     _image_usage: ImageUsageFlags,
@@ -2073,20 +2078,20 @@ impl ExtDebugReportFn {
     pub const SPEC_VERSION: u32 = 9u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDebugReportCallbackEXT = extern "system" fn(
+pub type PFN_vkCreateDebugReportCallbackEXT = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const DebugReportCallbackCreateInfoEXT,
     p_allocator: *const AllocationCallbacks,
     p_callback: *mut DebugReportCallbackEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyDebugReportCallbackEXT = extern "system" fn(
+pub type PFN_vkDestroyDebugReportCallbackEXT = unsafe extern "system" fn(
     instance: Instance,
     callback: DebugReportCallbackEXT,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkDebugReportMessageEXT = extern "system" fn(
+pub type PFN_vkDebugReportMessageEXT = unsafe extern "system" fn(
     instance: Instance,
     flags: DebugReportFlagsEXT,
     object_type: DebugReportObjectTypeEXT,
@@ -2097,18 +2102,18 @@ pub type PFN_vkDebugReportMessageEXT = extern "system" fn(
     p_message: *const c_char,
 );
 pub struct ExtDebugReportFn {
-    pub create_debug_report_callback_ext: extern "system" fn(
+    pub create_debug_report_callback_ext: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const DebugReportCallbackCreateInfoEXT,
         p_allocator: *const AllocationCallbacks,
         p_callback: *mut DebugReportCallbackEXT,
     ) -> Result,
-    pub destroy_debug_report_callback_ext: extern "system" fn(
+    pub destroy_debug_report_callback_ext: unsafe extern "system" fn(
         instance: Instance,
         callback: DebugReportCallbackEXT,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub debug_report_message_ext: extern "system" fn(
+    pub debug_report_message_ext: unsafe extern "system" fn(
         instance: Instance,
         flags: DebugReportFlagsEXT,
         object_type: DebugReportObjectTypeEXT,
@@ -2137,7 +2142,7 @@ impl ExtDebugReportFn {
     {
         ExtDebugReportFn {
             create_debug_report_callback_ext: unsafe {
-                extern "system" fn create_debug_report_callback_ext(
+                unsafe extern "system" fn create_debug_report_callback_ext(
                     _instance: Instance,
                     _p_create_info: *const DebugReportCallbackCreateInfoEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -2159,7 +2164,7 @@ impl ExtDebugReportFn {
                 }
             },
             destroy_debug_report_callback_ext: unsafe {
-                extern "system" fn destroy_debug_report_callback_ext(
+                unsafe extern "system" fn destroy_debug_report_callback_ext(
                     _instance: Instance,
                     _callback: DebugReportCallbackEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -2180,7 +2185,7 @@ impl ExtDebugReportFn {
                 }
             },
             debug_report_message_ext: unsafe {
-                extern "system" fn debug_report_message_ext(
+                unsafe extern "system" fn debug_report_message_ext(
                     _instance: Instance,
                     _flags: DebugReportFlagsEXT,
                     _object_type: DebugReportObjectTypeEXT,
@@ -2535,38 +2540,42 @@ impl ExtDebugMarkerFn {
     pub const SPEC_VERSION: u32 = 4u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkDebugMarkerSetObjectTagEXT =
-    extern "system" fn(device: Device, p_tag_info: *const DebugMarkerObjectTagInfoEXT) -> Result;
+pub type PFN_vkDebugMarkerSetObjectTagEXT = unsafe extern "system" fn(
+    device: Device,
+    p_tag_info: *const DebugMarkerObjectTagInfoEXT,
+) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDebugMarkerSetObjectNameEXT =
-    extern "system" fn(device: Device, p_name_info: *const DebugMarkerObjectNameInfoEXT) -> Result;
+pub type PFN_vkDebugMarkerSetObjectNameEXT = unsafe extern "system" fn(
+    device: Device,
+    p_name_info: *const DebugMarkerObjectNameInfoEXT,
+) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDebugMarkerBeginEXT = extern "system" fn(
+pub type PFN_vkCmdDebugMarkerBeginEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_marker_info: *const DebugMarkerMarkerInfoEXT,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDebugMarkerEndEXT = extern "system" fn(command_buffer: CommandBuffer);
+pub type PFN_vkCmdDebugMarkerEndEXT = unsafe extern "system" fn(command_buffer: CommandBuffer);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDebugMarkerInsertEXT = extern "system" fn(
+pub type PFN_vkCmdDebugMarkerInsertEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_marker_info: *const DebugMarkerMarkerInfoEXT,
 );
 pub struct ExtDebugMarkerFn {
-    pub debug_marker_set_object_tag_ext: extern "system" fn(
+    pub debug_marker_set_object_tag_ext: unsafe extern "system" fn(
         device: Device,
         p_tag_info: *const DebugMarkerObjectTagInfoEXT,
     ) -> Result,
-    pub debug_marker_set_object_name_ext: extern "system" fn(
+    pub debug_marker_set_object_name_ext: unsafe extern "system" fn(
         device: Device,
         p_name_info: *const DebugMarkerObjectNameInfoEXT,
     ) -> Result,
-    pub cmd_debug_marker_begin_ext: extern "system" fn(
+    pub cmd_debug_marker_begin_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_marker_info: *const DebugMarkerMarkerInfoEXT,
     ),
-    pub cmd_debug_marker_end_ext: extern "system" fn(command_buffer: CommandBuffer),
-    pub cmd_debug_marker_insert_ext: extern "system" fn(
+    pub cmd_debug_marker_end_ext: unsafe extern "system" fn(command_buffer: CommandBuffer),
+    pub cmd_debug_marker_insert_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_marker_info: *const DebugMarkerMarkerInfoEXT,
     ),
@@ -2591,7 +2600,7 @@ impl ExtDebugMarkerFn {
     {
         ExtDebugMarkerFn {
             debug_marker_set_object_tag_ext: unsafe {
-                extern "system" fn debug_marker_set_object_tag_ext(
+                unsafe extern "system" fn debug_marker_set_object_tag_ext(
                     _device: Device,
                     _p_tag_info: *const DebugMarkerObjectTagInfoEXT,
                 ) -> Result {
@@ -2611,7 +2620,7 @@ impl ExtDebugMarkerFn {
                 }
             },
             debug_marker_set_object_name_ext: unsafe {
-                extern "system" fn debug_marker_set_object_name_ext(
+                unsafe extern "system" fn debug_marker_set_object_name_ext(
                     _device: Device,
                     _p_name_info: *const DebugMarkerObjectNameInfoEXT,
                 ) -> Result {
@@ -2631,7 +2640,7 @@ impl ExtDebugMarkerFn {
                 }
             },
             cmd_debug_marker_begin_ext: unsafe {
-                extern "system" fn cmd_debug_marker_begin_ext(
+                unsafe extern "system" fn cmd_debug_marker_begin_ext(
                     _command_buffer: CommandBuffer,
                     _p_marker_info: *const DebugMarkerMarkerInfoEXT,
                 ) {
@@ -2650,7 +2659,7 @@ impl ExtDebugMarkerFn {
                 }
             },
             cmd_debug_marker_end_ext: unsafe {
-                extern "system" fn cmd_debug_marker_end_ext(_command_buffer: CommandBuffer) {
+                unsafe extern "system" fn cmd_debug_marker_end_ext(_command_buffer: CommandBuffer) {
                     panic!(concat!(
                         "Unable to load ",
                         stringify!(cmd_debug_marker_end_ext)
@@ -2666,7 +2675,7 @@ impl ExtDebugMarkerFn {
                 }
             },
             cmd_debug_marker_insert_ext: unsafe {
-                extern "system" fn cmd_debug_marker_insert_ext(
+                unsafe extern "system" fn cmd_debug_marker_insert_ext(
                     _command_buffer: CommandBuffer,
                     _p_marker_info: *const DebugMarkerMarkerInfoEXT,
                 ) {
@@ -2966,7 +2975,7 @@ impl ExtTransformFeedbackFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBindTransformFeedbackBuffersEXT = extern "system" fn(
+pub type PFN_vkCmdBindTransformFeedbackBuffersEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_binding: u32,
     binding_count: u32,
@@ -2975,7 +2984,7 @@ pub type PFN_vkCmdBindTransformFeedbackBuffersEXT = extern "system" fn(
     p_sizes: *const DeviceSize,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBeginTransformFeedbackEXT = extern "system" fn(
+pub type PFN_vkCmdBeginTransformFeedbackEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_counter_buffer: u32,
     counter_buffer_count: u32,
@@ -2983,7 +2992,7 @@ pub type PFN_vkCmdBeginTransformFeedbackEXT = extern "system" fn(
     p_counter_buffer_offsets: *const DeviceSize,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdEndTransformFeedbackEXT = extern "system" fn(
+pub type PFN_vkCmdEndTransformFeedbackEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_counter_buffer: u32,
     counter_buffer_count: u32,
@@ -2991,7 +3000,7 @@ pub type PFN_vkCmdEndTransformFeedbackEXT = extern "system" fn(
     p_counter_buffer_offsets: *const DeviceSize,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBeginQueryIndexedEXT = extern "system" fn(
+pub type PFN_vkCmdBeginQueryIndexedEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     query_pool: QueryPool,
     query: u32,
@@ -2999,14 +3008,14 @@ pub type PFN_vkCmdBeginQueryIndexedEXT = extern "system" fn(
     index: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdEndQueryIndexedEXT = extern "system" fn(
+pub type PFN_vkCmdEndQueryIndexedEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     query_pool: QueryPool,
     query: u32,
     index: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawIndirectByteCountEXT = extern "system" fn(
+pub type PFN_vkCmdDrawIndirectByteCountEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     instance_count: u32,
     first_instance: u32,
@@ -3016,7 +3025,7 @@ pub type PFN_vkCmdDrawIndirectByteCountEXT = extern "system" fn(
     vertex_stride: u32,
 );
 pub struct ExtTransformFeedbackFn {
-    pub cmd_bind_transform_feedback_buffers_ext: extern "system" fn(
+    pub cmd_bind_transform_feedback_buffers_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_binding: u32,
         binding_count: u32,
@@ -3024,34 +3033,34 @@ pub struct ExtTransformFeedbackFn {
         p_offsets: *const DeviceSize,
         p_sizes: *const DeviceSize,
     ),
-    pub cmd_begin_transform_feedback_ext: extern "system" fn(
+    pub cmd_begin_transform_feedback_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_counter_buffer: u32,
         counter_buffer_count: u32,
         p_counter_buffers: *const Buffer,
         p_counter_buffer_offsets: *const DeviceSize,
     ),
-    pub cmd_end_transform_feedback_ext: extern "system" fn(
+    pub cmd_end_transform_feedback_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_counter_buffer: u32,
         counter_buffer_count: u32,
         p_counter_buffers: *const Buffer,
         p_counter_buffer_offsets: *const DeviceSize,
     ),
-    pub cmd_begin_query_indexed_ext: extern "system" fn(
+    pub cmd_begin_query_indexed_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         query_pool: QueryPool,
         query: u32,
         flags: QueryControlFlags,
         index: u32,
     ),
-    pub cmd_end_query_indexed_ext: extern "system" fn(
+    pub cmd_end_query_indexed_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         query_pool: QueryPool,
         query: u32,
         index: u32,
     ),
-    pub cmd_draw_indirect_byte_count_ext: extern "system" fn(
+    pub cmd_draw_indirect_byte_count_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         instance_count: u32,
         first_instance: u32,
@@ -3082,7 +3091,7 @@ impl ExtTransformFeedbackFn {
     {
         ExtTransformFeedbackFn {
             cmd_bind_transform_feedback_buffers_ext: unsafe {
-                extern "system" fn cmd_bind_transform_feedback_buffers_ext(
+                unsafe extern "system" fn cmd_bind_transform_feedback_buffers_ext(
                     _command_buffer: CommandBuffer,
                     _first_binding: u32,
                     _binding_count: u32,
@@ -3106,7 +3115,7 @@ impl ExtTransformFeedbackFn {
                 }
             },
             cmd_begin_transform_feedback_ext: unsafe {
-                extern "system" fn cmd_begin_transform_feedback_ext(
+                unsafe extern "system" fn cmd_begin_transform_feedback_ext(
                     _command_buffer: CommandBuffer,
                     _first_counter_buffer: u32,
                     _counter_buffer_count: u32,
@@ -3129,7 +3138,7 @@ impl ExtTransformFeedbackFn {
                 }
             },
             cmd_end_transform_feedback_ext: unsafe {
-                extern "system" fn cmd_end_transform_feedback_ext(
+                unsafe extern "system" fn cmd_end_transform_feedback_ext(
                     _command_buffer: CommandBuffer,
                     _first_counter_buffer: u32,
                     _counter_buffer_count: u32,
@@ -3152,7 +3161,7 @@ impl ExtTransformFeedbackFn {
                 }
             },
             cmd_begin_query_indexed_ext: unsafe {
-                extern "system" fn cmd_begin_query_indexed_ext(
+                unsafe extern "system" fn cmd_begin_query_indexed_ext(
                     _command_buffer: CommandBuffer,
                     _query_pool: QueryPool,
                     _query: u32,
@@ -3174,7 +3183,7 @@ impl ExtTransformFeedbackFn {
                 }
             },
             cmd_end_query_indexed_ext: unsafe {
-                extern "system" fn cmd_end_query_indexed_ext(
+                unsafe extern "system" fn cmd_end_query_indexed_ext(
                     _command_buffer: CommandBuffer,
                     _query_pool: QueryPool,
                     _query: u32,
@@ -3195,7 +3204,7 @@ impl ExtTransformFeedbackFn {
                 }
             },
             cmd_draw_indirect_byte_count_ext: unsafe {
-                extern "system" fn cmd_draw_indirect_byte_count_ext(
+                unsafe extern "system" fn cmd_draw_indirect_byte_count_ext(
                     _command_buffer: CommandBuffer,
                     _instance_count: u32,
                     _first_instance: u32,
@@ -3390,17 +3399,17 @@ impl NvxImageViewHandleFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetImageViewHandleNVX =
-    extern "system" fn(device: Device, p_info: *const ImageViewHandleInfoNVX) -> u32;
+    unsafe extern "system" fn(device: Device, p_info: *const ImageViewHandleInfoNVX) -> u32;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetImageViewAddressNVX = extern "system" fn(
+pub type PFN_vkGetImageViewAddressNVX = unsafe extern "system" fn(
     device: Device,
     image_view: ImageView,
     p_properties: *mut ImageViewAddressPropertiesNVX,
 ) -> Result;
 pub struct NvxImageViewHandleFn {
     pub get_image_view_handle_nvx:
-        extern "system" fn(device: Device, p_info: *const ImageViewHandleInfoNVX) -> u32,
-    pub get_image_view_address_nvx: extern "system" fn(
+        unsafe extern "system" fn(device: Device, p_info: *const ImageViewHandleInfoNVX) -> u32,
+    pub get_image_view_address_nvx: unsafe extern "system" fn(
         device: Device,
         image_view: ImageView,
         p_properties: *mut ImageViewAddressPropertiesNVX,
@@ -3423,7 +3432,7 @@ impl NvxImageViewHandleFn {
     {
         NvxImageViewHandleFn {
             get_image_view_handle_nvx: unsafe {
-                extern "system" fn get_image_view_handle_nvx(
+                unsafe extern "system" fn get_image_view_handle_nvx(
                     _device: Device,
                     _p_info: *const ImageViewHandleInfoNVX,
                 ) -> u32 {
@@ -3442,7 +3451,7 @@ impl NvxImageViewHandleFn {
                 }
             },
             get_image_view_address_nvx: unsafe {
-                extern "system" fn get_image_view_address_nvx(
+                unsafe extern "system" fn get_image_view_address_nvx(
                     _device: Device,
                     _image_view: ImageView,
                     _p_properties: *mut ImageViewAddressPropertiesNVX,
@@ -3543,7 +3552,7 @@ impl AmdDrawIndirectCountFn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawIndirectCount = extern "system" fn(
+pub type PFN_vkCmdDrawIndirectCount = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     buffer: Buffer,
     offset: DeviceSize,
@@ -3553,7 +3562,7 @@ pub type PFN_vkCmdDrawIndirectCount = extern "system" fn(
     stride: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawIndexedIndirectCount = extern "system" fn(
+pub type PFN_vkCmdDrawIndexedIndirectCount = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     buffer: Buffer,
     offset: DeviceSize,
@@ -3563,7 +3572,7 @@ pub type PFN_vkCmdDrawIndexedIndirectCount = extern "system" fn(
     stride: u32,
 );
 pub struct AmdDrawIndirectCountFn {
-    pub cmd_draw_indirect_count_amd: extern "system" fn(
+    pub cmd_draw_indirect_count_amd: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
@@ -3572,7 +3581,7 @@ pub struct AmdDrawIndirectCountFn {
         max_draw_count: u32,
         stride: u32,
     ),
-    pub cmd_draw_indexed_indirect_count_amd: extern "system" fn(
+    pub cmd_draw_indexed_indirect_count_amd: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
@@ -3599,7 +3608,7 @@ impl AmdDrawIndirectCountFn {
     {
         AmdDrawIndirectCountFn {
             cmd_draw_indirect_count_amd: unsafe {
-                extern "system" fn cmd_draw_indirect_count_amd(
+                unsafe extern "system" fn cmd_draw_indirect_count_amd(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -3623,7 +3632,7 @@ impl AmdDrawIndirectCountFn {
                 }
             },
             cmd_draw_indexed_indirect_count_amd: unsafe {
-                extern "system" fn cmd_draw_indexed_indirect_count_amd(
+                unsafe extern "system" fn cmd_draw_indexed_indirect_count_amd(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -3888,7 +3897,7 @@ impl AmdShaderInfoFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetShaderInfoAMD = extern "system" fn(
+pub type PFN_vkGetShaderInfoAMD = unsafe extern "system" fn(
     device: Device,
     pipeline: Pipeline,
     shader_stage: ShaderStageFlags,
@@ -3897,7 +3906,7 @@ pub type PFN_vkGetShaderInfoAMD = extern "system" fn(
     p_info: *mut c_void,
 ) -> Result;
 pub struct AmdShaderInfoFn {
-    pub get_shader_info_amd: extern "system" fn(
+    pub get_shader_info_amd: unsafe extern "system" fn(
         device: Device,
         pipeline: Pipeline,
         shader_stage: ShaderStageFlags,
@@ -3922,7 +3931,7 @@ impl AmdShaderInfoFn {
     {
         AmdShaderInfoFn {
             get_shader_info_amd: unsafe {
-                extern "system" fn get_shader_info_amd(
+                unsafe extern "system" fn get_shader_info_amd(
                     _device: Device,
                     _pipeline: Pipeline,
                     _shader_stage: ShaderStageFlags,
@@ -4109,14 +4118,14 @@ impl GgpStreamDescriptorSurfaceFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateStreamDescriptorSurfaceGGP = extern "system" fn(
+pub type PFN_vkCreateStreamDescriptorSurfaceGGP = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const StreamDescriptorSurfaceCreateInfoGGP,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub struct GgpStreamDescriptorSurfaceFn {
-    pub create_stream_descriptor_surface_ggp: extern "system" fn(
+    pub create_stream_descriptor_surface_ggp: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const StreamDescriptorSurfaceCreateInfoGGP,
         p_allocator: *const AllocationCallbacks,
@@ -4139,7 +4148,7 @@ impl GgpStreamDescriptorSurfaceFn {
     {
         GgpStreamDescriptorSurfaceFn {
             create_stream_descriptor_surface_ggp: unsafe {
-                extern "system" fn create_stream_descriptor_surface_ggp(
+                unsafe extern "system" fn create_stream_descriptor_surface_ggp(
                     _instance: Instance,
                     _p_create_info: *const StreamDescriptorSurfaceCreateInfoGGP,
                     _p_allocator: *const AllocationCallbacks,
@@ -4366,18 +4375,8 @@ impl NvExternalMemoryCapabilitiesFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV = extern "system" fn(
-    physical_device: PhysicalDevice,
-    format: Format,
-    ty: ImageType,
-    tiling: ImageTiling,
-    usage: ImageUsageFlags,
-    flags: ImageCreateFlags,
-    external_handle_type: ExternalMemoryHandleTypeFlagsNV,
-    p_external_image_format_properties: *mut ExternalImageFormatPropertiesNV,
-) -> Result;
-pub struct NvExternalMemoryCapabilitiesFn {
-    pub get_physical_device_external_image_format_properties_nv: extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV =
+    unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         format: Format,
         ty: ImageType,
@@ -4386,7 +4385,19 @@ pub struct NvExternalMemoryCapabilitiesFn {
         flags: ImageCreateFlags,
         external_handle_type: ExternalMemoryHandleTypeFlagsNV,
         p_external_image_format_properties: *mut ExternalImageFormatPropertiesNV,
-    ) -> Result,
+    ) -> Result;
+pub struct NvExternalMemoryCapabilitiesFn {
+    pub get_physical_device_external_image_format_properties_nv:
+        unsafe extern "system" fn(
+            physical_device: PhysicalDevice,
+            format: Format,
+            ty: ImageType,
+            tiling: ImageTiling,
+            usage: ImageUsageFlags,
+            flags: ImageCreateFlags,
+            external_handle_type: ExternalMemoryHandleTypeFlagsNV,
+            p_external_image_format_properties: *mut ExternalImageFormatPropertiesNV,
+        ) -> Result,
 }
 unsafe impl Send for NvExternalMemoryCapabilitiesFn {}
 unsafe impl Sync for NvExternalMemoryCapabilitiesFn {}
@@ -4405,7 +4416,7 @@ impl NvExternalMemoryCapabilitiesFn {
     {
         NvExternalMemoryCapabilitiesFn {
             get_physical_device_external_image_format_properties_nv: unsafe {
-                extern "system" fn get_physical_device_external_image_format_properties_nv(
+                unsafe extern "system" fn get_physical_device_external_image_format_properties_nv(
                     _physical_device: PhysicalDevice,
                     _format: Format,
                     _ty: ImageType,
@@ -4495,14 +4506,14 @@ impl NvExternalMemoryWin32Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetMemoryWin32HandleNV = extern "system" fn(
+pub type PFN_vkGetMemoryWin32HandleNV = unsafe extern "system" fn(
     device: Device,
     memory: DeviceMemory,
     handle_type: ExternalMemoryHandleTypeFlagsNV,
     p_handle: *mut HANDLE,
 ) -> Result;
 pub struct NvExternalMemoryWin32Fn {
-    pub get_memory_win32_handle_nv: extern "system" fn(
+    pub get_memory_win32_handle_nv: unsafe extern "system" fn(
         device: Device,
         memory: DeviceMemory,
         handle_type: ExternalMemoryHandleTypeFlagsNV,
@@ -4525,7 +4536,7 @@ impl NvExternalMemoryWin32Fn {
     {
         NvExternalMemoryWin32Fn {
             get_memory_win32_handle_nv: unsafe {
-                extern "system" fn get_memory_win32_handle_nv(
+                unsafe extern "system" fn get_memory_win32_handle_nv(
                     _device: Device,
                     _memory: DeviceMemory,
                     _handle_type: ExternalMemoryHandleTypeFlagsNV,
@@ -4601,72 +4612,74 @@ impl KhrGetPhysicalDeviceProperties2Fn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceFeatures2 =
-    extern "system" fn(physical_device: PhysicalDevice, p_features: *mut PhysicalDeviceFeatures2);
+pub type PFN_vkGetPhysicalDeviceFeatures2 = unsafe extern "system" fn(
+    physical_device: PhysicalDevice,
+    p_features: *mut PhysicalDeviceFeatures2,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceProperties2 = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_properties: *mut PhysicalDeviceProperties2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceFormatProperties2 = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceFormatProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     format: Format,
     p_format_properties: *mut FormatProperties2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceImageFormatProperties2 = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceImageFormatProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_image_format_info: *const PhysicalDeviceImageFormatInfo2,
     p_image_format_properties: *mut ImageFormatProperties2,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceQueueFamilyProperties2 = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceQueueFamilyProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_queue_family_property_count: *mut u32,
     p_queue_family_properties: *mut QueueFamilyProperties2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceMemoryProperties2 = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceMemoryProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_memory_properties: *mut PhysicalDeviceMemoryProperties2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSparseImageFormatProperties2 = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSparseImageFormatProperties2 = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_format_info: *const PhysicalDeviceSparseImageFormatInfo2,
     p_property_count: *mut u32,
     p_properties: *mut SparseImageFormatProperties2,
 );
 pub struct KhrGetPhysicalDeviceProperties2Fn {
-    pub get_physical_device_features2_khr: extern "system" fn(
+    pub get_physical_device_features2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_features: *mut PhysicalDeviceFeatures2,
     ),
-    pub get_physical_device_properties2_khr: extern "system" fn(
+    pub get_physical_device_properties2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_properties: *mut PhysicalDeviceProperties2,
     ),
-    pub get_physical_device_format_properties2_khr: extern "system" fn(
+    pub get_physical_device_format_properties2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         format: Format,
         p_format_properties: *mut FormatProperties2,
     ),
-    pub get_physical_device_image_format_properties2_khr: extern "system" fn(
+    pub get_physical_device_image_format_properties2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_image_format_info: *const PhysicalDeviceImageFormatInfo2,
         p_image_format_properties: *mut ImageFormatProperties2,
     ) -> Result,
-    pub get_physical_device_queue_family_properties2_khr: extern "system" fn(
+    pub get_physical_device_queue_family_properties2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_queue_family_property_count: *mut u32,
         p_queue_family_properties: *mut QueueFamilyProperties2,
     ),
-    pub get_physical_device_memory_properties2_khr: extern "system" fn(
+    pub get_physical_device_memory_properties2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_memory_properties: *mut PhysicalDeviceMemoryProperties2,
     ),
-    pub get_physical_device_sparse_image_format_properties2_khr: extern "system" fn(
+    pub get_physical_device_sparse_image_format_properties2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_format_info: *const PhysicalDeviceSparseImageFormatInfo2,
         p_property_count: *mut u32,
@@ -4700,7 +4713,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
     {
         KhrGetPhysicalDeviceProperties2Fn {
             get_physical_device_features2_khr: unsafe {
-                extern "system" fn get_physical_device_features2_khr(
+                unsafe extern "system" fn get_physical_device_features2_khr(
                     _physical_device: PhysicalDevice,
                     _p_features: *mut PhysicalDeviceFeatures2,
                 ) {
@@ -4720,7 +4733,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
                 }
             },
             get_physical_device_properties2_khr: unsafe {
-                extern "system" fn get_physical_device_properties2_khr(
+                unsafe extern "system" fn get_physical_device_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_properties: *mut PhysicalDeviceProperties2,
                 ) {
@@ -4740,7 +4753,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
                 }
             },
             get_physical_device_format_properties2_khr: unsafe {
-                extern "system" fn get_physical_device_format_properties2_khr(
+                unsafe extern "system" fn get_physical_device_format_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _format: Format,
                     _p_format_properties: *mut FormatProperties2,
@@ -4761,7 +4774,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
                 }
             },
             get_physical_device_image_format_properties2_khr: unsafe {
-                extern "system" fn get_physical_device_image_format_properties2_khr(
+                unsafe extern "system" fn get_physical_device_image_format_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_image_format_info: *const PhysicalDeviceImageFormatInfo2,
                     _p_image_format_properties: *mut ImageFormatProperties2,
@@ -4782,7 +4795,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
                 }
             },
             get_physical_device_queue_family_properties2_khr: unsafe {
-                extern "system" fn get_physical_device_queue_family_properties2_khr(
+                unsafe extern "system" fn get_physical_device_queue_family_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_queue_family_property_count: *mut u32,
                     _p_queue_family_properties: *mut QueueFamilyProperties2,
@@ -4803,7 +4816,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
                 }
             },
             get_physical_device_memory_properties2_khr: unsafe {
-                extern "system" fn get_physical_device_memory_properties2_khr(
+                unsafe extern "system" fn get_physical_device_memory_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_memory_properties: *mut PhysicalDeviceMemoryProperties2,
                 ) {
@@ -4823,7 +4836,7 @@ impl KhrGetPhysicalDeviceProperties2Fn {
                 }
             },
             get_physical_device_sparse_image_format_properties2_khr: unsafe {
-                extern "system" fn get_physical_device_sparse_image_format_properties2_khr(
+                unsafe extern "system" fn get_physical_device_sparse_image_format_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_format_info: *const PhysicalDeviceSparseImageFormatInfo2,
                     _p_property_count: *mut u32,
@@ -4972,7 +4985,7 @@ impl KhrDeviceGroupFn {
     pub const SPEC_VERSION: u32 = 4u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceGroupPeerMemoryFeatures = extern "system" fn(
+pub type PFN_vkGetDeviceGroupPeerMemoryFeatures = unsafe extern "system" fn(
     device: Device,
     heap_index: u32,
     local_device_index: u32,
@@ -4981,9 +4994,9 @@ pub type PFN_vkGetDeviceGroupPeerMemoryFeatures = extern "system" fn(
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetDeviceMask =
-    extern "system" fn(command_buffer: CommandBuffer, device_mask: u32);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, device_mask: u32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDispatchBase = extern "system" fn(
+pub type PFN_vkCmdDispatchBase = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     base_group_x: u32,
     base_group_y: u32,
@@ -4993,7 +5006,7 @@ pub type PFN_vkCmdDispatchBase = extern "system" fn(
     group_count_z: u32,
 );
 pub struct KhrDeviceGroupFn {
-    pub get_device_group_peer_memory_features_khr: extern "system" fn(
+    pub get_device_group_peer_memory_features_khr: unsafe extern "system" fn(
         device: Device,
         heap_index: u32,
         local_device_index: u32,
@@ -5001,8 +5014,8 @@ pub struct KhrDeviceGroupFn {
         p_peer_memory_features: *mut PeerMemoryFeatureFlags,
     ),
     pub cmd_set_device_mask_khr:
-        extern "system" fn(command_buffer: CommandBuffer, device_mask: u32),
-    pub cmd_dispatch_base_khr: extern "system" fn(
+        unsafe extern "system" fn(command_buffer: CommandBuffer, device_mask: u32),
+    pub cmd_dispatch_base_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         base_group_x: u32,
         base_group_y: u32,
@@ -5011,22 +5024,22 @@ pub struct KhrDeviceGroupFn {
         group_count_y: u32,
         group_count_z: u32,
     ),
-    pub get_device_group_present_capabilities_khr: extern "system" fn(
+    pub get_device_group_present_capabilities_khr: unsafe extern "system" fn(
         device: Device,
         p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR,
     ) -> Result,
-    pub get_device_group_surface_present_modes_khr: extern "system" fn(
+    pub get_device_group_surface_present_modes_khr: unsafe extern "system" fn(
         device: Device,
         surface: SurfaceKHR,
         p_modes: *mut DeviceGroupPresentModeFlagsKHR,
     ) -> Result,
-    pub get_physical_device_present_rectangles_khr: extern "system" fn(
+    pub get_physical_device_present_rectangles_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         surface: SurfaceKHR,
         p_rect_count: *mut u32,
         p_rects: *mut Rect2D,
     ) -> Result,
-    pub acquire_next_image2_khr: extern "system" fn(
+    pub acquire_next_image2_khr: unsafe extern "system" fn(
         device: Device,
         p_acquire_info: *const AcquireNextImageInfoKHR,
         p_image_index: *mut u32,
@@ -5058,7 +5071,7 @@ impl KhrDeviceGroupFn {
     {
         KhrDeviceGroupFn {
             get_device_group_peer_memory_features_khr: unsafe {
-                extern "system" fn get_device_group_peer_memory_features_khr(
+                unsafe extern "system" fn get_device_group_peer_memory_features_khr(
                     _device: Device,
                     _heap_index: u32,
                     _local_device_index: u32,
@@ -5081,7 +5094,7 @@ impl KhrDeviceGroupFn {
                 }
             },
             cmd_set_device_mask_khr: unsafe {
-                extern "system" fn cmd_set_device_mask_khr(
+                unsafe extern "system" fn cmd_set_device_mask_khr(
                     _command_buffer: CommandBuffer,
                     _device_mask: u32,
                 ) {
@@ -5100,7 +5113,7 @@ impl KhrDeviceGroupFn {
                 }
             },
             cmd_dispatch_base_khr: unsafe {
-                extern "system" fn cmd_dispatch_base_khr(
+                unsafe extern "system" fn cmd_dispatch_base_khr(
                     _command_buffer: CommandBuffer,
                     _base_group_x: u32,
                     _base_group_y: u32,
@@ -5124,7 +5137,7 @@ impl KhrDeviceGroupFn {
                 }
             },
             get_device_group_present_capabilities_khr: unsafe {
-                extern "system" fn get_device_group_present_capabilities_khr(
+                unsafe extern "system" fn get_device_group_present_capabilities_khr(
                     _device: Device,
                     _p_device_group_present_capabilities: *mut DeviceGroupPresentCapabilitiesKHR,
                 ) -> Result {
@@ -5144,7 +5157,7 @@ impl KhrDeviceGroupFn {
                 }
             },
             get_device_group_surface_present_modes_khr: unsafe {
-                extern "system" fn get_device_group_surface_present_modes_khr(
+                unsafe extern "system" fn get_device_group_surface_present_modes_khr(
                     _device: Device,
                     _surface: SurfaceKHR,
                     _p_modes: *mut DeviceGroupPresentModeFlagsKHR,
@@ -5165,7 +5178,7 @@ impl KhrDeviceGroupFn {
                 }
             },
             get_physical_device_present_rectangles_khr: unsafe {
-                extern "system" fn get_physical_device_present_rectangles_khr(
+                unsafe extern "system" fn get_physical_device_present_rectangles_khr(
                     _physical_device: PhysicalDevice,
                     _surface: SurfaceKHR,
                     _p_rect_count: *mut u32,
@@ -5187,7 +5200,7 @@ impl KhrDeviceGroupFn {
                 }
             },
             acquire_next_image2_khr: unsafe {
-                extern "system" fn acquire_next_image2_khr(
+                unsafe extern "system" fn acquire_next_image2_khr(
                     _device: Device,
                     _p_acquire_info: *const AcquireNextImageInfoKHR,
                     _p_image_index: *mut u32,
@@ -5394,14 +5407,14 @@ impl NnViSurfaceFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateViSurfaceNN = extern "system" fn(
+pub type PFN_vkCreateViSurfaceNN = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const ViSurfaceCreateInfoNN,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub struct NnViSurfaceFn {
-    pub create_vi_surface_nn: extern "system" fn(
+    pub create_vi_surface_nn: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const ViSurfaceCreateInfoNN,
         p_allocator: *const AllocationCallbacks,
@@ -5424,7 +5437,7 @@ impl NnViSurfaceFn {
     {
         NnViSurfaceFn {
             create_vi_surface_nn: unsafe {
-                extern "system" fn create_vi_surface_nn(
+                unsafe extern "system" fn create_vi_surface_nn(
                     _instance: Instance,
                     _p_create_info: *const ViSurfaceCreateInfoNN,
                     _p_allocator: *const AllocationCallbacks,
@@ -5672,11 +5685,17 @@ impl KhrMaintenance1Fn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkTrimCommandPool =
-    extern "system" fn(device: Device, command_pool: CommandPool, flags: CommandPoolTrimFlags);
+pub type PFN_vkTrimCommandPool = unsafe extern "system" fn(
+    device: Device,
+    command_pool: CommandPool,
+    flags: CommandPoolTrimFlags,
+);
 pub struct KhrMaintenance1Fn {
-    pub trim_command_pool_khr:
-        extern "system" fn(device: Device, command_pool: CommandPool, flags: CommandPoolTrimFlags),
+    pub trim_command_pool_khr: unsafe extern "system" fn(
+        device: Device,
+        command_pool: CommandPool,
+        flags: CommandPoolTrimFlags,
+    ),
 }
 unsafe impl Send for KhrMaintenance1Fn {}
 unsafe impl Sync for KhrMaintenance1Fn {}
@@ -5694,7 +5713,7 @@ impl KhrMaintenance1Fn {
     {
         KhrMaintenance1Fn {
             trim_command_pool_khr: unsafe {
-                extern "system" fn trim_command_pool_khr(
+                unsafe extern "system" fn trim_command_pool_khr(
                     _device: Device,
                     _command_pool: CommandPool,
                     _flags: CommandPoolTrimFlags,
@@ -5749,13 +5768,13 @@ impl KhrDeviceGroupCreationFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkEnumeratePhysicalDeviceGroups = extern "system" fn(
+pub type PFN_vkEnumeratePhysicalDeviceGroups = unsafe extern "system" fn(
     instance: Instance,
     p_physical_device_group_count: *mut u32,
     p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties,
 ) -> Result;
 pub struct KhrDeviceGroupCreationFn {
-    pub enumerate_physical_device_groups_khr: extern "system" fn(
+    pub enumerate_physical_device_groups_khr: unsafe extern "system" fn(
         instance: Instance,
         p_physical_device_group_count: *mut u32,
         p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties,
@@ -5777,7 +5796,7 @@ impl KhrDeviceGroupCreationFn {
     {
         KhrDeviceGroupCreationFn {
             enumerate_physical_device_groups_khr: unsafe {
-                extern "system" fn enumerate_physical_device_groups_khr(
+                unsafe extern "system" fn enumerate_physical_device_groups_khr(
                     _instance: Instance,
                     _p_physical_device_group_count: *mut u32,
                     _p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties,
@@ -5833,13 +5852,13 @@ impl KhrExternalMemoryCapabilitiesFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceExternalBufferProperties = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceExternalBufferProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo,
     p_external_buffer_properties: *mut ExternalBufferProperties,
 );
 pub struct KhrExternalMemoryCapabilitiesFn {
-    pub get_physical_device_external_buffer_properties_khr: extern "system" fn(
+    pub get_physical_device_external_buffer_properties_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo,
         p_external_buffer_properties: *mut ExternalBufferProperties,
@@ -5862,7 +5881,7 @@ impl KhrExternalMemoryCapabilitiesFn {
     {
         KhrExternalMemoryCapabilitiesFn {
             get_physical_device_external_buffer_properties_khr: unsafe {
-                extern "system" fn get_physical_device_external_buffer_properties_khr(
+                unsafe extern "system" fn get_physical_device_external_buffer_properties_khr(
                     _physical_device: PhysicalDevice,
                     _p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo,
                     _p_external_buffer_properties: *mut ExternalBufferProperties,
@@ -6008,25 +6027,25 @@ impl KhrExternalMemoryWin32Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetMemoryWin32HandleKHR = extern "system" fn(
+pub type PFN_vkGetMemoryWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
     p_get_win32_handle_info: *const MemoryGetWin32HandleInfoKHR,
     p_handle: *mut HANDLE,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetMemoryWin32HandlePropertiesKHR = extern "system" fn(
+pub type PFN_vkGetMemoryWin32HandlePropertiesKHR = unsafe extern "system" fn(
     device: Device,
     handle_type: ExternalMemoryHandleTypeFlags,
     handle: HANDLE,
     p_memory_win32_handle_properties: *mut MemoryWin32HandlePropertiesKHR,
 ) -> Result;
 pub struct KhrExternalMemoryWin32Fn {
-    pub get_memory_win32_handle_khr: extern "system" fn(
+    pub get_memory_win32_handle_khr: unsafe extern "system" fn(
         device: Device,
         p_get_win32_handle_info: *const MemoryGetWin32HandleInfoKHR,
         p_handle: *mut HANDLE,
     ) -> Result,
-    pub get_memory_win32_handle_properties_khr: extern "system" fn(
+    pub get_memory_win32_handle_properties_khr: unsafe extern "system" fn(
         device: Device,
         handle_type: ExternalMemoryHandleTypeFlags,
         handle: HANDLE,
@@ -6050,7 +6069,7 @@ impl KhrExternalMemoryWin32Fn {
     {
         KhrExternalMemoryWin32Fn {
             get_memory_win32_handle_khr: unsafe {
-                extern "system" fn get_memory_win32_handle_khr(
+                unsafe extern "system" fn get_memory_win32_handle_khr(
                     _device: Device,
                     _p_get_win32_handle_info: *const MemoryGetWin32HandleInfoKHR,
                     _p_handle: *mut HANDLE,
@@ -6070,7 +6089,7 @@ impl KhrExternalMemoryWin32Fn {
                 }
             },
             get_memory_win32_handle_properties_khr: unsafe {
-                extern "system" fn get_memory_win32_handle_properties_khr(
+                unsafe extern "system" fn get_memory_win32_handle_properties_khr(
                     _device: Device,
                     _handle_type: ExternalMemoryHandleTypeFlags,
                     _handle: HANDLE,
@@ -6142,25 +6161,25 @@ impl KhrExternalMemoryFdFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetMemoryFdKHR = extern "system" fn(
+pub type PFN_vkGetMemoryFdKHR = unsafe extern "system" fn(
     device: Device,
     p_get_fd_info: *const MemoryGetFdInfoKHR,
     p_fd: *mut c_int,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetMemoryFdPropertiesKHR = extern "system" fn(
+pub type PFN_vkGetMemoryFdPropertiesKHR = unsafe extern "system" fn(
     device: Device,
     handle_type: ExternalMemoryHandleTypeFlags,
     fd: c_int,
     p_memory_fd_properties: *mut MemoryFdPropertiesKHR,
 ) -> Result;
 pub struct KhrExternalMemoryFdFn {
-    pub get_memory_fd_khr: extern "system" fn(
+    pub get_memory_fd_khr: unsafe extern "system" fn(
         device: Device,
         p_get_fd_info: *const MemoryGetFdInfoKHR,
         p_fd: *mut c_int,
     ) -> Result,
-    pub get_memory_fd_properties_khr: extern "system" fn(
+    pub get_memory_fd_properties_khr: unsafe extern "system" fn(
         device: Device,
         handle_type: ExternalMemoryHandleTypeFlags,
         fd: c_int,
@@ -6184,7 +6203,7 @@ impl KhrExternalMemoryFdFn {
     {
         KhrExternalMemoryFdFn {
             get_memory_fd_khr: unsafe {
-                extern "system" fn get_memory_fd_khr(
+                unsafe extern "system" fn get_memory_fd_khr(
                     _device: Device,
                     _p_get_fd_info: *const MemoryGetFdInfoKHR,
                     _p_fd: *mut c_int,
@@ -6200,7 +6219,7 @@ impl KhrExternalMemoryFdFn {
                 }
             },
             get_memory_fd_properties_khr: unsafe {
-                extern "system" fn get_memory_fd_properties_khr(
+                unsafe extern "system" fn get_memory_fd_properties_khr(
                     _device: Device,
                     _handle_type: ExternalMemoryHandleTypeFlags,
                     _fd: c_int,
@@ -6290,13 +6309,13 @@ impl KhrExternalSemaphoreCapabilitiesFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceExternalSemaphoreProperties = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceExternalSemaphoreProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo,
     p_external_semaphore_properties: *mut ExternalSemaphoreProperties,
 );
 pub struct KhrExternalSemaphoreCapabilitiesFn {
-    pub get_physical_device_external_semaphore_properties_khr: extern "system" fn(
+    pub get_physical_device_external_semaphore_properties_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo,
         p_external_semaphore_properties: *mut ExternalSemaphoreProperties,
@@ -6319,7 +6338,7 @@ impl KhrExternalSemaphoreCapabilitiesFn {
     {
         KhrExternalSemaphoreCapabilitiesFn {
             get_physical_device_external_semaphore_properties_khr: unsafe {
-                extern "system" fn get_physical_device_external_semaphore_properties_khr(
+                unsafe extern "system" fn get_physical_device_external_semaphore_properties_khr(
                     _physical_device: PhysicalDevice,
                     _p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo,
                     _p_external_semaphore_properties: *mut ExternalSemaphoreProperties,
@@ -6431,22 +6450,22 @@ impl KhrExternalSemaphoreWin32Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkImportSemaphoreWin32HandleKHR = extern "system" fn(
+pub type PFN_vkImportSemaphoreWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
     p_import_semaphore_win32_handle_info: *const ImportSemaphoreWin32HandleInfoKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetSemaphoreWin32HandleKHR = extern "system" fn(
+pub type PFN_vkGetSemaphoreWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
     p_get_win32_handle_info: *const SemaphoreGetWin32HandleInfoKHR,
     p_handle: *mut HANDLE,
 ) -> Result;
 pub struct KhrExternalSemaphoreWin32Fn {
-    pub import_semaphore_win32_handle_khr: extern "system" fn(
+    pub import_semaphore_win32_handle_khr: unsafe extern "system" fn(
         device: Device,
         p_import_semaphore_win32_handle_info: *const ImportSemaphoreWin32HandleInfoKHR,
     ) -> Result,
-    pub get_semaphore_win32_handle_khr: extern "system" fn(
+    pub get_semaphore_win32_handle_khr: unsafe extern "system" fn(
         device: Device,
         p_get_win32_handle_info: *const SemaphoreGetWin32HandleInfoKHR,
         p_handle: *mut HANDLE,
@@ -6469,7 +6488,7 @@ impl KhrExternalSemaphoreWin32Fn {
     {
         KhrExternalSemaphoreWin32Fn {
             import_semaphore_win32_handle_khr: unsafe {
-                extern "system" fn import_semaphore_win32_handle_khr(
+                unsafe extern "system" fn import_semaphore_win32_handle_khr(
                     _device: Device,
                     _p_import_semaphore_win32_handle_info: *const ImportSemaphoreWin32HandleInfoKHR,
                 ) -> Result {
@@ -6489,7 +6508,7 @@ impl KhrExternalSemaphoreWin32Fn {
                 }
             },
             get_semaphore_win32_handle_khr: unsafe {
-                extern "system" fn get_semaphore_win32_handle_khr(
+                unsafe extern "system" fn get_semaphore_win32_handle_khr(
                     _device: Device,
                     _p_get_win32_handle_info: *const SemaphoreGetWin32HandleInfoKHR,
                     _p_handle: *mut HANDLE,
@@ -6553,22 +6572,22 @@ impl KhrExternalSemaphoreFdFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkImportSemaphoreFdKHR = extern "system" fn(
+pub type PFN_vkImportSemaphoreFdKHR = unsafe extern "system" fn(
     device: Device,
     p_import_semaphore_fd_info: *const ImportSemaphoreFdInfoKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetSemaphoreFdKHR = extern "system" fn(
+pub type PFN_vkGetSemaphoreFdKHR = unsafe extern "system" fn(
     device: Device,
     p_get_fd_info: *const SemaphoreGetFdInfoKHR,
     p_fd: *mut c_int,
 ) -> Result;
 pub struct KhrExternalSemaphoreFdFn {
-    pub import_semaphore_fd_khr: extern "system" fn(
+    pub import_semaphore_fd_khr: unsafe extern "system" fn(
         device: Device,
         p_import_semaphore_fd_info: *const ImportSemaphoreFdInfoKHR,
     ) -> Result,
-    pub get_semaphore_fd_khr: extern "system" fn(
+    pub get_semaphore_fd_khr: unsafe extern "system" fn(
         device: Device,
         p_get_fd_info: *const SemaphoreGetFdInfoKHR,
         p_fd: *mut c_int,
@@ -6591,7 +6610,7 @@ impl KhrExternalSemaphoreFdFn {
     {
         KhrExternalSemaphoreFdFn {
             import_semaphore_fd_khr: unsafe {
-                extern "system" fn import_semaphore_fd_khr(
+                unsafe extern "system" fn import_semaphore_fd_khr(
                     _device: Device,
                     _p_import_semaphore_fd_info: *const ImportSemaphoreFdInfoKHR,
                 ) -> Result {
@@ -6610,7 +6629,7 @@ impl KhrExternalSemaphoreFdFn {
                 }
             },
             get_semaphore_fd_khr: unsafe {
-                extern "system" fn get_semaphore_fd_khr(
+                unsafe extern "system" fn get_semaphore_fd_khr(
                     _device: Device,
                     _p_get_fd_info: *const SemaphoreGetFdInfoKHR,
                     _p_fd: *mut c_int,
@@ -6662,7 +6681,7 @@ impl KhrPushDescriptorFn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdPushDescriptorSetKHR = extern "system" fn(
+pub type PFN_vkCmdPushDescriptorSetKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     pipeline_bind_point: PipelineBindPoint,
     layout: PipelineLayout,
@@ -6671,7 +6690,7 @@ pub type PFN_vkCmdPushDescriptorSetKHR = extern "system" fn(
     p_descriptor_writes: *const WriteDescriptorSet,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdPushDescriptorSetWithTemplateKHR = extern "system" fn(
+pub type PFN_vkCmdPushDescriptorSetWithTemplateKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     descriptor_update_template: DescriptorUpdateTemplate,
     layout: PipelineLayout,
@@ -6679,7 +6698,7 @@ pub type PFN_vkCmdPushDescriptorSetWithTemplateKHR = extern "system" fn(
     p_data: *const c_void,
 );
 pub struct KhrPushDescriptorFn {
-    pub cmd_push_descriptor_set_khr: extern "system" fn(
+    pub cmd_push_descriptor_set_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         pipeline_bind_point: PipelineBindPoint,
         layout: PipelineLayout,
@@ -6687,7 +6706,7 @@ pub struct KhrPushDescriptorFn {
         descriptor_write_count: u32,
         p_descriptor_writes: *const WriteDescriptorSet,
     ),
-    pub cmd_push_descriptor_set_with_template_khr: extern "system" fn(
+    pub cmd_push_descriptor_set_with_template_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         descriptor_update_template: DescriptorUpdateTemplate,
         layout: PipelineLayout,
@@ -6713,7 +6732,7 @@ impl KhrPushDescriptorFn {
     {
         KhrPushDescriptorFn {
             cmd_push_descriptor_set_khr: unsafe {
-                extern "system" fn cmd_push_descriptor_set_khr(
+                unsafe extern "system" fn cmd_push_descriptor_set_khr(
                     _command_buffer: CommandBuffer,
                     _pipeline_bind_point: PipelineBindPoint,
                     _layout: PipelineLayout,
@@ -6736,7 +6755,7 @@ impl KhrPushDescriptorFn {
                 }
             },
             cmd_push_descriptor_set_with_template_khr: unsafe {
-                extern "system" fn cmd_push_descriptor_set_with_template_khr(
+                unsafe extern "system" fn cmd_push_descriptor_set_with_template_khr(
                     _command_buffer: CommandBuffer,
                     _descriptor_update_template: DescriptorUpdateTemplate,
                     _layout: PipelineLayout,
@@ -6817,18 +6836,19 @@ impl ExtConditionalRenderingFn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBeginConditionalRenderingEXT = extern "system" fn(
+pub type PFN_vkCmdBeginConditionalRenderingEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_conditional_rendering_begin: *const ConditionalRenderingBeginInfoEXT,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdEndConditionalRenderingEXT = extern "system" fn(command_buffer: CommandBuffer);
+pub type PFN_vkCmdEndConditionalRenderingEXT =
+    unsafe extern "system" fn(command_buffer: CommandBuffer);
 pub struct ExtConditionalRenderingFn {
-    pub cmd_begin_conditional_rendering_ext: extern "system" fn(
+    pub cmd_begin_conditional_rendering_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_conditional_rendering_begin: *const ConditionalRenderingBeginInfoEXT,
     ),
-    pub cmd_end_conditional_rendering_ext: extern "system" fn(command_buffer: CommandBuffer),
+    pub cmd_end_conditional_rendering_ext: unsafe extern "system" fn(command_buffer: CommandBuffer),
 }
 unsafe impl Send for ExtConditionalRenderingFn {}
 unsafe impl Sync for ExtConditionalRenderingFn {}
@@ -6847,7 +6867,7 @@ impl ExtConditionalRenderingFn {
     {
         ExtConditionalRenderingFn {
             cmd_begin_conditional_rendering_ext: unsafe {
-                extern "system" fn cmd_begin_conditional_rendering_ext(
+                unsafe extern "system" fn cmd_begin_conditional_rendering_ext(
                     _command_buffer: CommandBuffer,
                     _p_conditional_rendering_begin: *const ConditionalRenderingBeginInfoEXT,
                 ) {
@@ -6867,7 +6887,7 @@ impl ExtConditionalRenderingFn {
                 }
             },
             cmd_end_conditional_rendering_ext: unsafe {
-                extern "system" fn cmd_end_conditional_rendering_ext(
+                unsafe extern "system" fn cmd_end_conditional_rendering_ext(
                     _command_buffer: CommandBuffer,
                 ) {
                     panic!(concat!(
@@ -7020,44 +7040,44 @@ impl KhrDescriptorUpdateTemplateFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDescriptorUpdateTemplate = extern "system" fn(
+pub type PFN_vkCreateDescriptorUpdateTemplate = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const DescriptorUpdateTemplateCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_descriptor_update_template: *mut DescriptorUpdateTemplate,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyDescriptorUpdateTemplate = extern "system" fn(
+pub type PFN_vkDestroyDescriptorUpdateTemplate = unsafe extern "system" fn(
     device: Device,
     descriptor_update_template: DescriptorUpdateTemplate,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkUpdateDescriptorSetWithTemplate = extern "system" fn(
+pub type PFN_vkUpdateDescriptorSetWithTemplate = unsafe extern "system" fn(
     device: Device,
     descriptor_set: DescriptorSet,
     descriptor_update_template: DescriptorUpdateTemplate,
     p_data: *const c_void,
 );
 pub struct KhrDescriptorUpdateTemplateFn {
-    pub create_descriptor_update_template_khr: extern "system" fn(
+    pub create_descriptor_update_template_khr: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const DescriptorUpdateTemplateCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_descriptor_update_template: *mut DescriptorUpdateTemplate,
     ) -> Result,
-    pub destroy_descriptor_update_template_khr: extern "system" fn(
+    pub destroy_descriptor_update_template_khr: unsafe extern "system" fn(
         device: Device,
         descriptor_update_template: DescriptorUpdateTemplate,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub update_descriptor_set_with_template_khr: extern "system" fn(
+    pub update_descriptor_set_with_template_khr: unsafe extern "system" fn(
         device: Device,
         descriptor_set: DescriptorSet,
         descriptor_update_template: DescriptorUpdateTemplate,
         p_data: *const c_void,
     ),
-    pub cmd_push_descriptor_set_with_template_khr: extern "system" fn(
+    pub cmd_push_descriptor_set_with_template_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         descriptor_update_template: DescriptorUpdateTemplate,
         layout: PipelineLayout,
@@ -7085,7 +7105,7 @@ impl KhrDescriptorUpdateTemplateFn {
     {
         KhrDescriptorUpdateTemplateFn {
             create_descriptor_update_template_khr: unsafe {
-                extern "system" fn create_descriptor_update_template_khr(
+                unsafe extern "system" fn create_descriptor_update_template_khr(
                     _device: Device,
                     _p_create_info: *const DescriptorUpdateTemplateCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -7107,7 +7127,7 @@ impl KhrDescriptorUpdateTemplateFn {
                 }
             },
             destroy_descriptor_update_template_khr: unsafe {
-                extern "system" fn destroy_descriptor_update_template_khr(
+                unsafe extern "system" fn destroy_descriptor_update_template_khr(
                     _device: Device,
                     _descriptor_update_template: DescriptorUpdateTemplate,
                     _p_allocator: *const AllocationCallbacks,
@@ -7128,7 +7148,7 @@ impl KhrDescriptorUpdateTemplateFn {
                 }
             },
             update_descriptor_set_with_template_khr: unsafe {
-                extern "system" fn update_descriptor_set_with_template_khr(
+                unsafe extern "system" fn update_descriptor_set_with_template_khr(
                     _device: Device,
                     _descriptor_set: DescriptorSet,
                     _descriptor_update_template: DescriptorUpdateTemplate,
@@ -7150,7 +7170,7 @@ impl KhrDescriptorUpdateTemplateFn {
                 }
             },
             cmd_push_descriptor_set_with_template_khr: unsafe {
-                extern "system" fn cmd_push_descriptor_set_with_template_khr(
+                unsafe extern "system" fn cmd_push_descriptor_set_with_template_khr(
                     _command_buffer: CommandBuffer,
                     _descriptor_update_template: DescriptorUpdateTemplate,
                     _layout: PipelineLayout,
@@ -7283,14 +7303,14 @@ impl NvClipSpaceWScalingFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetViewportWScalingNV = extern "system" fn(
+pub type PFN_vkCmdSetViewportWScalingNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_viewport: u32,
     viewport_count: u32,
     p_viewport_w_scalings: *const ViewportWScalingNV,
 );
 pub struct NvClipSpaceWScalingFn {
-    pub cmd_set_viewport_w_scaling_nv: extern "system" fn(
+    pub cmd_set_viewport_w_scaling_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_viewport: u32,
         viewport_count: u32,
@@ -7313,7 +7333,7 @@ impl NvClipSpaceWScalingFn {
     {
         NvClipSpaceWScalingFn {
             cmd_set_viewport_w_scaling_nv: unsafe {
-                extern "system" fn cmd_set_viewport_w_scaling_nv(
+                unsafe extern "system" fn cmd_set_viewport_w_scaling_nv(
                     _command_buffer: CommandBuffer,
                     _first_viewport: u32,
                     _viewport_count: u32,
@@ -7369,10 +7389,10 @@ impl ExtDirectModeDisplayFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkReleaseDisplayEXT =
-    extern "system" fn(physical_device: PhysicalDevice, display: DisplayKHR) -> Result;
+    unsafe extern "system" fn(physical_device: PhysicalDevice, display: DisplayKHR) -> Result;
 pub struct ExtDirectModeDisplayFn {
     pub release_display_ext:
-        extern "system" fn(physical_device: PhysicalDevice, display: DisplayKHR) -> Result,
+        unsafe extern "system" fn(physical_device: PhysicalDevice, display: DisplayKHR) -> Result,
 }
 unsafe impl Send for ExtDirectModeDisplayFn {}
 unsafe impl Sync for ExtDirectModeDisplayFn {}
@@ -7390,7 +7410,7 @@ impl ExtDirectModeDisplayFn {
     {
         ExtDirectModeDisplayFn {
             release_display_ext: unsafe {
-                extern "system" fn release_display_ext(
+                unsafe extern "system" fn release_display_ext(
                     _physical_device: PhysicalDevice,
                     _display: DisplayKHR,
                 ) -> Result {
@@ -7424,25 +7444,25 @@ impl ExtAcquireXlibDisplayFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkAcquireXlibDisplayEXT = extern "system" fn(
+pub type PFN_vkAcquireXlibDisplayEXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     dpy: *mut Display,
     display: DisplayKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetRandROutputDisplayEXT = extern "system" fn(
+pub type PFN_vkGetRandROutputDisplayEXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     dpy: *mut Display,
     rr_output: RROutput,
     p_display: *mut DisplayKHR,
 ) -> Result;
 pub struct ExtAcquireXlibDisplayFn {
-    pub acquire_xlib_display_ext: extern "system" fn(
+    pub acquire_xlib_display_ext: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         dpy: *mut Display,
         display: DisplayKHR,
     ) -> Result,
-    pub get_rand_r_output_display_ext: extern "system" fn(
+    pub get_rand_r_output_display_ext: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         dpy: *mut Display,
         rr_output: RROutput,
@@ -7466,7 +7486,7 @@ impl ExtAcquireXlibDisplayFn {
     {
         ExtAcquireXlibDisplayFn {
             acquire_xlib_display_ext: unsafe {
-                extern "system" fn acquire_xlib_display_ext(
+                unsafe extern "system" fn acquire_xlib_display_ext(
                     _physical_device: PhysicalDevice,
                     _dpy: *mut Display,
                     _display: DisplayKHR,
@@ -7486,7 +7506,7 @@ impl ExtAcquireXlibDisplayFn {
                 }
             },
             get_rand_r_output_display_ext: unsafe {
-                extern "system" fn get_rand_r_output_display_ext(
+                unsafe extern "system" fn get_rand_r_output_display_ext(
                     _physical_device: PhysicalDevice,
                     _dpy: *mut Display,
                     _rr_output: RROutput,
@@ -7537,13 +7557,13 @@ impl ExtDisplaySurfaceCounterFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     surface: SurfaceKHR,
     p_surface_capabilities: *mut SurfaceCapabilities2EXT,
 ) -> Result;
 pub struct ExtDisplaySurfaceCounterFn {
-    pub get_physical_device_surface_capabilities2_ext: extern "system" fn(
+    pub get_physical_device_surface_capabilities2_ext: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         surface: SurfaceKHR,
         p_surface_capabilities: *mut SurfaceCapabilities2EXT,
@@ -7566,7 +7586,7 @@ impl ExtDisplaySurfaceCounterFn {
     {
         ExtDisplaySurfaceCounterFn {
             get_physical_device_surface_capabilities2_ext: unsafe {
-                extern "system" fn get_physical_device_surface_capabilities2_ext(
+                unsafe extern "system" fn get_physical_device_surface_capabilities2_ext(
                     _physical_device: PhysicalDevice,
                     _surface: SurfaceKHR,
                     _p_surface_capabilities: *mut SurfaceCapabilities2EXT,
@@ -7618,20 +7638,20 @@ impl ExtDisplayControlFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkDisplayPowerControlEXT = extern "system" fn(
+pub type PFN_vkDisplayPowerControlEXT = unsafe extern "system" fn(
     device: Device,
     display: DisplayKHR,
     p_display_power_info: *const DisplayPowerInfoEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkRegisterDeviceEventEXT = extern "system" fn(
+pub type PFN_vkRegisterDeviceEventEXT = unsafe extern "system" fn(
     device: Device,
     p_device_event_info: *const DeviceEventInfoEXT,
     p_allocator: *const AllocationCallbacks,
     p_fence: *mut Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkRegisterDisplayEventEXT = extern "system" fn(
+pub type PFN_vkRegisterDisplayEventEXT = unsafe extern "system" fn(
     device: Device,
     display: DisplayKHR,
     p_display_event_info: *const DisplayEventInfoEXT,
@@ -7639,32 +7659,32 @@ pub type PFN_vkRegisterDisplayEventEXT = extern "system" fn(
     p_fence: *mut Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetSwapchainCounterEXT = extern "system" fn(
+pub type PFN_vkGetSwapchainCounterEXT = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
     counter: SurfaceCounterFlagsEXT,
     p_counter_value: *mut u64,
 ) -> Result;
 pub struct ExtDisplayControlFn {
-    pub display_power_control_ext: extern "system" fn(
+    pub display_power_control_ext: unsafe extern "system" fn(
         device: Device,
         display: DisplayKHR,
         p_display_power_info: *const DisplayPowerInfoEXT,
     ) -> Result,
-    pub register_device_event_ext: extern "system" fn(
+    pub register_device_event_ext: unsafe extern "system" fn(
         device: Device,
         p_device_event_info: *const DeviceEventInfoEXT,
         p_allocator: *const AllocationCallbacks,
         p_fence: *mut Fence,
     ) -> Result,
-    pub register_display_event_ext: extern "system" fn(
+    pub register_display_event_ext: unsafe extern "system" fn(
         device: Device,
         display: DisplayKHR,
         p_display_event_info: *const DisplayEventInfoEXT,
         p_allocator: *const AllocationCallbacks,
         p_fence: *mut Fence,
     ) -> Result,
-    pub get_swapchain_counter_ext: extern "system" fn(
+    pub get_swapchain_counter_ext: unsafe extern "system" fn(
         device: Device,
         swapchain: SwapchainKHR,
         counter: SurfaceCounterFlagsEXT,
@@ -7690,7 +7710,7 @@ impl ExtDisplayControlFn {
     {
         ExtDisplayControlFn {
             display_power_control_ext: unsafe {
-                extern "system" fn display_power_control_ext(
+                unsafe extern "system" fn display_power_control_ext(
                     _device: Device,
                     _display: DisplayKHR,
                     _p_display_power_info: *const DisplayPowerInfoEXT,
@@ -7710,7 +7730,7 @@ impl ExtDisplayControlFn {
                 }
             },
             register_device_event_ext: unsafe {
-                extern "system" fn register_device_event_ext(
+                unsafe extern "system" fn register_device_event_ext(
                     _device: Device,
                     _p_device_event_info: *const DeviceEventInfoEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -7731,7 +7751,7 @@ impl ExtDisplayControlFn {
                 }
             },
             register_display_event_ext: unsafe {
-                extern "system" fn register_display_event_ext(
+                unsafe extern "system" fn register_display_event_ext(
                     _device: Device,
                     _display: DisplayKHR,
                     _p_display_event_info: *const DisplayEventInfoEXT,
@@ -7753,7 +7773,7 @@ impl ExtDisplayControlFn {
                 }
             },
             get_swapchain_counter_ext: unsafe {
-                extern "system" fn get_swapchain_counter_ext(
+                unsafe extern "system" fn get_swapchain_counter_ext(
                     _device: Device,
                     _swapchain: SwapchainKHR,
                     _counter: SurfaceCounterFlagsEXT,
@@ -7846,25 +7866,25 @@ impl GoogleDisplayTimingFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetRefreshCycleDurationGOOGLE = extern "system" fn(
+pub type PFN_vkGetRefreshCycleDurationGOOGLE = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
     p_display_timing_properties: *mut RefreshCycleDurationGOOGLE,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPastPresentationTimingGOOGLE = extern "system" fn(
+pub type PFN_vkGetPastPresentationTimingGOOGLE = unsafe extern "system" fn(
     device: Device,
     swapchain: SwapchainKHR,
     p_presentation_timing_count: *mut u32,
     p_presentation_timings: *mut PastPresentationTimingGOOGLE,
 ) -> Result;
 pub struct GoogleDisplayTimingFn {
-    pub get_refresh_cycle_duration_google: extern "system" fn(
+    pub get_refresh_cycle_duration_google: unsafe extern "system" fn(
         device: Device,
         swapchain: SwapchainKHR,
         p_display_timing_properties: *mut RefreshCycleDurationGOOGLE,
     ) -> Result,
-    pub get_past_presentation_timing_google: extern "system" fn(
+    pub get_past_presentation_timing_google: unsafe extern "system" fn(
         device: Device,
         swapchain: SwapchainKHR,
         p_presentation_timing_count: *mut u32,
@@ -7888,7 +7908,7 @@ impl GoogleDisplayTimingFn {
     {
         GoogleDisplayTimingFn {
             get_refresh_cycle_duration_google: unsafe {
-                extern "system" fn get_refresh_cycle_duration_google(
+                unsafe extern "system" fn get_refresh_cycle_duration_google(
                     _device: Device,
                     _swapchain: SwapchainKHR,
                     _p_display_timing_properties: *mut RefreshCycleDurationGOOGLE,
@@ -7909,7 +7929,7 @@ impl GoogleDisplayTimingFn {
                 }
             },
             get_past_presentation_timing_google: unsafe {
-                extern "system" fn get_past_presentation_timing_google(
+                unsafe extern "system" fn get_past_presentation_timing_google(
                     _device: Device,
                     _swapchain: SwapchainKHR,
                     _p_presentation_timing_count: *mut u32,
@@ -8101,14 +8121,14 @@ impl ExtDiscardRectanglesFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetDiscardRectangleEXT = extern "system" fn(
+pub type PFN_vkCmdSetDiscardRectangleEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_discard_rectangle: u32,
     discard_rectangle_count: u32,
     p_discard_rectangles: *const Rect2D,
 );
 pub struct ExtDiscardRectanglesFn {
-    pub cmd_set_discard_rectangle_ext: extern "system" fn(
+    pub cmd_set_discard_rectangle_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_discard_rectangle: u32,
         discard_rectangle_count: u32,
@@ -8131,7 +8151,7 @@ impl ExtDiscardRectanglesFn {
     {
         ExtDiscardRectanglesFn {
             cmd_set_discard_rectangle_ext: unsafe {
-                extern "system" fn cmd_set_discard_rectangle_ext(
+                unsafe extern "system" fn cmd_set_discard_rectangle_ext(
                     _command_buffer: CommandBuffer,
                     _first_discard_rectangle: u32,
                     _discard_rectangle_count: u32,
@@ -8381,14 +8401,14 @@ impl ExtHdrMetadataFn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkSetHdrMetadataEXT = extern "system" fn(
+pub type PFN_vkSetHdrMetadataEXT = unsafe extern "system" fn(
     device: Device,
     swapchain_count: u32,
     p_swapchains: *const SwapchainKHR,
     p_metadata: *const HdrMetadataEXT,
 );
 pub struct ExtHdrMetadataFn {
-    pub set_hdr_metadata_ext: extern "system" fn(
+    pub set_hdr_metadata_ext: unsafe extern "system" fn(
         device: Device,
         swapchain_count: u32,
         p_swapchains: *const SwapchainKHR,
@@ -8411,7 +8431,7 @@ impl ExtHdrMetadataFn {
     {
         ExtHdrMetadataFn {
             set_hdr_metadata_ext: unsafe {
-                extern "system" fn set_hdr_metadata_ext(
+                unsafe extern "system" fn set_hdr_metadata_ext(
                     _device: Device,
                     _swapchain_count: u32,
                     _p_swapchains: *const SwapchainKHR,
@@ -8544,45 +8564,47 @@ impl KhrCreateRenderpass2Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateRenderPass2 = extern "system" fn(
+pub type PFN_vkCreateRenderPass2 = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const RenderPassCreateInfo2,
     p_allocator: *const AllocationCallbacks,
     p_render_pass: *mut RenderPass,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBeginRenderPass2 = extern "system" fn(
+pub type PFN_vkCmdBeginRenderPass2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_render_pass_begin: *const RenderPassBeginInfo,
     p_subpass_begin_info: *const SubpassBeginInfo,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdNextSubpass2 = extern "system" fn(
+pub type PFN_vkCmdNextSubpass2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_subpass_begin_info: *const SubpassBeginInfo,
     p_subpass_end_info: *const SubpassEndInfo,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdEndRenderPass2 =
-    extern "system" fn(command_buffer: CommandBuffer, p_subpass_end_info: *const SubpassEndInfo);
+pub type PFN_vkCmdEndRenderPass2 = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_subpass_end_info: *const SubpassEndInfo,
+);
 pub struct KhrCreateRenderpass2Fn {
-    pub create_render_pass2_khr: extern "system" fn(
+    pub create_render_pass2_khr: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const RenderPassCreateInfo2,
         p_allocator: *const AllocationCallbacks,
         p_render_pass: *mut RenderPass,
     ) -> Result,
-    pub cmd_begin_render_pass2_khr: extern "system" fn(
+    pub cmd_begin_render_pass2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_render_pass_begin: *const RenderPassBeginInfo,
         p_subpass_begin_info: *const SubpassBeginInfo,
     ),
-    pub cmd_next_subpass2_khr: extern "system" fn(
+    pub cmd_next_subpass2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_subpass_begin_info: *const SubpassBeginInfo,
         p_subpass_end_info: *const SubpassEndInfo,
     ),
-    pub cmd_end_render_pass2_khr: extern "system" fn(
+    pub cmd_end_render_pass2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_subpass_end_info: *const SubpassEndInfo,
     ),
@@ -8606,7 +8628,7 @@ impl KhrCreateRenderpass2Fn {
     {
         KhrCreateRenderpass2Fn {
             create_render_pass2_khr: unsafe {
-                extern "system" fn create_render_pass2_khr(
+                unsafe extern "system" fn create_render_pass2_khr(
                     _device: Device,
                     _p_create_info: *const RenderPassCreateInfo2,
                     _p_allocator: *const AllocationCallbacks,
@@ -8627,7 +8649,7 @@ impl KhrCreateRenderpass2Fn {
                 }
             },
             cmd_begin_render_pass2_khr: unsafe {
-                extern "system" fn cmd_begin_render_pass2_khr(
+                unsafe extern "system" fn cmd_begin_render_pass2_khr(
                     _command_buffer: CommandBuffer,
                     _p_render_pass_begin: *const RenderPassBeginInfo,
                     _p_subpass_begin_info: *const SubpassBeginInfo,
@@ -8647,7 +8669,7 @@ impl KhrCreateRenderpass2Fn {
                 }
             },
             cmd_next_subpass2_khr: unsafe {
-                extern "system" fn cmd_next_subpass2_khr(
+                unsafe extern "system" fn cmd_next_subpass2_khr(
                     _command_buffer: CommandBuffer,
                     _p_subpass_begin_info: *const SubpassBeginInfo,
                     _p_subpass_end_info: *const SubpassEndInfo,
@@ -8667,7 +8689,7 @@ impl KhrCreateRenderpass2Fn {
                 }
             },
             cmd_end_render_pass2_khr: unsafe {
-                extern "system" fn cmd_end_render_pass2_khr(
+                unsafe extern "system" fn cmd_end_render_pass2_khr(
                     _command_buffer: CommandBuffer,
                     _p_subpass_end_info: *const SubpassEndInfo,
                 ) {
@@ -8784,10 +8806,10 @@ impl KhrSharedPresentableImageFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetSwapchainStatusKHR =
-    extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result;
+    unsafe extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result;
 pub struct KhrSharedPresentableImageFn {
     pub get_swapchain_status_khr:
-        extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result,
+        unsafe extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result,
 }
 unsafe impl Send for KhrSharedPresentableImageFn {}
 unsafe impl Sync for KhrSharedPresentableImageFn {}
@@ -8805,7 +8827,7 @@ impl KhrSharedPresentableImageFn {
     {
         KhrSharedPresentableImageFn {
             get_swapchain_status_khr: unsafe {
-                extern "system" fn get_swapchain_status_khr(
+                unsafe extern "system" fn get_swapchain_status_khr(
                     _device: Device,
                     _swapchain: SwapchainKHR,
                 ) -> Result {
@@ -8858,13 +8880,13 @@ impl KhrExternalFenceCapabilitiesFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceExternalFenceProperties = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceExternalFenceProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_external_fence_info: *const PhysicalDeviceExternalFenceInfo,
     p_external_fence_properties: *mut ExternalFenceProperties,
 );
 pub struct KhrExternalFenceCapabilitiesFn {
-    pub get_physical_device_external_fence_properties_khr: extern "system" fn(
+    pub get_physical_device_external_fence_properties_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_external_fence_info: *const PhysicalDeviceExternalFenceInfo,
         p_external_fence_properties: *mut ExternalFenceProperties,
@@ -8887,7 +8909,7 @@ impl KhrExternalFenceCapabilitiesFn {
     {
         KhrExternalFenceCapabilitiesFn {
             get_physical_device_external_fence_properties_khr: unsafe {
-                extern "system" fn get_physical_device_external_fence_properties_khr(
+                unsafe extern "system" fn get_physical_device_external_fence_properties_khr(
                     _physical_device: PhysicalDevice,
                     _p_external_fence_info: *const PhysicalDeviceExternalFenceInfo,
                     _p_external_fence_properties: *mut ExternalFenceProperties,
@@ -8995,22 +9017,22 @@ impl KhrExternalFenceWin32Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkImportFenceWin32HandleKHR = extern "system" fn(
+pub type PFN_vkImportFenceWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
     p_import_fence_win32_handle_info: *const ImportFenceWin32HandleInfoKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetFenceWin32HandleKHR = extern "system" fn(
+pub type PFN_vkGetFenceWin32HandleKHR = unsafe extern "system" fn(
     device: Device,
     p_get_win32_handle_info: *const FenceGetWin32HandleInfoKHR,
     p_handle: *mut HANDLE,
 ) -> Result;
 pub struct KhrExternalFenceWin32Fn {
-    pub import_fence_win32_handle_khr: extern "system" fn(
+    pub import_fence_win32_handle_khr: unsafe extern "system" fn(
         device: Device,
         p_import_fence_win32_handle_info: *const ImportFenceWin32HandleInfoKHR,
     ) -> Result,
-    pub get_fence_win32_handle_khr: extern "system" fn(
+    pub get_fence_win32_handle_khr: unsafe extern "system" fn(
         device: Device,
         p_get_win32_handle_info: *const FenceGetWin32HandleInfoKHR,
         p_handle: *mut HANDLE,
@@ -9033,7 +9055,7 @@ impl KhrExternalFenceWin32Fn {
     {
         KhrExternalFenceWin32Fn {
             import_fence_win32_handle_khr: unsafe {
-                extern "system" fn import_fence_win32_handle_khr(
+                unsafe extern "system" fn import_fence_win32_handle_khr(
                     _device: Device,
                     _p_import_fence_win32_handle_info: *const ImportFenceWin32HandleInfoKHR,
                 ) -> Result {
@@ -9053,7 +9075,7 @@ impl KhrExternalFenceWin32Fn {
                 }
             },
             get_fence_win32_handle_khr: unsafe {
-                extern "system" fn get_fence_win32_handle_khr(
+                unsafe extern "system" fn get_fence_win32_handle_khr(
                     _device: Device,
                     _p_get_win32_handle_info: *const FenceGetWin32HandleInfoKHR,
                     _p_handle: *mut HANDLE,
@@ -9112,22 +9134,22 @@ impl KhrExternalFenceFdFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkImportFenceFdKHR = extern "system" fn(
+pub type PFN_vkImportFenceFdKHR = unsafe extern "system" fn(
     device: Device,
     p_import_fence_fd_info: *const ImportFenceFdInfoKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetFenceFdKHR = extern "system" fn(
+pub type PFN_vkGetFenceFdKHR = unsafe extern "system" fn(
     device: Device,
     p_get_fd_info: *const FenceGetFdInfoKHR,
     p_fd: *mut c_int,
 ) -> Result;
 pub struct KhrExternalFenceFdFn {
-    pub import_fence_fd_khr: extern "system" fn(
+    pub import_fence_fd_khr: unsafe extern "system" fn(
         device: Device,
         p_import_fence_fd_info: *const ImportFenceFdInfoKHR,
     ) -> Result,
-    pub get_fence_fd_khr: extern "system" fn(
+    pub get_fence_fd_khr: unsafe extern "system" fn(
         device: Device,
         p_get_fd_info: *const FenceGetFdInfoKHR,
         p_fd: *mut c_int,
@@ -9150,7 +9172,7 @@ impl KhrExternalFenceFdFn {
     {
         KhrExternalFenceFdFn {
             import_fence_fd_khr: unsafe {
-                extern "system" fn import_fence_fd_khr(
+                unsafe extern "system" fn import_fence_fd_khr(
                     _device: Device,
                     _p_import_fence_fd_info: *const ImportFenceFdInfoKHR,
                 ) -> Result {
@@ -9166,7 +9188,7 @@ impl KhrExternalFenceFdFn {
                 }
             },
             get_fence_fd_khr: unsafe {
-                extern "system" fn get_fence_fd_khr(
+                unsafe extern "system" fn get_fence_fd_khr(
                     _device: Device,
                     _p_get_fd_info: *const FenceGetFdInfoKHR,
                     _p_fd: *mut c_int,
@@ -9218,7 +9240,7 @@ impl KhrPerformanceQueryFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-    extern "system" fn(
+    unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         queue_family_index: u32,
         p_counter_count: *mut u32,
@@ -9226,33 +9248,37 @@ pub type PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
         p_counter_descriptions: *mut PerformanceCounterDescriptionKHR,
     ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR = extern "system" fn(
-    physical_device: PhysicalDevice,
-    p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
-    p_num_passes: *mut u32,
-);
+pub type PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR =
+    unsafe extern "system" fn(
+        physical_device: PhysicalDevice,
+        p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
+        p_num_passes: *mut u32,
+    );
 #[allow(non_camel_case_types)]
 pub type PFN_vkAcquireProfilingLockKHR =
-    extern "system" fn(device: Device, p_info: *const AcquireProfilingLockInfoKHR) -> Result;
+    unsafe extern "system" fn(device: Device, p_info: *const AcquireProfilingLockInfoKHR) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkReleaseProfilingLockKHR = extern "system" fn(device: Device);
+pub type PFN_vkReleaseProfilingLockKHR = unsafe extern "system" fn(device: Device);
 pub struct KhrPerformanceQueryFn {
     pub enumerate_physical_device_queue_family_performance_query_counters_khr:
-        extern "system" fn(
+        unsafe extern "system" fn(
             physical_device: PhysicalDevice,
             queue_family_index: u32,
             p_counter_count: *mut u32,
             p_counters: *mut PerformanceCounterKHR,
             p_counter_descriptions: *mut PerformanceCounterDescriptionKHR,
         ) -> Result,
-    pub get_physical_device_queue_family_performance_query_passes_khr: extern "system" fn(
-        physical_device: PhysicalDevice,
-        p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
-        p_num_passes: *mut u32,
-    ),
-    pub acquire_profiling_lock_khr:
-        extern "system" fn(device: Device, p_info: *const AcquireProfilingLockInfoKHR) -> Result,
-    pub release_profiling_lock_khr: extern "system" fn(device: Device),
+    pub get_physical_device_queue_family_performance_query_passes_khr:
+        unsafe extern "system" fn(
+            physical_device: PhysicalDevice,
+            p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
+            p_num_passes: *mut u32,
+        ),
+    pub acquire_profiling_lock_khr: unsafe extern "system" fn(
+        device: Device,
+        p_info: *const AcquireProfilingLockInfoKHR,
+    ) -> Result,
+    pub release_profiling_lock_khr: unsafe extern "system" fn(device: Device),
 }
 unsafe impl Send for KhrPerformanceQueryFn {}
 unsafe impl Sync for KhrPerformanceQueryFn {}
@@ -9275,7 +9301,7 @@ impl KhrPerformanceQueryFn {
     {
         KhrPerformanceQueryFn {
             enumerate_physical_device_queue_family_performance_query_counters_khr: unsafe {
-                extern "system" fn enumerate_physical_device_queue_family_performance_query_counters_khr(
+                unsafe extern "system" fn enumerate_physical_device_queue_family_performance_query_counters_khr(
                     _physical_device: PhysicalDevice,
                     _queue_family_index: u32,
                     _p_counter_count: *mut u32,
@@ -9300,7 +9326,7 @@ impl KhrPerformanceQueryFn {
                 }
             },
             get_physical_device_queue_family_performance_query_passes_khr: unsafe {
-                extern "system" fn get_physical_device_queue_family_performance_query_passes_khr(
+                unsafe extern "system" fn get_physical_device_queue_family_performance_query_passes_khr(
                     _physical_device: PhysicalDevice,
                     _p_performance_query_create_info: *const QueryPoolPerformanceCreateInfoKHR,
                     _p_num_passes: *mut u32,
@@ -9321,7 +9347,7 @@ impl KhrPerformanceQueryFn {
                 }
             },
             acquire_profiling_lock_khr: unsafe {
-                extern "system" fn acquire_profiling_lock_khr(
+                unsafe extern "system" fn acquire_profiling_lock_khr(
                     _device: Device,
                     _p_info: *const AcquireProfilingLockInfoKHR,
                 ) -> Result {
@@ -9340,7 +9366,7 @@ impl KhrPerformanceQueryFn {
                 }
             },
             release_profiling_lock_khr: unsafe {
-                extern "system" fn release_profiling_lock_khr(_device: Device) {
+                unsafe extern "system" fn release_profiling_lock_khr(_device: Device) {
                     panic!(concat!(
                         "Unable to load ",
                         stringify!(release_profiling_lock_khr)
@@ -9539,25 +9565,25 @@ impl KhrGetSurfaceCapabilities2Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
     p_surface_capabilities: *mut SurfaceCapabilities2KHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSurfaceFormats2KHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSurfaceFormats2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
     p_surface_format_count: *mut u32,
     p_surface_formats: *mut SurfaceFormat2KHR,
 ) -> Result;
 pub struct KhrGetSurfaceCapabilities2Fn {
-    pub get_physical_device_surface_capabilities2_khr: extern "system" fn(
+    pub get_physical_device_surface_capabilities2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
         p_surface_capabilities: *mut SurfaceCapabilities2KHR,
     ) -> Result,
-    pub get_physical_device_surface_formats2_khr: extern "system" fn(
+    pub get_physical_device_surface_formats2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
         p_surface_format_count: *mut u32,
@@ -9582,7 +9608,7 @@ impl KhrGetSurfaceCapabilities2Fn {
     {
         KhrGetSurfaceCapabilities2Fn {
             get_physical_device_surface_capabilities2_khr: unsafe {
-                extern "system" fn get_physical_device_surface_capabilities2_khr(
+                unsafe extern "system" fn get_physical_device_surface_capabilities2_khr(
                     _physical_device: PhysicalDevice,
                     _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
                     _p_surface_capabilities: *mut SurfaceCapabilities2KHR,
@@ -9603,7 +9629,7 @@ impl KhrGetSurfaceCapabilities2Fn {
                 }
             },
             get_physical_device_surface_formats2_khr: unsafe {
-                extern "system" fn get_physical_device_surface_formats2_khr(
+                unsafe extern "system" fn get_physical_device_surface_formats2_khr(
                     _physical_device: PhysicalDevice,
                     _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
                     _p_surface_format_count: *mut u32,
@@ -9708,48 +9734,48 @@ impl KhrGetDisplayProperties2Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceDisplayProperties2KHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceDisplayProperties2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
     p_properties: *mut DisplayProperties2KHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
     p_properties: *mut DisplayPlaneProperties2KHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDisplayModeProperties2KHR = extern "system" fn(
+pub type PFN_vkGetDisplayModeProperties2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     display: DisplayKHR,
     p_property_count: *mut u32,
     p_properties: *mut DisplayModeProperties2KHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDisplayPlaneCapabilities2KHR = extern "system" fn(
+pub type PFN_vkGetDisplayPlaneCapabilities2KHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_display_plane_info: *const DisplayPlaneInfo2KHR,
     p_capabilities: *mut DisplayPlaneCapabilities2KHR,
 ) -> Result;
 pub struct KhrGetDisplayProperties2Fn {
-    pub get_physical_device_display_properties2_khr: extern "system" fn(
+    pub get_physical_device_display_properties2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_property_count: *mut u32,
         p_properties: *mut DisplayProperties2KHR,
     ) -> Result,
-    pub get_physical_device_display_plane_properties2_khr: extern "system" fn(
+    pub get_physical_device_display_plane_properties2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_property_count: *mut u32,
         p_properties: *mut DisplayPlaneProperties2KHR,
     ) -> Result,
-    pub get_display_mode_properties2_khr: extern "system" fn(
+    pub get_display_mode_properties2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         display: DisplayKHR,
         p_property_count: *mut u32,
         p_properties: *mut DisplayModeProperties2KHR,
     ) -> Result,
-    pub get_display_plane_capabilities2_khr: extern "system" fn(
+    pub get_display_plane_capabilities2_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_display_plane_info: *const DisplayPlaneInfo2KHR,
         p_capabilities: *mut DisplayPlaneCapabilities2KHR,
@@ -9776,7 +9802,7 @@ impl KhrGetDisplayProperties2Fn {
     {
         KhrGetDisplayProperties2Fn {
             get_physical_device_display_properties2_khr: unsafe {
-                extern "system" fn get_physical_device_display_properties2_khr(
+                unsafe extern "system" fn get_physical_device_display_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
                     _p_properties: *mut DisplayProperties2KHR,
@@ -9797,7 +9823,7 @@ impl KhrGetDisplayProperties2Fn {
                 }
             },
             get_physical_device_display_plane_properties2_khr: unsafe {
-                extern "system" fn get_physical_device_display_plane_properties2_khr(
+                unsafe extern "system" fn get_physical_device_display_plane_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
                     _p_properties: *mut DisplayPlaneProperties2KHR,
@@ -9818,7 +9844,7 @@ impl KhrGetDisplayProperties2Fn {
                 }
             },
             get_display_mode_properties2_khr: unsafe {
-                extern "system" fn get_display_mode_properties2_khr(
+                unsafe extern "system" fn get_display_mode_properties2_khr(
                     _physical_device: PhysicalDevice,
                     _display: DisplayKHR,
                     _p_property_count: *mut u32,
@@ -9840,7 +9866,7 @@ impl KhrGetDisplayProperties2Fn {
                 }
             },
             get_display_plane_capabilities2_khr: unsafe {
-                extern "system" fn get_display_plane_capabilities2_khr(
+                unsafe extern "system" fn get_display_plane_capabilities2_khr(
                     _physical_device: PhysicalDevice,
                     _p_display_plane_info: *const DisplayPlaneInfo2KHR,
                     _p_capabilities: *mut DisplayPlaneCapabilities2KHR,
@@ -9945,14 +9971,14 @@ impl MvkIosSurfaceFn {
     pub const SPEC_VERSION: u32 = 3u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateIOSSurfaceMVK = extern "system" fn(
+pub type PFN_vkCreateIOSSurfaceMVK = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const IOSSurfaceCreateInfoMVK,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub struct MvkIosSurfaceFn {
-    pub create_ios_surface_mvk: extern "system" fn(
+    pub create_ios_surface_mvk: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const IOSSurfaceCreateInfoMVK,
         p_allocator: *const AllocationCallbacks,
@@ -9975,7 +10001,7 @@ impl MvkIosSurfaceFn {
     {
         MvkIosSurfaceFn {
             create_ios_surface_mvk: unsafe {
-                extern "system" fn create_ios_surface_mvk(
+                unsafe extern "system" fn create_ios_surface_mvk(
                     _instance: Instance,
                     _p_create_info: *const IOSSurfaceCreateInfoMVK,
                     _p_allocator: *const AllocationCallbacks,
@@ -10020,14 +10046,14 @@ impl MvkMacosSurfaceFn {
     pub const SPEC_VERSION: u32 = 3u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateMacOSSurfaceMVK = extern "system" fn(
+pub type PFN_vkCreateMacOSSurfaceMVK = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const MacOSSurfaceCreateInfoMVK,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub struct MvkMacosSurfaceFn {
-    pub create_mac_os_surface_mvk: extern "system" fn(
+    pub create_mac_os_surface_mvk: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const MacOSSurfaceCreateInfoMVK,
         p_allocator: *const AllocationCallbacks,
@@ -10050,7 +10076,7 @@ impl MvkMacosSurfaceFn {
     {
         MvkMacosSurfaceFn {
             create_mac_os_surface_mvk: unsafe {
-                extern "system" fn create_mac_os_surface_mvk(
+                unsafe extern "system" fn create_mac_os_surface_mvk(
                     _instance: Instance,
                     _p_create_info: *const MacOSSurfaceCreateInfoMVK,
                     _p_allocator: *const AllocationCallbacks,
@@ -10198,76 +10224,90 @@ impl ExtDebugUtilsFn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkSetDebugUtilsObjectNameEXT =
-    extern "system" fn(device: Device, p_name_info: *const DebugUtilsObjectNameInfoEXT) -> Result;
+pub type PFN_vkSetDebugUtilsObjectNameEXT = unsafe extern "system" fn(
+    device: Device,
+    p_name_info: *const DebugUtilsObjectNameInfoEXT,
+) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkSetDebugUtilsObjectTagEXT =
-    extern "system" fn(device: Device, p_tag_info: *const DebugUtilsObjectTagInfoEXT) -> Result;
+pub type PFN_vkSetDebugUtilsObjectTagEXT = unsafe extern "system" fn(
+    device: Device,
+    p_tag_info: *const DebugUtilsObjectTagInfoEXT,
+) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkQueueBeginDebugUtilsLabelEXT =
-    extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT);
+    unsafe extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT);
 #[allow(non_camel_case_types)]
-pub type PFN_vkQueueEndDebugUtilsLabelEXT = extern "system" fn(queue: Queue);
+pub type PFN_vkQueueEndDebugUtilsLabelEXT = unsafe extern "system" fn(queue: Queue);
 #[allow(non_camel_case_types)]
 pub type PFN_vkQueueInsertDebugUtilsLabelEXT =
-    extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT);
+    unsafe extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBeginDebugUtilsLabelEXT =
-    extern "system" fn(command_buffer: CommandBuffer, p_label_info: *const DebugUtilsLabelEXT);
+pub type PFN_vkCmdBeginDebugUtilsLabelEXT = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_label_info: *const DebugUtilsLabelEXT,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdEndDebugUtilsLabelEXT = extern "system" fn(command_buffer: CommandBuffer);
+pub type PFN_vkCmdEndDebugUtilsLabelEXT = unsafe extern "system" fn(command_buffer: CommandBuffer);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdInsertDebugUtilsLabelEXT =
-    extern "system" fn(command_buffer: CommandBuffer, p_label_info: *const DebugUtilsLabelEXT);
+pub type PFN_vkCmdInsertDebugUtilsLabelEXT = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_label_info: *const DebugUtilsLabelEXT,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDebugUtilsMessengerEXT = extern "system" fn(
+pub type PFN_vkCreateDebugUtilsMessengerEXT = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const DebugUtilsMessengerCreateInfoEXT,
     p_allocator: *const AllocationCallbacks,
     p_messenger: *mut DebugUtilsMessengerEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyDebugUtilsMessengerEXT = extern "system" fn(
+pub type PFN_vkDestroyDebugUtilsMessengerEXT = unsafe extern "system" fn(
     instance: Instance,
     messenger: DebugUtilsMessengerEXT,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkSubmitDebugUtilsMessageEXT = extern "system" fn(
+pub type PFN_vkSubmitDebugUtilsMessageEXT = unsafe extern "system" fn(
     instance: Instance,
     message_severity: DebugUtilsMessageSeverityFlagsEXT,
     message_types: DebugUtilsMessageTypeFlagsEXT,
     p_callback_data: *const DebugUtilsMessengerCallbackDataEXT,
 );
 pub struct ExtDebugUtilsFn {
-    pub set_debug_utils_object_name_ext: extern "system" fn(
+    pub set_debug_utils_object_name_ext: unsafe extern "system" fn(
         device: Device,
         p_name_info: *const DebugUtilsObjectNameInfoEXT,
     ) -> Result,
-    pub set_debug_utils_object_tag_ext:
-        extern "system" fn(device: Device, p_tag_info: *const DebugUtilsObjectTagInfoEXT) -> Result,
+    pub set_debug_utils_object_tag_ext: unsafe extern "system" fn(
+        device: Device,
+        p_tag_info: *const DebugUtilsObjectTagInfoEXT,
+    ) -> Result,
     pub queue_begin_debug_utils_label_ext:
-        extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT),
-    pub queue_end_debug_utils_label_ext: extern "system" fn(queue: Queue),
+        unsafe extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT),
+    pub queue_end_debug_utils_label_ext: unsafe extern "system" fn(queue: Queue),
     pub queue_insert_debug_utils_label_ext:
-        extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT),
-    pub cmd_begin_debug_utils_label_ext:
-        extern "system" fn(command_buffer: CommandBuffer, p_label_info: *const DebugUtilsLabelEXT),
-    pub cmd_end_debug_utils_label_ext: extern "system" fn(command_buffer: CommandBuffer),
-    pub cmd_insert_debug_utils_label_ext:
-        extern "system" fn(command_buffer: CommandBuffer, p_label_info: *const DebugUtilsLabelEXT),
-    pub create_debug_utils_messenger_ext: extern "system" fn(
+        unsafe extern "system" fn(queue: Queue, p_label_info: *const DebugUtilsLabelEXT),
+    pub cmd_begin_debug_utils_label_ext: unsafe extern "system" fn(
+        command_buffer: CommandBuffer,
+        p_label_info: *const DebugUtilsLabelEXT,
+    ),
+    pub cmd_end_debug_utils_label_ext: unsafe extern "system" fn(command_buffer: CommandBuffer),
+    pub cmd_insert_debug_utils_label_ext: unsafe extern "system" fn(
+        command_buffer: CommandBuffer,
+        p_label_info: *const DebugUtilsLabelEXT,
+    ),
+    pub create_debug_utils_messenger_ext: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const DebugUtilsMessengerCreateInfoEXT,
         p_allocator: *const AllocationCallbacks,
         p_messenger: *mut DebugUtilsMessengerEXT,
     ) -> Result,
-    pub destroy_debug_utils_messenger_ext: extern "system" fn(
+    pub destroy_debug_utils_messenger_ext: unsafe extern "system" fn(
         instance: Instance,
         messenger: DebugUtilsMessengerEXT,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub submit_debug_utils_message_ext: extern "system" fn(
+    pub submit_debug_utils_message_ext: unsafe extern "system" fn(
         instance: Instance,
         message_severity: DebugUtilsMessageSeverityFlagsEXT,
         message_types: DebugUtilsMessageTypeFlagsEXT,
@@ -10300,7 +10340,7 @@ impl ExtDebugUtilsFn {
     {
         ExtDebugUtilsFn {
             set_debug_utils_object_name_ext: unsafe {
-                extern "system" fn set_debug_utils_object_name_ext(
+                unsafe extern "system" fn set_debug_utils_object_name_ext(
                     _device: Device,
                     _p_name_info: *const DebugUtilsObjectNameInfoEXT,
                 ) -> Result {
@@ -10320,7 +10360,7 @@ impl ExtDebugUtilsFn {
                 }
             },
             set_debug_utils_object_tag_ext: unsafe {
-                extern "system" fn set_debug_utils_object_tag_ext(
+                unsafe extern "system" fn set_debug_utils_object_tag_ext(
                     _device: Device,
                     _p_tag_info: *const DebugUtilsObjectTagInfoEXT,
                 ) -> Result {
@@ -10340,7 +10380,7 @@ impl ExtDebugUtilsFn {
                 }
             },
             queue_begin_debug_utils_label_ext: unsafe {
-                extern "system" fn queue_begin_debug_utils_label_ext(
+                unsafe extern "system" fn queue_begin_debug_utils_label_ext(
                     _queue: Queue,
                     _p_label_info: *const DebugUtilsLabelEXT,
                 ) {
@@ -10360,7 +10400,7 @@ impl ExtDebugUtilsFn {
                 }
             },
             queue_end_debug_utils_label_ext: unsafe {
-                extern "system" fn queue_end_debug_utils_label_ext(_queue: Queue) {
+                unsafe extern "system" fn queue_end_debug_utils_label_ext(_queue: Queue) {
                     panic!(concat!(
                         "Unable to load ",
                         stringify!(queue_end_debug_utils_label_ext)
@@ -10377,7 +10417,7 @@ impl ExtDebugUtilsFn {
                 }
             },
             queue_insert_debug_utils_label_ext: unsafe {
-                extern "system" fn queue_insert_debug_utils_label_ext(
+                unsafe extern "system" fn queue_insert_debug_utils_label_ext(
                     _queue: Queue,
                     _p_label_info: *const DebugUtilsLabelEXT,
                 ) {
@@ -10397,7 +10437,7 @@ impl ExtDebugUtilsFn {
                 }
             },
             cmd_begin_debug_utils_label_ext: unsafe {
-                extern "system" fn cmd_begin_debug_utils_label_ext(
+                unsafe extern "system" fn cmd_begin_debug_utils_label_ext(
                     _command_buffer: CommandBuffer,
                     _p_label_info: *const DebugUtilsLabelEXT,
                 ) {
@@ -10417,7 +10457,9 @@ impl ExtDebugUtilsFn {
                 }
             },
             cmd_end_debug_utils_label_ext: unsafe {
-                extern "system" fn cmd_end_debug_utils_label_ext(_command_buffer: CommandBuffer) {
+                unsafe extern "system" fn cmd_end_debug_utils_label_ext(
+                    _command_buffer: CommandBuffer,
+                ) {
                     panic!(concat!(
                         "Unable to load ",
                         stringify!(cmd_end_debug_utils_label_ext)
@@ -10434,7 +10476,7 @@ impl ExtDebugUtilsFn {
                 }
             },
             cmd_insert_debug_utils_label_ext: unsafe {
-                extern "system" fn cmd_insert_debug_utils_label_ext(
+                unsafe extern "system" fn cmd_insert_debug_utils_label_ext(
                     _command_buffer: CommandBuffer,
                     _p_label_info: *const DebugUtilsLabelEXT,
                 ) {
@@ -10454,7 +10496,7 @@ impl ExtDebugUtilsFn {
                 }
             },
             create_debug_utils_messenger_ext: unsafe {
-                extern "system" fn create_debug_utils_messenger_ext(
+                unsafe extern "system" fn create_debug_utils_messenger_ext(
                     _instance: Instance,
                     _p_create_info: *const DebugUtilsMessengerCreateInfoEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -10476,7 +10518,7 @@ impl ExtDebugUtilsFn {
                 }
             },
             destroy_debug_utils_messenger_ext: unsafe {
-                extern "system" fn destroy_debug_utils_messenger_ext(
+                unsafe extern "system" fn destroy_debug_utils_messenger_ext(
                     _instance: Instance,
                     _messenger: DebugUtilsMessengerEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -10497,7 +10539,7 @@ impl ExtDebugUtilsFn {
                 }
             },
             submit_debug_utils_message_ext: unsafe {
-                extern "system" fn submit_debug_utils_message_ext(
+                unsafe extern "system" fn submit_debug_utils_message_ext(
                     _instance: Instance,
                     _message_severity: DebugUtilsMessageSeverityFlagsEXT,
                     _message_types: DebugUtilsMessageTypeFlagsEXT,
@@ -10645,24 +10687,24 @@ impl AndroidExternalMemoryAndroidHardwareBufferFn {
     pub const SPEC_VERSION: u32 = 3u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetAndroidHardwareBufferPropertiesANDROID = extern "system" fn(
+pub type PFN_vkGetAndroidHardwareBufferPropertiesANDROID = unsafe extern "system" fn(
     device: Device,
     buffer: *const AHardwareBuffer,
     p_properties: *mut AndroidHardwareBufferPropertiesANDROID,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetMemoryAndroidHardwareBufferANDROID = extern "system" fn(
+pub type PFN_vkGetMemoryAndroidHardwareBufferANDROID = unsafe extern "system" fn(
     device: Device,
     p_info: *const MemoryGetAndroidHardwareBufferInfoANDROID,
     p_buffer: *mut *mut AHardwareBuffer,
 ) -> Result;
 pub struct AndroidExternalMemoryAndroidHardwareBufferFn {
-    pub get_android_hardware_buffer_properties_android: extern "system" fn(
+    pub get_android_hardware_buffer_properties_android: unsafe extern "system" fn(
         device: Device,
         buffer: *const AHardwareBuffer,
         p_properties: *mut AndroidHardwareBufferPropertiesANDROID,
     ) -> Result,
-    pub get_memory_android_hardware_buffer_android: extern "system" fn(
+    pub get_memory_android_hardware_buffer_android: unsafe extern "system" fn(
         device: Device,
         p_info: *const MemoryGetAndroidHardwareBufferInfoANDROID,
         p_buffer: *mut *mut AHardwareBuffer,
@@ -10687,7 +10729,7 @@ impl AndroidExternalMemoryAndroidHardwareBufferFn {
     {
         AndroidExternalMemoryAndroidHardwareBufferFn {
             get_android_hardware_buffer_properties_android: unsafe {
-                extern "system" fn get_android_hardware_buffer_properties_android(
+                unsafe extern "system" fn get_android_hardware_buffer_properties_android(
                     _device: Device,
                     _buffer: *const AHardwareBuffer,
                     _p_properties: *mut AndroidHardwareBufferPropertiesANDROID,
@@ -10708,7 +10750,7 @@ impl AndroidExternalMemoryAndroidHardwareBufferFn {
                 }
             },
             get_memory_android_hardware_buffer_android: unsafe {
-                extern "system" fn get_memory_android_hardware_buffer_android(
+                unsafe extern "system" fn get_memory_android_hardware_buffer_android(
                     _device: Device,
                     _p_info: *const MemoryGetAndroidHardwareBufferInfoANDROID,
                     _p_buffer: *mut *mut AHardwareBuffer,
@@ -11130,22 +11172,22 @@ impl ExtSampleLocationsFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetSampleLocationsEXT = extern "system" fn(
+pub type PFN_vkCmdSetSampleLocationsEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_sample_locations_info: *const SampleLocationsInfoEXT,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     samples: SampleCountFlags,
     p_multisample_properties: *mut MultisamplePropertiesEXT,
 );
 pub struct ExtSampleLocationsFn {
-    pub cmd_set_sample_locations_ext: extern "system" fn(
+    pub cmd_set_sample_locations_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_sample_locations_info: *const SampleLocationsInfoEXT,
     ),
-    pub get_physical_device_multisample_properties_ext: extern "system" fn(
+    pub get_physical_device_multisample_properties_ext: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         samples: SampleCountFlags,
         p_multisample_properties: *mut MultisamplePropertiesEXT,
@@ -11169,7 +11211,7 @@ impl ExtSampleLocationsFn {
     {
         ExtSampleLocationsFn {
             cmd_set_sample_locations_ext: unsafe {
-                extern "system" fn cmd_set_sample_locations_ext(
+                unsafe extern "system" fn cmd_set_sample_locations_ext(
                     _command_buffer: CommandBuffer,
                     _p_sample_locations_info: *const SampleLocationsInfoEXT,
                 ) {
@@ -11189,7 +11231,7 @@ impl ExtSampleLocationsFn {
                 }
             },
             get_physical_device_multisample_properties_ext: unsafe {
-                extern "system" fn get_physical_device_multisample_properties_ext(
+                unsafe extern "system" fn get_physical_device_multisample_properties_ext(
                     _physical_device: PhysicalDevice,
                     _samples: SampleCountFlags,
                     _p_multisample_properties: *mut MultisamplePropertiesEXT,
@@ -11292,36 +11334,36 @@ impl KhrGetMemoryRequirements2Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetImageMemoryRequirements2 = extern "system" fn(
+pub type PFN_vkGetImageMemoryRequirements2 = unsafe extern "system" fn(
     device: Device,
     p_info: *const ImageMemoryRequirementsInfo2,
     p_memory_requirements: *mut MemoryRequirements2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetBufferMemoryRequirements2 = extern "system" fn(
+pub type PFN_vkGetBufferMemoryRequirements2 = unsafe extern "system" fn(
     device: Device,
     p_info: *const BufferMemoryRequirementsInfo2,
     p_memory_requirements: *mut MemoryRequirements2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetImageSparseMemoryRequirements2 = extern "system" fn(
+pub type PFN_vkGetImageSparseMemoryRequirements2 = unsafe extern "system" fn(
     device: Device,
     p_info: *const ImageSparseMemoryRequirementsInfo2,
     p_sparse_memory_requirement_count: *mut u32,
     p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
 );
 pub struct KhrGetMemoryRequirements2Fn {
-    pub get_image_memory_requirements2_khr: extern "system" fn(
+    pub get_image_memory_requirements2_khr: unsafe extern "system" fn(
         device: Device,
         p_info: *const ImageMemoryRequirementsInfo2,
         p_memory_requirements: *mut MemoryRequirements2,
     ),
-    pub get_buffer_memory_requirements2_khr: extern "system" fn(
+    pub get_buffer_memory_requirements2_khr: unsafe extern "system" fn(
         device: Device,
         p_info: *const BufferMemoryRequirementsInfo2,
         p_memory_requirements: *mut MemoryRequirements2,
     ),
-    pub get_image_sparse_memory_requirements2_khr: extern "system" fn(
+    pub get_image_sparse_memory_requirements2_khr: unsafe extern "system" fn(
         device: Device,
         p_info: *const ImageSparseMemoryRequirementsInfo2,
         p_sparse_memory_requirement_count: *mut u32,
@@ -11347,7 +11389,7 @@ impl KhrGetMemoryRequirements2Fn {
     {
         KhrGetMemoryRequirements2Fn {
             get_image_memory_requirements2_khr: unsafe {
-                extern "system" fn get_image_memory_requirements2_khr(
+                unsafe extern "system" fn get_image_memory_requirements2_khr(
                     _device: Device,
                     _p_info: *const ImageMemoryRequirementsInfo2,
                     _p_memory_requirements: *mut MemoryRequirements2,
@@ -11368,7 +11410,7 @@ impl KhrGetMemoryRequirements2Fn {
                 }
             },
             get_buffer_memory_requirements2_khr: unsafe {
-                extern "system" fn get_buffer_memory_requirements2_khr(
+                unsafe extern "system" fn get_buffer_memory_requirements2_khr(
                     _device: Device,
                     _p_info: *const BufferMemoryRequirementsInfo2,
                     _p_memory_requirements: *mut MemoryRequirements2,
@@ -11389,7 +11431,7 @@ impl KhrGetMemoryRequirements2Fn {
                 }
             },
             get_image_sparse_memory_requirements2_khr: unsafe {
-                extern "system" fn get_image_sparse_memory_requirements2_khr(
+                unsafe extern "system" fn get_image_sparse_memory_requirements2_khr(
                     _device: Device,
                     _p_info: *const ImageSparseMemoryRequirementsInfo2,
                     _p_sparse_memory_requirement_count: *mut u32,
@@ -11753,27 +11795,27 @@ impl KhrAccelerationStructureFn {
     pub const SPEC_VERSION: u32 = 11u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateAccelerationStructureKHR = extern "system" fn(
+pub type PFN_vkCreateAccelerationStructureKHR = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const AccelerationStructureCreateInfoKHR,
     p_allocator: *const AllocationCallbacks,
     p_acceleration_structure: *mut AccelerationStructureKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyAccelerationStructureKHR = extern "system" fn(
+pub type PFN_vkDestroyAccelerationStructureKHR = unsafe extern "system" fn(
     device: Device,
     acceleration_structure: AccelerationStructureKHR,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBuildAccelerationStructuresKHR = extern "system" fn(
+pub type PFN_vkCmdBuildAccelerationStructuresKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     info_count: u32,
     p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
     pp_build_range_infos: *const *const AccelerationStructureBuildRangeInfoKHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBuildAccelerationStructuresIndirectKHR = extern "system" fn(
+pub type PFN_vkCmdBuildAccelerationStructuresIndirectKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     info_count: u32,
     p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
@@ -11782,7 +11824,7 @@ pub type PFN_vkCmdBuildAccelerationStructuresIndirectKHR = extern "system" fn(
     pp_max_primitive_counts: *const *const u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkBuildAccelerationStructuresKHR = extern "system" fn(
+pub type PFN_vkBuildAccelerationStructuresKHR = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
     info_count: u32,
@@ -11790,25 +11832,25 @@ pub type PFN_vkBuildAccelerationStructuresKHR = extern "system" fn(
     pp_build_range_infos: *const *const AccelerationStructureBuildRangeInfoKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCopyAccelerationStructureKHR = extern "system" fn(
+pub type PFN_vkCopyAccelerationStructureKHR = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
     p_info: *const CopyAccelerationStructureInfoKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCopyAccelerationStructureToMemoryKHR = extern "system" fn(
+pub type PFN_vkCopyAccelerationStructureToMemoryKHR = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
     p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCopyMemoryToAccelerationStructureKHR = extern "system" fn(
+pub type PFN_vkCopyMemoryToAccelerationStructureKHR = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
     p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkWriteAccelerationStructuresPropertiesKHR = extern "system" fn(
+pub type PFN_vkWriteAccelerationStructuresPropertiesKHR = unsafe extern "system" fn(
     device: Device,
     acceleration_structure_count: u32,
     p_acceleration_structures: *const AccelerationStructureKHR,
@@ -11818,27 +11860,28 @@ pub type PFN_vkWriteAccelerationStructuresPropertiesKHR = extern "system" fn(
     stride: usize,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyAccelerationStructureKHR = extern "system" fn(
+pub type PFN_vkCmdCopyAccelerationStructureKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_info: *const CopyAccelerationStructureInfoKHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyAccelerationStructureToMemoryKHR = extern "system" fn(
+pub type PFN_vkCmdCopyAccelerationStructureToMemoryKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyMemoryToAccelerationStructureKHR = extern "system" fn(
+pub type PFN_vkCmdCopyMemoryToAccelerationStructureKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetAccelerationStructureDeviceAddressKHR = extern "system" fn(
-    device: Device,
-    p_info: *const AccelerationStructureDeviceAddressInfoKHR,
-) -> DeviceAddress;
+pub type PFN_vkGetAccelerationStructureDeviceAddressKHR =
+    unsafe extern "system" fn(
+        device: Device,
+        p_info: *const AccelerationStructureDeviceAddressInfoKHR,
+    ) -> DeviceAddress;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWriteAccelerationStructuresPropertiesKHR = extern "system" fn(
+pub type PFN_vkCmdWriteAccelerationStructuresPropertiesKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     acceleration_structure_count: u32,
     p_acceleration_structures: *const AccelerationStructureKHR,
@@ -11847,13 +11890,13 @@ pub type PFN_vkCmdWriteAccelerationStructuresPropertiesKHR = extern "system" fn(
     first_query: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceAccelerationStructureCompatibilityKHR = extern "system" fn(
+pub type PFN_vkGetDeviceAccelerationStructureCompatibilityKHR = unsafe extern "system" fn(
     device: Device,
     p_version_info: *const AccelerationStructureVersionInfoKHR,
     p_compatibility: *mut AccelerationStructureCompatibilityKHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetAccelerationStructureBuildSizesKHR = extern "system" fn(
+pub type PFN_vkGetAccelerationStructureBuildSizesKHR = unsafe extern "system" fn(
     device: Device,
     build_type: AccelerationStructureBuildTypeKHR,
     p_build_info: *const AccelerationStructureBuildGeometryInfoKHR,
@@ -11861,24 +11904,24 @@ pub type PFN_vkGetAccelerationStructureBuildSizesKHR = extern "system" fn(
     p_size_info: *mut AccelerationStructureBuildSizesInfoKHR,
 );
 pub struct KhrAccelerationStructureFn {
-    pub create_acceleration_structure_khr: extern "system" fn(
+    pub create_acceleration_structure_khr: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const AccelerationStructureCreateInfoKHR,
         p_allocator: *const AllocationCallbacks,
         p_acceleration_structure: *mut AccelerationStructureKHR,
     ) -> Result,
-    pub destroy_acceleration_structure_khr: extern "system" fn(
+    pub destroy_acceleration_structure_khr: unsafe extern "system" fn(
         device: Device,
         acceleration_structure: AccelerationStructureKHR,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub cmd_build_acceleration_structures_khr: extern "system" fn(
+    pub cmd_build_acceleration_structures_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         info_count: u32,
         p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
         pp_build_range_infos: *const *const AccelerationStructureBuildRangeInfoKHR,
     ),
-    pub cmd_build_acceleration_structures_indirect_khr: extern "system" fn(
+    pub cmd_build_acceleration_structures_indirect_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         info_count: u32,
         p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
@@ -11886,29 +11929,29 @@ pub struct KhrAccelerationStructureFn {
         p_indirect_strides: *const u32,
         pp_max_primitive_counts: *const *const u32,
     ),
-    pub build_acceleration_structures_khr: extern "system" fn(
+    pub build_acceleration_structures_khr: unsafe extern "system" fn(
         device: Device,
         deferred_operation: DeferredOperationKHR,
         info_count: u32,
         p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
         pp_build_range_infos: *const *const AccelerationStructureBuildRangeInfoKHR,
     ) -> Result,
-    pub copy_acceleration_structure_khr: extern "system" fn(
+    pub copy_acceleration_structure_khr: unsafe extern "system" fn(
         device: Device,
         deferred_operation: DeferredOperationKHR,
         p_info: *const CopyAccelerationStructureInfoKHR,
     ) -> Result,
-    pub copy_acceleration_structure_to_memory_khr: extern "system" fn(
+    pub copy_acceleration_structure_to_memory_khr: unsafe extern "system" fn(
         device: Device,
         deferred_operation: DeferredOperationKHR,
         p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
     ) -> Result,
-    pub copy_memory_to_acceleration_structure_khr: extern "system" fn(
+    pub copy_memory_to_acceleration_structure_khr: unsafe extern "system" fn(
         device: Device,
         deferred_operation: DeferredOperationKHR,
         p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
     ) -> Result,
-    pub write_acceleration_structures_properties_khr: extern "system" fn(
+    pub write_acceleration_structures_properties_khr: unsafe extern "system" fn(
         device: Device,
         acceleration_structure_count: u32,
         p_acceleration_structures: *const AccelerationStructureKHR,
@@ -11917,23 +11960,24 @@ pub struct KhrAccelerationStructureFn {
         p_data: *mut c_void,
         stride: usize,
     ) -> Result,
-    pub cmd_copy_acceleration_structure_khr: extern "system" fn(
+    pub cmd_copy_acceleration_structure_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_info: *const CopyAccelerationStructureInfoKHR,
     ),
-    pub cmd_copy_acceleration_structure_to_memory_khr: extern "system" fn(
+    pub cmd_copy_acceleration_structure_to_memory_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
     ),
-    pub cmd_copy_memory_to_acceleration_structure_khr: extern "system" fn(
+    pub cmd_copy_memory_to_acceleration_structure_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
     ),
-    pub get_acceleration_structure_device_address_khr: extern "system" fn(
+    pub get_acceleration_structure_device_address_khr: unsafe extern "system" fn(
         device: Device,
         p_info: *const AccelerationStructureDeviceAddressInfoKHR,
-    ) -> DeviceAddress,
-    pub cmd_write_acceleration_structures_properties_khr: extern "system" fn(
+    )
+        -> DeviceAddress,
+    pub cmd_write_acceleration_structures_properties_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         acceleration_structure_count: u32,
         p_acceleration_structures: *const AccelerationStructureKHR,
@@ -11941,12 +11985,12 @@ pub struct KhrAccelerationStructureFn {
         query_pool: QueryPool,
         first_query: u32,
     ),
-    pub get_device_acceleration_structure_compatibility_khr: extern "system" fn(
+    pub get_device_acceleration_structure_compatibility_khr: unsafe extern "system" fn(
         device: Device,
         p_version_info: *const AccelerationStructureVersionInfoKHR,
         p_compatibility: *mut AccelerationStructureCompatibilityKHR,
     ),
-    pub get_acceleration_structure_build_sizes_khr: extern "system" fn(
+    pub get_acceleration_structure_build_sizes_khr: unsafe extern "system" fn(
         device: Device,
         build_type: AccelerationStructureBuildTypeKHR,
         p_build_info: *const AccelerationStructureBuildGeometryInfoKHR,
@@ -11995,7 +12039,7 @@ impl KhrAccelerationStructureFn {
     {
         KhrAccelerationStructureFn {
             create_acceleration_structure_khr: unsafe {
-                extern "system" fn create_acceleration_structure_khr(
+                unsafe extern "system" fn create_acceleration_structure_khr(
                     _device: Device,
                     _p_create_info: *const AccelerationStructureCreateInfoKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -12017,7 +12061,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             destroy_acceleration_structure_khr: unsafe {
-                extern "system" fn destroy_acceleration_structure_khr(
+                unsafe extern "system" fn destroy_acceleration_structure_khr(
                     _device: Device,
                     _acceleration_structure: AccelerationStructureKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -12038,7 +12082,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             cmd_build_acceleration_structures_khr: unsafe {
-                extern "system" fn cmd_build_acceleration_structures_khr(
+                unsafe extern "system" fn cmd_build_acceleration_structures_khr(
                     _command_buffer: CommandBuffer,
                     _info_count: u32,
                     _p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
@@ -12060,7 +12104,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             cmd_build_acceleration_structures_indirect_khr: unsafe {
-                extern "system" fn cmd_build_acceleration_structures_indirect_khr(
+                unsafe extern "system" fn cmd_build_acceleration_structures_indirect_khr(
                     _command_buffer: CommandBuffer,
                     _info_count: u32,
                     _p_infos: *const AccelerationStructureBuildGeometryInfoKHR,
@@ -12084,7 +12128,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             build_acceleration_structures_khr: unsafe {
-                extern "system" fn build_acceleration_structures_khr(
+                unsafe extern "system" fn build_acceleration_structures_khr(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
                     _info_count: u32,
@@ -12107,7 +12151,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             copy_acceleration_structure_khr: unsafe {
-                extern "system" fn copy_acceleration_structure_khr(
+                unsafe extern "system" fn copy_acceleration_structure_khr(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
                     _p_info: *const CopyAccelerationStructureInfoKHR,
@@ -12128,7 +12172,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             copy_acceleration_structure_to_memory_khr: unsafe {
-                extern "system" fn copy_acceleration_structure_to_memory_khr(
+                unsafe extern "system" fn copy_acceleration_structure_to_memory_khr(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
                     _p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
@@ -12149,7 +12193,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             copy_memory_to_acceleration_structure_khr: unsafe {
-                extern "system" fn copy_memory_to_acceleration_structure_khr(
+                unsafe extern "system" fn copy_memory_to_acceleration_structure_khr(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
                     _p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
@@ -12170,7 +12214,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             write_acceleration_structures_properties_khr: unsafe {
-                extern "system" fn write_acceleration_structures_properties_khr(
+                unsafe extern "system" fn write_acceleration_structures_properties_khr(
                     _device: Device,
                     _acceleration_structure_count: u32,
                     _p_acceleration_structures: *const AccelerationStructureKHR,
@@ -12195,7 +12239,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             cmd_copy_acceleration_structure_khr: unsafe {
-                extern "system" fn cmd_copy_acceleration_structure_khr(
+                unsafe extern "system" fn cmd_copy_acceleration_structure_khr(
                     _command_buffer: CommandBuffer,
                     _p_info: *const CopyAccelerationStructureInfoKHR,
                 ) {
@@ -12215,7 +12259,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             cmd_copy_acceleration_structure_to_memory_khr: unsafe {
-                extern "system" fn cmd_copy_acceleration_structure_to_memory_khr(
+                unsafe extern "system" fn cmd_copy_acceleration_structure_to_memory_khr(
                     _command_buffer: CommandBuffer,
                     _p_info: *const CopyAccelerationStructureToMemoryInfoKHR,
                 ) {
@@ -12235,7 +12279,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             cmd_copy_memory_to_acceleration_structure_khr: unsafe {
-                extern "system" fn cmd_copy_memory_to_acceleration_structure_khr(
+                unsafe extern "system" fn cmd_copy_memory_to_acceleration_structure_khr(
                     _command_buffer: CommandBuffer,
                     _p_info: *const CopyMemoryToAccelerationStructureInfoKHR,
                 ) {
@@ -12255,7 +12299,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             get_acceleration_structure_device_address_khr: unsafe {
-                extern "system" fn get_acceleration_structure_device_address_khr(
+                unsafe extern "system" fn get_acceleration_structure_device_address_khr(
                     _device: Device,
                     _p_info: *const AccelerationStructureDeviceAddressInfoKHR,
                 ) -> DeviceAddress {
@@ -12275,7 +12319,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             cmd_write_acceleration_structures_properties_khr: unsafe {
-                extern "system" fn cmd_write_acceleration_structures_properties_khr(
+                unsafe extern "system" fn cmd_write_acceleration_structures_properties_khr(
                     _command_buffer: CommandBuffer,
                     _acceleration_structure_count: u32,
                     _p_acceleration_structures: *const AccelerationStructureKHR,
@@ -12299,7 +12343,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             get_device_acceleration_structure_compatibility_khr: unsafe {
-                extern "system" fn get_device_acceleration_structure_compatibility_khr(
+                unsafe extern "system" fn get_device_acceleration_structure_compatibility_khr(
                     _device: Device,
                     _p_version_info: *const AccelerationStructureVersionInfoKHR,
                     _p_compatibility: *mut AccelerationStructureCompatibilityKHR,
@@ -12320,7 +12364,7 @@ impl KhrAccelerationStructureFn {
                 }
             },
             get_acceleration_structure_build_sizes_khr: unsafe {
-                extern "system" fn get_acceleration_structure_build_sizes_khr(
+                unsafe extern "system" fn get_acceleration_structure_build_sizes_khr(
                     _device: Device,
                     _build_type: AccelerationStructureBuildTypeKHR,
                     _p_build_info: *const AccelerationStructureBuildGeometryInfoKHR,
@@ -12667,7 +12711,7 @@ impl KhrRayTracingPipelineFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdTraceRaysKHR = extern "system" fn(
+pub type PFN_vkCmdTraceRaysKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_raygen_shader_binding_table: *const StridedDeviceAddressRegionKHR,
     p_miss_shader_binding_table: *const StridedDeviceAddressRegionKHR,
@@ -12678,7 +12722,7 @@ pub type PFN_vkCmdTraceRaysKHR = extern "system" fn(
     depth: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateRayTracingPipelinesKHR = extern "system" fn(
+pub type PFN_vkCreateRayTracingPipelinesKHR = unsafe extern "system" fn(
     device: Device,
     deferred_operation: DeferredOperationKHR,
     pipeline_cache: PipelineCache,
@@ -12688,7 +12732,7 @@ pub type PFN_vkCreateRayTracingPipelinesKHR = extern "system" fn(
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetRayTracingShaderGroupHandlesKHR = extern "system" fn(
+pub type PFN_vkGetRayTracingShaderGroupHandlesKHR = unsafe extern "system" fn(
     device: Device,
     pipeline: Pipeline,
     first_group: u32,
@@ -12697,16 +12741,17 @@ pub type PFN_vkGetRayTracingShaderGroupHandlesKHR = extern "system" fn(
     p_data: *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR = extern "system" fn(
-    device: Device,
-    pipeline: Pipeline,
-    first_group: u32,
-    group_count: u32,
-    data_size: usize,
-    p_data: *mut c_void,
-) -> Result;
+pub type PFN_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR =
+    unsafe extern "system" fn(
+        device: Device,
+        pipeline: Pipeline,
+        first_group: u32,
+        group_count: u32,
+        data_size: usize,
+        p_data: *mut c_void,
+    ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdTraceRaysIndirectKHR = extern "system" fn(
+pub type PFN_vkCmdTraceRaysIndirectKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_raygen_shader_binding_table: *const StridedDeviceAddressRegionKHR,
     p_miss_shader_binding_table: *const StridedDeviceAddressRegionKHR,
@@ -12715,7 +12760,7 @@ pub type PFN_vkCmdTraceRaysIndirectKHR = extern "system" fn(
     indirect_device_address: DeviceAddress,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetRayTracingShaderGroupStackSizeKHR = extern "system" fn(
+pub type PFN_vkGetRayTracingShaderGroupStackSizeKHR = unsafe extern "system" fn(
     device: Device,
     pipeline: Pipeline,
     group: u32,
@@ -12723,9 +12768,9 @@ pub type PFN_vkGetRayTracingShaderGroupStackSizeKHR = extern "system" fn(
 ) -> DeviceSize;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetRayTracingPipelineStackSizeKHR =
-    extern "system" fn(command_buffer: CommandBuffer, pipeline_stack_size: u32);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, pipeline_stack_size: u32);
 pub struct KhrRayTracingPipelineFn {
-    pub cmd_trace_rays_khr: extern "system" fn(
+    pub cmd_trace_rays_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_raygen_shader_binding_table: *const StridedDeviceAddressRegionKHR,
         p_miss_shader_binding_table: *const StridedDeviceAddressRegionKHR,
@@ -12735,7 +12780,7 @@ pub struct KhrRayTracingPipelineFn {
         height: u32,
         depth: u32,
     ),
-    pub create_ray_tracing_pipelines_khr: extern "system" fn(
+    pub create_ray_tracing_pipelines_khr: unsafe extern "system" fn(
         device: Device,
         deferred_operation: DeferredOperationKHR,
         pipeline_cache: PipelineCache,
@@ -12744,7 +12789,7 @@ pub struct KhrRayTracingPipelineFn {
         p_allocator: *const AllocationCallbacks,
         p_pipelines: *mut Pipeline,
     ) -> Result,
-    pub get_ray_tracing_shader_group_handles_khr: extern "system" fn(
+    pub get_ray_tracing_shader_group_handles_khr: unsafe extern "system" fn(
         device: Device,
         pipeline: Pipeline,
         first_group: u32,
@@ -12752,15 +12797,16 @@ pub struct KhrRayTracingPipelineFn {
         data_size: usize,
         p_data: *mut c_void,
     ) -> Result,
-    pub get_ray_tracing_capture_replay_shader_group_handles_khr: extern "system" fn(
-        device: Device,
-        pipeline: Pipeline,
-        first_group: u32,
-        group_count: u32,
-        data_size: usize,
-        p_data: *mut c_void,
-    ) -> Result,
-    pub cmd_trace_rays_indirect_khr: extern "system" fn(
+    pub get_ray_tracing_capture_replay_shader_group_handles_khr:
+        unsafe extern "system" fn(
+            device: Device,
+            pipeline: Pipeline,
+            first_group: u32,
+            group_count: u32,
+            data_size: usize,
+            p_data: *mut c_void,
+        ) -> Result,
+    pub cmd_trace_rays_indirect_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_raygen_shader_binding_table: *const StridedDeviceAddressRegionKHR,
         p_miss_shader_binding_table: *const StridedDeviceAddressRegionKHR,
@@ -12768,14 +12814,14 @@ pub struct KhrRayTracingPipelineFn {
         p_callable_shader_binding_table: *const StridedDeviceAddressRegionKHR,
         indirect_device_address: DeviceAddress,
     ),
-    pub get_ray_tracing_shader_group_stack_size_khr: extern "system" fn(
+    pub get_ray_tracing_shader_group_stack_size_khr: unsafe extern "system" fn(
         device: Device,
         pipeline: Pipeline,
         group: u32,
         group_shader: ShaderGroupShaderKHR,
     ) -> DeviceSize,
     pub cmd_set_ray_tracing_pipeline_stack_size_khr:
-        extern "system" fn(command_buffer: CommandBuffer, pipeline_stack_size: u32),
+        unsafe extern "system" fn(command_buffer: CommandBuffer, pipeline_stack_size: u32),
 }
 unsafe impl Send for KhrRayTracingPipelineFn {}
 unsafe impl Sync for KhrRayTracingPipelineFn {}
@@ -12802,7 +12848,7 @@ impl KhrRayTracingPipelineFn {
     {
         KhrRayTracingPipelineFn {
             cmd_trace_rays_khr: unsafe {
-                extern "system" fn cmd_trace_rays_khr(
+                unsafe extern "system" fn cmd_trace_rays_khr(
                     _command_buffer: CommandBuffer,
                     _p_raygen_shader_binding_table: *const StridedDeviceAddressRegionKHR,
                     _p_miss_shader_binding_table: *const StridedDeviceAddressRegionKHR,
@@ -12823,7 +12869,7 @@ impl KhrRayTracingPipelineFn {
                 }
             },
             create_ray_tracing_pipelines_khr: unsafe {
-                extern "system" fn create_ray_tracing_pipelines_khr(
+                unsafe extern "system" fn create_ray_tracing_pipelines_khr(
                     _device: Device,
                     _deferred_operation: DeferredOperationKHR,
                     _pipeline_cache: PipelineCache,
@@ -12848,7 +12894,7 @@ impl KhrRayTracingPipelineFn {
                 }
             },
             get_ray_tracing_shader_group_handles_khr: unsafe {
-                extern "system" fn get_ray_tracing_shader_group_handles_khr(
+                unsafe extern "system" fn get_ray_tracing_shader_group_handles_khr(
                     _device: Device,
                     _pipeline: Pipeline,
                     _first_group: u32,
@@ -12872,7 +12918,7 @@ impl KhrRayTracingPipelineFn {
                 }
             },
             get_ray_tracing_capture_replay_shader_group_handles_khr: unsafe {
-                extern "system" fn get_ray_tracing_capture_replay_shader_group_handles_khr(
+                unsafe extern "system" fn get_ray_tracing_capture_replay_shader_group_handles_khr(
                     _device: Device,
                     _pipeline: Pipeline,
                     _first_group: u32,
@@ -12896,7 +12942,7 @@ impl KhrRayTracingPipelineFn {
                 }
             },
             cmd_trace_rays_indirect_khr: unsafe {
-                extern "system" fn cmd_trace_rays_indirect_khr(
+                unsafe extern "system" fn cmd_trace_rays_indirect_khr(
                     _command_buffer: CommandBuffer,
                     _p_raygen_shader_binding_table: *const StridedDeviceAddressRegionKHR,
                     _p_miss_shader_binding_table: *const StridedDeviceAddressRegionKHR,
@@ -12919,7 +12965,7 @@ impl KhrRayTracingPipelineFn {
                 }
             },
             get_ray_tracing_shader_group_stack_size_khr: unsafe {
-                extern "system" fn get_ray_tracing_shader_group_stack_size_khr(
+                unsafe extern "system" fn get_ray_tracing_shader_group_stack_size_khr(
                     _device: Device,
                     _pipeline: Pipeline,
                     _group: u32,
@@ -12941,7 +12987,7 @@ impl KhrRayTracingPipelineFn {
                 }
             },
             cmd_set_ray_tracing_pipeline_stack_size_khr: unsafe {
-                extern "system" fn cmd_set_ray_tracing_pipeline_stack_size_khr(
+                unsafe extern "system" fn cmd_set_ray_tracing_pipeline_stack_size_khr(
                     _command_buffer: CommandBuffer,
                     _pipeline_stack_size: u32,
                 ) {
@@ -13337,26 +13383,26 @@ impl KhrSamplerYcbcrConversionFn {
     pub const SPEC_VERSION: u32 = 14u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateSamplerYcbcrConversion = extern "system" fn(
+pub type PFN_vkCreateSamplerYcbcrConversion = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const SamplerYcbcrConversionCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_ycbcr_conversion: *mut SamplerYcbcrConversion,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroySamplerYcbcrConversion = extern "system" fn(
+pub type PFN_vkDestroySamplerYcbcrConversion = unsafe extern "system" fn(
     device: Device,
     ycbcr_conversion: SamplerYcbcrConversion,
     p_allocator: *const AllocationCallbacks,
 );
 pub struct KhrSamplerYcbcrConversionFn {
-    pub create_sampler_ycbcr_conversion_khr: extern "system" fn(
+    pub create_sampler_ycbcr_conversion_khr: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const SamplerYcbcrConversionCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_ycbcr_conversion: *mut SamplerYcbcrConversion,
     ) -> Result,
-    pub destroy_sampler_ycbcr_conversion_khr: extern "system" fn(
+    pub destroy_sampler_ycbcr_conversion_khr: unsafe extern "system" fn(
         device: Device,
         ycbcr_conversion: SamplerYcbcrConversion,
         p_allocator: *const AllocationCallbacks,
@@ -13379,7 +13425,7 @@ impl KhrSamplerYcbcrConversionFn {
     {
         KhrSamplerYcbcrConversionFn {
             create_sampler_ycbcr_conversion_khr: unsafe {
-                extern "system" fn create_sampler_ycbcr_conversion_khr(
+                unsafe extern "system" fn create_sampler_ycbcr_conversion_khr(
                     _device: Device,
                     _p_create_info: *const SamplerYcbcrConversionCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -13401,7 +13447,7 @@ impl KhrSamplerYcbcrConversionFn {
                 }
             },
             destroy_sampler_ycbcr_conversion_khr: unsafe {
-                extern "system" fn destroy_sampler_ycbcr_conversion_khr(
+                unsafe extern "system" fn destroy_sampler_ycbcr_conversion_khr(
                     _device: Device,
                     _ycbcr_conversion: SamplerYcbcrConversion,
                     _p_allocator: *const AllocationCallbacks,
@@ -13728,24 +13774,24 @@ impl KhrBindMemory2Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkBindBufferMemory2 = extern "system" fn(
+pub type PFN_vkBindBufferMemory2 = unsafe extern "system" fn(
     device: Device,
     bind_info_count: u32,
     p_bind_infos: *const BindBufferMemoryInfo,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkBindImageMemory2 = extern "system" fn(
+pub type PFN_vkBindImageMemory2 = unsafe extern "system" fn(
     device: Device,
     bind_info_count: u32,
     p_bind_infos: *const BindImageMemoryInfo,
 ) -> Result;
 pub struct KhrBindMemory2Fn {
-    pub bind_buffer_memory2_khr: extern "system" fn(
+    pub bind_buffer_memory2_khr: unsafe extern "system" fn(
         device: Device,
         bind_info_count: u32,
         p_bind_infos: *const BindBufferMemoryInfo,
     ) -> Result,
-    pub bind_image_memory2_khr: extern "system" fn(
+    pub bind_image_memory2_khr: unsafe extern "system" fn(
         device: Device,
         bind_info_count: u32,
         p_bind_infos: *const BindImageMemoryInfo,
@@ -13768,7 +13814,7 @@ impl KhrBindMemory2Fn {
     {
         KhrBindMemory2Fn {
             bind_buffer_memory2_khr: unsafe {
-                extern "system" fn bind_buffer_memory2_khr(
+                unsafe extern "system" fn bind_buffer_memory2_khr(
                     _device: Device,
                     _bind_info_count: u32,
                     _p_bind_infos: *const BindBufferMemoryInfo,
@@ -13788,7 +13834,7 @@ impl KhrBindMemory2Fn {
                 }
             },
             bind_image_memory2_khr: unsafe {
-                extern "system" fn bind_image_memory2_khr(
+                unsafe extern "system" fn bind_image_memory2_khr(
                     _device: Device,
                     _bind_info_count: u32,
                     _p_bind_infos: *const BindImageMemoryInfo,
@@ -13848,13 +13894,13 @@ impl ExtImageDrmFormatModifierFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetImageDrmFormatModifierPropertiesEXT = extern "system" fn(
+pub type PFN_vkGetImageDrmFormatModifierPropertiesEXT = unsafe extern "system" fn(
     device: Device,
     image: Image,
     p_properties: *mut ImageDrmFormatModifierPropertiesEXT,
 ) -> Result;
 pub struct ExtImageDrmFormatModifierFn {
-    pub get_image_drm_format_modifier_properties_ext: extern "system" fn(
+    pub get_image_drm_format_modifier_properties_ext: unsafe extern "system" fn(
         device: Device,
         image: Image,
         p_properties: *mut ImageDrmFormatModifierPropertiesEXT,
@@ -13877,7 +13923,7 @@ impl ExtImageDrmFormatModifierFn {
     {
         ExtImageDrmFormatModifierFn {
             get_image_drm_format_modifier_properties_ext: unsafe {
-                extern "system" fn get_image_drm_format_modifier_properties_ext(
+                unsafe extern "system" fn get_image_drm_format_modifier_properties_ext(
                     _device: Device,
                     _image: Image,
                     _p_properties: *mut ImageDrmFormatModifierPropertiesEXT,
@@ -13984,51 +14030,51 @@ impl ExtValidationCacheFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateValidationCacheEXT = extern "system" fn(
+pub type PFN_vkCreateValidationCacheEXT = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const ValidationCacheCreateInfoEXT,
     p_allocator: *const AllocationCallbacks,
     p_validation_cache: *mut ValidationCacheEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyValidationCacheEXT = extern "system" fn(
+pub type PFN_vkDestroyValidationCacheEXT = unsafe extern "system" fn(
     device: Device,
     validation_cache: ValidationCacheEXT,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkMergeValidationCachesEXT = extern "system" fn(
+pub type PFN_vkMergeValidationCachesEXT = unsafe extern "system" fn(
     device: Device,
     dst_cache: ValidationCacheEXT,
     src_cache_count: u32,
     p_src_caches: *const ValidationCacheEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetValidationCacheDataEXT = extern "system" fn(
+pub type PFN_vkGetValidationCacheDataEXT = unsafe extern "system" fn(
     device: Device,
     validation_cache: ValidationCacheEXT,
     p_data_size: *mut usize,
     p_data: *mut c_void,
 ) -> Result;
 pub struct ExtValidationCacheFn {
-    pub create_validation_cache_ext: extern "system" fn(
+    pub create_validation_cache_ext: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const ValidationCacheCreateInfoEXT,
         p_allocator: *const AllocationCallbacks,
         p_validation_cache: *mut ValidationCacheEXT,
     ) -> Result,
-    pub destroy_validation_cache_ext: extern "system" fn(
+    pub destroy_validation_cache_ext: unsafe extern "system" fn(
         device: Device,
         validation_cache: ValidationCacheEXT,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub merge_validation_caches_ext: extern "system" fn(
+    pub merge_validation_caches_ext: unsafe extern "system" fn(
         device: Device,
         dst_cache: ValidationCacheEXT,
         src_cache_count: u32,
         p_src_caches: *const ValidationCacheEXT,
     ) -> Result,
-    pub get_validation_cache_data_ext: extern "system" fn(
+    pub get_validation_cache_data_ext: unsafe extern "system" fn(
         device: Device,
         validation_cache: ValidationCacheEXT,
         p_data_size: *mut usize,
@@ -14054,7 +14100,7 @@ impl ExtValidationCacheFn {
     {
         ExtValidationCacheFn {
             create_validation_cache_ext: unsafe {
-                extern "system" fn create_validation_cache_ext(
+                unsafe extern "system" fn create_validation_cache_ext(
                     _device: Device,
                     _p_create_info: *const ValidationCacheCreateInfoEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -14076,7 +14122,7 @@ impl ExtValidationCacheFn {
                 }
             },
             destroy_validation_cache_ext: unsafe {
-                extern "system" fn destroy_validation_cache_ext(
+                unsafe extern "system" fn destroy_validation_cache_ext(
                     _device: Device,
                     _validation_cache: ValidationCacheEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -14097,7 +14143,7 @@ impl ExtValidationCacheFn {
                 }
             },
             merge_validation_caches_ext: unsafe {
-                extern "system" fn merge_validation_caches_ext(
+                unsafe extern "system" fn merge_validation_caches_ext(
                     _device: Device,
                     _dst_cache: ValidationCacheEXT,
                     _src_cache_count: u32,
@@ -14119,7 +14165,7 @@ impl ExtValidationCacheFn {
                 }
             },
             get_validation_cache_data_ext: unsafe {
-                extern "system" fn get_validation_cache_data_ext(
+                unsafe extern "system" fn get_validation_cache_data_ext(
                     _device: Device,
                     _validation_cache: ValidationCacheEXT,
                     _p_data_size: *mut usize,
@@ -14332,38 +14378,38 @@ impl NvShadingRateImageFn {
     pub const SPEC_VERSION: u32 = 3u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBindShadingRateImageNV = extern "system" fn(
+pub type PFN_vkCmdBindShadingRateImageNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     image_view: ImageView,
     image_layout: ImageLayout,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetViewportShadingRatePaletteNV = extern "system" fn(
+pub type PFN_vkCmdSetViewportShadingRatePaletteNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_viewport: u32,
     viewport_count: u32,
     p_shading_rate_palettes: *const ShadingRatePaletteNV,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetCoarseSampleOrderNV = extern "system" fn(
+pub type PFN_vkCmdSetCoarseSampleOrderNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     sample_order_type: CoarseSampleOrderTypeNV,
     custom_sample_order_count: u32,
     p_custom_sample_orders: *const CoarseSampleOrderCustomNV,
 );
 pub struct NvShadingRateImageFn {
-    pub cmd_bind_shading_rate_image_nv: extern "system" fn(
+    pub cmd_bind_shading_rate_image_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         image_view: ImageView,
         image_layout: ImageLayout,
     ),
-    pub cmd_set_viewport_shading_rate_palette_nv: extern "system" fn(
+    pub cmd_set_viewport_shading_rate_palette_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_viewport: u32,
         viewport_count: u32,
         p_shading_rate_palettes: *const ShadingRatePaletteNV,
     ),
-    pub cmd_set_coarse_sample_order_nv: extern "system" fn(
+    pub cmd_set_coarse_sample_order_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         sample_order_type: CoarseSampleOrderTypeNV,
         custom_sample_order_count: u32,
@@ -14388,7 +14434,7 @@ impl NvShadingRateImageFn {
     {
         NvShadingRateImageFn {
             cmd_bind_shading_rate_image_nv: unsafe {
-                extern "system" fn cmd_bind_shading_rate_image_nv(
+                unsafe extern "system" fn cmd_bind_shading_rate_image_nv(
                     _command_buffer: CommandBuffer,
                     _image_view: ImageView,
                     _image_layout: ImageLayout,
@@ -14409,7 +14455,7 @@ impl NvShadingRateImageFn {
                 }
             },
             cmd_set_viewport_shading_rate_palette_nv: unsafe {
-                extern "system" fn cmd_set_viewport_shading_rate_palette_nv(
+                unsafe extern "system" fn cmd_set_viewport_shading_rate_palette_nv(
                     _command_buffer: CommandBuffer,
                     _first_viewport: u32,
                     _viewport_count: u32,
@@ -14431,7 +14477,7 @@ impl NvShadingRateImageFn {
                 }
             },
             cmd_set_coarse_sample_order_nv: unsafe {
-                extern "system" fn cmd_set_coarse_sample_order_nv(
+                unsafe extern "system" fn cmd_set_coarse_sample_order_nv(
                     _command_buffer: CommandBuffer,
                     _sample_order_type: CoarseSampleOrderTypeNV,
                     _custom_sample_order_count: u32,
@@ -14543,32 +14589,32 @@ impl NvRayTracingFn {
     pub const SPEC_VERSION: u32 = 3u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateAccelerationStructureNV = extern "system" fn(
+pub type PFN_vkCreateAccelerationStructureNV = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const AccelerationStructureCreateInfoNV,
     p_allocator: *const AllocationCallbacks,
     p_acceleration_structure: *mut AccelerationStructureNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyAccelerationStructureNV = extern "system" fn(
+pub type PFN_vkDestroyAccelerationStructureNV = unsafe extern "system" fn(
     device: Device,
     acceleration_structure: AccelerationStructureNV,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetAccelerationStructureMemoryRequirementsNV = extern "system" fn(
+pub type PFN_vkGetAccelerationStructureMemoryRequirementsNV = unsafe extern "system" fn(
     device: Device,
     p_info: *const AccelerationStructureMemoryRequirementsInfoNV,
     p_memory_requirements: *mut MemoryRequirements2KHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkBindAccelerationStructureMemoryNV = extern "system" fn(
+pub type PFN_vkBindAccelerationStructureMemoryNV = unsafe extern "system" fn(
     device: Device,
     bind_info_count: u32,
     p_bind_infos: *const BindAccelerationStructureMemoryInfoNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBuildAccelerationStructureNV = extern "system" fn(
+pub type PFN_vkCmdBuildAccelerationStructureNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_info: *const AccelerationStructureInfoNV,
     instance_data: Buffer,
@@ -14580,14 +14626,14 @@ pub type PFN_vkCmdBuildAccelerationStructureNV = extern "system" fn(
     scratch_offset: DeviceSize,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyAccelerationStructureNV = extern "system" fn(
+pub type PFN_vkCmdCopyAccelerationStructureNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     dst: AccelerationStructureNV,
     src: AccelerationStructureNV,
     mode: CopyAccelerationStructureModeKHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdTraceRaysNV = extern "system" fn(
+pub type PFN_vkCmdTraceRaysNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     raygen_shader_binding_table_buffer: Buffer,
     raygen_shader_binding_offset: DeviceSize,
@@ -14605,7 +14651,7 @@ pub type PFN_vkCmdTraceRaysNV = extern "system" fn(
     depth: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateRayTracingPipelinesNV = extern "system" fn(
+pub type PFN_vkCreateRayTracingPipelinesNV = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
     create_info_count: u32,
@@ -14614,7 +14660,7 @@ pub type PFN_vkCreateRayTracingPipelinesNV = extern "system" fn(
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetAccelerationStructureHandleNV = extern "system" fn(
+pub type PFN_vkGetAccelerationStructureHandleNV = unsafe extern "system" fn(
     device: Device,
     pipeline: Pipeline,
     first_group: u32,
@@ -14623,14 +14669,14 @@ pub type PFN_vkGetAccelerationStructureHandleNV = extern "system" fn(
     p_data: *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWriteAccelerationStructuresPropertiesNV = extern "system" fn(
+pub type PFN_vkCmdWriteAccelerationStructuresPropertiesNV = unsafe extern "system" fn(
     device: Device,
     acceleration_structure: AccelerationStructureNV,
     data_size: usize,
     p_data: *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCompileDeferredNV = extern "system" fn(
+pub type PFN_vkCompileDeferredNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     acceleration_structure_count: u32,
     p_acceleration_structures: *const AccelerationStructureNV,
@@ -14639,28 +14685,28 @@ pub type PFN_vkCompileDeferredNV = extern "system" fn(
     first_query: u32,
 );
 pub struct NvRayTracingFn {
-    pub create_acceleration_structure_nv: extern "system" fn(
+    pub create_acceleration_structure_nv: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const AccelerationStructureCreateInfoNV,
         p_allocator: *const AllocationCallbacks,
         p_acceleration_structure: *mut AccelerationStructureNV,
     ) -> Result,
-    pub destroy_acceleration_structure_nv: extern "system" fn(
+    pub destroy_acceleration_structure_nv: unsafe extern "system" fn(
         device: Device,
         acceleration_structure: AccelerationStructureNV,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub get_acceleration_structure_memory_requirements_nv: extern "system" fn(
+    pub get_acceleration_structure_memory_requirements_nv: unsafe extern "system" fn(
         device: Device,
         p_info: *const AccelerationStructureMemoryRequirementsInfoNV,
         p_memory_requirements: *mut MemoryRequirements2KHR,
     ),
-    pub bind_acceleration_structure_memory_nv: extern "system" fn(
+    pub bind_acceleration_structure_memory_nv: unsafe extern "system" fn(
         device: Device,
         bind_info_count: u32,
         p_bind_infos: *const BindAccelerationStructureMemoryInfoNV,
     ) -> Result,
-    pub cmd_build_acceleration_structure_nv: extern "system" fn(
+    pub cmd_build_acceleration_structure_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_info: *const AccelerationStructureInfoNV,
         instance_data: Buffer,
@@ -14671,13 +14717,13 @@ pub struct NvRayTracingFn {
         scratch: Buffer,
         scratch_offset: DeviceSize,
     ),
-    pub cmd_copy_acceleration_structure_nv: extern "system" fn(
+    pub cmd_copy_acceleration_structure_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         dst: AccelerationStructureNV,
         src: AccelerationStructureNV,
         mode: CopyAccelerationStructureModeKHR,
     ),
-    pub cmd_trace_rays_nv: extern "system" fn(
+    pub cmd_trace_rays_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         raygen_shader_binding_table_buffer: Buffer,
         raygen_shader_binding_offset: DeviceSize,
@@ -14694,7 +14740,7 @@ pub struct NvRayTracingFn {
         height: u32,
         depth: u32,
     ),
-    pub create_ray_tracing_pipelines_nv: extern "system" fn(
+    pub create_ray_tracing_pipelines_nv: unsafe extern "system" fn(
         device: Device,
         pipeline_cache: PipelineCache,
         create_info_count: u32,
@@ -14702,7 +14748,7 @@ pub struct NvRayTracingFn {
         p_allocator: *const AllocationCallbacks,
         p_pipelines: *mut Pipeline,
     ) -> Result,
-    pub get_ray_tracing_shader_group_handles_nv: extern "system" fn(
+    pub get_ray_tracing_shader_group_handles_nv: unsafe extern "system" fn(
         device: Device,
         pipeline: Pipeline,
         first_group: u32,
@@ -14710,13 +14756,13 @@ pub struct NvRayTracingFn {
         data_size: usize,
         p_data: *mut c_void,
     ) -> Result,
-    pub get_acceleration_structure_handle_nv: extern "system" fn(
+    pub get_acceleration_structure_handle_nv: unsafe extern "system" fn(
         device: Device,
         acceleration_structure: AccelerationStructureNV,
         data_size: usize,
         p_data: *mut c_void,
     ) -> Result,
-    pub cmd_write_acceleration_structures_properties_nv: extern "system" fn(
+    pub cmd_write_acceleration_structures_properties_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         acceleration_structure_count: u32,
         p_acceleration_structures: *const AccelerationStructureNV,
@@ -14725,7 +14771,7 @@ pub struct NvRayTracingFn {
         first_query: u32,
     ),
     pub compile_deferred_nv:
-        extern "system" fn(device: Device, pipeline: Pipeline, shader: u32) -> Result,
+        unsafe extern "system" fn(device: Device, pipeline: Pipeline, shader: u32) -> Result,
 }
 unsafe impl Send for NvRayTracingFn {}
 unsafe impl Sync for NvRayTracingFn {}
@@ -14756,7 +14802,7 @@ impl NvRayTracingFn {
     {
         NvRayTracingFn {
             create_acceleration_structure_nv: unsafe {
-                extern "system" fn create_acceleration_structure_nv(
+                unsafe extern "system" fn create_acceleration_structure_nv(
                     _device: Device,
                     _p_create_info: *const AccelerationStructureCreateInfoNV,
                     _p_allocator: *const AllocationCallbacks,
@@ -14778,7 +14824,7 @@ impl NvRayTracingFn {
                 }
             },
             destroy_acceleration_structure_nv: unsafe {
-                extern "system" fn destroy_acceleration_structure_nv(
+                unsafe extern "system" fn destroy_acceleration_structure_nv(
                     _device: Device,
                     _acceleration_structure: AccelerationStructureNV,
                     _p_allocator: *const AllocationCallbacks,
@@ -14799,7 +14845,7 @@ impl NvRayTracingFn {
                 }
             },
             get_acceleration_structure_memory_requirements_nv: unsafe {
-                extern "system" fn get_acceleration_structure_memory_requirements_nv(
+                unsafe extern "system" fn get_acceleration_structure_memory_requirements_nv(
                     _device: Device,
                     _p_info: *const AccelerationStructureMemoryRequirementsInfoNV,
                     _p_memory_requirements: *mut MemoryRequirements2KHR,
@@ -14820,7 +14866,7 @@ impl NvRayTracingFn {
                 }
             },
             bind_acceleration_structure_memory_nv: unsafe {
-                extern "system" fn bind_acceleration_structure_memory_nv(
+                unsafe extern "system" fn bind_acceleration_structure_memory_nv(
                     _device: Device,
                     _bind_info_count: u32,
                     _p_bind_infos: *const BindAccelerationStructureMemoryInfoNV,
@@ -14841,7 +14887,7 @@ impl NvRayTracingFn {
                 }
             },
             cmd_build_acceleration_structure_nv: unsafe {
-                extern "system" fn cmd_build_acceleration_structure_nv(
+                unsafe extern "system" fn cmd_build_acceleration_structure_nv(
                     _command_buffer: CommandBuffer,
                     _p_info: *const AccelerationStructureInfoNV,
                     _instance_data: Buffer,
@@ -14868,7 +14914,7 @@ impl NvRayTracingFn {
                 }
             },
             cmd_copy_acceleration_structure_nv: unsafe {
-                extern "system" fn cmd_copy_acceleration_structure_nv(
+                unsafe extern "system" fn cmd_copy_acceleration_structure_nv(
                     _command_buffer: CommandBuffer,
                     _dst: AccelerationStructureNV,
                     _src: AccelerationStructureNV,
@@ -14890,7 +14936,7 @@ impl NvRayTracingFn {
                 }
             },
             cmd_trace_rays_nv: unsafe {
-                extern "system" fn cmd_trace_rays_nv(
+                unsafe extern "system" fn cmd_trace_rays_nv(
                     _command_buffer: CommandBuffer,
                     _raygen_shader_binding_table_buffer: Buffer,
                     _raygen_shader_binding_offset: DeviceSize,
@@ -14918,7 +14964,7 @@ impl NvRayTracingFn {
                 }
             },
             create_ray_tracing_pipelines_nv: unsafe {
-                extern "system" fn create_ray_tracing_pipelines_nv(
+                unsafe extern "system" fn create_ray_tracing_pipelines_nv(
                     _device: Device,
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
@@ -14942,7 +14988,7 @@ impl NvRayTracingFn {
                 }
             },
             get_ray_tracing_shader_group_handles_nv: unsafe {
-                extern "system" fn get_ray_tracing_shader_group_handles_nv(
+                unsafe extern "system" fn get_ray_tracing_shader_group_handles_nv(
                     _device: Device,
                     _pipeline: Pipeline,
                     _first_group: u32,
@@ -14966,7 +15012,7 @@ impl NvRayTracingFn {
                 }
             },
             get_acceleration_structure_handle_nv: unsafe {
-                extern "system" fn get_acceleration_structure_handle_nv(
+                unsafe extern "system" fn get_acceleration_structure_handle_nv(
                     _device: Device,
                     _acceleration_structure: AccelerationStructureNV,
                     _data_size: usize,
@@ -14988,7 +15034,7 @@ impl NvRayTracingFn {
                 }
             },
             cmd_write_acceleration_structures_properties_nv: unsafe {
-                extern "system" fn cmd_write_acceleration_structures_properties_nv(
+                unsafe extern "system" fn cmd_write_acceleration_structures_properties_nv(
                     _command_buffer: CommandBuffer,
                     _acceleration_structure_count: u32,
                     _p_acceleration_structures: *const AccelerationStructureNV,
@@ -15012,7 +15058,7 @@ impl NvRayTracingFn {
                 }
             },
             compile_deferred_nv: unsafe {
-                extern "system" fn compile_deferred_nv(
+                unsafe extern "system" fn compile_deferred_nv(
                     _device: Device,
                     _pipeline: Pipeline,
                     _shader: u32,
@@ -15489,13 +15535,13 @@ impl KhrMaintenance3Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDescriptorSetLayoutSupport = extern "system" fn(
+pub type PFN_vkGetDescriptorSetLayoutSupport = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const DescriptorSetLayoutCreateInfo,
     p_support: *mut DescriptorSetLayoutSupport,
 );
 pub struct KhrMaintenance3Fn {
-    pub get_descriptor_set_layout_support_khr: extern "system" fn(
+    pub get_descriptor_set_layout_support_khr: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const DescriptorSetLayoutCreateInfo,
         p_support: *mut DescriptorSetLayoutSupport,
@@ -15517,7 +15563,7 @@ impl KhrMaintenance3Fn {
     {
         KhrMaintenance3Fn {
             get_descriptor_set_layout_support_khr: unsafe {
-                extern "system" fn get_descriptor_set_layout_support_khr(
+                unsafe extern "system" fn get_descriptor_set_layout_support_khr(
                     _device: Device,
                     _p_create_info: *const DescriptorSetLayoutCreateInfo,
                     _p_support: *mut DescriptorSetLayoutSupport,
@@ -15566,7 +15612,7 @@ impl KhrDrawIndirectCountFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 pub struct KhrDrawIndirectCountFn {
-    pub cmd_draw_indirect_count_khr: extern "system" fn(
+    pub cmd_draw_indirect_count_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
@@ -15575,7 +15621,7 @@ pub struct KhrDrawIndirectCountFn {
         max_draw_count: u32,
         stride: u32,
     ),
-    pub cmd_draw_indexed_indirect_count_khr: extern "system" fn(
+    pub cmd_draw_indexed_indirect_count_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
@@ -15602,7 +15648,7 @@ impl KhrDrawIndirectCountFn {
     {
         KhrDrawIndirectCountFn {
             cmd_draw_indirect_count_khr: unsafe {
-                extern "system" fn cmd_draw_indirect_count_khr(
+                unsafe extern "system" fn cmd_draw_indirect_count_khr(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -15626,7 +15672,7 @@ impl KhrDrawIndirectCountFn {
                 }
             },
             cmd_draw_indexed_indirect_count_khr: unsafe {
-                extern "system" fn cmd_draw_indexed_indirect_count_khr(
+                unsafe extern "system" fn cmd_draw_indexed_indirect_count_khr(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -15941,14 +15987,14 @@ impl ExtExternalMemoryHostFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetMemoryHostPointerPropertiesEXT = extern "system" fn(
+pub type PFN_vkGetMemoryHostPointerPropertiesEXT = unsafe extern "system" fn(
     device: Device,
     handle_type: ExternalMemoryHandleTypeFlags,
     p_host_pointer: *const c_void,
     p_memory_host_pointer_properties: *mut MemoryHostPointerPropertiesEXT,
 ) -> Result;
 pub struct ExtExternalMemoryHostFn {
-    pub get_memory_host_pointer_properties_ext: extern "system" fn(
+    pub get_memory_host_pointer_properties_ext: unsafe extern "system" fn(
         device: Device,
         handle_type: ExternalMemoryHandleTypeFlags,
         p_host_pointer: *const c_void,
@@ -15971,7 +16017,7 @@ impl ExtExternalMemoryHostFn {
     {
         ExtExternalMemoryHostFn {
             get_memory_host_pointer_properties_ext: unsafe {
-                extern "system" fn get_memory_host_pointer_properties_ext(
+                unsafe extern "system" fn get_memory_host_pointer_properties_ext(
                     _device: Device,
                     _handle_type: ExternalMemoryHandleTypeFlags,
                     _p_host_pointer: *const c_void,
@@ -16038,7 +16084,7 @@ impl AmdBufferMarkerFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWriteBufferMarkerAMD = extern "system" fn(
+pub type PFN_vkCmdWriteBufferMarkerAMD = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     pipeline_stage: PipelineStageFlags,
     dst_buffer: Buffer,
@@ -16046,7 +16092,7 @@ pub type PFN_vkCmdWriteBufferMarkerAMD = extern "system" fn(
     marker: u32,
 );
 pub struct AmdBufferMarkerFn {
-    pub cmd_write_buffer_marker_amd: extern "system" fn(
+    pub cmd_write_buffer_marker_amd: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         pipeline_stage: PipelineStageFlags,
         dst_buffer: Buffer,
@@ -16070,7 +16116,7 @@ impl AmdBufferMarkerFn {
     {
         AmdBufferMarkerFn {
             cmd_write_buffer_marker_amd: unsafe {
-                extern "system" fn cmd_write_buffer_marker_amd(
+                unsafe extern "system" fn cmd_write_buffer_marker_amd(
                     _command_buffer: CommandBuffer,
                     _pipeline_stage: PipelineStageFlags,
                     _dst_buffer: Buffer,
@@ -16224,13 +16270,13 @@ impl ExtCalibratedTimestampsFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_time_domain_count: *mut u32,
     p_time_domains: *mut TimeDomainEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetCalibratedTimestampsEXT = extern "system" fn(
+pub type PFN_vkGetCalibratedTimestampsEXT = unsafe extern "system" fn(
     device: Device,
     timestamp_count: u32,
     p_timestamp_infos: *const CalibratedTimestampInfoEXT,
@@ -16238,12 +16284,13 @@ pub type PFN_vkGetCalibratedTimestampsEXT = extern "system" fn(
     p_max_deviation: *mut u64,
 ) -> Result;
 pub struct ExtCalibratedTimestampsFn {
-    pub get_physical_device_calibrateable_time_domains_ext: extern "system" fn(
+    pub get_physical_device_calibrateable_time_domains_ext: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_time_domain_count: *mut u32,
         p_time_domains: *mut TimeDomainEXT,
-    ) -> Result,
-    pub get_calibrated_timestamps_ext: extern "system" fn(
+    )
+        -> Result,
+    pub get_calibrated_timestamps_ext: unsafe extern "system" fn(
         device: Device,
         timestamp_count: u32,
         p_timestamp_infos: *const CalibratedTimestampInfoEXT,
@@ -16269,7 +16316,7 @@ impl ExtCalibratedTimestampsFn {
     {
         ExtCalibratedTimestampsFn {
             get_physical_device_calibrateable_time_domains_ext: unsafe {
-                extern "system" fn get_physical_device_calibrateable_time_domains_ext(
+                unsafe extern "system" fn get_physical_device_calibrateable_time_domains_ext(
                     _physical_device: PhysicalDevice,
                     _p_time_domain_count: *mut u32,
                     _p_time_domains: *mut TimeDomainEXT,
@@ -16290,7 +16337,7 @@ impl ExtCalibratedTimestampsFn {
                 }
             },
             get_calibrated_timestamps_ext: unsafe {
-                extern "system" fn get_calibrated_timestamps_ext(
+                unsafe extern "system" fn get_calibrated_timestamps_ext(
                     _device: Device,
                     _timestamp_count: u32,
                     _p_timestamp_infos: *const CalibratedTimestampInfoEXT,
@@ -16892,9 +16939,9 @@ impl NvMeshShaderFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDrawMeshTasksNV =
-    extern "system" fn(command_buffer: CommandBuffer, task_count: u32, first_task: u32);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, task_count: u32, first_task: u32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawMeshTasksIndirectNV = extern "system" fn(
+pub type PFN_vkCmdDrawMeshTasksIndirectNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     buffer: Buffer,
     offset: DeviceSize,
@@ -16902,7 +16949,7 @@ pub type PFN_vkCmdDrawMeshTasksIndirectNV = extern "system" fn(
     stride: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawMeshTasksIndirectCountNV = extern "system" fn(
+pub type PFN_vkCmdDrawMeshTasksIndirectCountNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     buffer: Buffer,
     offset: DeviceSize,
@@ -16913,15 +16960,15 @@ pub type PFN_vkCmdDrawMeshTasksIndirectCountNV = extern "system" fn(
 );
 pub struct NvMeshShaderFn {
     pub cmd_draw_mesh_tasks_nv:
-        extern "system" fn(command_buffer: CommandBuffer, task_count: u32, first_task: u32),
-    pub cmd_draw_mesh_tasks_indirect_nv: extern "system" fn(
+        unsafe extern "system" fn(command_buffer: CommandBuffer, task_count: u32, first_task: u32),
+    pub cmd_draw_mesh_tasks_indirect_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
         draw_count: u32,
         stride: u32,
     ),
-    pub cmd_draw_mesh_tasks_indirect_count_nv: extern "system" fn(
+    pub cmd_draw_mesh_tasks_indirect_count_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
@@ -16949,7 +16996,7 @@ impl NvMeshShaderFn {
     {
         NvMeshShaderFn {
             cmd_draw_mesh_tasks_nv: unsafe {
-                extern "system" fn cmd_draw_mesh_tasks_nv(
+                unsafe extern "system" fn cmd_draw_mesh_tasks_nv(
                     _command_buffer: CommandBuffer,
                     _task_count: u32,
                     _first_task: u32,
@@ -16969,7 +17016,7 @@ impl NvMeshShaderFn {
                 }
             },
             cmd_draw_mesh_tasks_indirect_nv: unsafe {
-                extern "system" fn cmd_draw_mesh_tasks_indirect_nv(
+                unsafe extern "system" fn cmd_draw_mesh_tasks_indirect_nv(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -16992,7 +17039,7 @@ impl NvMeshShaderFn {
                 }
             },
             cmd_draw_mesh_tasks_indirect_count_nv: unsafe {
-                extern "system" fn cmd_draw_mesh_tasks_indirect_count_nv(
+                unsafe extern "system" fn cmd_draw_mesh_tasks_indirect_count_nv(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -17146,14 +17193,14 @@ impl NvScissorExclusiveFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetExclusiveScissorNV = extern "system" fn(
+pub type PFN_vkCmdSetExclusiveScissorNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_exclusive_scissor: u32,
     exclusive_scissor_count: u32,
     p_exclusive_scissors: *const Rect2D,
 );
 pub struct NvScissorExclusiveFn {
-    pub cmd_set_exclusive_scissor_nv: extern "system" fn(
+    pub cmd_set_exclusive_scissor_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_exclusive_scissor: u32,
         exclusive_scissor_count: u32,
@@ -17176,7 +17223,7 @@ impl NvScissorExclusiveFn {
     {
         NvScissorExclusiveFn {
             cmd_set_exclusive_scissor_nv: unsafe {
-                extern "system" fn cmd_set_exclusive_scissor_nv(
+                unsafe extern "system" fn cmd_set_exclusive_scissor_nv(
                     _command_buffer: CommandBuffer,
                     _first_exclusive_scissor: u32,
                     _exclusive_scissor_count: u32,
@@ -17236,17 +17283,19 @@ impl NvDeviceDiagnosticCheckpointsFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetCheckpointNV =
-    extern "system" fn(command_buffer: CommandBuffer, p_checkpoint_marker: *const c_void);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, p_checkpoint_marker: *const c_void);
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetQueueCheckpointDataNV = extern "system" fn(
+pub type PFN_vkGetQueueCheckpointDataNV = unsafe extern "system" fn(
     queue: Queue,
     p_checkpoint_data_count: *mut u32,
     p_checkpoint_data: *mut CheckpointDataNV,
 );
 pub struct NvDeviceDiagnosticCheckpointsFn {
-    pub cmd_set_checkpoint_nv:
-        extern "system" fn(command_buffer: CommandBuffer, p_checkpoint_marker: *const c_void),
-    pub get_queue_checkpoint_data_nv: extern "system" fn(
+    pub cmd_set_checkpoint_nv: unsafe extern "system" fn(
+        command_buffer: CommandBuffer,
+        p_checkpoint_marker: *const c_void,
+    ),
+    pub get_queue_checkpoint_data_nv: unsafe extern "system" fn(
         queue: Queue,
         p_checkpoint_data_count: *mut u32,
         p_checkpoint_data: *mut CheckpointDataNV,
@@ -17269,7 +17318,7 @@ impl NvDeviceDiagnosticCheckpointsFn {
     {
         NvDeviceDiagnosticCheckpointsFn {
             cmd_set_checkpoint_nv: unsafe {
-                extern "system" fn cmd_set_checkpoint_nv(
+                unsafe extern "system" fn cmd_set_checkpoint_nv(
                     _command_buffer: CommandBuffer,
                     _p_checkpoint_marker: *const c_void,
                 ) {
@@ -17288,7 +17337,7 @@ impl NvDeviceDiagnosticCheckpointsFn {
                 }
             },
             get_queue_checkpoint_data_nv: unsafe {
-                extern "system" fn get_queue_checkpoint_data_nv(
+                unsafe extern "system" fn get_queue_checkpoint_data_nv(
                     _queue: Queue,
                     _p_checkpoint_data_count: *mut u32,
                     _p_checkpoint_data: *mut CheckpointDataNV,
@@ -17345,26 +17394,31 @@ impl KhrTimelineSemaphoreFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetSemaphoreCounterValue =
-    extern "system" fn(device: Device, semaphore: Semaphore, p_value: *mut u64) -> Result;
+    unsafe extern "system" fn(device: Device, semaphore: Semaphore, p_value: *mut u64) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkWaitSemaphores = extern "system" fn(
+pub type PFN_vkWaitSemaphores = unsafe extern "system" fn(
     device: Device,
     p_wait_info: *const SemaphoreWaitInfo,
     timeout: u64,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkSignalSemaphore =
-    extern "system" fn(device: Device, p_signal_info: *const SemaphoreSignalInfo) -> Result;
+    unsafe extern "system" fn(device: Device, p_signal_info: *const SemaphoreSignalInfo) -> Result;
 pub struct KhrTimelineSemaphoreFn {
-    pub get_semaphore_counter_value_khr:
-        extern "system" fn(device: Device, semaphore: Semaphore, p_value: *mut u64) -> Result,
-    pub wait_semaphores_khr: extern "system" fn(
+    pub get_semaphore_counter_value_khr: unsafe extern "system" fn(
+        device: Device,
+        semaphore: Semaphore,
+        p_value: *mut u64,
+    ) -> Result,
+    pub wait_semaphores_khr: unsafe extern "system" fn(
         device: Device,
         p_wait_info: *const SemaphoreWaitInfo,
         timeout: u64,
     ) -> Result,
-    pub signal_semaphore_khr:
-        extern "system" fn(device: Device, p_signal_info: *const SemaphoreSignalInfo) -> Result,
+    pub signal_semaphore_khr: unsafe extern "system" fn(
+        device: Device,
+        p_signal_info: *const SemaphoreSignalInfo,
+    ) -> Result,
 }
 unsafe impl Send for KhrTimelineSemaphoreFn {}
 unsafe impl Sync for KhrTimelineSemaphoreFn {}
@@ -17384,7 +17438,7 @@ impl KhrTimelineSemaphoreFn {
     {
         KhrTimelineSemaphoreFn {
             get_semaphore_counter_value_khr: unsafe {
-                extern "system" fn get_semaphore_counter_value_khr(
+                unsafe extern "system" fn get_semaphore_counter_value_khr(
                     _device: Device,
                     _semaphore: Semaphore,
                     _p_value: *mut u64,
@@ -17405,7 +17459,7 @@ impl KhrTimelineSemaphoreFn {
                 }
             },
             wait_semaphores_khr: unsafe {
-                extern "system" fn wait_semaphores_khr(
+                unsafe extern "system" fn wait_semaphores_khr(
                     _device: Device,
                     _p_wait_info: *const SemaphoreWaitInfo,
                     _timeout: u64,
@@ -17422,7 +17476,7 @@ impl KhrTimelineSemaphoreFn {
                 }
             },
             signal_semaphore_khr: unsafe {
-                extern "system" fn signal_semaphore_khr(
+                unsafe extern "system" fn signal_semaphore_khr(
                     _device: Device,
                     _p_signal_info: *const SemaphoreSignalInfo,
                 ) -> Result {
@@ -17562,73 +17616,79 @@ impl IntelPerformanceQueryFn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkInitializePerformanceApiINTEL = extern "system" fn(
+pub type PFN_vkInitializePerformanceApiINTEL = unsafe extern "system" fn(
     device: Device,
     p_initialize_info: *const InitializePerformanceApiInfoINTEL,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkUninitializePerformanceApiINTEL = extern "system" fn(device: Device);
+pub type PFN_vkUninitializePerformanceApiINTEL = unsafe extern "system" fn(device: Device);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetPerformanceMarkerINTEL = extern "system" fn(
+pub type PFN_vkCmdSetPerformanceMarkerINTEL = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_marker_info: *const PerformanceMarkerInfoINTEL,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetPerformanceStreamMarkerINTEL = extern "system" fn(
+pub type PFN_vkCmdSetPerformanceStreamMarkerINTEL = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_marker_info: *const PerformanceStreamMarkerInfoINTEL,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetPerformanceOverrideINTEL = extern "system" fn(
+pub type PFN_vkCmdSetPerformanceOverrideINTEL = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_override_info: *const PerformanceOverrideInfoINTEL,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkAcquirePerformanceConfigurationINTEL = extern "system" fn(
+pub type PFN_vkAcquirePerformanceConfigurationINTEL = unsafe extern "system" fn(
     device: Device,
     p_acquire_info: *const PerformanceConfigurationAcquireInfoINTEL,
     p_configuration: *mut PerformanceConfigurationINTEL,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkReleasePerformanceConfigurationINTEL =
-    extern "system" fn(device: Device, configuration: PerformanceConfigurationINTEL) -> Result;
+pub type PFN_vkReleasePerformanceConfigurationINTEL = unsafe extern "system" fn(
+    device: Device,
+    configuration: PerformanceConfigurationINTEL,
+) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkQueueSetPerformanceConfigurationINTEL =
-    extern "system" fn(queue: Queue, configuration: PerformanceConfigurationINTEL) -> Result;
+    unsafe extern "system" fn(queue: Queue, configuration: PerformanceConfigurationINTEL) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPerformanceParameterINTEL = extern "system" fn(
+pub type PFN_vkGetPerformanceParameterINTEL = unsafe extern "system" fn(
     device: Device,
     parameter: PerformanceParameterTypeINTEL,
     p_value: *mut PerformanceValueINTEL,
 ) -> Result;
 pub struct IntelPerformanceQueryFn {
-    pub initialize_performance_api_intel: extern "system" fn(
+    pub initialize_performance_api_intel: unsafe extern "system" fn(
         device: Device,
         p_initialize_info: *const InitializePerformanceApiInfoINTEL,
     ) -> Result,
-    pub uninitialize_performance_api_intel: extern "system" fn(device: Device),
-    pub cmd_set_performance_marker_intel: extern "system" fn(
+    pub uninitialize_performance_api_intel: unsafe extern "system" fn(device: Device),
+    pub cmd_set_performance_marker_intel: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_marker_info: *const PerformanceMarkerInfoINTEL,
     ) -> Result,
-    pub cmd_set_performance_stream_marker_intel: extern "system" fn(
+    pub cmd_set_performance_stream_marker_intel: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_marker_info: *const PerformanceStreamMarkerInfoINTEL,
     ) -> Result,
-    pub cmd_set_performance_override_intel: extern "system" fn(
+    pub cmd_set_performance_override_intel: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_override_info: *const PerformanceOverrideInfoINTEL,
     ) -> Result,
-    pub acquire_performance_configuration_intel: extern "system" fn(
+    pub acquire_performance_configuration_intel: unsafe extern "system" fn(
         device: Device,
         p_acquire_info: *const PerformanceConfigurationAcquireInfoINTEL,
         p_configuration: *mut PerformanceConfigurationINTEL,
     ) -> Result,
-    pub release_performance_configuration_intel:
-        extern "system" fn(device: Device, configuration: PerformanceConfigurationINTEL) -> Result,
-    pub queue_set_performance_configuration_intel:
-        extern "system" fn(queue: Queue, configuration: PerformanceConfigurationINTEL) -> Result,
-    pub get_performance_parameter_intel: extern "system" fn(
+    pub release_performance_configuration_intel: unsafe extern "system" fn(
+        device: Device,
+        configuration: PerformanceConfigurationINTEL,
+    ) -> Result,
+    pub queue_set_performance_configuration_intel: unsafe extern "system" fn(
+        queue: Queue,
+        configuration: PerformanceConfigurationINTEL,
+    ) -> Result,
+    pub get_performance_parameter_intel: unsafe extern "system" fn(
         device: Device,
         parameter: PerformanceParameterTypeINTEL,
         p_value: *mut PerformanceValueINTEL,
@@ -17659,7 +17719,7 @@ impl IntelPerformanceQueryFn {
     {
         IntelPerformanceQueryFn {
             initialize_performance_api_intel: unsafe {
-                extern "system" fn initialize_performance_api_intel(
+                unsafe extern "system" fn initialize_performance_api_intel(
                     _device: Device,
                     _p_initialize_info: *const InitializePerformanceApiInfoINTEL,
                 ) -> Result {
@@ -17679,7 +17739,7 @@ impl IntelPerformanceQueryFn {
                 }
             },
             uninitialize_performance_api_intel: unsafe {
-                extern "system" fn uninitialize_performance_api_intel(_device: Device) {
+                unsafe extern "system" fn uninitialize_performance_api_intel(_device: Device) {
                     panic!(concat!(
                         "Unable to load ",
                         stringify!(uninitialize_performance_api_intel)
@@ -17696,7 +17756,7 @@ impl IntelPerformanceQueryFn {
                 }
             },
             cmd_set_performance_marker_intel: unsafe {
-                extern "system" fn cmd_set_performance_marker_intel(
+                unsafe extern "system" fn cmd_set_performance_marker_intel(
                     _command_buffer: CommandBuffer,
                     _p_marker_info: *const PerformanceMarkerInfoINTEL,
                 ) -> Result {
@@ -17716,7 +17776,7 @@ impl IntelPerformanceQueryFn {
                 }
             },
             cmd_set_performance_stream_marker_intel: unsafe {
-                extern "system" fn cmd_set_performance_stream_marker_intel(
+                unsafe extern "system" fn cmd_set_performance_stream_marker_intel(
                     _command_buffer: CommandBuffer,
                     _p_marker_info: *const PerformanceStreamMarkerInfoINTEL,
                 ) -> Result {
@@ -17736,7 +17796,7 @@ impl IntelPerformanceQueryFn {
                 }
             },
             cmd_set_performance_override_intel: unsafe {
-                extern "system" fn cmd_set_performance_override_intel(
+                unsafe extern "system" fn cmd_set_performance_override_intel(
                     _command_buffer: CommandBuffer,
                     _p_override_info: *const PerformanceOverrideInfoINTEL,
                 ) -> Result {
@@ -17756,7 +17816,7 @@ impl IntelPerformanceQueryFn {
                 }
             },
             acquire_performance_configuration_intel: unsafe {
-                extern "system" fn acquire_performance_configuration_intel(
+                unsafe extern "system" fn acquire_performance_configuration_intel(
                     _device: Device,
                     _p_acquire_info: *const PerformanceConfigurationAcquireInfoINTEL,
                     _p_configuration: *mut PerformanceConfigurationINTEL,
@@ -17777,7 +17837,7 @@ impl IntelPerformanceQueryFn {
                 }
             },
             release_performance_configuration_intel: unsafe {
-                extern "system" fn release_performance_configuration_intel(
+                unsafe extern "system" fn release_performance_configuration_intel(
                     _device: Device,
                     _configuration: PerformanceConfigurationINTEL,
                 ) -> Result {
@@ -17797,7 +17857,7 @@ impl IntelPerformanceQueryFn {
                 }
             },
             queue_set_performance_configuration_intel: unsafe {
-                extern "system" fn queue_set_performance_configuration_intel(
+                unsafe extern "system" fn queue_set_performance_configuration_intel(
                     _queue: Queue,
                     _configuration: PerformanceConfigurationINTEL,
                 ) -> Result {
@@ -17817,7 +17877,7 @@ impl IntelPerformanceQueryFn {
                 }
             },
             get_performance_parameter_intel: unsafe {
-                extern "system" fn get_performance_parameter_intel(
+                unsafe extern "system" fn get_performance_parameter_intel(
                     _device: Device,
                     _parameter: PerformanceParameterTypeINTEL,
                     _p_value: *mut PerformanceValueINTEL,
@@ -18010,11 +18070,17 @@ impl AmdDisplayNativeHdrFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkSetLocalDimmingAMD =
-    extern "system" fn(device: Device, swap_chain: SwapchainKHR, local_dimming_enable: Bool32);
+pub type PFN_vkSetLocalDimmingAMD = unsafe extern "system" fn(
+    device: Device,
+    swap_chain: SwapchainKHR,
+    local_dimming_enable: Bool32,
+);
 pub struct AmdDisplayNativeHdrFn {
-    pub set_local_dimming_amd:
-        extern "system" fn(device: Device, swap_chain: SwapchainKHR, local_dimming_enable: Bool32),
+    pub set_local_dimming_amd: unsafe extern "system" fn(
+        device: Device,
+        swap_chain: SwapchainKHR,
+        local_dimming_enable: Bool32,
+    ),
 }
 unsafe impl Send for AmdDisplayNativeHdrFn {}
 unsafe impl Sync for AmdDisplayNativeHdrFn {}
@@ -18032,7 +18098,7 @@ impl AmdDisplayNativeHdrFn {
     {
         AmdDisplayNativeHdrFn {
             set_local_dimming_amd: unsafe {
-                extern "system" fn set_local_dimming_amd(
+                unsafe extern "system" fn set_local_dimming_amd(
                     _device: Device,
                     _swap_chain: SwapchainKHR,
                     _local_dimming_enable: Bool32,
@@ -18083,14 +18149,14 @@ impl FuchsiaImagepipeSurfaceFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateImagePipeSurfaceFUCHSIA = extern "system" fn(
+pub type PFN_vkCreateImagePipeSurfaceFUCHSIA = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const ImagePipeSurfaceCreateInfoFUCHSIA,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub struct FuchsiaImagepipeSurfaceFn {
-    pub create_image_pipe_surface_fuchsia: extern "system" fn(
+    pub create_image_pipe_surface_fuchsia: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const ImagePipeSurfaceCreateInfoFUCHSIA,
         p_allocator: *const AllocationCallbacks,
@@ -18113,7 +18179,7 @@ impl FuchsiaImagepipeSurfaceFn {
     {
         FuchsiaImagepipeSurfaceFn {
             create_image_pipe_surface_fuchsia: unsafe {
-                extern "system" fn create_image_pipe_surface_fuchsia(
+                unsafe extern "system" fn create_image_pipe_surface_fuchsia(
                     _instance: Instance,
                     _p_create_info: *const ImagePipeSurfaceCreateInfoFUCHSIA,
                     _p_allocator: *const AllocationCallbacks,
@@ -18209,14 +18275,14 @@ impl ExtMetalSurfaceFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateMetalSurfaceEXT = extern "system" fn(
+pub type PFN_vkCreateMetalSurfaceEXT = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const MetalSurfaceCreateInfoEXT,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub struct ExtMetalSurfaceFn {
-    pub create_metal_surface_ext: extern "system" fn(
+    pub create_metal_surface_ext: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const MetalSurfaceCreateInfoEXT,
         p_allocator: *const AllocationCallbacks,
@@ -18239,7 +18305,7 @@ impl ExtMetalSurfaceFn {
     {
         ExtMetalSurfaceFn {
             create_metal_surface_ext: unsafe {
-                extern "system" fn create_metal_surface_ext(
+                unsafe extern "system" fn create_metal_surface_ext(
                     _instance: Instance,
                     _p_create_info: *const MetalSurfaceCreateInfoEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -18546,24 +18612,24 @@ impl KhrFragmentShadingRateFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceFragmentShadingRatesKHR = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_fragment_shading_rate_count: *mut u32,
     p_fragment_shading_rates: *mut PhysicalDeviceFragmentShadingRateKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetFragmentShadingRateKHR = extern "system" fn(
+pub type PFN_vkCmdSetFragmentShadingRateKHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_fragment_size: *const Extent2D,
     combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
 );
 pub struct KhrFragmentShadingRateFn {
-    pub get_physical_device_fragment_shading_rates_khr: extern "system" fn(
+    pub get_physical_device_fragment_shading_rates_khr: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_fragment_shading_rate_count: *mut u32,
         p_fragment_shading_rates: *mut PhysicalDeviceFragmentShadingRateKHR,
     ) -> Result,
-    pub cmd_set_fragment_shading_rate_khr: extern "system" fn(
+    pub cmd_set_fragment_shading_rate_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_fragment_size: *const Extent2D,
         combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
@@ -18587,7 +18653,7 @@ impl KhrFragmentShadingRateFn {
     {
         KhrFragmentShadingRateFn {
             get_physical_device_fragment_shading_rates_khr: unsafe {
-                extern "system" fn get_physical_device_fragment_shading_rates_khr(
+                unsafe extern "system" fn get_physical_device_fragment_shading_rates_khr(
                     _physical_device: PhysicalDevice,
                     _p_fragment_shading_rate_count: *mut u32,
                     _p_fragment_shading_rates: *mut PhysicalDeviceFragmentShadingRateKHR,
@@ -18608,7 +18674,7 @@ impl KhrFragmentShadingRateFn {
                 }
             },
             cmd_set_fragment_shading_rate_khr: unsafe {
-                extern "system" fn cmd_set_fragment_shading_rate_khr(
+                unsafe extern "system" fn cmd_set_fragment_shading_rate_khr(
                     _command_buffer: CommandBuffer,
                     _p_fragment_size: *const Extent2D,
                     _combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
@@ -19169,11 +19235,15 @@ impl ExtBufferDeviceAddressFn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetBufferDeviceAddress =
-    extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> DeviceAddress;
+pub type PFN_vkGetBufferDeviceAddress = unsafe extern "system" fn(
+    device: Device,
+    p_info: *const BufferDeviceAddressInfo,
+) -> DeviceAddress;
 pub struct ExtBufferDeviceAddressFn {
-    pub get_buffer_device_address_ext:
-        extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> DeviceAddress,
+    pub get_buffer_device_address_ext: unsafe extern "system" fn(
+        device: Device,
+        p_info: *const BufferDeviceAddressInfo,
+    ) -> DeviceAddress,
 }
 unsafe impl Send for ExtBufferDeviceAddressFn {}
 unsafe impl Sync for ExtBufferDeviceAddressFn {}
@@ -19191,7 +19261,7 @@ impl ExtBufferDeviceAddressFn {
     {
         ExtBufferDeviceAddressFn {
             get_buffer_device_address_ext: unsafe {
-                extern "system" fn get_buffer_device_address_ext(
+                unsafe extern "system" fn get_buffer_device_address_ext(
                     _device: Device,
                     _p_info: *const BufferDeviceAddressInfo,
                 ) -> DeviceAddress {
@@ -19258,13 +19328,13 @@ impl ExtToolingInfoFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceToolPropertiesEXT = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceToolPropertiesEXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_tool_count: *mut u32,
     p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
 ) -> Result;
 pub struct ExtToolingInfoFn {
-    pub get_physical_device_tool_properties_ext: extern "system" fn(
+    pub get_physical_device_tool_properties_ext: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_tool_count: *mut u32,
         p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
@@ -19286,7 +19356,7 @@ impl ExtToolingInfoFn {
     {
         ExtToolingInfoFn {
             get_physical_device_tool_properties_ext: unsafe {
-                extern "system" fn get_physical_device_tool_properties_ext(
+                unsafe extern "system" fn get_physical_device_tool_properties_ext(
                     _physical_device: PhysicalDevice,
                     _p_tool_count: *mut u32,
                     _p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
@@ -19419,17 +19489,19 @@ impl NvCooperativeMatrixFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
     p_properties: *mut CooperativeMatrixPropertiesNV,
-) -> Result;
+)
+    -> Result;
 pub struct NvCooperativeMatrixFn {
-    pub get_physical_device_cooperative_matrix_properties_nv: extern "system" fn(
+    pub get_physical_device_cooperative_matrix_properties_nv: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_property_count: *mut u32,
         p_properties: *mut CooperativeMatrixPropertiesNV,
-    ) -> Result,
+    )
+        -> Result,
 }
 unsafe impl Send for NvCooperativeMatrixFn {}
 unsafe impl Sync for NvCooperativeMatrixFn {}
@@ -19448,7 +19520,7 @@ impl NvCooperativeMatrixFn {
     {
         NvCooperativeMatrixFn {
             get_physical_device_cooperative_matrix_properties_nv: unsafe {
-                extern "system" fn get_physical_device_cooperative_matrix_properties_nv(
+                unsafe extern "system" fn get_physical_device_cooperative_matrix_properties_nv(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
                     _p_properties: *mut CooperativeMatrixPropertiesNV,
@@ -19505,14 +19577,14 @@ impl NvCoverageReductionModeFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV =
-    extern "system" fn(
+    unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_combination_count: *mut u32,
         p_combinations: *mut FramebufferMixedSamplesCombinationNV,
     ) -> Result;
 pub struct NvCoverageReductionModeFn {
     pub get_physical_device_supported_framebuffer_mixed_samples_combinations_nv:
-        extern "system" fn(
+        unsafe extern "system" fn(
             physical_device: PhysicalDevice,
             p_combination_count: *mut u32,
             p_combinations: *mut FramebufferMixedSamplesCombinationNV,
@@ -19535,7 +19607,7 @@ impl NvCoverageReductionModeFn {
     {
         NvCoverageReductionModeFn {
             get_physical_device_supported_framebuffer_mixed_samples_combinations_nv: unsafe {
-                extern "system" fn get_physical_device_supported_framebuffer_mixed_samples_combinations_nv(
+                unsafe extern "system" fn get_physical_device_supported_framebuffer_mixed_samples_combinations_nv(
                     _physical_device: PhysicalDevice,
                     _p_combination_count: *mut u32,
                     _p_combinations: *mut FramebufferMixedSamplesCombinationNV,
@@ -19698,7 +19770,7 @@ impl ExtFullScreenExclusiveFn {
     pub const SPEC_VERSION: u32 = 4u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
     p_present_mode_count: *mut u32,
@@ -19706,28 +19778,28 @@ pub type PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT = extern "system" fn(
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkAcquireFullScreenExclusiveModeEXT =
-    extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result;
+    unsafe extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkReleaseFullScreenExclusiveModeEXT =
-    extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result;
+    unsafe extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceGroupSurfacePresentModes2EXT = extern "system" fn(
+pub type PFN_vkGetDeviceGroupSurfacePresentModes2EXT = unsafe extern "system" fn(
     device: Device,
     p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
     p_modes: *mut DeviceGroupPresentModeFlagsKHR,
 ) -> Result;
 pub struct ExtFullScreenExclusiveFn {
-    pub get_physical_device_surface_present_modes2_ext: extern "system" fn(
+    pub get_physical_device_surface_present_modes2_ext: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
         p_present_mode_count: *mut u32,
         p_present_modes: *mut PresentModeKHR,
     ) -> Result,
     pub acquire_full_screen_exclusive_mode_ext:
-        extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result,
+        unsafe extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result,
     pub release_full_screen_exclusive_mode_ext:
-        extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result,
-    pub get_device_group_surface_present_modes2_ext: extern "system" fn(
+        unsafe extern "system" fn(device: Device, swapchain: SwapchainKHR) -> Result,
+    pub get_device_group_surface_present_modes2_ext: unsafe extern "system" fn(
         device: Device,
         p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
         p_modes: *mut DeviceGroupPresentModeFlagsKHR,
@@ -19754,7 +19826,7 @@ impl ExtFullScreenExclusiveFn {
     {
         ExtFullScreenExclusiveFn {
             get_physical_device_surface_present_modes2_ext: unsafe {
-                extern "system" fn get_physical_device_surface_present_modes2_ext(
+                unsafe extern "system" fn get_physical_device_surface_present_modes2_ext(
                     _physical_device: PhysicalDevice,
                     _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
                     _p_present_mode_count: *mut u32,
@@ -19776,7 +19848,7 @@ impl ExtFullScreenExclusiveFn {
                 }
             },
             acquire_full_screen_exclusive_mode_ext: unsafe {
-                extern "system" fn acquire_full_screen_exclusive_mode_ext(
+                unsafe extern "system" fn acquire_full_screen_exclusive_mode_ext(
                     _device: Device,
                     _swapchain: SwapchainKHR,
                 ) -> Result {
@@ -19796,7 +19868,7 @@ impl ExtFullScreenExclusiveFn {
                 }
             },
             release_full_screen_exclusive_mode_ext: unsafe {
-                extern "system" fn release_full_screen_exclusive_mode_ext(
+                unsafe extern "system" fn release_full_screen_exclusive_mode_ext(
                     _device: Device,
                     _swapchain: SwapchainKHR,
                 ) -> Result {
@@ -19816,7 +19888,7 @@ impl ExtFullScreenExclusiveFn {
                 }
             },
             get_device_group_surface_present_modes2_ext: unsafe {
-                extern "system" fn get_device_group_surface_present_modes2_ext(
+                unsafe extern "system" fn get_device_group_surface_present_modes2_ext(
                     _device: Device,
                     _p_surface_info: *const PhysicalDeviceSurfaceInfo2KHR,
                     _p_modes: *mut DeviceGroupPresentModeFlagsKHR,
@@ -19903,14 +19975,14 @@ impl ExtHeadlessSurfaceFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateHeadlessSurfaceEXT = extern "system" fn(
+pub type PFN_vkCreateHeadlessSurfaceEXT = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const HeadlessSurfaceCreateInfoEXT,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 pub struct ExtHeadlessSurfaceFn {
-    pub create_headless_surface_ext: extern "system" fn(
+    pub create_headless_surface_ext: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const HeadlessSurfaceCreateInfoEXT,
         p_allocator: *const AllocationCallbacks,
@@ -19933,7 +20005,7 @@ impl ExtHeadlessSurfaceFn {
     {
         ExtHeadlessSurfaceFn {
             create_headless_surface_ext: unsafe {
-                extern "system" fn create_headless_surface_ext(
+                unsafe extern "system" fn create_headless_surface_ext(
                     _instance: Instance,
                     _p_create_info: *const HeadlessSurfaceCreateInfoEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -19979,17 +20051,21 @@ impl KhrBufferDeviceAddressFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetBufferOpaqueCaptureAddress =
-    extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> DeviceAddress;
+pub type PFN_vkGetBufferOpaqueCaptureAddress = unsafe extern "system" fn(
+    device: Device,
+    p_info: *const BufferDeviceAddressInfo,
+) -> DeviceAddress;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceMemoryOpaqueCaptureAddress =
-    extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> u64;
+    unsafe extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> u64;
 pub struct KhrBufferDeviceAddressFn {
-    pub get_buffer_device_address_khr:
-        extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> DeviceAddress,
+    pub get_buffer_device_address_khr: unsafe extern "system" fn(
+        device: Device,
+        p_info: *const BufferDeviceAddressInfo,
+    ) -> DeviceAddress,
     pub get_buffer_opaque_capture_address_khr:
-        extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> u64,
-    pub get_device_memory_opaque_capture_address_khr: extern "system" fn(
+        unsafe extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> u64,
+    pub get_device_memory_opaque_capture_address_khr: unsafe extern "system" fn(
         device: Device,
         p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
     ) -> u64,
@@ -20013,7 +20089,7 @@ impl KhrBufferDeviceAddressFn {
     {
         KhrBufferDeviceAddressFn {
             get_buffer_device_address_khr: unsafe {
-                extern "system" fn get_buffer_device_address_khr(
+                unsafe extern "system" fn get_buffer_device_address_khr(
                     _device: Device,
                     _p_info: *const BufferDeviceAddressInfo,
                 ) -> DeviceAddress {
@@ -20033,7 +20109,7 @@ impl KhrBufferDeviceAddressFn {
                 }
             },
             get_buffer_opaque_capture_address_khr: unsafe {
-                extern "system" fn get_buffer_opaque_capture_address_khr(
+                unsafe extern "system" fn get_buffer_opaque_capture_address_khr(
                     _device: Device,
                     _p_info: *const BufferDeviceAddressInfo,
                 ) -> u64 {
@@ -20053,7 +20129,7 @@ impl KhrBufferDeviceAddressFn {
                 }
             },
             get_device_memory_opaque_capture_address_khr: unsafe {
-                extern "system" fn get_device_memory_opaque_capture_address_khr(
+                unsafe extern "system" fn get_device_memory_opaque_capture_address_khr(
                     _device: Device,
                     _p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
                 ) -> u64 {
@@ -20175,13 +20251,13 @@ impl ExtLineRasterizationFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetLineStippleEXT = extern "system" fn(
+pub type PFN_vkCmdSetLineStippleEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     line_stipple_factor: u32,
     line_stipple_pattern: u16,
 );
 pub struct ExtLineRasterizationFn {
-    pub cmd_set_line_stipple_ext: extern "system" fn(
+    pub cmd_set_line_stipple_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         line_stipple_factor: u32,
         line_stipple_pattern: u16,
@@ -20203,7 +20279,7 @@ impl ExtLineRasterizationFn {
     {
         ExtLineRasterizationFn {
             cmd_set_line_stipple_ext: unsafe {
-                extern "system" fn cmd_set_line_stipple_ext(
+                unsafe extern "system" fn cmd_set_line_stipple_ext(
                     _command_buffer: CommandBuffer,
                     _line_stipple_factor: u32,
                     _line_stipple_pattern: u16,
@@ -20285,10 +20361,14 @@ impl ExtHostQueryResetFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkResetQueryPool =
-    extern "system" fn(device: Device, query_pool: QueryPool, first_query: u32, query_count: u32);
+pub type PFN_vkResetQueryPool = unsafe extern "system" fn(
+    device: Device,
+    query_pool: QueryPool,
+    first_query: u32,
+    query_count: u32,
+);
 pub struct ExtHostQueryResetFn {
-    pub reset_query_pool_ext: extern "system" fn(
+    pub reset_query_pool_ext: unsafe extern "system" fn(
         device: Device,
         query_pool: QueryPool,
         first_query: u32,
@@ -20311,7 +20391,7 @@ impl ExtHostQueryResetFn {
     {
         ExtHostQueryResetFn {
             reset_query_pool_ext: unsafe {
-                extern "system" fn reset_query_pool_ext(
+                unsafe extern "system" fn reset_query_pool_ext(
                     _device: Device,
                     _query_pool: QueryPool,
                     _first_query: u32,
@@ -20478,27 +20558,27 @@ impl ExtExtendedDynamicStateFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetCullModeEXT =
-    extern "system" fn(command_buffer: CommandBuffer, cull_mode: CullModeFlags);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, cull_mode: CullModeFlags);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetFrontFaceEXT =
-    extern "system" fn(command_buffer: CommandBuffer, front_face: FrontFace);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, front_face: FrontFace);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetPrimitiveTopologyEXT =
-    extern "system" fn(command_buffer: CommandBuffer, primitive_topology: PrimitiveTopology);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, primitive_topology: PrimitiveTopology);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetViewportWithCountEXT = extern "system" fn(
+pub type PFN_vkCmdSetViewportWithCountEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     viewport_count: u32,
     p_viewports: *const Viewport,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetScissorWithCountEXT = extern "system" fn(
+pub type PFN_vkCmdSetScissorWithCountEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     scissor_count: u32,
     p_scissors: *const Rect2D,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBindVertexBuffers2EXT = extern "system" fn(
+pub type PFN_vkCmdBindVertexBuffers2EXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_binding: u32,
     binding_count: u32,
@@ -20509,21 +20589,21 @@ pub type PFN_vkCmdBindVertexBuffers2EXT = extern "system" fn(
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetDepthTestEnableEXT =
-    extern "system" fn(command_buffer: CommandBuffer, depth_test_enable: Bool32);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, depth_test_enable: Bool32);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetDepthWriteEnableEXT =
-    extern "system" fn(command_buffer: CommandBuffer, depth_write_enable: Bool32);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, depth_write_enable: Bool32);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetDepthCompareOpEXT =
-    extern "system" fn(command_buffer: CommandBuffer, depth_compare_op: CompareOp);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, depth_compare_op: CompareOp);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetDepthBoundsTestEnableEXT =
-    extern "system" fn(command_buffer: CommandBuffer, depth_bounds_test_enable: Bool32);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, depth_bounds_test_enable: Bool32);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetStencilTestEnableEXT =
-    extern "system" fn(command_buffer: CommandBuffer, stencil_test_enable: Bool32);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, stencil_test_enable: Bool32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetStencilOpEXT = extern "system" fn(
+pub type PFN_vkCmdSetStencilOpEXT = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     face_mask: StencilFaceFlags,
     fail_op: StencilOp,
@@ -20533,22 +20613,24 @@ pub type PFN_vkCmdSetStencilOpEXT = extern "system" fn(
 );
 pub struct ExtExtendedDynamicStateFn {
     pub cmd_set_cull_mode_ext:
-        extern "system" fn(command_buffer: CommandBuffer, cull_mode: CullModeFlags),
+        unsafe extern "system" fn(command_buffer: CommandBuffer, cull_mode: CullModeFlags),
     pub cmd_set_front_face_ext:
-        extern "system" fn(command_buffer: CommandBuffer, front_face: FrontFace),
-    pub cmd_set_primitive_topology_ext:
-        extern "system" fn(command_buffer: CommandBuffer, primitive_topology: PrimitiveTopology),
-    pub cmd_set_viewport_with_count_ext: extern "system" fn(
+        unsafe extern "system" fn(command_buffer: CommandBuffer, front_face: FrontFace),
+    pub cmd_set_primitive_topology_ext: unsafe extern "system" fn(
+        command_buffer: CommandBuffer,
+        primitive_topology: PrimitiveTopology,
+    ),
+    pub cmd_set_viewport_with_count_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         viewport_count: u32,
         p_viewports: *const Viewport,
     ),
-    pub cmd_set_scissor_with_count_ext: extern "system" fn(
+    pub cmd_set_scissor_with_count_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         scissor_count: u32,
         p_scissors: *const Rect2D,
     ),
-    pub cmd_bind_vertex_buffers2_ext: extern "system" fn(
+    pub cmd_bind_vertex_buffers2_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_binding: u32,
         binding_count: u32,
@@ -20558,16 +20640,16 @@ pub struct ExtExtendedDynamicStateFn {
         p_strides: *const DeviceSize,
     ),
     pub cmd_set_depth_test_enable_ext:
-        extern "system" fn(command_buffer: CommandBuffer, depth_test_enable: Bool32),
+        unsafe extern "system" fn(command_buffer: CommandBuffer, depth_test_enable: Bool32),
     pub cmd_set_depth_write_enable_ext:
-        extern "system" fn(command_buffer: CommandBuffer, depth_write_enable: Bool32),
+        unsafe extern "system" fn(command_buffer: CommandBuffer, depth_write_enable: Bool32),
     pub cmd_set_depth_compare_op_ext:
-        extern "system" fn(command_buffer: CommandBuffer, depth_compare_op: CompareOp),
+        unsafe extern "system" fn(command_buffer: CommandBuffer, depth_compare_op: CompareOp),
     pub cmd_set_depth_bounds_test_enable_ext:
-        extern "system" fn(command_buffer: CommandBuffer, depth_bounds_test_enable: Bool32),
+        unsafe extern "system" fn(command_buffer: CommandBuffer, depth_bounds_test_enable: Bool32),
     pub cmd_set_stencil_test_enable_ext:
-        extern "system" fn(command_buffer: CommandBuffer, stencil_test_enable: Bool32),
-    pub cmd_set_stencil_op_ext: extern "system" fn(
+        unsafe extern "system" fn(command_buffer: CommandBuffer, stencil_test_enable: Bool32),
+    pub cmd_set_stencil_op_ext: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         face_mask: StencilFaceFlags,
         fail_op: StencilOp,
@@ -20603,7 +20685,7 @@ impl ExtExtendedDynamicStateFn {
     {
         ExtExtendedDynamicStateFn {
             cmd_set_cull_mode_ext: unsafe {
-                extern "system" fn cmd_set_cull_mode_ext(
+                unsafe extern "system" fn cmd_set_cull_mode_ext(
                     _command_buffer: CommandBuffer,
                     _cull_mode: CullModeFlags,
                 ) {
@@ -20622,7 +20704,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_front_face_ext: unsafe {
-                extern "system" fn cmd_set_front_face_ext(
+                unsafe extern "system" fn cmd_set_front_face_ext(
                     _command_buffer: CommandBuffer,
                     _front_face: FrontFace,
                 ) {
@@ -20641,7 +20723,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_primitive_topology_ext: unsafe {
-                extern "system" fn cmd_set_primitive_topology_ext(
+                unsafe extern "system" fn cmd_set_primitive_topology_ext(
                     _command_buffer: CommandBuffer,
                     _primitive_topology: PrimitiveTopology,
                 ) {
@@ -20661,7 +20743,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_viewport_with_count_ext: unsafe {
-                extern "system" fn cmd_set_viewport_with_count_ext(
+                unsafe extern "system" fn cmd_set_viewport_with_count_ext(
                     _command_buffer: CommandBuffer,
                     _viewport_count: u32,
                     _p_viewports: *const Viewport,
@@ -20682,7 +20764,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_scissor_with_count_ext: unsafe {
-                extern "system" fn cmd_set_scissor_with_count_ext(
+                unsafe extern "system" fn cmd_set_scissor_with_count_ext(
                     _command_buffer: CommandBuffer,
                     _scissor_count: u32,
                     _p_scissors: *const Rect2D,
@@ -20703,7 +20785,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_bind_vertex_buffers2_ext: unsafe {
-                extern "system" fn cmd_bind_vertex_buffers2_ext(
+                unsafe extern "system" fn cmd_bind_vertex_buffers2_ext(
                     _command_buffer: CommandBuffer,
                     _first_binding: u32,
                     _binding_count: u32,
@@ -20728,7 +20810,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_depth_test_enable_ext: unsafe {
-                extern "system" fn cmd_set_depth_test_enable_ext(
+                unsafe extern "system" fn cmd_set_depth_test_enable_ext(
                     _command_buffer: CommandBuffer,
                     _depth_test_enable: Bool32,
                 ) {
@@ -20748,7 +20830,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_depth_write_enable_ext: unsafe {
-                extern "system" fn cmd_set_depth_write_enable_ext(
+                unsafe extern "system" fn cmd_set_depth_write_enable_ext(
                     _command_buffer: CommandBuffer,
                     _depth_write_enable: Bool32,
                 ) {
@@ -20768,7 +20850,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_depth_compare_op_ext: unsafe {
-                extern "system" fn cmd_set_depth_compare_op_ext(
+                unsafe extern "system" fn cmd_set_depth_compare_op_ext(
                     _command_buffer: CommandBuffer,
                     _depth_compare_op: CompareOp,
                 ) {
@@ -20787,7 +20869,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_depth_bounds_test_enable_ext: unsafe {
-                extern "system" fn cmd_set_depth_bounds_test_enable_ext(
+                unsafe extern "system" fn cmd_set_depth_bounds_test_enable_ext(
                     _command_buffer: CommandBuffer,
                     _depth_bounds_test_enable: Bool32,
                 ) {
@@ -20807,7 +20889,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_stencil_test_enable_ext: unsafe {
-                extern "system" fn cmd_set_stencil_test_enable_ext(
+                unsafe extern "system" fn cmd_set_stencil_test_enable_ext(
                     _command_buffer: CommandBuffer,
                     _stencil_test_enable: Bool32,
                 ) {
@@ -20827,7 +20909,7 @@ impl ExtExtendedDynamicStateFn {
                 }
             },
             cmd_set_stencil_op_ext: unsafe {
-                extern "system" fn cmd_set_stencil_op_ext(
+                unsafe extern "system" fn cmd_set_stencil_op_ext(
                     _command_buffer: CommandBuffer,
                     _face_mask: StencilFaceFlags,
                     _fail_op: StencilOp,
@@ -21034,43 +21116,43 @@ impl KhrDeferredHostOperationsFn {
     pub const SPEC_VERSION: u32 = 4u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDeferredOperationKHR = extern "system" fn(
+pub type PFN_vkCreateDeferredOperationKHR = unsafe extern "system" fn(
     device: Device,
     p_allocator: *const AllocationCallbacks,
     p_deferred_operation: *mut DeferredOperationKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyDeferredOperationKHR = extern "system" fn(
+pub type PFN_vkDestroyDeferredOperationKHR = unsafe extern "system" fn(
     device: Device,
     operation: DeferredOperationKHR,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeferredOperationMaxConcurrencyKHR =
-    extern "system" fn(device: Device, operation: DeferredOperationKHR) -> u32;
+    unsafe extern "system" fn(device: Device, operation: DeferredOperationKHR) -> u32;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeferredOperationResultKHR =
-    extern "system" fn(device: Device, operation: DeferredOperationKHR) -> Result;
+    unsafe extern "system" fn(device: Device, operation: DeferredOperationKHR) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkDeferredOperationJoinKHR =
-    extern "system" fn(device: Device, operation: DeferredOperationKHR) -> Result;
+    unsafe extern "system" fn(device: Device, operation: DeferredOperationKHR) -> Result;
 pub struct KhrDeferredHostOperationsFn {
-    pub create_deferred_operation_khr: extern "system" fn(
+    pub create_deferred_operation_khr: unsafe extern "system" fn(
         device: Device,
         p_allocator: *const AllocationCallbacks,
         p_deferred_operation: *mut DeferredOperationKHR,
     ) -> Result,
-    pub destroy_deferred_operation_khr: extern "system" fn(
+    pub destroy_deferred_operation_khr: unsafe extern "system" fn(
         device: Device,
         operation: DeferredOperationKHR,
         p_allocator: *const AllocationCallbacks,
     ),
     pub get_deferred_operation_max_concurrency_khr:
-        extern "system" fn(device: Device, operation: DeferredOperationKHR) -> u32,
+        unsafe extern "system" fn(device: Device, operation: DeferredOperationKHR) -> u32,
     pub get_deferred_operation_result_khr:
-        extern "system" fn(device: Device, operation: DeferredOperationKHR) -> Result,
+        unsafe extern "system" fn(device: Device, operation: DeferredOperationKHR) -> Result,
     pub deferred_operation_join_khr:
-        extern "system" fn(device: Device, operation: DeferredOperationKHR) -> Result,
+        unsafe extern "system" fn(device: Device, operation: DeferredOperationKHR) -> Result,
 }
 unsafe impl Send for KhrDeferredHostOperationsFn {}
 unsafe impl Sync for KhrDeferredHostOperationsFn {}
@@ -21093,7 +21175,7 @@ impl KhrDeferredHostOperationsFn {
     {
         KhrDeferredHostOperationsFn {
             create_deferred_operation_khr: unsafe {
-                extern "system" fn create_deferred_operation_khr(
+                unsafe extern "system" fn create_deferred_operation_khr(
                     _device: Device,
                     _p_allocator: *const AllocationCallbacks,
                     _p_deferred_operation: *mut DeferredOperationKHR,
@@ -21114,7 +21196,7 @@ impl KhrDeferredHostOperationsFn {
                 }
             },
             destroy_deferred_operation_khr: unsafe {
-                extern "system" fn destroy_deferred_operation_khr(
+                unsafe extern "system" fn destroy_deferred_operation_khr(
                     _device: Device,
                     _operation: DeferredOperationKHR,
                     _p_allocator: *const AllocationCallbacks,
@@ -21135,7 +21217,7 @@ impl KhrDeferredHostOperationsFn {
                 }
             },
             get_deferred_operation_max_concurrency_khr: unsafe {
-                extern "system" fn get_deferred_operation_max_concurrency_khr(
+                unsafe extern "system" fn get_deferred_operation_max_concurrency_khr(
                     _device: Device,
                     _operation: DeferredOperationKHR,
                 ) -> u32 {
@@ -21155,7 +21237,7 @@ impl KhrDeferredHostOperationsFn {
                 }
             },
             get_deferred_operation_result_khr: unsafe {
-                extern "system" fn get_deferred_operation_result_khr(
+                unsafe extern "system" fn get_deferred_operation_result_khr(
                     _device: Device,
                     _operation: DeferredOperationKHR,
                 ) -> Result {
@@ -21175,7 +21257,7 @@ impl KhrDeferredHostOperationsFn {
                 }
             },
             deferred_operation_join_khr: unsafe {
-                extern "system" fn deferred_operation_join_khr(
+                unsafe extern "system" fn deferred_operation_join_khr(
                     _device: Device,
                     _operation: DeferredOperationKHR,
                 ) -> Result {
@@ -21267,45 +21349,47 @@ impl KhrPipelineExecutablePropertiesFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPipelineExecutablePropertiesKHR = extern "system" fn(
+pub type PFN_vkGetPipelineExecutablePropertiesKHR = unsafe extern "system" fn(
     device: Device,
     p_pipeline_info: *const PipelineInfoKHR,
     p_executable_count: *mut u32,
     p_properties: *mut PipelineExecutablePropertiesKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPipelineExecutableStatisticsKHR = extern "system" fn(
+pub type PFN_vkGetPipelineExecutableStatisticsKHR = unsafe extern "system" fn(
     device: Device,
     p_executable_info: *const PipelineExecutableInfoKHR,
     p_statistic_count: *mut u32,
     p_statistics: *mut PipelineExecutableStatisticKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPipelineExecutableInternalRepresentationsKHR = extern "system" fn(
-    device: Device,
-    p_executable_info: *const PipelineExecutableInfoKHR,
-    p_internal_representation_count: *mut u32,
-    p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR,
-) -> Result;
+pub type PFN_vkGetPipelineExecutableInternalRepresentationsKHR =
+    unsafe extern "system" fn(
+        device: Device,
+        p_executable_info: *const PipelineExecutableInfoKHR,
+        p_internal_representation_count: *mut u32,
+        p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR,
+    ) -> Result;
 pub struct KhrPipelineExecutablePropertiesFn {
-    pub get_pipeline_executable_properties_khr: extern "system" fn(
+    pub get_pipeline_executable_properties_khr: unsafe extern "system" fn(
         device: Device,
         p_pipeline_info: *const PipelineInfoKHR,
         p_executable_count: *mut u32,
         p_properties: *mut PipelineExecutablePropertiesKHR,
     ) -> Result,
-    pub get_pipeline_executable_statistics_khr: extern "system" fn(
+    pub get_pipeline_executable_statistics_khr: unsafe extern "system" fn(
         device: Device,
         p_executable_info: *const PipelineExecutableInfoKHR,
         p_statistic_count: *mut u32,
         p_statistics: *mut PipelineExecutableStatisticKHR,
     ) -> Result,
-    pub get_pipeline_executable_internal_representations_khr: extern "system" fn(
+    pub get_pipeline_executable_internal_representations_khr: unsafe extern "system" fn(
         device: Device,
         p_executable_info: *const PipelineExecutableInfoKHR,
         p_internal_representation_count: *mut u32,
         p_internal_representations: *mut PipelineExecutableInternalRepresentationKHR,
-    ) -> Result,
+    )
+        -> Result,
 }
 unsafe impl Send for KhrPipelineExecutablePropertiesFn {}
 unsafe impl Sync for KhrPipelineExecutablePropertiesFn {}
@@ -21326,7 +21410,7 @@ impl KhrPipelineExecutablePropertiesFn {
     {
         KhrPipelineExecutablePropertiesFn {
             get_pipeline_executable_properties_khr: unsafe {
-                extern "system" fn get_pipeline_executable_properties_khr(
+                unsafe extern "system" fn get_pipeline_executable_properties_khr(
                     _device: Device,
                     _p_pipeline_info: *const PipelineInfoKHR,
                     _p_executable_count: *mut u32,
@@ -21348,7 +21432,7 @@ impl KhrPipelineExecutablePropertiesFn {
                 }
             },
             get_pipeline_executable_statistics_khr: unsafe {
-                extern "system" fn get_pipeline_executable_statistics_khr(
+                unsafe extern "system" fn get_pipeline_executable_statistics_khr(
                     _device: Device,
                     _p_executable_info: *const PipelineExecutableInfoKHR,
                     _p_statistic_count: *mut u32,
@@ -21370,7 +21454,7 @@ impl KhrPipelineExecutablePropertiesFn {
                 }
             },
             get_pipeline_executable_internal_representations_khr: unsafe {
-                extern "system" fn get_pipeline_executable_internal_representations_khr(
+                unsafe extern "system" fn get_pipeline_executable_internal_representations_khr(
                     _device: Device,
                     _p_executable_info: *const PipelineExecutableInfoKHR,
                     _p_internal_representation_count: *mut u32,
@@ -21646,70 +21730,70 @@ impl NvDeviceGeneratedCommandsFn {
     pub const SPEC_VERSION: u32 = 3u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetGeneratedCommandsMemoryRequirementsNV = extern "system" fn(
+pub type PFN_vkGetGeneratedCommandsMemoryRequirementsNV = unsafe extern "system" fn(
     device: Device,
     p_info: *const GeneratedCommandsMemoryRequirementsInfoNV,
     p_memory_requirements: *mut MemoryRequirements2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdPreprocessGeneratedCommandsNV = extern "system" fn(
+pub type PFN_vkCmdPreprocessGeneratedCommandsNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_generated_commands_info: *const GeneratedCommandsInfoNV,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdExecuteGeneratedCommandsNV = extern "system" fn(
+pub type PFN_vkCmdExecuteGeneratedCommandsNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     is_preprocessed: Bool32,
     p_generated_commands_info: *const GeneratedCommandsInfoNV,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBindPipelineShaderGroupNV = extern "system" fn(
+pub type PFN_vkCmdBindPipelineShaderGroupNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     pipeline_bind_point: PipelineBindPoint,
     pipeline: Pipeline,
     group_index: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateIndirectCommandsLayoutNV = extern "system" fn(
+pub type PFN_vkCreateIndirectCommandsLayoutNV = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const IndirectCommandsLayoutCreateInfoNV,
     p_allocator: *const AllocationCallbacks,
     p_indirect_commands_layout: *mut IndirectCommandsLayoutNV,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyIndirectCommandsLayoutNV = extern "system" fn(
+pub type PFN_vkDestroyIndirectCommandsLayoutNV = unsafe extern "system" fn(
     device: Device,
     indirect_commands_layout: IndirectCommandsLayoutNV,
     p_allocator: *const AllocationCallbacks,
 );
 pub struct NvDeviceGeneratedCommandsFn {
-    pub get_generated_commands_memory_requirements_nv: extern "system" fn(
+    pub get_generated_commands_memory_requirements_nv: unsafe extern "system" fn(
         device: Device,
         p_info: *const GeneratedCommandsMemoryRequirementsInfoNV,
         p_memory_requirements: *mut MemoryRequirements2,
     ),
-    pub cmd_preprocess_generated_commands_nv: extern "system" fn(
+    pub cmd_preprocess_generated_commands_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_generated_commands_info: *const GeneratedCommandsInfoNV,
     ),
-    pub cmd_execute_generated_commands_nv: extern "system" fn(
+    pub cmd_execute_generated_commands_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         is_preprocessed: Bool32,
         p_generated_commands_info: *const GeneratedCommandsInfoNV,
     ),
-    pub cmd_bind_pipeline_shader_group_nv: extern "system" fn(
+    pub cmd_bind_pipeline_shader_group_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         pipeline_bind_point: PipelineBindPoint,
         pipeline: Pipeline,
         group_index: u32,
     ),
-    pub create_indirect_commands_layout_nv: extern "system" fn(
+    pub create_indirect_commands_layout_nv: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const IndirectCommandsLayoutCreateInfoNV,
         p_allocator: *const AllocationCallbacks,
         p_indirect_commands_layout: *mut IndirectCommandsLayoutNV,
     ) -> Result,
-    pub destroy_indirect_commands_layout_nv: extern "system" fn(
+    pub destroy_indirect_commands_layout_nv: unsafe extern "system" fn(
         device: Device,
         indirect_commands_layout: IndirectCommandsLayoutNV,
         p_allocator: *const AllocationCallbacks,
@@ -21737,7 +21821,7 @@ impl NvDeviceGeneratedCommandsFn {
     {
         NvDeviceGeneratedCommandsFn {
             get_generated_commands_memory_requirements_nv: unsafe {
-                extern "system" fn get_generated_commands_memory_requirements_nv(
+                unsafe extern "system" fn get_generated_commands_memory_requirements_nv(
                     _device: Device,
                     _p_info: *const GeneratedCommandsMemoryRequirementsInfoNV,
                     _p_memory_requirements: *mut MemoryRequirements2,
@@ -21758,7 +21842,7 @@ impl NvDeviceGeneratedCommandsFn {
                 }
             },
             cmd_preprocess_generated_commands_nv: unsafe {
-                extern "system" fn cmd_preprocess_generated_commands_nv(
+                unsafe extern "system" fn cmd_preprocess_generated_commands_nv(
                     _command_buffer: CommandBuffer,
                     _p_generated_commands_info: *const GeneratedCommandsInfoNV,
                 ) {
@@ -21778,7 +21862,7 @@ impl NvDeviceGeneratedCommandsFn {
                 }
             },
             cmd_execute_generated_commands_nv: unsafe {
-                extern "system" fn cmd_execute_generated_commands_nv(
+                unsafe extern "system" fn cmd_execute_generated_commands_nv(
                     _command_buffer: CommandBuffer,
                     _is_preprocessed: Bool32,
                     _p_generated_commands_info: *const GeneratedCommandsInfoNV,
@@ -21799,7 +21883,7 @@ impl NvDeviceGeneratedCommandsFn {
                 }
             },
             cmd_bind_pipeline_shader_group_nv: unsafe {
-                extern "system" fn cmd_bind_pipeline_shader_group_nv(
+                unsafe extern "system" fn cmd_bind_pipeline_shader_group_nv(
                     _command_buffer: CommandBuffer,
                     _pipeline_bind_point: PipelineBindPoint,
                     _pipeline: Pipeline,
@@ -21821,7 +21905,7 @@ impl NvDeviceGeneratedCommandsFn {
                 }
             },
             create_indirect_commands_layout_nv: unsafe {
-                extern "system" fn create_indirect_commands_layout_nv(
+                unsafe extern "system" fn create_indirect_commands_layout_nv(
                     _device: Device,
                     _p_create_info: *const IndirectCommandsLayoutCreateInfoNV,
                     _p_allocator: *const AllocationCallbacks,
@@ -21843,7 +21927,7 @@ impl NvDeviceGeneratedCommandsFn {
                 }
             },
             destroy_indirect_commands_layout_nv: unsafe {
-                extern "system" fn destroy_indirect_commands_layout_nv(
+                unsafe extern "system" fn destroy_indirect_commands_layout_nv(
                     _device: Device,
                     _indirect_commands_layout: IndirectCommandsLayoutNV,
                     _p_allocator: *const AllocationCallbacks,
@@ -22575,20 +22659,20 @@ impl ExtPrivateDataFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreatePrivateDataSlotEXT = extern "system" fn(
+pub type PFN_vkCreatePrivateDataSlotEXT = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const PrivateDataSlotCreateInfoEXT,
     p_allocator: *const AllocationCallbacks,
     p_private_data_slot: *mut PrivateDataSlotEXT,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyPrivateDataSlotEXT = extern "system" fn(
+pub type PFN_vkDestroyPrivateDataSlotEXT = unsafe extern "system" fn(
     device: Device,
     private_data_slot: PrivateDataSlotEXT,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkSetPrivateDataEXT = extern "system" fn(
+pub type PFN_vkSetPrivateDataEXT = unsafe extern "system" fn(
     device: Device,
     object_type: ObjectType,
     object_handle: u64,
@@ -22596,7 +22680,7 @@ pub type PFN_vkSetPrivateDataEXT = extern "system" fn(
     data: u64,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPrivateDataEXT = extern "system" fn(
+pub type PFN_vkGetPrivateDataEXT = unsafe extern "system" fn(
     device: Device,
     object_type: ObjectType,
     object_handle: u64,
@@ -22604,25 +22688,25 @@ pub type PFN_vkGetPrivateDataEXT = extern "system" fn(
     p_data: *mut u64,
 );
 pub struct ExtPrivateDataFn {
-    pub create_private_data_slot_ext: extern "system" fn(
+    pub create_private_data_slot_ext: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const PrivateDataSlotCreateInfoEXT,
         p_allocator: *const AllocationCallbacks,
         p_private_data_slot: *mut PrivateDataSlotEXT,
     ) -> Result,
-    pub destroy_private_data_slot_ext: extern "system" fn(
+    pub destroy_private_data_slot_ext: unsafe extern "system" fn(
         device: Device,
         private_data_slot: PrivateDataSlotEXT,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub set_private_data_ext: extern "system" fn(
+    pub set_private_data_ext: unsafe extern "system" fn(
         device: Device,
         object_type: ObjectType,
         object_handle: u64,
         private_data_slot: PrivateDataSlotEXT,
         data: u64,
     ) -> Result,
-    pub get_private_data_ext: extern "system" fn(
+    pub get_private_data_ext: unsafe extern "system" fn(
         device: Device,
         object_type: ObjectType,
         object_handle: u64,
@@ -22649,7 +22733,7 @@ impl ExtPrivateDataFn {
     {
         ExtPrivateDataFn {
             create_private_data_slot_ext: unsafe {
-                extern "system" fn create_private_data_slot_ext(
+                unsafe extern "system" fn create_private_data_slot_ext(
                     _device: Device,
                     _p_create_info: *const PrivateDataSlotCreateInfoEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -22671,7 +22755,7 @@ impl ExtPrivateDataFn {
                 }
             },
             destroy_private_data_slot_ext: unsafe {
-                extern "system" fn destroy_private_data_slot_ext(
+                unsafe extern "system" fn destroy_private_data_slot_ext(
                     _device: Device,
                     _private_data_slot: PrivateDataSlotEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -22692,7 +22776,7 @@ impl ExtPrivateDataFn {
                 }
             },
             set_private_data_ext: unsafe {
-                extern "system" fn set_private_data_ext(
+                unsafe extern "system" fn set_private_data_ext(
                     _device: Device,
                     _object_type: ObjectType,
                     _object_handle: u64,
@@ -22711,7 +22795,7 @@ impl ExtPrivateDataFn {
                 }
             },
             get_private_data_ext: unsafe {
-                extern "system" fn get_private_data_ext(
+                unsafe extern "system" fn get_private_data_ext(
                     _device: Device,
                     _object_type: ObjectType,
                     _object_handle: u64,
@@ -23266,43 +23350,45 @@ impl KhrSynchronization2Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetEvent2KHR = extern "system" fn(
+pub type PFN_vkCmdSetEvent2KHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     event: Event,
     p_dependency_info: *const DependencyInfoKHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdResetEvent2KHR = extern "system" fn(
+pub type PFN_vkCmdResetEvent2KHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     event: Event,
     stage_mask: PipelineStageFlags2KHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWaitEvents2KHR = extern "system" fn(
+pub type PFN_vkCmdWaitEvents2KHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     event_count: u32,
     p_events: *const Event,
     p_dependency_infos: *const DependencyInfoKHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdPipelineBarrier2KHR =
-    extern "system" fn(command_buffer: CommandBuffer, p_dependency_info: *const DependencyInfoKHR);
+pub type PFN_vkCmdPipelineBarrier2KHR = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_dependency_info: *const DependencyInfoKHR,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWriteTimestamp2KHR = extern "system" fn(
+pub type PFN_vkCmdWriteTimestamp2KHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     stage: PipelineStageFlags2KHR,
     query_pool: QueryPool,
     query: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkQueueSubmit2KHR = extern "system" fn(
+pub type PFN_vkQueueSubmit2KHR = unsafe extern "system" fn(
     queue: Queue,
     submit_count: u32,
     p_submits: *const SubmitInfo2KHR,
     fence: Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWriteBufferMarker2AMD = extern "system" fn(
+pub type PFN_vkCmdWriteBufferMarker2AMD = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     stage: PipelineStageFlags2KHR,
     dst_buffer: Buffer,
@@ -23310,52 +23396,52 @@ pub type PFN_vkCmdWriteBufferMarker2AMD = extern "system" fn(
     marker: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetQueueCheckpointData2NV = extern "system" fn(
+pub type PFN_vkGetQueueCheckpointData2NV = unsafe extern "system" fn(
     queue: Queue,
     p_checkpoint_data_count: *mut u32,
     p_checkpoint_data: *mut CheckpointData2NV,
 );
 pub struct KhrSynchronization2Fn {
-    pub cmd_set_event2_khr: extern "system" fn(
+    pub cmd_set_event2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         event: Event,
         p_dependency_info: *const DependencyInfoKHR,
     ),
-    pub cmd_reset_event2_khr: extern "system" fn(
+    pub cmd_reset_event2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         event: Event,
         stage_mask: PipelineStageFlags2KHR,
     ),
-    pub cmd_wait_events2_khr: extern "system" fn(
+    pub cmd_wait_events2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         event_count: u32,
         p_events: *const Event,
         p_dependency_infos: *const DependencyInfoKHR,
     ),
-    pub cmd_pipeline_barrier2_khr: extern "system" fn(
+    pub cmd_pipeline_barrier2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_dependency_info: *const DependencyInfoKHR,
     ),
-    pub cmd_write_timestamp2_khr: extern "system" fn(
+    pub cmd_write_timestamp2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         stage: PipelineStageFlags2KHR,
         query_pool: QueryPool,
         query: u32,
     ),
-    pub queue_submit2_khr: extern "system" fn(
+    pub queue_submit2_khr: unsafe extern "system" fn(
         queue: Queue,
         submit_count: u32,
         p_submits: *const SubmitInfo2KHR,
         fence: Fence,
     ) -> Result,
-    pub cmd_write_buffer_marker2_amd: extern "system" fn(
+    pub cmd_write_buffer_marker2_amd: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         stage: PipelineStageFlags2KHR,
         dst_buffer: Buffer,
         dst_offset: DeviceSize,
         marker: u32,
     ),
-    pub get_queue_checkpoint_data2_nv: extern "system" fn(
+    pub get_queue_checkpoint_data2_nv: unsafe extern "system" fn(
         queue: Queue,
         p_checkpoint_data_count: *mut u32,
         p_checkpoint_data: *mut CheckpointData2NV,
@@ -23384,7 +23470,7 @@ impl KhrSynchronization2Fn {
     {
         KhrSynchronization2Fn {
             cmd_set_event2_khr: unsafe {
-                extern "system" fn cmd_set_event2_khr(
+                unsafe extern "system" fn cmd_set_event2_khr(
                     _command_buffer: CommandBuffer,
                     _event: Event,
                     _p_dependency_info: *const DependencyInfoKHR,
@@ -23400,7 +23486,7 @@ impl KhrSynchronization2Fn {
                 }
             },
             cmd_reset_event2_khr: unsafe {
-                extern "system" fn cmd_reset_event2_khr(
+                unsafe extern "system" fn cmd_reset_event2_khr(
                     _command_buffer: CommandBuffer,
                     _event: Event,
                     _stage_mask: PipelineStageFlags2KHR,
@@ -23417,7 +23503,7 @@ impl KhrSynchronization2Fn {
                 }
             },
             cmd_wait_events2_khr: unsafe {
-                extern "system" fn cmd_wait_events2_khr(
+                unsafe extern "system" fn cmd_wait_events2_khr(
                     _command_buffer: CommandBuffer,
                     _event_count: u32,
                     _p_events: *const Event,
@@ -23435,7 +23521,7 @@ impl KhrSynchronization2Fn {
                 }
             },
             cmd_pipeline_barrier2_khr: unsafe {
-                extern "system" fn cmd_pipeline_barrier2_khr(
+                unsafe extern "system" fn cmd_pipeline_barrier2_khr(
                     _command_buffer: CommandBuffer,
                     _p_dependency_info: *const DependencyInfoKHR,
                 ) {
@@ -23454,7 +23540,7 @@ impl KhrSynchronization2Fn {
                 }
             },
             cmd_write_timestamp2_khr: unsafe {
-                extern "system" fn cmd_write_timestamp2_khr(
+                unsafe extern "system" fn cmd_write_timestamp2_khr(
                     _command_buffer: CommandBuffer,
                     _stage: PipelineStageFlags2KHR,
                     _query_pool: QueryPool,
@@ -23475,7 +23561,7 @@ impl KhrSynchronization2Fn {
                 }
             },
             queue_submit2_khr: unsafe {
-                extern "system" fn queue_submit2_khr(
+                unsafe extern "system" fn queue_submit2_khr(
                     _queue: Queue,
                     _submit_count: u32,
                     _p_submits: *const SubmitInfo2KHR,
@@ -23492,7 +23578,7 @@ impl KhrSynchronization2Fn {
                 }
             },
             cmd_write_buffer_marker2_amd: unsafe {
-                extern "system" fn cmd_write_buffer_marker2_amd(
+                unsafe extern "system" fn cmd_write_buffer_marker2_amd(
                     _command_buffer: CommandBuffer,
                     _stage: PipelineStageFlags2KHR,
                     _dst_buffer: Buffer,
@@ -23515,7 +23601,7 @@ impl KhrSynchronization2Fn {
                 }
             },
             get_queue_checkpoint_data2_nv: unsafe {
-                extern "system" fn get_queue_checkpoint_data2_nv(
+                unsafe extern "system" fn get_queue_checkpoint_data2_nv(
                     _queue: Queue,
                     _p_checkpoint_data_count: *mut u32,
                     _p_checkpoint_data: *mut CheckpointData2NV,
@@ -24045,13 +24131,13 @@ impl NvFragmentShadingRateEnumsFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetFragmentShadingRateEnumNV = extern "system" fn(
+pub type PFN_vkCmdSetFragmentShadingRateEnumNV = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     shading_rate: FragmentShadingRateNV,
     combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
 );
 pub struct NvFragmentShadingRateEnumsFn {
-    pub cmd_set_fragment_shading_rate_enum_nv: extern "system" fn(
+    pub cmd_set_fragment_shading_rate_enum_nv: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         shading_rate: FragmentShadingRateNV,
         combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
@@ -24073,7 +24159,7 @@ impl NvFragmentShadingRateEnumsFn {
     {
         NvFragmentShadingRateEnumsFn {
             cmd_set_fragment_shading_rate_enum_nv: unsafe {
-                extern "system" fn cmd_set_fragment_shading_rate_enum_nv(
+                unsafe extern "system" fn cmd_set_fragment_shading_rate_enum_nv(
                     _command_buffer: CommandBuffer,
                     _shading_rate: FragmentShadingRateNV,
                     _combiner_ops: *const [FragmentShadingRateCombinerOpKHR; 2],
@@ -24392,53 +24478,57 @@ impl KhrCopyCommands2Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyBuffer2KHR = extern "system" fn(
+pub type PFN_vkCmdCopyBuffer2KHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_copy_buffer_info: *const CopyBufferInfo2KHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyImage2KHR =
-    extern "system" fn(command_buffer: CommandBuffer, p_copy_image_info: *const CopyImageInfo2KHR);
+pub type PFN_vkCmdCopyImage2KHR = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_copy_image_info: *const CopyImageInfo2KHR,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyBufferToImage2KHR = extern "system" fn(
+pub type PFN_vkCmdCopyBufferToImage2KHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2KHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyImageToBuffer2KHR = extern "system" fn(
+pub type PFN_vkCmdCopyImageToBuffer2KHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2KHR,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBlitImage2KHR =
-    extern "system" fn(command_buffer: CommandBuffer, p_blit_image_info: *const BlitImageInfo2KHR);
+pub type PFN_vkCmdBlitImage2KHR = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    p_blit_image_info: *const BlitImageInfo2KHR,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdResolveImage2KHR = extern "system" fn(
+pub type PFN_vkCmdResolveImage2KHR = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_resolve_image_info: *const ResolveImageInfo2KHR,
 );
 pub struct KhrCopyCommands2Fn {
-    pub cmd_copy_buffer2_khr: extern "system" fn(
+    pub cmd_copy_buffer2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_copy_buffer_info: *const CopyBufferInfo2KHR,
     ),
-    pub cmd_copy_image2_khr: extern "system" fn(
+    pub cmd_copy_image2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_copy_image_info: *const CopyImageInfo2KHR,
     ),
-    pub cmd_copy_buffer_to_image2_khr: extern "system" fn(
+    pub cmd_copy_buffer_to_image2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2KHR,
     ),
-    pub cmd_copy_image_to_buffer2_khr: extern "system" fn(
+    pub cmd_copy_image_to_buffer2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2KHR,
     ),
-    pub cmd_blit_image2_khr: extern "system" fn(
+    pub cmd_blit_image2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_blit_image_info: *const BlitImageInfo2KHR,
     ),
-    pub cmd_resolve_image2_khr: extern "system" fn(
+    pub cmd_resolve_image2_khr: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_resolve_image_info: *const ResolveImageInfo2KHR,
     ),
@@ -24464,7 +24554,7 @@ impl KhrCopyCommands2Fn {
     {
         KhrCopyCommands2Fn {
             cmd_copy_buffer2_khr: unsafe {
-                extern "system" fn cmd_copy_buffer2_khr(
+                unsafe extern "system" fn cmd_copy_buffer2_khr(
                     _command_buffer: CommandBuffer,
                     _p_copy_buffer_info: *const CopyBufferInfo2KHR,
                 ) {
@@ -24480,7 +24570,7 @@ impl KhrCopyCommands2Fn {
                 }
             },
             cmd_copy_image2_khr: unsafe {
-                extern "system" fn cmd_copy_image2_khr(
+                unsafe extern "system" fn cmd_copy_image2_khr(
                     _command_buffer: CommandBuffer,
                     _p_copy_image_info: *const CopyImageInfo2KHR,
                 ) {
@@ -24496,7 +24586,7 @@ impl KhrCopyCommands2Fn {
                 }
             },
             cmd_copy_buffer_to_image2_khr: unsafe {
-                extern "system" fn cmd_copy_buffer_to_image2_khr(
+                unsafe extern "system" fn cmd_copy_buffer_to_image2_khr(
                     _command_buffer: CommandBuffer,
                     _p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2KHR,
                 ) {
@@ -24516,7 +24606,7 @@ impl KhrCopyCommands2Fn {
                 }
             },
             cmd_copy_image_to_buffer2_khr: unsafe {
-                extern "system" fn cmd_copy_image_to_buffer2_khr(
+                unsafe extern "system" fn cmd_copy_image_to_buffer2_khr(
                     _command_buffer: CommandBuffer,
                     _p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2KHR,
                 ) {
@@ -24536,7 +24626,7 @@ impl KhrCopyCommands2Fn {
                 }
             },
             cmd_blit_image2_khr: unsafe {
-                extern "system" fn cmd_blit_image2_khr(
+                unsafe extern "system" fn cmd_blit_image2_khr(
                     _command_buffer: CommandBuffer,
                     _p_blit_image_info: *const BlitImageInfo2KHR,
                 ) {
@@ -24552,7 +24642,7 @@ impl KhrCopyCommands2Fn {
                 }
             },
             cmd_resolve_image2_khr: unsafe {
-                extern "system" fn cmd_resolve_image2_khr(
+                unsafe extern "system" fn cmd_resolve_image2_khr(
                     _command_buffer: CommandBuffer,
                     _p_resolve_image_info: *const ResolveImageInfo2KHR,
                 ) {
@@ -24847,17 +24937,17 @@ impl NvAcquireWinrtDisplayFn {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkAcquireWinrtDisplayNV =
-    extern "system" fn(physical_device: PhysicalDevice, display: DisplayKHR) -> Result;
+    unsafe extern "system" fn(physical_device: PhysicalDevice, display: DisplayKHR) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetWinrtDisplayNV = extern "system" fn(
+pub type PFN_vkGetWinrtDisplayNV = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     device_relative_id: u32,
     p_display: *mut DisplayKHR,
 ) -> Result;
 pub struct NvAcquireWinrtDisplayFn {
     pub acquire_winrt_display_nv:
-        extern "system" fn(physical_device: PhysicalDevice, display: DisplayKHR) -> Result,
-    pub get_winrt_display_nv: extern "system" fn(
+        unsafe extern "system" fn(physical_device: PhysicalDevice, display: DisplayKHR) -> Result,
+    pub get_winrt_display_nv: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         device_relative_id: u32,
         p_display: *mut DisplayKHR,
@@ -24880,7 +24970,7 @@ impl NvAcquireWinrtDisplayFn {
     {
         NvAcquireWinrtDisplayFn {
             acquire_winrt_display_nv: unsafe {
-                extern "system" fn acquire_winrt_display_nv(
+                unsafe extern "system" fn acquire_winrt_display_nv(
                     _physical_device: PhysicalDevice,
                     _display: DisplayKHR,
                 ) -> Result {
@@ -24899,7 +24989,7 @@ impl NvAcquireWinrtDisplayFn {
                 }
             },
             get_winrt_display_nv: unsafe {
-                extern "system" fn get_winrt_display_nv(
+                unsafe extern "system" fn get_winrt_display_nv(
                     _physical_device: PhysicalDevice,
                     _device_relative_id: u32,
                     _p_display: *mut DisplayKHR,
@@ -24943,30 +25033,32 @@ impl ExtDirectfbSurfaceFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDirectFBSurfaceEXT = extern "system" fn(
+pub type PFN_vkCreateDirectFBSurfaceEXT = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const DirectFBSurfaceCreateInfoEXT,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceDirectFBPresentationSupportEXT = extern "system" fn(
-    physical_device: PhysicalDevice,
-    queue_family_index: u32,
-    dfb: *mut IDirectFB,
-) -> Bool32;
+pub type PFN_vkGetPhysicalDeviceDirectFBPresentationSupportEXT =
+    unsafe extern "system" fn(
+        physical_device: PhysicalDevice,
+        queue_family_index: u32,
+        dfb: *mut IDirectFB,
+    ) -> Bool32;
 pub struct ExtDirectfbSurfaceFn {
-    pub create_direct_fb_surface_ext: extern "system" fn(
+    pub create_direct_fb_surface_ext: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const DirectFBSurfaceCreateInfoEXT,
         p_allocator: *const AllocationCallbacks,
         p_surface: *mut SurfaceKHR,
     ) -> Result,
-    pub get_physical_device_direct_fb_presentation_support_ext: extern "system" fn(
+    pub get_physical_device_direct_fb_presentation_support_ext: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         queue_family_index: u32,
         dfb: *mut IDirectFB,
-    ) -> Bool32,
+    )
+        -> Bool32,
 }
 unsafe impl Send for ExtDirectfbSurfaceFn {}
 unsafe impl Sync for ExtDirectfbSurfaceFn {}
@@ -24986,7 +25078,7 @@ impl ExtDirectfbSurfaceFn {
     {
         ExtDirectfbSurfaceFn {
             create_direct_fb_surface_ext: unsafe {
-                extern "system" fn create_direct_fb_surface_ext(
+                unsafe extern "system" fn create_direct_fb_surface_ext(
                     _instance: Instance,
                     _p_create_info: *const DirectFBSurfaceCreateInfoEXT,
                     _p_allocator: *const AllocationCallbacks,
@@ -25008,7 +25100,7 @@ impl ExtDirectfbSurfaceFn {
                 }
             },
             get_physical_device_direct_fb_presentation_support_ext: unsafe {
-                extern "system" fn get_physical_device_direct_fb_presentation_support_ext(
+                unsafe extern "system" fn get_physical_device_direct_fb_presentation_support_ext(
                     _physical_device: PhysicalDevice,
                     _queue_family_index: u32,
                     _dfb: *mut IDirectFB,
@@ -25431,25 +25523,25 @@ impl FuchsiaExternalMemoryFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetMemoryZirconHandleFUCHSIA = extern "system" fn(
+pub type PFN_vkGetMemoryZirconHandleFUCHSIA = unsafe extern "system" fn(
     device: Device,
     p_get_zircon_handle_info: *const MemoryGetZirconHandleInfoFUCHSIA,
     p_zircon_handle: *mut zx_handle_t,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetMemoryZirconHandlePropertiesFUCHSIA = extern "system" fn(
+pub type PFN_vkGetMemoryZirconHandlePropertiesFUCHSIA = unsafe extern "system" fn(
     device: Device,
     handle_type: ExternalMemoryHandleTypeFlags,
     zircon_handle: zx_handle_t,
     p_memory_zircon_handle_properties: *mut MemoryZirconHandlePropertiesFUCHSIA,
 ) -> Result;
 pub struct FuchsiaExternalMemoryFn {
-    pub get_memory_zircon_handle_fuchsia: extern "system" fn(
+    pub get_memory_zircon_handle_fuchsia: unsafe extern "system" fn(
         device: Device,
         p_get_zircon_handle_info: *const MemoryGetZirconHandleInfoFUCHSIA,
         p_zircon_handle: *mut zx_handle_t,
     ) -> Result,
-    pub get_memory_zircon_handle_properties_fuchsia: extern "system" fn(
+    pub get_memory_zircon_handle_properties_fuchsia: unsafe extern "system" fn(
         device: Device,
         handle_type: ExternalMemoryHandleTypeFlags,
         zircon_handle: zx_handle_t,
@@ -25474,7 +25566,7 @@ impl FuchsiaExternalMemoryFn {
     {
         FuchsiaExternalMemoryFn {
             get_memory_zircon_handle_fuchsia: unsafe {
-                extern "system" fn get_memory_zircon_handle_fuchsia(
+                unsafe extern "system" fn get_memory_zircon_handle_fuchsia(
                     _device: Device,
                     _p_get_zircon_handle_info: *const MemoryGetZirconHandleInfoFUCHSIA,
                     _p_zircon_handle: *mut zx_handle_t,
@@ -25495,7 +25587,7 @@ impl FuchsiaExternalMemoryFn {
                 }
             },
             get_memory_zircon_handle_properties_fuchsia: unsafe {
-                extern "system" fn get_memory_zircon_handle_properties_fuchsia(
+                unsafe extern "system" fn get_memory_zircon_handle_properties_fuchsia(
                     _device: Device,
                     _handle_type: ExternalMemoryHandleTypeFlags,
                     _zircon_handle: zx_handle_t,
@@ -25567,22 +25659,22 @@ impl FuchsiaExternalSemaphoreFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkImportSemaphoreZirconHandleFUCHSIA = extern "system" fn(
+pub type PFN_vkImportSemaphoreZirconHandleFUCHSIA = unsafe extern "system" fn(
     device: Device,
     p_import_semaphore_zircon_handle_info: *const ImportSemaphoreZirconHandleInfoFUCHSIA,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetSemaphoreZirconHandleFUCHSIA = extern "system" fn(
+pub type PFN_vkGetSemaphoreZirconHandleFUCHSIA = unsafe extern "system" fn(
     device: Device,
     p_get_zircon_handle_info: *const SemaphoreGetZirconHandleInfoFUCHSIA,
     p_zircon_handle: *mut zx_handle_t,
 ) -> Result;
 pub struct FuchsiaExternalSemaphoreFn {
-    pub import_semaphore_zircon_handle_fuchsia: extern "system" fn(
+    pub import_semaphore_zircon_handle_fuchsia: unsafe extern "system" fn(
         device: Device,
         p_import_semaphore_zircon_handle_info: *const ImportSemaphoreZirconHandleInfoFUCHSIA,
     ) -> Result,
-    pub get_semaphore_zircon_handle_fuchsia: extern "system" fn(
+    pub get_semaphore_zircon_handle_fuchsia: unsafe extern "system" fn(
         device: Device,
         p_get_zircon_handle_info: *const SemaphoreGetZirconHandleInfoFUCHSIA,
         p_zircon_handle: *mut zx_handle_t,
@@ -25605,7 +25697,7 @@ impl FuchsiaExternalSemaphoreFn {
     {
         FuchsiaExternalSemaphoreFn {
             import_semaphore_zircon_handle_fuchsia: unsafe {
-                extern "system" fn import_semaphore_zircon_handle_fuchsia(
+                unsafe extern "system" fn import_semaphore_zircon_handle_fuchsia(
                     _device: Device,
                     _p_import_semaphore_zircon_handle_info : * const ImportSemaphoreZirconHandleInfoFUCHSIA,
                 ) -> Result {
@@ -25625,7 +25717,7 @@ impl FuchsiaExternalSemaphoreFn {
                 }
             },
             get_semaphore_zircon_handle_fuchsia: unsafe {
-                extern "system" fn get_semaphore_zircon_handle_fuchsia(
+                unsafe extern "system" fn get_semaphore_zircon_handle_fuchsia(
                     _device: Device,
                     _p_get_zircon_handle_info: *const SemaphoreGetZirconHandleInfoFUCHSIA,
                     _p_zircon_handle: *mut zx_handle_t,
@@ -25993,30 +26085,31 @@ impl QnxScreenSurfaceFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateScreenSurfaceQNX = extern "system" fn(
+pub type PFN_vkCreateScreenSurfaceQNX = unsafe extern "system" fn(
     instance: Instance,
     p_create_info: *const ScreenSurfaceCreateInfoQNX,
     p_allocator: *const AllocationCallbacks,
     p_surface: *mut SurfaceKHR,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     queue_family_index: u32,
     window: *mut _screen_window,
 ) -> Bool32;
 pub struct QnxScreenSurfaceFn {
-    pub create_screen_surface_qnx: extern "system" fn(
+    pub create_screen_surface_qnx: unsafe extern "system" fn(
         instance: Instance,
         p_create_info: *const ScreenSurfaceCreateInfoQNX,
         p_allocator: *const AllocationCallbacks,
         p_surface: *mut SurfaceKHR,
     ) -> Result,
-    pub get_physical_device_screen_presentation_support_qnx: extern "system" fn(
+    pub get_physical_device_screen_presentation_support_qnx: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         queue_family_index: u32,
         window: *mut _screen_window,
-    ) -> Bool32,
+    )
+        -> Bool32,
 }
 unsafe impl Send for QnxScreenSurfaceFn {}
 unsafe impl Sync for QnxScreenSurfaceFn {}
@@ -26036,7 +26129,7 @@ impl QnxScreenSurfaceFn {
     {
         QnxScreenSurfaceFn {
             create_screen_surface_qnx: unsafe {
-                extern "system" fn create_screen_surface_qnx(
+                unsafe extern "system" fn create_screen_surface_qnx(
                     _instance: Instance,
                     _p_create_info: *const ScreenSurfaceCreateInfoQNX,
                     _p_allocator: *const AllocationCallbacks,
@@ -26057,7 +26150,7 @@ impl QnxScreenSurfaceFn {
                 }
             },
             get_physical_device_screen_presentation_support_qnx: unsafe {
-                extern "system" fn get_physical_device_screen_presentation_support_qnx(
+                unsafe extern "system" fn get_physical_device_screen_presentation_support_qnx(
                     _physical_device: PhysicalDevice,
                     _queue_family_index: u32,
                     _window: *mut _screen_window,

--- a/ash/src/vk/features.rs
+++ b/ash/src/vk/features.rs
@@ -4,10 +4,10 @@ use crate::vk::enums::*;
 use std::os::raw::*;
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetInstanceProcAddr =
-    extern "system" fn(instance: Instance, p_name: *const c_char) -> PFN_vkVoidFunction;
+    unsafe extern "system" fn(instance: Instance, p_name: *const c_char) -> PFN_vkVoidFunction;
 pub struct StaticFn {
     pub get_instance_proc_addr:
-        extern "system" fn(instance: Instance, p_name: *const c_char) -> PFN_vkVoidFunction,
+        unsafe extern "system" fn(instance: Instance, p_name: *const c_char) -> PFN_vkVoidFunction,
 }
 unsafe impl Send for StaticFn {}
 unsafe impl Sync for StaticFn {}
@@ -25,7 +25,7 @@ impl StaticFn {
     {
         StaticFn {
             get_instance_proc_addr: unsafe {
-                extern "system" fn get_instance_proc_addr(
+                unsafe extern "system" fn get_instance_proc_addr(
                     _instance: Instance,
                     _p_name: *const c_char,
                 ) -> PFN_vkVoidFunction {
@@ -55,32 +55,34 @@ impl StaticFn {
     }
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateInstance = extern "system" fn(
+pub type PFN_vkCreateInstance = unsafe extern "system" fn(
     p_create_info: *const InstanceCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_instance: *mut Instance,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkEnumerateInstanceExtensionProperties = extern "system" fn(
+pub type PFN_vkEnumerateInstanceExtensionProperties = unsafe extern "system" fn(
     p_layer_name: *const c_char,
     p_property_count: *mut u32,
     p_properties: *mut ExtensionProperties,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkEnumerateInstanceLayerProperties =
-    extern "system" fn(p_property_count: *mut u32, p_properties: *mut LayerProperties) -> Result;
+pub type PFN_vkEnumerateInstanceLayerProperties = unsafe extern "system" fn(
+    p_property_count: *mut u32,
+    p_properties: *mut LayerProperties,
+) -> Result;
 pub struct EntryFnV1_0 {
-    pub create_instance: extern "system" fn(
+    pub create_instance: unsafe extern "system" fn(
         p_create_info: *const InstanceCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_instance: *mut Instance,
     ) -> Result,
-    pub enumerate_instance_extension_properties: extern "system" fn(
+    pub enumerate_instance_extension_properties: unsafe extern "system" fn(
         p_layer_name: *const c_char,
         p_property_count: *mut u32,
         p_properties: *mut ExtensionProperties,
     ) -> Result,
-    pub enumerate_instance_layer_properties: extern "system" fn(
+    pub enumerate_instance_layer_properties: unsafe extern "system" fn(
         p_property_count: *mut u32,
         p_properties: *mut LayerProperties,
     ) -> Result,
@@ -103,7 +105,7 @@ impl EntryFnV1_0 {
     {
         EntryFnV1_0 {
             create_instance: unsafe {
-                extern "system" fn create_instance(
+                unsafe extern "system" fn create_instance(
                     _p_create_info: *const InstanceCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
                     _p_instance: *mut Instance,
@@ -119,7 +121,7 @@ impl EntryFnV1_0 {
                 }
             },
             enumerate_instance_extension_properties: unsafe {
-                extern "system" fn enumerate_instance_extension_properties(
+                unsafe extern "system" fn enumerate_instance_extension_properties(
                     _p_layer_name: *const c_char,
                     _p_property_count: *mut u32,
                     _p_properties: *mut ExtensionProperties,
@@ -140,7 +142,7 @@ impl EntryFnV1_0 {
                 }
             },
             enumerate_instance_layer_properties: unsafe {
-                extern "system" fn enumerate_instance_layer_properties(
+                unsafe extern "system" fn enumerate_instance_layer_properties(
                     _p_property_count: *mut u32,
                     _p_properties: *mut LayerProperties,
                 ) -> Result {
@@ -190,24 +192,26 @@ impl EntryFnV1_0 {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyInstance =
-    extern "system" fn(instance: Instance, p_allocator: *const AllocationCallbacks);
+    unsafe extern "system" fn(instance: Instance, p_allocator: *const AllocationCallbacks);
 #[allow(non_camel_case_types)]
-pub type PFN_vkEnumeratePhysicalDevices = extern "system" fn(
+pub type PFN_vkEnumeratePhysicalDevices = unsafe extern "system" fn(
     instance: Instance,
     p_physical_device_count: *mut u32,
     p_physical_devices: *mut PhysicalDevice,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceFeatures =
-    extern "system" fn(physical_device: PhysicalDevice, p_features: *mut PhysicalDeviceFeatures);
+pub type PFN_vkGetPhysicalDeviceFeatures = unsafe extern "system" fn(
+    physical_device: PhysicalDevice,
+    p_features: *mut PhysicalDeviceFeatures,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceFormatProperties = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceFormatProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     format: Format,
     p_format_properties: *mut FormatProperties,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceImageFormatProperties = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceImageFormatProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     format: Format,
     ty: ImageType,
@@ -217,46 +221,46 @@ pub type PFN_vkGetPhysicalDeviceImageFormatProperties = extern "system" fn(
     p_image_format_properties: *mut ImageFormatProperties,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceProperties = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_properties: *mut PhysicalDeviceProperties,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceQueueFamilyProperties = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceQueueFamilyProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_queue_family_property_count: *mut u32,
     p_queue_family_properties: *mut QueueFamilyProperties,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceMemoryProperties = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceMemoryProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_memory_properties: *mut PhysicalDeviceMemoryProperties,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkGetDeviceProcAddr =
-    extern "system" fn(device: Device, p_name: *const c_char) -> PFN_vkVoidFunction;
+    unsafe extern "system" fn(device: Device, p_name: *const c_char) -> PFN_vkVoidFunction;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDevice = extern "system" fn(
+pub type PFN_vkCreateDevice = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_create_info: *const DeviceCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_device: *mut Device,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkEnumerateDeviceExtensionProperties = extern "system" fn(
+pub type PFN_vkEnumerateDeviceExtensionProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_layer_name: *const c_char,
     p_property_count: *mut u32,
     p_properties: *mut ExtensionProperties,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkEnumerateDeviceLayerProperties = extern "system" fn(
+pub type PFN_vkEnumerateDeviceLayerProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_property_count: *mut u32,
     p_properties: *mut LayerProperties,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceSparseImageFormatProperties = extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceSparseImageFormatProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     format: Format,
     ty: ImageType,
@@ -268,22 +272,22 @@ pub type PFN_vkGetPhysicalDeviceSparseImageFormatProperties = extern "system" fn
 );
 pub struct InstanceFnV1_0 {
     pub destroy_instance:
-        extern "system" fn(instance: Instance, p_allocator: *const AllocationCallbacks),
-    pub enumerate_physical_devices: extern "system" fn(
+        unsafe extern "system" fn(instance: Instance, p_allocator: *const AllocationCallbacks),
+    pub enumerate_physical_devices: unsafe extern "system" fn(
         instance: Instance,
         p_physical_device_count: *mut u32,
         p_physical_devices: *mut PhysicalDevice,
     ) -> Result,
-    pub get_physical_device_features: extern "system" fn(
+    pub get_physical_device_features: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_features: *mut PhysicalDeviceFeatures,
     ),
-    pub get_physical_device_format_properties: extern "system" fn(
+    pub get_physical_device_format_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         format: Format,
         p_format_properties: *mut FormatProperties,
     ),
-    pub get_physical_device_image_format_properties: extern "system" fn(
+    pub get_physical_device_image_format_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         format: Format,
         ty: ImageType,
@@ -292,39 +296,39 @@ pub struct InstanceFnV1_0 {
         flags: ImageCreateFlags,
         p_image_format_properties: *mut ImageFormatProperties,
     ) -> Result,
-    pub get_physical_device_properties: extern "system" fn(
+    pub get_physical_device_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_properties: *mut PhysicalDeviceProperties,
     ),
-    pub get_physical_device_queue_family_properties: extern "system" fn(
+    pub get_physical_device_queue_family_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_queue_family_property_count: *mut u32,
         p_queue_family_properties: *mut QueueFamilyProperties,
     ),
-    pub get_physical_device_memory_properties: extern "system" fn(
+    pub get_physical_device_memory_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_memory_properties: *mut PhysicalDeviceMemoryProperties,
     ),
     pub get_device_proc_addr:
-        extern "system" fn(device: Device, p_name: *const c_char) -> PFN_vkVoidFunction,
-    pub create_device: extern "system" fn(
+        unsafe extern "system" fn(device: Device, p_name: *const c_char) -> PFN_vkVoidFunction,
+    pub create_device: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_create_info: *const DeviceCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_device: *mut Device,
     ) -> Result,
-    pub enumerate_device_extension_properties: extern "system" fn(
+    pub enumerate_device_extension_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_layer_name: *const c_char,
         p_property_count: *mut u32,
         p_properties: *mut ExtensionProperties,
     ) -> Result,
-    pub enumerate_device_layer_properties: extern "system" fn(
+    pub enumerate_device_layer_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_property_count: *mut u32,
         p_properties: *mut LayerProperties,
     ) -> Result,
-    pub get_physical_device_sparse_image_format_properties: extern "system" fn(
+    pub get_physical_device_sparse_image_format_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         format: Format,
         ty: ImageType,
@@ -366,7 +370,7 @@ impl InstanceFnV1_0 {
     {
         InstanceFnV1_0 {
             destroy_instance: unsafe {
-                extern "system" fn destroy_instance(
+                unsafe extern "system" fn destroy_instance(
                     _instance: Instance,
                     _p_allocator: *const AllocationCallbacks,
                 ) {
@@ -381,7 +385,7 @@ impl InstanceFnV1_0 {
                 }
             },
             enumerate_physical_devices: unsafe {
-                extern "system" fn enumerate_physical_devices(
+                unsafe extern "system" fn enumerate_physical_devices(
                     _instance: Instance,
                     _p_physical_device_count: *mut u32,
                     _p_physical_devices: *mut PhysicalDevice,
@@ -402,7 +406,7 @@ impl InstanceFnV1_0 {
                 }
             },
             get_physical_device_features: unsafe {
-                extern "system" fn get_physical_device_features(
+                unsafe extern "system" fn get_physical_device_features(
                     _physical_device: PhysicalDevice,
                     _p_features: *mut PhysicalDeviceFeatures,
                 ) {
@@ -422,7 +426,7 @@ impl InstanceFnV1_0 {
                 }
             },
             get_physical_device_format_properties: unsafe {
-                extern "system" fn get_physical_device_format_properties(
+                unsafe extern "system" fn get_physical_device_format_properties(
                     _physical_device: PhysicalDevice,
                     _format: Format,
                     _p_format_properties: *mut FormatProperties,
@@ -443,7 +447,7 @@ impl InstanceFnV1_0 {
                 }
             },
             get_physical_device_image_format_properties: unsafe {
-                extern "system" fn get_physical_device_image_format_properties(
+                unsafe extern "system" fn get_physical_device_image_format_properties(
                     _physical_device: PhysicalDevice,
                     _format: Format,
                     _ty: ImageType,
@@ -468,7 +472,7 @@ impl InstanceFnV1_0 {
                 }
             },
             get_physical_device_properties: unsafe {
-                extern "system" fn get_physical_device_properties(
+                unsafe extern "system" fn get_physical_device_properties(
                     _physical_device: PhysicalDevice,
                     _p_properties: *mut PhysicalDeviceProperties,
                 ) {
@@ -488,7 +492,7 @@ impl InstanceFnV1_0 {
                 }
             },
             get_physical_device_queue_family_properties: unsafe {
-                extern "system" fn get_physical_device_queue_family_properties(
+                unsafe extern "system" fn get_physical_device_queue_family_properties(
                     _physical_device: PhysicalDevice,
                     _p_queue_family_property_count: *mut u32,
                     _p_queue_family_properties: *mut QueueFamilyProperties,
@@ -509,7 +513,7 @@ impl InstanceFnV1_0 {
                 }
             },
             get_physical_device_memory_properties: unsafe {
-                extern "system" fn get_physical_device_memory_properties(
+                unsafe extern "system" fn get_physical_device_memory_properties(
                     _physical_device: PhysicalDevice,
                     _p_memory_properties: *mut PhysicalDeviceMemoryProperties,
                 ) {
@@ -529,7 +533,7 @@ impl InstanceFnV1_0 {
                 }
             },
             get_device_proc_addr: unsafe {
-                extern "system" fn get_device_proc_addr(
+                unsafe extern "system" fn get_device_proc_addr(
                     _device: Device,
                     _p_name: *const c_char,
                 ) -> PFN_vkVoidFunction {
@@ -545,7 +549,7 @@ impl InstanceFnV1_0 {
                 }
             },
             create_device: unsafe {
-                extern "system" fn create_device(
+                unsafe extern "system" fn create_device(
                     _physical_device: PhysicalDevice,
                     _p_create_info: *const DeviceCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -562,7 +566,7 @@ impl InstanceFnV1_0 {
                 }
             },
             enumerate_device_extension_properties: unsafe {
-                extern "system" fn enumerate_device_extension_properties(
+                unsafe extern "system" fn enumerate_device_extension_properties(
                     _physical_device: PhysicalDevice,
                     _p_layer_name: *const c_char,
                     _p_property_count: *mut u32,
@@ -584,7 +588,7 @@ impl InstanceFnV1_0 {
                 }
             },
             enumerate_device_layer_properties: unsafe {
-                extern "system" fn enumerate_device_layer_properties(
+                unsafe extern "system" fn enumerate_device_layer_properties(
                     _physical_device: PhysicalDevice,
                     _p_property_count: *mut u32,
                     _p_properties: *mut LayerProperties,
@@ -605,7 +609,7 @@ impl InstanceFnV1_0 {
                 }
             },
             get_physical_device_sparse_image_format_properties: unsafe {
-                extern "system" fn get_physical_device_sparse_image_format_properties(
+                unsafe extern "system" fn get_physical_device_sparse_image_format_properties(
                     _physical_device: PhysicalDevice,
                     _format: Format,
                     _ty: ImageType,
@@ -784,40 +788,40 @@ impl InstanceFnV1_0 {
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkDestroyDevice =
-    extern "system" fn(device: Device, p_allocator: *const AllocationCallbacks);
+    unsafe extern "system" fn(device: Device, p_allocator: *const AllocationCallbacks);
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceQueue = extern "system" fn(
+pub type PFN_vkGetDeviceQueue = unsafe extern "system" fn(
     device: Device,
     queue_family_index: u32,
     queue_index: u32,
     p_queue: *mut Queue,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkQueueSubmit = extern "system" fn(
+pub type PFN_vkQueueSubmit = unsafe extern "system" fn(
     queue: Queue,
     submit_count: u32,
     p_submits: *const SubmitInfo,
     fence: Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkQueueWaitIdle = extern "system" fn(queue: Queue) -> Result;
+pub type PFN_vkQueueWaitIdle = unsafe extern "system" fn(queue: Queue) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDeviceWaitIdle = extern "system" fn(device: Device) -> Result;
+pub type PFN_vkDeviceWaitIdle = unsafe extern "system" fn(device: Device) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkAllocateMemory = extern "system" fn(
+pub type PFN_vkAllocateMemory = unsafe extern "system" fn(
     device: Device,
     p_allocate_info: *const MemoryAllocateInfo,
     p_allocator: *const AllocationCallbacks,
     p_memory: *mut DeviceMemory,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkFreeMemory = extern "system" fn(
+pub type PFN_vkFreeMemory = unsafe extern "system" fn(
     device: Device,
     memory: DeviceMemory,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkMapMemory = extern "system" fn(
+pub type PFN_vkMapMemory = unsafe extern "system" fn(
     device: Device,
     memory: DeviceMemory,
     offset: DeviceSize,
@@ -826,82 +830,85 @@ pub type PFN_vkMapMemory = extern "system" fn(
     pp_data: *mut *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkUnmapMemory = extern "system" fn(device: Device, memory: DeviceMemory);
+pub type PFN_vkUnmapMemory = unsafe extern "system" fn(device: Device, memory: DeviceMemory);
 #[allow(non_camel_case_types)]
-pub type PFN_vkFlushMappedMemoryRanges = extern "system" fn(
+pub type PFN_vkFlushMappedMemoryRanges = unsafe extern "system" fn(
     device: Device,
     memory_range_count: u32,
     p_memory_ranges: *const MappedMemoryRange,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkInvalidateMappedMemoryRanges = extern "system" fn(
+pub type PFN_vkInvalidateMappedMemoryRanges = unsafe extern "system" fn(
     device: Device,
     memory_range_count: u32,
     p_memory_ranges: *const MappedMemoryRange,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceMemoryCommitment = extern "system" fn(
+pub type PFN_vkGetDeviceMemoryCommitment = unsafe extern "system" fn(
     device: Device,
     memory: DeviceMemory,
     p_committed_memory_in_bytes: *mut DeviceSize,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkBindBufferMemory = extern "system" fn(
+pub type PFN_vkBindBufferMemory = unsafe extern "system" fn(
     device: Device,
     buffer: Buffer,
     memory: DeviceMemory,
     memory_offset: DeviceSize,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkBindImageMemory = extern "system" fn(
+pub type PFN_vkBindImageMemory = unsafe extern "system" fn(
     device: Device,
     image: Image,
     memory: DeviceMemory,
     memory_offset: DeviceSize,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetBufferMemoryRequirements = extern "system" fn(
+pub type PFN_vkGetBufferMemoryRequirements = unsafe extern "system" fn(
     device: Device,
     buffer: Buffer,
     p_memory_requirements: *mut MemoryRequirements,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetImageMemoryRequirements = extern "system" fn(
+pub type PFN_vkGetImageMemoryRequirements = unsafe extern "system" fn(
     device: Device,
     image: Image,
     p_memory_requirements: *mut MemoryRequirements,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetImageSparseMemoryRequirements = extern "system" fn(
+pub type PFN_vkGetImageSparseMemoryRequirements = unsafe extern "system" fn(
     device: Device,
     image: Image,
     p_sparse_memory_requirement_count: *mut u32,
     p_sparse_memory_requirements: *mut SparseImageMemoryRequirements,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkQueueBindSparse = extern "system" fn(
+pub type PFN_vkQueueBindSparse = unsafe extern "system" fn(
     queue: Queue,
     bind_info_count: u32,
     p_bind_info: *const BindSparseInfo,
     fence: Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateFence = extern "system" fn(
+pub type PFN_vkCreateFence = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const FenceCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_fence: *mut Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyFence =
-    extern "system" fn(device: Device, fence: Fence, p_allocator: *const AllocationCallbacks);
+pub type PFN_vkDestroyFence = unsafe extern "system" fn(
+    device: Device,
+    fence: Fence,
+    p_allocator: *const AllocationCallbacks,
+);
 #[allow(non_camel_case_types)]
 pub type PFN_vkResetFences =
-    extern "system" fn(device: Device, fence_count: u32, p_fences: *const Fence) -> Result;
+    unsafe extern "system" fn(device: Device, fence_count: u32, p_fences: *const Fence) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetFenceStatus = extern "system" fn(device: Device, fence: Fence) -> Result;
+pub type PFN_vkGetFenceStatus = unsafe extern "system" fn(device: Device, fence: Fence) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkWaitForFences = extern "system" fn(
+pub type PFN_vkWaitForFences = unsafe extern "system" fn(
     device: Device,
     fence_count: u32,
     p_fences: *const Fence,
@@ -909,49 +916,52 @@ pub type PFN_vkWaitForFences = extern "system" fn(
     timeout: u64,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateSemaphore = extern "system" fn(
+pub type PFN_vkCreateSemaphore = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const SemaphoreCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_semaphore: *mut Semaphore,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroySemaphore = extern "system" fn(
+pub type PFN_vkDestroySemaphore = unsafe extern "system" fn(
     device: Device,
     semaphore: Semaphore,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateEvent = extern "system" fn(
+pub type PFN_vkCreateEvent = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const EventCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_event: *mut Event,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyEvent =
-    extern "system" fn(device: Device, event: Event, p_allocator: *const AllocationCallbacks);
+pub type PFN_vkDestroyEvent = unsafe extern "system" fn(
+    device: Device,
+    event: Event,
+    p_allocator: *const AllocationCallbacks,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetEventStatus = extern "system" fn(device: Device, event: Event) -> Result;
+pub type PFN_vkGetEventStatus = unsafe extern "system" fn(device: Device, event: Event) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkSetEvent = extern "system" fn(device: Device, event: Event) -> Result;
+pub type PFN_vkSetEvent = unsafe extern "system" fn(device: Device, event: Event) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkResetEvent = extern "system" fn(device: Device, event: Event) -> Result;
+pub type PFN_vkResetEvent = unsafe extern "system" fn(device: Device, event: Event) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateQueryPool = extern "system" fn(
+pub type PFN_vkCreateQueryPool = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const QueryPoolCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_query_pool: *mut QueryPool,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyQueryPool = extern "system" fn(
+pub type PFN_vkDestroyQueryPool = unsafe extern "system" fn(
     device: Device,
     query_pool: QueryPool,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetQueryPoolResults = extern "system" fn(
+pub type PFN_vkGetQueryPoolResults = unsafe extern "system" fn(
     device: Device,
     query_pool: QueryPool,
     first_query: u32,
@@ -962,100 +972,106 @@ pub type PFN_vkGetQueryPoolResults = extern "system" fn(
     flags: QueryResultFlags,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateBuffer = extern "system" fn(
+pub type PFN_vkCreateBuffer = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const BufferCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_buffer: *mut Buffer,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyBuffer =
-    extern "system" fn(device: Device, buffer: Buffer, p_allocator: *const AllocationCallbacks);
+pub type PFN_vkDestroyBuffer = unsafe extern "system" fn(
+    device: Device,
+    buffer: Buffer,
+    p_allocator: *const AllocationCallbacks,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateBufferView = extern "system" fn(
+pub type PFN_vkCreateBufferView = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const BufferViewCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_view: *mut BufferView,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyBufferView = extern "system" fn(
+pub type PFN_vkDestroyBufferView = unsafe extern "system" fn(
     device: Device,
     buffer_view: BufferView,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateImage = extern "system" fn(
+pub type PFN_vkCreateImage = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const ImageCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_image: *mut Image,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyImage =
-    extern "system" fn(device: Device, image: Image, p_allocator: *const AllocationCallbacks);
+pub type PFN_vkDestroyImage = unsafe extern "system" fn(
+    device: Device,
+    image: Image,
+    p_allocator: *const AllocationCallbacks,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetImageSubresourceLayout = extern "system" fn(
+pub type PFN_vkGetImageSubresourceLayout = unsafe extern "system" fn(
     device: Device,
     image: Image,
     p_subresource: *const ImageSubresource,
     p_layout: *mut SubresourceLayout,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateImageView = extern "system" fn(
+pub type PFN_vkCreateImageView = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const ImageViewCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_view: *mut ImageView,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyImageView = extern "system" fn(
+pub type PFN_vkDestroyImageView = unsafe extern "system" fn(
     device: Device,
     image_view: ImageView,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateShaderModule = extern "system" fn(
+pub type PFN_vkCreateShaderModule = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const ShaderModuleCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_shader_module: *mut ShaderModule,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyShaderModule = extern "system" fn(
+pub type PFN_vkDestroyShaderModule = unsafe extern "system" fn(
     device: Device,
     shader_module: ShaderModule,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreatePipelineCache = extern "system" fn(
+pub type PFN_vkCreatePipelineCache = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const PipelineCacheCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_pipeline_cache: *mut PipelineCache,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyPipelineCache = extern "system" fn(
+pub type PFN_vkDestroyPipelineCache = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPipelineCacheData = extern "system" fn(
+pub type PFN_vkGetPipelineCacheData = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
     p_data_size: *mut usize,
     p_data: *mut c_void,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkMergePipelineCaches = extern "system" fn(
+pub type PFN_vkMergePipelineCaches = unsafe extern "system" fn(
     device: Device,
     dst_cache: PipelineCache,
     src_cache_count: u32,
     p_src_caches: *const PipelineCache,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateGraphicsPipelines = extern "system" fn(
+pub type PFN_vkCreateGraphicsPipelines = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
     create_info_count: u32,
@@ -1064,7 +1080,7 @@ pub type PFN_vkCreateGraphicsPipelines = extern "system" fn(
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateComputePipelines = extern "system" fn(
+pub type PFN_vkCreateComputePipelines = unsafe extern "system" fn(
     device: Device,
     pipeline_cache: PipelineCache,
     create_info_count: u32,
@@ -1073,78 +1089,84 @@ pub type PFN_vkCreateComputePipelines = extern "system" fn(
     p_pipelines: *mut Pipeline,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyPipeline =
-    extern "system" fn(device: Device, pipeline: Pipeline, p_allocator: *const AllocationCallbacks);
+pub type PFN_vkDestroyPipeline = unsafe extern "system" fn(
+    device: Device,
+    pipeline: Pipeline,
+    p_allocator: *const AllocationCallbacks,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreatePipelineLayout = extern "system" fn(
+pub type PFN_vkCreatePipelineLayout = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const PipelineLayoutCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_pipeline_layout: *mut PipelineLayout,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyPipelineLayout = extern "system" fn(
+pub type PFN_vkDestroyPipelineLayout = unsafe extern "system" fn(
     device: Device,
     pipeline_layout: PipelineLayout,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateSampler = extern "system" fn(
+pub type PFN_vkCreateSampler = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const SamplerCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_sampler: *mut Sampler,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroySampler =
-    extern "system" fn(device: Device, sampler: Sampler, p_allocator: *const AllocationCallbacks);
+pub type PFN_vkDestroySampler = unsafe extern "system" fn(
+    device: Device,
+    sampler: Sampler,
+    p_allocator: *const AllocationCallbacks,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDescriptorSetLayout = extern "system" fn(
+pub type PFN_vkCreateDescriptorSetLayout = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const DescriptorSetLayoutCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_set_layout: *mut DescriptorSetLayout,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyDescriptorSetLayout = extern "system" fn(
+pub type PFN_vkDestroyDescriptorSetLayout = unsafe extern "system" fn(
     device: Device,
     descriptor_set_layout: DescriptorSetLayout,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateDescriptorPool = extern "system" fn(
+pub type PFN_vkCreateDescriptorPool = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const DescriptorPoolCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_descriptor_pool: *mut DescriptorPool,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyDescriptorPool = extern "system" fn(
+pub type PFN_vkDestroyDescriptorPool = unsafe extern "system" fn(
     device: Device,
     descriptor_pool: DescriptorPool,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkResetDescriptorPool = extern "system" fn(
+pub type PFN_vkResetDescriptorPool = unsafe extern "system" fn(
     device: Device,
     descriptor_pool: DescriptorPool,
     flags: DescriptorPoolResetFlags,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkAllocateDescriptorSets = extern "system" fn(
+pub type PFN_vkAllocateDescriptorSets = unsafe extern "system" fn(
     device: Device,
     p_allocate_info: *const DescriptorSetAllocateInfo,
     p_descriptor_sets: *mut DescriptorSet,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkFreeDescriptorSets = extern "system" fn(
+pub type PFN_vkFreeDescriptorSets = unsafe extern "system" fn(
     device: Device,
     descriptor_pool: DescriptorPool,
     descriptor_set_count: u32,
     p_descriptor_sets: *const DescriptorSet,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkUpdateDescriptorSets = extern "system" fn(
+pub type PFN_vkUpdateDescriptorSets = unsafe extern "system" fn(
     device: Device,
     descriptor_write_count: u32,
     p_descriptor_writes: *const WriteDescriptorSet,
@@ -1152,100 +1174,107 @@ pub type PFN_vkUpdateDescriptorSets = extern "system" fn(
     p_descriptor_copies: *const CopyDescriptorSet,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateFramebuffer = extern "system" fn(
+pub type PFN_vkCreateFramebuffer = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const FramebufferCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_framebuffer: *mut Framebuffer,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyFramebuffer = extern "system" fn(
+pub type PFN_vkDestroyFramebuffer = unsafe extern "system" fn(
     device: Device,
     framebuffer: Framebuffer,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateRenderPass = extern "system" fn(
+pub type PFN_vkCreateRenderPass = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const RenderPassCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_render_pass: *mut RenderPass,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyRenderPass = extern "system" fn(
+pub type PFN_vkDestroyRenderPass = unsafe extern "system" fn(
     device: Device,
     render_pass: RenderPass,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetRenderAreaGranularity =
-    extern "system" fn(device: Device, render_pass: RenderPass, p_granularity: *mut Extent2D);
+pub type PFN_vkGetRenderAreaGranularity = unsafe extern "system" fn(
+    device: Device,
+    render_pass: RenderPass,
+    p_granularity: *mut Extent2D,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreateCommandPool = extern "system" fn(
+pub type PFN_vkCreateCommandPool = unsafe extern "system" fn(
     device: Device,
     p_create_info: *const CommandPoolCreateInfo,
     p_allocator: *const AllocationCallbacks,
     p_command_pool: *mut CommandPool,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyCommandPool = extern "system" fn(
+pub type PFN_vkDestroyCommandPool = unsafe extern "system" fn(
     device: Device,
     command_pool: CommandPool,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkResetCommandPool = extern "system" fn(
+pub type PFN_vkResetCommandPool = unsafe extern "system" fn(
     device: Device,
     command_pool: CommandPool,
     flags: CommandPoolResetFlags,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkAllocateCommandBuffers = extern "system" fn(
+pub type PFN_vkAllocateCommandBuffers = unsafe extern "system" fn(
     device: Device,
     p_allocate_info: *const CommandBufferAllocateInfo,
     p_command_buffers: *mut CommandBuffer,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkFreeCommandBuffers = extern "system" fn(
+pub type PFN_vkFreeCommandBuffers = unsafe extern "system" fn(
     device: Device,
     command_pool: CommandPool,
     command_buffer_count: u32,
     p_command_buffers: *const CommandBuffer,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkBeginCommandBuffer = extern "system" fn(
+pub type PFN_vkBeginCommandBuffer = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_begin_info: *const CommandBufferBeginInfo,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkEndCommandBuffer = extern "system" fn(command_buffer: CommandBuffer) -> Result;
+pub type PFN_vkEndCommandBuffer =
+    unsafe extern "system" fn(command_buffer: CommandBuffer) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkResetCommandBuffer =
-    extern "system" fn(command_buffer: CommandBuffer, flags: CommandBufferResetFlags) -> Result;
+pub type PFN_vkResetCommandBuffer = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    flags: CommandBufferResetFlags,
+) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBindPipeline = extern "system" fn(
+pub type PFN_vkCmdBindPipeline = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     pipeline_bind_point: PipelineBindPoint,
     pipeline: Pipeline,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetViewport = extern "system" fn(
+pub type PFN_vkCmdSetViewport = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_viewport: u32,
     viewport_count: u32,
     p_viewports: *const Viewport,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetScissor = extern "system" fn(
+pub type PFN_vkCmdSetScissor = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_scissor: u32,
     scissor_count: u32,
     p_scissors: *const Rect2D,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetLineWidth = extern "system" fn(command_buffer: CommandBuffer, line_width: f32);
+pub type PFN_vkCmdSetLineWidth =
+    unsafe extern "system" fn(command_buffer: CommandBuffer, line_width: f32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetDepthBias = extern "system" fn(
+pub type PFN_vkCmdSetDepthBias = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     depth_bias_constant_factor: f32,
     depth_bias_clamp: f32,
@@ -1253,24 +1282,33 @@ pub type PFN_vkCmdSetDepthBias = extern "system" fn(
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetBlendConstants =
-    extern "system" fn(command_buffer: CommandBuffer, blend_constants: *const [f32; 4]);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, blend_constants: *const [f32; 4]);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetDepthBounds =
-    extern "system" fn(command_buffer: CommandBuffer, min_depth_bounds: f32, max_depth_bounds: f32);
+pub type PFN_vkCmdSetDepthBounds = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    min_depth_bounds: f32,
+    max_depth_bounds: f32,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetStencilCompareMask = extern "system" fn(
+pub type PFN_vkCmdSetStencilCompareMask = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     face_mask: StencilFaceFlags,
     compare_mask: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetStencilWriteMask =
-    extern "system" fn(command_buffer: CommandBuffer, face_mask: StencilFaceFlags, write_mask: u32);
+pub type PFN_vkCmdSetStencilWriteMask = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    face_mask: StencilFaceFlags,
+    write_mask: u32,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetStencilReference =
-    extern "system" fn(command_buffer: CommandBuffer, face_mask: StencilFaceFlags, reference: u32);
+pub type PFN_vkCmdSetStencilReference = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    face_mask: StencilFaceFlags,
+    reference: u32,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBindDescriptorSets = extern "system" fn(
+pub type PFN_vkCmdBindDescriptorSets = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     pipeline_bind_point: PipelineBindPoint,
     layout: PipelineLayout,
@@ -1281,14 +1319,14 @@ pub type PFN_vkCmdBindDescriptorSets = extern "system" fn(
     p_dynamic_offsets: *const u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBindIndexBuffer = extern "system" fn(
+pub type PFN_vkCmdBindIndexBuffer = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     buffer: Buffer,
     offset: DeviceSize,
     index_type: IndexType,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBindVertexBuffers = extern "system" fn(
+pub type PFN_vkCmdBindVertexBuffers = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_binding: u32,
     binding_count: u32,
@@ -1296,7 +1334,7 @@ pub type PFN_vkCmdBindVertexBuffers = extern "system" fn(
     p_offsets: *const DeviceSize,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDraw = extern "system" fn(
+pub type PFN_vkCmdDraw = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     vertex_count: u32,
     instance_count: u32,
@@ -1304,7 +1342,7 @@ pub type PFN_vkCmdDraw = extern "system" fn(
     first_instance: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawIndexed = extern "system" fn(
+pub type PFN_vkCmdDrawIndexed = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     index_count: u32,
     instance_count: u32,
@@ -1313,7 +1351,7 @@ pub type PFN_vkCmdDrawIndexed = extern "system" fn(
     first_instance: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawIndirect = extern "system" fn(
+pub type PFN_vkCmdDrawIndirect = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     buffer: Buffer,
     offset: DeviceSize,
@@ -1321,7 +1359,7 @@ pub type PFN_vkCmdDrawIndirect = extern "system" fn(
     stride: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDrawIndexedIndirect = extern "system" fn(
+pub type PFN_vkCmdDrawIndexedIndirect = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     buffer: Buffer,
     offset: DeviceSize,
@@ -1329,7 +1367,7 @@ pub type PFN_vkCmdDrawIndexedIndirect = extern "system" fn(
     stride: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdDispatch = extern "system" fn(
+pub type PFN_vkCmdDispatch = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     group_count_x: u32,
     group_count_y: u32,
@@ -1337,9 +1375,9 @@ pub type PFN_vkCmdDispatch = extern "system" fn(
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDispatchIndirect =
-    extern "system" fn(command_buffer: CommandBuffer, buffer: Buffer, offset: DeviceSize);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, buffer: Buffer, offset: DeviceSize);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyBuffer = extern "system" fn(
+pub type PFN_vkCmdCopyBuffer = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     src_buffer: Buffer,
     dst_buffer: Buffer,
@@ -1347,7 +1385,7 @@ pub type PFN_vkCmdCopyBuffer = extern "system" fn(
     p_regions: *const BufferCopy,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyImage = extern "system" fn(
+pub type PFN_vkCmdCopyImage = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     src_image: Image,
     src_image_layout: ImageLayout,
@@ -1357,7 +1395,7 @@ pub type PFN_vkCmdCopyImage = extern "system" fn(
     p_regions: *const ImageCopy,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBlitImage = extern "system" fn(
+pub type PFN_vkCmdBlitImage = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     src_image: Image,
     src_image_layout: ImageLayout,
@@ -1368,7 +1406,7 @@ pub type PFN_vkCmdBlitImage = extern "system" fn(
     filter: Filter,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyBufferToImage = extern "system" fn(
+pub type PFN_vkCmdCopyBufferToImage = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     src_buffer: Buffer,
     dst_image: Image,
@@ -1377,7 +1415,7 @@ pub type PFN_vkCmdCopyBufferToImage = extern "system" fn(
     p_regions: *const BufferImageCopy,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyImageToBuffer = extern "system" fn(
+pub type PFN_vkCmdCopyImageToBuffer = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     src_image: Image,
     src_image_layout: ImageLayout,
@@ -1386,7 +1424,7 @@ pub type PFN_vkCmdCopyImageToBuffer = extern "system" fn(
     p_regions: *const BufferImageCopy,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdUpdateBuffer = extern "system" fn(
+pub type PFN_vkCmdUpdateBuffer = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     dst_buffer: Buffer,
     dst_offset: DeviceSize,
@@ -1394,7 +1432,7 @@ pub type PFN_vkCmdUpdateBuffer = extern "system" fn(
     p_data: *const c_void,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdFillBuffer = extern "system" fn(
+pub type PFN_vkCmdFillBuffer = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     dst_buffer: Buffer,
     dst_offset: DeviceSize,
@@ -1402,7 +1440,7 @@ pub type PFN_vkCmdFillBuffer = extern "system" fn(
     data: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdClearColorImage = extern "system" fn(
+pub type PFN_vkCmdClearColorImage = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     image: Image,
     image_layout: ImageLayout,
@@ -1411,7 +1449,7 @@ pub type PFN_vkCmdClearColorImage = extern "system" fn(
     p_ranges: *const ImageSubresourceRange,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdClearDepthStencilImage = extern "system" fn(
+pub type PFN_vkCmdClearDepthStencilImage = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     image: Image,
     image_layout: ImageLayout,
@@ -1420,7 +1458,7 @@ pub type PFN_vkCmdClearDepthStencilImage = extern "system" fn(
     p_ranges: *const ImageSubresourceRange,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdClearAttachments = extern "system" fn(
+pub type PFN_vkCmdClearAttachments = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     attachment_count: u32,
     p_attachments: *const ClearAttachment,
@@ -1428,7 +1466,7 @@ pub type PFN_vkCmdClearAttachments = extern "system" fn(
     p_rects: *const ClearRect,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdResolveImage = extern "system" fn(
+pub type PFN_vkCmdResolveImage = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     src_image: Image,
     src_image_layout: ImageLayout,
@@ -1438,13 +1476,19 @@ pub type PFN_vkCmdResolveImage = extern "system" fn(
     p_regions: *const ImageResolve,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetEvent =
-    extern "system" fn(command_buffer: CommandBuffer, event: Event, stage_mask: PipelineStageFlags);
+pub type PFN_vkCmdSetEvent = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    event: Event,
+    stage_mask: PipelineStageFlags,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdResetEvent =
-    extern "system" fn(command_buffer: CommandBuffer, event: Event, stage_mask: PipelineStageFlags);
+pub type PFN_vkCmdResetEvent = unsafe extern "system" fn(
+    command_buffer: CommandBuffer,
+    event: Event,
+    stage_mask: PipelineStageFlags,
+);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWaitEvents = extern "system" fn(
+pub type PFN_vkCmdWaitEvents = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     event_count: u32,
     p_events: *const Event,
@@ -1458,7 +1502,7 @@ pub type PFN_vkCmdWaitEvents = extern "system" fn(
     p_image_memory_barriers: *const ImageMemoryBarrier,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdPipelineBarrier = extern "system" fn(
+pub type PFN_vkCmdPipelineBarrier = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     src_stage_mask: PipelineStageFlags,
     dst_stage_mask: PipelineStageFlags,
@@ -1471,7 +1515,7 @@ pub type PFN_vkCmdPipelineBarrier = extern "system" fn(
     p_image_memory_barriers: *const ImageMemoryBarrier,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBeginQuery = extern "system" fn(
+pub type PFN_vkCmdBeginQuery = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     query_pool: QueryPool,
     query: u32,
@@ -1479,23 +1523,23 @@ pub type PFN_vkCmdBeginQuery = extern "system" fn(
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdEndQuery =
-    extern "system" fn(command_buffer: CommandBuffer, query_pool: QueryPool, query: u32);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, query_pool: QueryPool, query: u32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdResetQueryPool = extern "system" fn(
+pub type PFN_vkCmdResetQueryPool = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     query_pool: QueryPool,
     first_query: u32,
     query_count: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWriteTimestamp = extern "system" fn(
+pub type PFN_vkCmdWriteTimestamp = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     pipeline_stage: PipelineStageFlags,
     query_pool: QueryPool,
     query: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyQueryPoolResults = extern "system" fn(
+pub type PFN_vkCmdCopyQueryPoolResults = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     query_pool: QueryPool,
     first_query: u32,
@@ -1506,7 +1550,7 @@ pub type PFN_vkCmdCopyQueryPoolResults = extern "system" fn(
     flags: QueryResultFlags,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdPushConstants = extern "system" fn(
+pub type PFN_vkCmdPushConstants = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     layout: PipelineLayout,
     stage_flags: ShaderStageFlags,
@@ -1515,50 +1559,51 @@ pub type PFN_vkCmdPushConstants = extern "system" fn(
     p_values: *const c_void,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBeginRenderPass = extern "system" fn(
+pub type PFN_vkCmdBeginRenderPass = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     p_render_pass_begin: *const RenderPassBeginInfo,
     contents: SubpassContents,
 );
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdNextSubpass =
-    extern "system" fn(command_buffer: CommandBuffer, contents: SubpassContents);
+    unsafe extern "system" fn(command_buffer: CommandBuffer, contents: SubpassContents);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdEndRenderPass = extern "system" fn(command_buffer: CommandBuffer);
+pub type PFN_vkCmdEndRenderPass = unsafe extern "system" fn(command_buffer: CommandBuffer);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdExecuteCommands = extern "system" fn(
+pub type PFN_vkCmdExecuteCommands = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     command_buffer_count: u32,
     p_command_buffers: *const CommandBuffer,
 );
 pub struct DeviceFnV1_0 {
-    pub destroy_device: extern "system" fn(device: Device, p_allocator: *const AllocationCallbacks),
-    pub get_device_queue: extern "system" fn(
+    pub destroy_device:
+        unsafe extern "system" fn(device: Device, p_allocator: *const AllocationCallbacks),
+    pub get_device_queue: unsafe extern "system" fn(
         device: Device,
         queue_family_index: u32,
         queue_index: u32,
         p_queue: *mut Queue,
     ),
-    pub queue_submit: extern "system" fn(
+    pub queue_submit: unsafe extern "system" fn(
         queue: Queue,
         submit_count: u32,
         p_submits: *const SubmitInfo,
         fence: Fence,
     ) -> Result,
-    pub queue_wait_idle: extern "system" fn(queue: Queue) -> Result,
-    pub device_wait_idle: extern "system" fn(device: Device) -> Result,
-    pub allocate_memory: extern "system" fn(
+    pub queue_wait_idle: unsafe extern "system" fn(queue: Queue) -> Result,
+    pub device_wait_idle: unsafe extern "system" fn(device: Device) -> Result,
+    pub allocate_memory: unsafe extern "system" fn(
         device: Device,
         p_allocate_info: *const MemoryAllocateInfo,
         p_allocator: *const AllocationCallbacks,
         p_memory: *mut DeviceMemory,
     ) -> Result,
-    pub free_memory: extern "system" fn(
+    pub free_memory: unsafe extern "system" fn(
         device: Device,
         memory: DeviceMemory,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub map_memory: extern "system" fn(
+    pub map_memory: unsafe extern "system" fn(
         device: Device,
         memory: DeviceMemory,
         offset: DeviceSize,
@@ -1566,108 +1611,117 @@ pub struct DeviceFnV1_0 {
         flags: MemoryMapFlags,
         pp_data: *mut *mut c_void,
     ) -> Result,
-    pub unmap_memory: extern "system" fn(device: Device, memory: DeviceMemory),
-    pub flush_mapped_memory_ranges: extern "system" fn(
+    pub unmap_memory: unsafe extern "system" fn(device: Device, memory: DeviceMemory),
+    pub flush_mapped_memory_ranges: unsafe extern "system" fn(
         device: Device,
         memory_range_count: u32,
         p_memory_ranges: *const MappedMemoryRange,
     ) -> Result,
-    pub invalidate_mapped_memory_ranges: extern "system" fn(
+    pub invalidate_mapped_memory_ranges: unsafe extern "system" fn(
         device: Device,
         memory_range_count: u32,
         p_memory_ranges: *const MappedMemoryRange,
     ) -> Result,
-    pub get_device_memory_commitment: extern "system" fn(
+    pub get_device_memory_commitment: unsafe extern "system" fn(
         device: Device,
         memory: DeviceMemory,
         p_committed_memory_in_bytes: *mut DeviceSize,
     ),
-    pub bind_buffer_memory: extern "system" fn(
+    pub bind_buffer_memory: unsafe extern "system" fn(
         device: Device,
         buffer: Buffer,
         memory: DeviceMemory,
         memory_offset: DeviceSize,
     ) -> Result,
-    pub bind_image_memory: extern "system" fn(
+    pub bind_image_memory: unsafe extern "system" fn(
         device: Device,
         image: Image,
         memory: DeviceMemory,
         memory_offset: DeviceSize,
     ) -> Result,
-    pub get_buffer_memory_requirements: extern "system" fn(
+    pub get_buffer_memory_requirements: unsafe extern "system" fn(
         device: Device,
         buffer: Buffer,
         p_memory_requirements: *mut MemoryRequirements,
     ),
-    pub get_image_memory_requirements: extern "system" fn(
+    pub get_image_memory_requirements: unsafe extern "system" fn(
         device: Device,
         image: Image,
         p_memory_requirements: *mut MemoryRequirements,
     ),
-    pub get_image_sparse_memory_requirements: extern "system" fn(
+    pub get_image_sparse_memory_requirements: unsafe extern "system" fn(
         device: Device,
         image: Image,
         p_sparse_memory_requirement_count: *mut u32,
         p_sparse_memory_requirements: *mut SparseImageMemoryRequirements,
     ),
-    pub queue_bind_sparse: extern "system" fn(
+    pub queue_bind_sparse: unsafe extern "system" fn(
         queue: Queue,
         bind_info_count: u32,
         p_bind_info: *const BindSparseInfo,
         fence: Fence,
     ) -> Result,
-    pub create_fence: extern "system" fn(
+    pub create_fence: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const FenceCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_fence: *mut Fence,
     ) -> Result,
-    pub destroy_fence:
-        extern "system" fn(device: Device, fence: Fence, p_allocator: *const AllocationCallbacks),
-    pub reset_fences:
-        extern "system" fn(device: Device, fence_count: u32, p_fences: *const Fence) -> Result,
-    pub get_fence_status: extern "system" fn(device: Device, fence: Fence) -> Result,
-    pub wait_for_fences: extern "system" fn(
+    pub destroy_fence: unsafe extern "system" fn(
+        device: Device,
+        fence: Fence,
+        p_allocator: *const AllocationCallbacks,
+    ),
+    pub reset_fences: unsafe extern "system" fn(
+        device: Device,
+        fence_count: u32,
+        p_fences: *const Fence,
+    ) -> Result,
+    pub get_fence_status: unsafe extern "system" fn(device: Device, fence: Fence) -> Result,
+    pub wait_for_fences: unsafe extern "system" fn(
         device: Device,
         fence_count: u32,
         p_fences: *const Fence,
         wait_all: Bool32,
         timeout: u64,
     ) -> Result,
-    pub create_semaphore: extern "system" fn(
+    pub create_semaphore: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const SemaphoreCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_semaphore: *mut Semaphore,
     ) -> Result,
-    pub destroy_semaphore: extern "system" fn(
+    pub destroy_semaphore: unsafe extern "system" fn(
         device: Device,
         semaphore: Semaphore,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_event: extern "system" fn(
+    pub create_event: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const EventCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_event: *mut Event,
     ) -> Result,
-    pub destroy_event:
-        extern "system" fn(device: Device, event: Event, p_allocator: *const AllocationCallbacks),
-    pub get_event_status: extern "system" fn(device: Device, event: Event) -> Result,
-    pub set_event: extern "system" fn(device: Device, event: Event) -> Result,
-    pub reset_event: extern "system" fn(device: Device, event: Event) -> Result,
-    pub create_query_pool: extern "system" fn(
+    pub destroy_event: unsafe extern "system" fn(
+        device: Device,
+        event: Event,
+        p_allocator: *const AllocationCallbacks,
+    ),
+    pub get_event_status: unsafe extern "system" fn(device: Device, event: Event) -> Result,
+    pub set_event: unsafe extern "system" fn(device: Device, event: Event) -> Result,
+    pub reset_event: unsafe extern "system" fn(device: Device, event: Event) -> Result,
+    pub create_query_pool: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const QueryPoolCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_query_pool: *mut QueryPool,
     ) -> Result,
-    pub destroy_query_pool: extern "system" fn(
+    pub destroy_query_pool: unsafe extern "system" fn(
         device: Device,
         query_pool: QueryPool,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub get_query_pool_results: extern "system" fn(
+    pub get_query_pool_results: unsafe extern "system" fn(
         device: Device,
         query_pool: QueryPool,
         first_query: u32,
@@ -1677,85 +1731,91 @@ pub struct DeviceFnV1_0 {
         stride: DeviceSize,
         flags: QueryResultFlags,
     ) -> Result,
-    pub create_buffer: extern "system" fn(
+    pub create_buffer: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const BufferCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_buffer: *mut Buffer,
     ) -> Result,
-    pub destroy_buffer:
-        extern "system" fn(device: Device, buffer: Buffer, p_allocator: *const AllocationCallbacks),
-    pub create_buffer_view: extern "system" fn(
+    pub destroy_buffer: unsafe extern "system" fn(
+        device: Device,
+        buffer: Buffer,
+        p_allocator: *const AllocationCallbacks,
+    ),
+    pub create_buffer_view: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const BufferViewCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_view: *mut BufferView,
     ) -> Result,
-    pub destroy_buffer_view: extern "system" fn(
+    pub destroy_buffer_view: unsafe extern "system" fn(
         device: Device,
         buffer_view: BufferView,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_image: extern "system" fn(
+    pub create_image: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const ImageCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_image: *mut Image,
     ) -> Result,
-    pub destroy_image:
-        extern "system" fn(device: Device, image: Image, p_allocator: *const AllocationCallbacks),
-    pub get_image_subresource_layout: extern "system" fn(
+    pub destroy_image: unsafe extern "system" fn(
+        device: Device,
+        image: Image,
+        p_allocator: *const AllocationCallbacks,
+    ),
+    pub get_image_subresource_layout: unsafe extern "system" fn(
         device: Device,
         image: Image,
         p_subresource: *const ImageSubresource,
         p_layout: *mut SubresourceLayout,
     ),
-    pub create_image_view: extern "system" fn(
+    pub create_image_view: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const ImageViewCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_view: *mut ImageView,
     ) -> Result,
-    pub destroy_image_view: extern "system" fn(
+    pub destroy_image_view: unsafe extern "system" fn(
         device: Device,
         image_view: ImageView,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_shader_module: extern "system" fn(
+    pub create_shader_module: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const ShaderModuleCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_shader_module: *mut ShaderModule,
     ) -> Result,
-    pub destroy_shader_module: extern "system" fn(
+    pub destroy_shader_module: unsafe extern "system" fn(
         device: Device,
         shader_module: ShaderModule,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_pipeline_cache: extern "system" fn(
+    pub create_pipeline_cache: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const PipelineCacheCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_pipeline_cache: *mut PipelineCache,
     ) -> Result,
-    pub destroy_pipeline_cache: extern "system" fn(
+    pub destroy_pipeline_cache: unsafe extern "system" fn(
         device: Device,
         pipeline_cache: PipelineCache,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub get_pipeline_cache_data: extern "system" fn(
+    pub get_pipeline_cache_data: unsafe extern "system" fn(
         device: Device,
         pipeline_cache: PipelineCache,
         p_data_size: *mut usize,
         p_data: *mut c_void,
     ) -> Result,
-    pub merge_pipeline_caches: extern "system" fn(
+    pub merge_pipeline_caches: unsafe extern "system" fn(
         device: Device,
         dst_cache: PipelineCache,
         src_cache_count: u32,
         p_src_caches: *const PipelineCache,
     ) -> Result,
-    pub create_graphics_pipelines: extern "system" fn(
+    pub create_graphics_pipelines: unsafe extern "system" fn(
         device: Device,
         pipeline_cache: PipelineCache,
         create_info_count: u32,
@@ -1763,7 +1823,7 @@ pub struct DeviceFnV1_0 {
         p_allocator: *const AllocationCallbacks,
         p_pipelines: *mut Pipeline,
     ) -> Result,
-    pub create_compute_pipelines: extern "system" fn(
+    pub create_compute_pipelines: unsafe extern "system" fn(
         device: Device,
         pipeline_cache: PipelineCache,
         create_info_count: u32,
@@ -1771,183 +1831,189 @@ pub struct DeviceFnV1_0 {
         p_allocator: *const AllocationCallbacks,
         p_pipelines: *mut Pipeline,
     ) -> Result,
-    pub destroy_pipeline: extern "system" fn(
+    pub destroy_pipeline: unsafe extern "system" fn(
         device: Device,
         pipeline: Pipeline,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_pipeline_layout: extern "system" fn(
+    pub create_pipeline_layout: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const PipelineLayoutCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_pipeline_layout: *mut PipelineLayout,
     ) -> Result,
-    pub destroy_pipeline_layout: extern "system" fn(
+    pub destroy_pipeline_layout: unsafe extern "system" fn(
         device: Device,
         pipeline_layout: PipelineLayout,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_sampler: extern "system" fn(
+    pub create_sampler: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const SamplerCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_sampler: *mut Sampler,
     ) -> Result,
-    pub destroy_sampler: extern "system" fn(
+    pub destroy_sampler: unsafe extern "system" fn(
         device: Device,
         sampler: Sampler,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_descriptor_set_layout: extern "system" fn(
+    pub create_descriptor_set_layout: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const DescriptorSetLayoutCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_set_layout: *mut DescriptorSetLayout,
     ) -> Result,
-    pub destroy_descriptor_set_layout: extern "system" fn(
+    pub destroy_descriptor_set_layout: unsafe extern "system" fn(
         device: Device,
         descriptor_set_layout: DescriptorSetLayout,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_descriptor_pool: extern "system" fn(
+    pub create_descriptor_pool: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const DescriptorPoolCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_descriptor_pool: *mut DescriptorPool,
     ) -> Result,
-    pub destroy_descriptor_pool: extern "system" fn(
+    pub destroy_descriptor_pool: unsafe extern "system" fn(
         device: Device,
         descriptor_pool: DescriptorPool,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub reset_descriptor_pool: extern "system" fn(
+    pub reset_descriptor_pool: unsafe extern "system" fn(
         device: Device,
         descriptor_pool: DescriptorPool,
         flags: DescriptorPoolResetFlags,
     ) -> Result,
-    pub allocate_descriptor_sets: extern "system" fn(
+    pub allocate_descriptor_sets: unsafe extern "system" fn(
         device: Device,
         p_allocate_info: *const DescriptorSetAllocateInfo,
         p_descriptor_sets: *mut DescriptorSet,
     ) -> Result,
-    pub free_descriptor_sets: extern "system" fn(
+    pub free_descriptor_sets: unsafe extern "system" fn(
         device: Device,
         descriptor_pool: DescriptorPool,
         descriptor_set_count: u32,
         p_descriptor_sets: *const DescriptorSet,
     ) -> Result,
-    pub update_descriptor_sets: extern "system" fn(
+    pub update_descriptor_sets: unsafe extern "system" fn(
         device: Device,
         descriptor_write_count: u32,
         p_descriptor_writes: *const WriteDescriptorSet,
         descriptor_copy_count: u32,
         p_descriptor_copies: *const CopyDescriptorSet,
     ),
-    pub create_framebuffer: extern "system" fn(
+    pub create_framebuffer: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const FramebufferCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_framebuffer: *mut Framebuffer,
     ) -> Result,
-    pub destroy_framebuffer: extern "system" fn(
+    pub destroy_framebuffer: unsafe extern "system" fn(
         device: Device,
         framebuffer: Framebuffer,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_render_pass: extern "system" fn(
+    pub create_render_pass: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const RenderPassCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_render_pass: *mut RenderPass,
     ) -> Result,
-    pub destroy_render_pass: extern "system" fn(
+    pub destroy_render_pass: unsafe extern "system" fn(
         device: Device,
         render_pass: RenderPass,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub get_render_area_granularity:
-        extern "system" fn(device: Device, render_pass: RenderPass, p_granularity: *mut Extent2D),
-    pub create_command_pool: extern "system" fn(
+    pub get_render_area_granularity: unsafe extern "system" fn(
+        device: Device,
+        render_pass: RenderPass,
+        p_granularity: *mut Extent2D,
+    ),
+    pub create_command_pool: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const CommandPoolCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_command_pool: *mut CommandPool,
     ) -> Result,
-    pub destroy_command_pool: extern "system" fn(
+    pub destroy_command_pool: unsafe extern "system" fn(
         device: Device,
         command_pool: CommandPool,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub reset_command_pool: extern "system" fn(
+    pub reset_command_pool: unsafe extern "system" fn(
         device: Device,
         command_pool: CommandPool,
         flags: CommandPoolResetFlags,
     ) -> Result,
-    pub allocate_command_buffers: extern "system" fn(
+    pub allocate_command_buffers: unsafe extern "system" fn(
         device: Device,
         p_allocate_info: *const CommandBufferAllocateInfo,
         p_command_buffers: *mut CommandBuffer,
     ) -> Result,
-    pub free_command_buffers: extern "system" fn(
+    pub free_command_buffers: unsafe extern "system" fn(
         device: Device,
         command_pool: CommandPool,
         command_buffer_count: u32,
         p_command_buffers: *const CommandBuffer,
     ),
-    pub begin_command_buffer: extern "system" fn(
+    pub begin_command_buffer: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_begin_info: *const CommandBufferBeginInfo,
     ) -> Result,
-    pub end_command_buffer: extern "system" fn(command_buffer: CommandBuffer) -> Result,
-    pub reset_command_buffer:
-        extern "system" fn(command_buffer: CommandBuffer, flags: CommandBufferResetFlags) -> Result,
-    pub cmd_bind_pipeline: extern "system" fn(
+    pub end_command_buffer: unsafe extern "system" fn(command_buffer: CommandBuffer) -> Result,
+    pub reset_command_buffer: unsafe extern "system" fn(
+        command_buffer: CommandBuffer,
+        flags: CommandBufferResetFlags,
+    ) -> Result,
+    pub cmd_bind_pipeline: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         pipeline_bind_point: PipelineBindPoint,
         pipeline: Pipeline,
     ),
-    pub cmd_set_viewport: extern "system" fn(
+    pub cmd_set_viewport: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_viewport: u32,
         viewport_count: u32,
         p_viewports: *const Viewport,
     ),
-    pub cmd_set_scissor: extern "system" fn(
+    pub cmd_set_scissor: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_scissor: u32,
         scissor_count: u32,
         p_scissors: *const Rect2D,
     ),
-    pub cmd_set_line_width: extern "system" fn(command_buffer: CommandBuffer, line_width: f32),
-    pub cmd_set_depth_bias: extern "system" fn(
+    pub cmd_set_line_width:
+        unsafe extern "system" fn(command_buffer: CommandBuffer, line_width: f32),
+    pub cmd_set_depth_bias: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         depth_bias_constant_factor: f32,
         depth_bias_clamp: f32,
         depth_bias_slope_factor: f32,
     ),
     pub cmd_set_blend_constants:
-        extern "system" fn(command_buffer: CommandBuffer, blend_constants: *const [f32; 4]),
-    pub cmd_set_depth_bounds: extern "system" fn(
+        unsafe extern "system" fn(command_buffer: CommandBuffer, blend_constants: *const [f32; 4]),
+    pub cmd_set_depth_bounds: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         min_depth_bounds: f32,
         max_depth_bounds: f32,
     ),
-    pub cmd_set_stencil_compare_mask: extern "system" fn(
+    pub cmd_set_stencil_compare_mask: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         face_mask: StencilFaceFlags,
         compare_mask: u32,
     ),
-    pub cmd_set_stencil_write_mask: extern "system" fn(
+    pub cmd_set_stencil_write_mask: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         face_mask: StencilFaceFlags,
         write_mask: u32,
     ),
-    pub cmd_set_stencil_reference: extern "system" fn(
+    pub cmd_set_stencil_reference: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         face_mask: StencilFaceFlags,
         reference: u32,
     ),
-    pub cmd_bind_descriptor_sets: extern "system" fn(
+    pub cmd_bind_descriptor_sets: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         pipeline_bind_point: PipelineBindPoint,
         layout: PipelineLayout,
@@ -1957,27 +2023,27 @@ pub struct DeviceFnV1_0 {
         dynamic_offset_count: u32,
         p_dynamic_offsets: *const u32,
     ),
-    pub cmd_bind_index_buffer: extern "system" fn(
+    pub cmd_bind_index_buffer: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
         index_type: IndexType,
     ),
-    pub cmd_bind_vertex_buffers: extern "system" fn(
+    pub cmd_bind_vertex_buffers: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         first_binding: u32,
         binding_count: u32,
         p_buffers: *const Buffer,
         p_offsets: *const DeviceSize,
     ),
-    pub cmd_draw: extern "system" fn(
+    pub cmd_draw: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         vertex_count: u32,
         instance_count: u32,
         first_vertex: u32,
         first_instance: u32,
     ),
-    pub cmd_draw_indexed: extern "system" fn(
+    pub cmd_draw_indexed: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         index_count: u32,
         instance_count: u32,
@@ -1985,36 +2051,39 @@ pub struct DeviceFnV1_0 {
         vertex_offset: i32,
         first_instance: u32,
     ),
-    pub cmd_draw_indirect: extern "system" fn(
+    pub cmd_draw_indirect: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
         draw_count: u32,
         stride: u32,
     ),
-    pub cmd_draw_indexed_indirect: extern "system" fn(
+    pub cmd_draw_indexed_indirect: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
         draw_count: u32,
         stride: u32,
     ),
-    pub cmd_dispatch: extern "system" fn(
+    pub cmd_dispatch: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         group_count_x: u32,
         group_count_y: u32,
         group_count_z: u32,
     ),
-    pub cmd_dispatch_indirect:
-        extern "system" fn(command_buffer: CommandBuffer, buffer: Buffer, offset: DeviceSize),
-    pub cmd_copy_buffer: extern "system" fn(
+    pub cmd_dispatch_indirect: unsafe extern "system" fn(
+        command_buffer: CommandBuffer,
+        buffer: Buffer,
+        offset: DeviceSize,
+    ),
+    pub cmd_copy_buffer: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         src_buffer: Buffer,
         dst_buffer: Buffer,
         region_count: u32,
         p_regions: *const BufferCopy,
     ),
-    pub cmd_copy_image: extern "system" fn(
+    pub cmd_copy_image: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         src_image: Image,
         src_image_layout: ImageLayout,
@@ -2023,7 +2092,7 @@ pub struct DeviceFnV1_0 {
         region_count: u32,
         p_regions: *const ImageCopy,
     ),
-    pub cmd_blit_image: extern "system" fn(
+    pub cmd_blit_image: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         src_image: Image,
         src_image_layout: ImageLayout,
@@ -2033,7 +2102,7 @@ pub struct DeviceFnV1_0 {
         p_regions: *const ImageBlit,
         filter: Filter,
     ),
-    pub cmd_copy_buffer_to_image: extern "system" fn(
+    pub cmd_copy_buffer_to_image: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         src_buffer: Buffer,
         dst_image: Image,
@@ -2041,7 +2110,7 @@ pub struct DeviceFnV1_0 {
         region_count: u32,
         p_regions: *const BufferImageCopy,
     ),
-    pub cmd_copy_image_to_buffer: extern "system" fn(
+    pub cmd_copy_image_to_buffer: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         src_image: Image,
         src_image_layout: ImageLayout,
@@ -2049,21 +2118,21 @@ pub struct DeviceFnV1_0 {
         region_count: u32,
         p_regions: *const BufferImageCopy,
     ),
-    pub cmd_update_buffer: extern "system" fn(
+    pub cmd_update_buffer: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         dst_buffer: Buffer,
         dst_offset: DeviceSize,
         data_size: DeviceSize,
         p_data: *const c_void,
     ),
-    pub cmd_fill_buffer: extern "system" fn(
+    pub cmd_fill_buffer: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         dst_buffer: Buffer,
         dst_offset: DeviceSize,
         size: DeviceSize,
         data: u32,
     ),
-    pub cmd_clear_color_image: extern "system" fn(
+    pub cmd_clear_color_image: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         image: Image,
         image_layout: ImageLayout,
@@ -2071,7 +2140,7 @@ pub struct DeviceFnV1_0 {
         range_count: u32,
         p_ranges: *const ImageSubresourceRange,
     ),
-    pub cmd_clear_depth_stencil_image: extern "system" fn(
+    pub cmd_clear_depth_stencil_image: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         image: Image,
         image_layout: ImageLayout,
@@ -2079,14 +2148,14 @@ pub struct DeviceFnV1_0 {
         range_count: u32,
         p_ranges: *const ImageSubresourceRange,
     ),
-    pub cmd_clear_attachments: extern "system" fn(
+    pub cmd_clear_attachments: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         attachment_count: u32,
         p_attachments: *const ClearAttachment,
         rect_count: u32,
         p_rects: *const ClearRect,
     ),
-    pub cmd_resolve_image: extern "system" fn(
+    pub cmd_resolve_image: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         src_image: Image,
         src_image_layout: ImageLayout,
@@ -2095,17 +2164,17 @@ pub struct DeviceFnV1_0 {
         region_count: u32,
         p_regions: *const ImageResolve,
     ),
-    pub cmd_set_event: extern "system" fn(
+    pub cmd_set_event: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         event: Event,
         stage_mask: PipelineStageFlags,
     ),
-    pub cmd_reset_event: extern "system" fn(
+    pub cmd_reset_event: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         event: Event,
         stage_mask: PipelineStageFlags,
     ),
-    pub cmd_wait_events: extern "system" fn(
+    pub cmd_wait_events: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         event_count: u32,
         p_events: *const Event,
@@ -2118,7 +2187,7 @@ pub struct DeviceFnV1_0 {
         image_memory_barrier_count: u32,
         p_image_memory_barriers: *const ImageMemoryBarrier,
     ),
-    pub cmd_pipeline_barrier: extern "system" fn(
+    pub cmd_pipeline_barrier: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         src_stage_mask: PipelineStageFlags,
         dst_stage_mask: PipelineStageFlags,
@@ -2130,27 +2199,27 @@ pub struct DeviceFnV1_0 {
         image_memory_barrier_count: u32,
         p_image_memory_barriers: *const ImageMemoryBarrier,
     ),
-    pub cmd_begin_query: extern "system" fn(
+    pub cmd_begin_query: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         query_pool: QueryPool,
         query: u32,
         flags: QueryControlFlags,
     ),
     pub cmd_end_query:
-        extern "system" fn(command_buffer: CommandBuffer, query_pool: QueryPool, query: u32),
-    pub cmd_reset_query_pool: extern "system" fn(
+        unsafe extern "system" fn(command_buffer: CommandBuffer, query_pool: QueryPool, query: u32),
+    pub cmd_reset_query_pool: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         query_pool: QueryPool,
         first_query: u32,
         query_count: u32,
     ),
-    pub cmd_write_timestamp: extern "system" fn(
+    pub cmd_write_timestamp: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         pipeline_stage: PipelineStageFlags,
         query_pool: QueryPool,
         query: u32,
     ),
-    pub cmd_copy_query_pool_results: extern "system" fn(
+    pub cmd_copy_query_pool_results: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         query_pool: QueryPool,
         first_query: u32,
@@ -2160,7 +2229,7 @@ pub struct DeviceFnV1_0 {
         stride: DeviceSize,
         flags: QueryResultFlags,
     ),
-    pub cmd_push_constants: extern "system" fn(
+    pub cmd_push_constants: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         layout: PipelineLayout,
         stage_flags: ShaderStageFlags,
@@ -2168,15 +2237,15 @@ pub struct DeviceFnV1_0 {
         size: u32,
         p_values: *const c_void,
     ),
-    pub cmd_begin_render_pass: extern "system" fn(
+    pub cmd_begin_render_pass: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_render_pass_begin: *const RenderPassBeginInfo,
         contents: SubpassContents,
     ),
     pub cmd_next_subpass:
-        extern "system" fn(command_buffer: CommandBuffer, contents: SubpassContents),
-    pub cmd_end_render_pass: extern "system" fn(command_buffer: CommandBuffer),
-    pub cmd_execute_commands: extern "system" fn(
+        unsafe extern "system" fn(command_buffer: CommandBuffer, contents: SubpassContents),
+    pub cmd_end_render_pass: unsafe extern "system" fn(command_buffer: CommandBuffer),
+    pub cmd_execute_commands: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         command_buffer_count: u32,
         p_command_buffers: *const CommandBuffer,
@@ -2317,7 +2386,7 @@ impl DeviceFnV1_0 {
     {
         DeviceFnV1_0 {
             destroy_device: unsafe {
-                extern "system" fn destroy_device(
+                unsafe extern "system" fn destroy_device(
                     _device: Device,
                     _p_allocator: *const AllocationCallbacks,
                 ) {
@@ -2332,7 +2401,7 @@ impl DeviceFnV1_0 {
                 }
             },
             get_device_queue: unsafe {
-                extern "system" fn get_device_queue(
+                unsafe extern "system" fn get_device_queue(
                     _device: Device,
                     _queue_family_index: u32,
                     _queue_index: u32,
@@ -2349,7 +2418,7 @@ impl DeviceFnV1_0 {
                 }
             },
             queue_submit: unsafe {
-                extern "system" fn queue_submit(
+                unsafe extern "system" fn queue_submit(
                     _queue: Queue,
                     _submit_count: u32,
                     _p_submits: *const SubmitInfo,
@@ -2366,7 +2435,7 @@ impl DeviceFnV1_0 {
                 }
             },
             queue_wait_idle: unsafe {
-                extern "system" fn queue_wait_idle(_queue: Queue) -> Result {
+                unsafe extern "system" fn queue_wait_idle(_queue: Queue) -> Result {
                     panic!(concat!("Unable to load ", stringify!(queue_wait_idle)))
                 }
                 let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkQueueWaitIdle\0");
@@ -2378,7 +2447,7 @@ impl DeviceFnV1_0 {
                 }
             },
             device_wait_idle: unsafe {
-                extern "system" fn device_wait_idle(_device: Device) -> Result {
+                unsafe extern "system" fn device_wait_idle(_device: Device) -> Result {
                     panic!(concat!("Unable to load ", stringify!(device_wait_idle)))
                 }
                 let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkDeviceWaitIdle\0");
@@ -2390,7 +2459,7 @@ impl DeviceFnV1_0 {
                 }
             },
             allocate_memory: unsafe {
-                extern "system" fn allocate_memory(
+                unsafe extern "system" fn allocate_memory(
                     _device: Device,
                     _p_allocate_info: *const MemoryAllocateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -2407,7 +2476,7 @@ impl DeviceFnV1_0 {
                 }
             },
             free_memory: unsafe {
-                extern "system" fn free_memory(
+                unsafe extern "system" fn free_memory(
                     _device: Device,
                     _memory: DeviceMemory,
                     _p_allocator: *const AllocationCallbacks,
@@ -2423,7 +2492,7 @@ impl DeviceFnV1_0 {
                 }
             },
             map_memory: unsafe {
-                extern "system" fn map_memory(
+                unsafe extern "system" fn map_memory(
                     _device: Device,
                     _memory: DeviceMemory,
                     _offset: DeviceSize,
@@ -2442,7 +2511,7 @@ impl DeviceFnV1_0 {
                 }
             },
             unmap_memory: unsafe {
-                extern "system" fn unmap_memory(_device: Device, _memory: DeviceMemory) {
+                unsafe extern "system" fn unmap_memory(_device: Device, _memory: DeviceMemory) {
                     panic!(concat!("Unable to load ", stringify!(unmap_memory)))
                 }
                 let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkUnmapMemory\0");
@@ -2454,7 +2523,7 @@ impl DeviceFnV1_0 {
                 }
             },
             flush_mapped_memory_ranges: unsafe {
-                extern "system" fn flush_mapped_memory_ranges(
+                unsafe extern "system" fn flush_mapped_memory_ranges(
                     _device: Device,
                     _memory_range_count: u32,
                     _p_memory_ranges: *const MappedMemoryRange,
@@ -2474,7 +2543,7 @@ impl DeviceFnV1_0 {
                 }
             },
             invalidate_mapped_memory_ranges: unsafe {
-                extern "system" fn invalidate_mapped_memory_ranges(
+                unsafe extern "system" fn invalidate_mapped_memory_ranges(
                     _device: Device,
                     _memory_range_count: u32,
                     _p_memory_ranges: *const MappedMemoryRange,
@@ -2495,7 +2564,7 @@ impl DeviceFnV1_0 {
                 }
             },
             get_device_memory_commitment: unsafe {
-                extern "system" fn get_device_memory_commitment(
+                unsafe extern "system" fn get_device_memory_commitment(
                     _device: Device,
                     _memory: DeviceMemory,
                     _p_committed_memory_in_bytes: *mut DeviceSize,
@@ -2516,7 +2585,7 @@ impl DeviceFnV1_0 {
                 }
             },
             bind_buffer_memory: unsafe {
-                extern "system" fn bind_buffer_memory(
+                unsafe extern "system" fn bind_buffer_memory(
                     _device: Device,
                     _buffer: Buffer,
                     _memory: DeviceMemory,
@@ -2534,7 +2603,7 @@ impl DeviceFnV1_0 {
                 }
             },
             bind_image_memory: unsafe {
-                extern "system" fn bind_image_memory(
+                unsafe extern "system" fn bind_image_memory(
                     _device: Device,
                     _image: Image,
                     _memory: DeviceMemory,
@@ -2551,7 +2620,7 @@ impl DeviceFnV1_0 {
                 }
             },
             get_buffer_memory_requirements: unsafe {
-                extern "system" fn get_buffer_memory_requirements(
+                unsafe extern "system" fn get_buffer_memory_requirements(
                     _device: Device,
                     _buffer: Buffer,
                     _p_memory_requirements: *mut MemoryRequirements,
@@ -2572,7 +2641,7 @@ impl DeviceFnV1_0 {
                 }
             },
             get_image_memory_requirements: unsafe {
-                extern "system" fn get_image_memory_requirements(
+                unsafe extern "system" fn get_image_memory_requirements(
                     _device: Device,
                     _image: Image,
                     _p_memory_requirements: *mut MemoryRequirements,
@@ -2593,7 +2662,7 @@ impl DeviceFnV1_0 {
                 }
             },
             get_image_sparse_memory_requirements: unsafe {
-                extern "system" fn get_image_sparse_memory_requirements(
+                unsafe extern "system" fn get_image_sparse_memory_requirements(
                     _device: Device,
                     _image: Image,
                     _p_sparse_memory_requirement_count: *mut u32,
@@ -2615,7 +2684,7 @@ impl DeviceFnV1_0 {
                 }
             },
             queue_bind_sparse: unsafe {
-                extern "system" fn queue_bind_sparse(
+                unsafe extern "system" fn queue_bind_sparse(
                     _queue: Queue,
                     _bind_info_count: u32,
                     _p_bind_info: *const BindSparseInfo,
@@ -2632,7 +2701,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_fence: unsafe {
-                extern "system" fn create_fence(
+                unsafe extern "system" fn create_fence(
                     _device: Device,
                     _p_create_info: *const FenceCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -2649,7 +2718,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_fence: unsafe {
-                extern "system" fn destroy_fence(
+                unsafe extern "system" fn destroy_fence(
                     _device: Device,
                     _fence: Fence,
                     _p_allocator: *const AllocationCallbacks,
@@ -2665,7 +2734,7 @@ impl DeviceFnV1_0 {
                 }
             },
             reset_fences: unsafe {
-                extern "system" fn reset_fences(
+                unsafe extern "system" fn reset_fences(
                     _device: Device,
                     _fence_count: u32,
                     _p_fences: *const Fence,
@@ -2681,7 +2750,10 @@ impl DeviceFnV1_0 {
                 }
             },
             get_fence_status: unsafe {
-                extern "system" fn get_fence_status(_device: Device, _fence: Fence) -> Result {
+                unsafe extern "system" fn get_fence_status(
+                    _device: Device,
+                    _fence: Fence,
+                ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(get_fence_status)))
                 }
                 let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkGetFenceStatus\0");
@@ -2693,7 +2765,7 @@ impl DeviceFnV1_0 {
                 }
             },
             wait_for_fences: unsafe {
-                extern "system" fn wait_for_fences(
+                unsafe extern "system" fn wait_for_fences(
                     _device: Device,
                     _fence_count: u32,
                     _p_fences: *const Fence,
@@ -2711,7 +2783,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_semaphore: unsafe {
-                extern "system" fn create_semaphore(
+                unsafe extern "system" fn create_semaphore(
                     _device: Device,
                     _p_create_info: *const SemaphoreCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -2728,7 +2800,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_semaphore: unsafe {
-                extern "system" fn destroy_semaphore(
+                unsafe extern "system" fn destroy_semaphore(
                     _device: Device,
                     _semaphore: Semaphore,
                     _p_allocator: *const AllocationCallbacks,
@@ -2745,7 +2817,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_event: unsafe {
-                extern "system" fn create_event(
+                unsafe extern "system" fn create_event(
                     _device: Device,
                     _p_create_info: *const EventCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -2762,7 +2834,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_event: unsafe {
-                extern "system" fn destroy_event(
+                unsafe extern "system" fn destroy_event(
                     _device: Device,
                     _event: Event,
                     _p_allocator: *const AllocationCallbacks,
@@ -2778,7 +2850,10 @@ impl DeviceFnV1_0 {
                 }
             },
             get_event_status: unsafe {
-                extern "system" fn get_event_status(_device: Device, _event: Event) -> Result {
+                unsafe extern "system" fn get_event_status(
+                    _device: Device,
+                    _event: Event,
+                ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(get_event_status)))
                 }
                 let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkGetEventStatus\0");
@@ -2790,7 +2865,7 @@ impl DeviceFnV1_0 {
                 }
             },
             set_event: unsafe {
-                extern "system" fn set_event(_device: Device, _event: Event) -> Result {
+                unsafe extern "system" fn set_event(_device: Device, _event: Event) -> Result {
                     panic!(concat!("Unable to load ", stringify!(set_event)))
                 }
                 let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkSetEvent\0");
@@ -2802,7 +2877,7 @@ impl DeviceFnV1_0 {
                 }
             },
             reset_event: unsafe {
-                extern "system" fn reset_event(_device: Device, _event: Event) -> Result {
+                unsafe extern "system" fn reset_event(_device: Device, _event: Event) -> Result {
                     panic!(concat!("Unable to load ", stringify!(reset_event)))
                 }
                 let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkResetEvent\0");
@@ -2814,7 +2889,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_query_pool: unsafe {
-                extern "system" fn create_query_pool(
+                unsafe extern "system" fn create_query_pool(
                     _device: Device,
                     _p_create_info: *const QueryPoolCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -2831,7 +2906,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_query_pool: unsafe {
-                extern "system" fn destroy_query_pool(
+                unsafe extern "system" fn destroy_query_pool(
                     _device: Device,
                     _query_pool: QueryPool,
                     _p_allocator: *const AllocationCallbacks,
@@ -2848,7 +2923,7 @@ impl DeviceFnV1_0 {
                 }
             },
             get_query_pool_results: unsafe {
-                extern "system" fn get_query_pool_results(
+                unsafe extern "system" fn get_query_pool_results(
                     _device: Device,
                     _query_pool: QueryPool,
                     _first_query: u32,
@@ -2873,7 +2948,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_buffer: unsafe {
-                extern "system" fn create_buffer(
+                unsafe extern "system" fn create_buffer(
                     _device: Device,
                     _p_create_info: *const BufferCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -2890,7 +2965,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_buffer: unsafe {
-                extern "system" fn destroy_buffer(
+                unsafe extern "system" fn destroy_buffer(
                     _device: Device,
                     _buffer: Buffer,
                     _p_allocator: *const AllocationCallbacks,
@@ -2906,7 +2981,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_buffer_view: unsafe {
-                extern "system" fn create_buffer_view(
+                unsafe extern "system" fn create_buffer_view(
                     _device: Device,
                     _p_create_info: *const BufferViewCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -2924,7 +2999,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_buffer_view: unsafe {
-                extern "system" fn destroy_buffer_view(
+                unsafe extern "system" fn destroy_buffer_view(
                     _device: Device,
                     _buffer_view: BufferView,
                     _p_allocator: *const AllocationCallbacks,
@@ -2941,7 +3016,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_image: unsafe {
-                extern "system" fn create_image(
+                unsafe extern "system" fn create_image(
                     _device: Device,
                     _p_create_info: *const ImageCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -2958,7 +3033,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_image: unsafe {
-                extern "system" fn destroy_image(
+                unsafe extern "system" fn destroy_image(
                     _device: Device,
                     _image: Image,
                     _p_allocator: *const AllocationCallbacks,
@@ -2974,7 +3049,7 @@ impl DeviceFnV1_0 {
                 }
             },
             get_image_subresource_layout: unsafe {
-                extern "system" fn get_image_subresource_layout(
+                unsafe extern "system" fn get_image_subresource_layout(
                     _device: Device,
                     _image: Image,
                     _p_subresource: *const ImageSubresource,
@@ -2996,7 +3071,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_image_view: unsafe {
-                extern "system" fn create_image_view(
+                unsafe extern "system" fn create_image_view(
                     _device: Device,
                     _p_create_info: *const ImageViewCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3013,7 +3088,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_image_view: unsafe {
-                extern "system" fn destroy_image_view(
+                unsafe extern "system" fn destroy_image_view(
                     _device: Device,
                     _image_view: ImageView,
                     _p_allocator: *const AllocationCallbacks,
@@ -3030,7 +3105,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_shader_module: unsafe {
-                extern "system" fn create_shader_module(
+                unsafe extern "system" fn create_shader_module(
                     _device: Device,
                     _p_create_info: *const ShaderModuleCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3048,7 +3123,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_shader_module: unsafe {
-                extern "system" fn destroy_shader_module(
+                unsafe extern "system" fn destroy_shader_module(
                     _device: Device,
                     _shader_module: ShaderModule,
                     _p_allocator: *const AllocationCallbacks,
@@ -3068,7 +3143,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_pipeline_cache: unsafe {
-                extern "system" fn create_pipeline_cache(
+                unsafe extern "system" fn create_pipeline_cache(
                     _device: Device,
                     _p_create_info: *const PipelineCacheCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3089,7 +3164,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_pipeline_cache: unsafe {
-                extern "system" fn destroy_pipeline_cache(
+                unsafe extern "system" fn destroy_pipeline_cache(
                     _device: Device,
                     _pipeline_cache: PipelineCache,
                     _p_allocator: *const AllocationCallbacks,
@@ -3109,7 +3184,7 @@ impl DeviceFnV1_0 {
                 }
             },
             get_pipeline_cache_data: unsafe {
-                extern "system" fn get_pipeline_cache_data(
+                unsafe extern "system" fn get_pipeline_cache_data(
                     _device: Device,
                     _pipeline_cache: PipelineCache,
                     _p_data_size: *mut usize,
@@ -3130,7 +3205,7 @@ impl DeviceFnV1_0 {
                 }
             },
             merge_pipeline_caches: unsafe {
-                extern "system" fn merge_pipeline_caches(
+                unsafe extern "system" fn merge_pipeline_caches(
                     _device: Device,
                     _dst_cache: PipelineCache,
                     _src_cache_count: u32,
@@ -3151,7 +3226,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_graphics_pipelines: unsafe {
-                extern "system" fn create_graphics_pipelines(
+                unsafe extern "system" fn create_graphics_pipelines(
                     _device: Device,
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
@@ -3174,7 +3249,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_compute_pipelines: unsafe {
-                extern "system" fn create_compute_pipelines(
+                unsafe extern "system" fn create_compute_pipelines(
                     _device: Device,
                     _pipeline_cache: PipelineCache,
                     _create_info_count: u32,
@@ -3197,7 +3272,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_pipeline: unsafe {
-                extern "system" fn destroy_pipeline(
+                unsafe extern "system" fn destroy_pipeline(
                     _device: Device,
                     _pipeline: Pipeline,
                     _p_allocator: *const AllocationCallbacks,
@@ -3213,7 +3288,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_pipeline_layout: unsafe {
-                extern "system" fn create_pipeline_layout(
+                unsafe extern "system" fn create_pipeline_layout(
                     _device: Device,
                     _p_create_info: *const PipelineLayoutCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3234,7 +3309,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_pipeline_layout: unsafe {
-                extern "system" fn destroy_pipeline_layout(
+                unsafe extern "system" fn destroy_pipeline_layout(
                     _device: Device,
                     _pipeline_layout: PipelineLayout,
                     _p_allocator: *const AllocationCallbacks,
@@ -3254,7 +3329,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_sampler: unsafe {
-                extern "system" fn create_sampler(
+                unsafe extern "system" fn create_sampler(
                     _device: Device,
                     _p_create_info: *const SamplerCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3271,7 +3346,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_sampler: unsafe {
-                extern "system" fn destroy_sampler(
+                unsafe extern "system" fn destroy_sampler(
                     _device: Device,
                     _sampler: Sampler,
                     _p_allocator: *const AllocationCallbacks,
@@ -3287,7 +3362,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_descriptor_set_layout: unsafe {
-                extern "system" fn create_descriptor_set_layout(
+                unsafe extern "system" fn create_descriptor_set_layout(
                     _device: Device,
                     _p_create_info: *const DescriptorSetLayoutCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3309,7 +3384,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_descriptor_set_layout: unsafe {
-                extern "system" fn destroy_descriptor_set_layout(
+                unsafe extern "system" fn destroy_descriptor_set_layout(
                     _device: Device,
                     _descriptor_set_layout: DescriptorSetLayout,
                     _p_allocator: *const AllocationCallbacks,
@@ -3330,7 +3405,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_descriptor_pool: unsafe {
-                extern "system" fn create_descriptor_pool(
+                unsafe extern "system" fn create_descriptor_pool(
                     _device: Device,
                     _p_create_info: *const DescriptorPoolCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3351,7 +3426,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_descriptor_pool: unsafe {
-                extern "system" fn destroy_descriptor_pool(
+                unsafe extern "system" fn destroy_descriptor_pool(
                     _device: Device,
                     _descriptor_pool: DescriptorPool,
                     _p_allocator: *const AllocationCallbacks,
@@ -3371,7 +3446,7 @@ impl DeviceFnV1_0 {
                 }
             },
             reset_descriptor_pool: unsafe {
-                extern "system" fn reset_descriptor_pool(
+                unsafe extern "system" fn reset_descriptor_pool(
                     _device: Device,
                     _descriptor_pool: DescriptorPool,
                     _flags: DescriptorPoolResetFlags,
@@ -3391,7 +3466,7 @@ impl DeviceFnV1_0 {
                 }
             },
             allocate_descriptor_sets: unsafe {
-                extern "system" fn allocate_descriptor_sets(
+                unsafe extern "system" fn allocate_descriptor_sets(
                     _device: Device,
                     _p_allocate_info: *const DescriptorSetAllocateInfo,
                     _p_descriptor_sets: *mut DescriptorSet,
@@ -3411,7 +3486,7 @@ impl DeviceFnV1_0 {
                 }
             },
             free_descriptor_sets: unsafe {
-                extern "system" fn free_descriptor_sets(
+                unsafe extern "system" fn free_descriptor_sets(
                     _device: Device,
                     _descriptor_pool: DescriptorPool,
                     _descriptor_set_count: u32,
@@ -3429,7 +3504,7 @@ impl DeviceFnV1_0 {
                 }
             },
             update_descriptor_sets: unsafe {
-                extern "system" fn update_descriptor_sets(
+                unsafe extern "system" fn update_descriptor_sets(
                     _device: Device,
                     _descriptor_write_count: u32,
                     _p_descriptor_writes: *const WriteDescriptorSet,
@@ -3451,7 +3526,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_framebuffer: unsafe {
-                extern "system" fn create_framebuffer(
+                unsafe extern "system" fn create_framebuffer(
                     _device: Device,
                     _p_create_info: *const FramebufferCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3469,7 +3544,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_framebuffer: unsafe {
-                extern "system" fn destroy_framebuffer(
+                unsafe extern "system" fn destroy_framebuffer(
                     _device: Device,
                     _framebuffer: Framebuffer,
                     _p_allocator: *const AllocationCallbacks,
@@ -3486,7 +3561,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_render_pass: unsafe {
-                extern "system" fn create_render_pass(
+                unsafe extern "system" fn create_render_pass(
                     _device: Device,
                     _p_create_info: *const RenderPassCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3504,7 +3579,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_render_pass: unsafe {
-                extern "system" fn destroy_render_pass(
+                unsafe extern "system" fn destroy_render_pass(
                     _device: Device,
                     _render_pass: RenderPass,
                     _p_allocator: *const AllocationCallbacks,
@@ -3521,7 +3596,7 @@ impl DeviceFnV1_0 {
                 }
             },
             get_render_area_granularity: unsafe {
-                extern "system" fn get_render_area_granularity(
+                unsafe extern "system" fn get_render_area_granularity(
                     _device: Device,
                     _render_pass: RenderPass,
                     _p_granularity: *mut Extent2D,
@@ -3542,7 +3617,7 @@ impl DeviceFnV1_0 {
                 }
             },
             create_command_pool: unsafe {
-                extern "system" fn create_command_pool(
+                unsafe extern "system" fn create_command_pool(
                     _device: Device,
                     _p_create_info: *const CommandPoolCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -3560,7 +3635,7 @@ impl DeviceFnV1_0 {
                 }
             },
             destroy_command_pool: unsafe {
-                extern "system" fn destroy_command_pool(
+                unsafe extern "system" fn destroy_command_pool(
                     _device: Device,
                     _command_pool: CommandPool,
                     _p_allocator: *const AllocationCallbacks,
@@ -3577,7 +3652,7 @@ impl DeviceFnV1_0 {
                 }
             },
             reset_command_pool: unsafe {
-                extern "system" fn reset_command_pool(
+                unsafe extern "system" fn reset_command_pool(
                     _device: Device,
                     _command_pool: CommandPool,
                     _flags: CommandPoolResetFlags,
@@ -3594,7 +3669,7 @@ impl DeviceFnV1_0 {
                 }
             },
             allocate_command_buffers: unsafe {
-                extern "system" fn allocate_command_buffers(
+                unsafe extern "system" fn allocate_command_buffers(
                     _device: Device,
                     _p_allocate_info: *const CommandBufferAllocateInfo,
                     _p_command_buffers: *mut CommandBuffer,
@@ -3614,7 +3689,7 @@ impl DeviceFnV1_0 {
                 }
             },
             free_command_buffers: unsafe {
-                extern "system" fn free_command_buffers(
+                unsafe extern "system" fn free_command_buffers(
                     _device: Device,
                     _command_pool: CommandPool,
                     _command_buffer_count: u32,
@@ -3632,7 +3707,7 @@ impl DeviceFnV1_0 {
                 }
             },
             begin_command_buffer: unsafe {
-                extern "system" fn begin_command_buffer(
+                unsafe extern "system" fn begin_command_buffer(
                     _command_buffer: CommandBuffer,
                     _p_begin_info: *const CommandBufferBeginInfo,
                 ) -> Result {
@@ -3648,7 +3723,9 @@ impl DeviceFnV1_0 {
                 }
             },
             end_command_buffer: unsafe {
-                extern "system" fn end_command_buffer(_command_buffer: CommandBuffer) -> Result {
+                unsafe extern "system" fn end_command_buffer(
+                    _command_buffer: CommandBuffer,
+                ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(end_command_buffer)))
                 }
                 let cname =
@@ -3661,7 +3738,7 @@ impl DeviceFnV1_0 {
                 }
             },
             reset_command_buffer: unsafe {
-                extern "system" fn reset_command_buffer(
+                unsafe extern "system" fn reset_command_buffer(
                     _command_buffer: CommandBuffer,
                     _flags: CommandBufferResetFlags,
                 ) -> Result {
@@ -3677,7 +3754,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_bind_pipeline: unsafe {
-                extern "system" fn cmd_bind_pipeline(
+                unsafe extern "system" fn cmd_bind_pipeline(
                     _command_buffer: CommandBuffer,
                     _pipeline_bind_point: PipelineBindPoint,
                     _pipeline: Pipeline,
@@ -3693,7 +3770,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_viewport: unsafe {
-                extern "system" fn cmd_set_viewport(
+                unsafe extern "system" fn cmd_set_viewport(
                     _command_buffer: CommandBuffer,
                     _first_viewport: u32,
                     _viewport_count: u32,
@@ -3710,7 +3787,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_scissor: unsafe {
-                extern "system" fn cmd_set_scissor(
+                unsafe extern "system" fn cmd_set_scissor(
                     _command_buffer: CommandBuffer,
                     _first_scissor: u32,
                     _scissor_count: u32,
@@ -3727,7 +3804,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_line_width: unsafe {
-                extern "system" fn cmd_set_line_width(
+                unsafe extern "system" fn cmd_set_line_width(
                     _command_buffer: CommandBuffer,
                     _line_width: f32,
                 ) {
@@ -3742,7 +3819,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_depth_bias: unsafe {
-                extern "system" fn cmd_set_depth_bias(
+                unsafe extern "system" fn cmd_set_depth_bias(
                     _command_buffer: CommandBuffer,
                     _depth_bias_constant_factor: f32,
                     _depth_bias_clamp: f32,
@@ -3759,7 +3836,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_blend_constants: unsafe {
-                extern "system" fn cmd_set_blend_constants(
+                unsafe extern "system" fn cmd_set_blend_constants(
                     _command_buffer: CommandBuffer,
                     _blend_constants: *const [f32; 4],
                 ) {
@@ -3778,7 +3855,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_depth_bounds: unsafe {
-                extern "system" fn cmd_set_depth_bounds(
+                unsafe extern "system" fn cmd_set_depth_bounds(
                     _command_buffer: CommandBuffer,
                     _min_depth_bounds: f32,
                     _max_depth_bounds: f32,
@@ -3795,7 +3872,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_stencil_compare_mask: unsafe {
-                extern "system" fn cmd_set_stencil_compare_mask(
+                unsafe extern "system" fn cmd_set_stencil_compare_mask(
                     _command_buffer: CommandBuffer,
                     _face_mask: StencilFaceFlags,
                     _compare_mask: u32,
@@ -3816,7 +3893,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_stencil_write_mask: unsafe {
-                extern "system" fn cmd_set_stencil_write_mask(
+                unsafe extern "system" fn cmd_set_stencil_write_mask(
                     _command_buffer: CommandBuffer,
                     _face_mask: StencilFaceFlags,
                     _write_mask: u32,
@@ -3836,7 +3913,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_stencil_reference: unsafe {
-                extern "system" fn cmd_set_stencil_reference(
+                unsafe extern "system" fn cmd_set_stencil_reference(
                     _command_buffer: CommandBuffer,
                     _face_mask: StencilFaceFlags,
                     _reference: u32,
@@ -3856,7 +3933,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_bind_descriptor_sets: unsafe {
-                extern "system" fn cmd_bind_descriptor_sets(
+                unsafe extern "system" fn cmd_bind_descriptor_sets(
                     _command_buffer: CommandBuffer,
                     _pipeline_bind_point: PipelineBindPoint,
                     _layout: PipelineLayout,
@@ -3881,7 +3958,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_bind_index_buffer: unsafe {
-                extern "system" fn cmd_bind_index_buffer(
+                unsafe extern "system" fn cmd_bind_index_buffer(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -3902,7 +3979,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_bind_vertex_buffers: unsafe {
-                extern "system" fn cmd_bind_vertex_buffers(
+                unsafe extern "system" fn cmd_bind_vertex_buffers(
                     _command_buffer: CommandBuffer,
                     _first_binding: u32,
                     _binding_count: u32,
@@ -3924,7 +4001,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_draw: unsafe {
-                extern "system" fn cmd_draw(
+                unsafe extern "system" fn cmd_draw(
                     _command_buffer: CommandBuffer,
                     _vertex_count: u32,
                     _instance_count: u32,
@@ -3942,7 +4019,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_draw_indexed: unsafe {
-                extern "system" fn cmd_draw_indexed(
+                unsafe extern "system" fn cmd_draw_indexed(
                     _command_buffer: CommandBuffer,
                     _index_count: u32,
                     _instance_count: u32,
@@ -3961,7 +4038,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_draw_indirect: unsafe {
-                extern "system" fn cmd_draw_indirect(
+                unsafe extern "system" fn cmd_draw_indirect(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -3979,7 +4056,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_draw_indexed_indirect: unsafe {
-                extern "system" fn cmd_draw_indexed_indirect(
+                unsafe extern "system" fn cmd_draw_indexed_indirect(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -4001,7 +4078,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_dispatch: unsafe {
-                extern "system" fn cmd_dispatch(
+                unsafe extern "system" fn cmd_dispatch(
                     _command_buffer: CommandBuffer,
                     _group_count_x: u32,
                     _group_count_y: u32,
@@ -4018,7 +4095,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_dispatch_indirect: unsafe {
-                extern "system" fn cmd_dispatch_indirect(
+                unsafe extern "system" fn cmd_dispatch_indirect(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -4038,7 +4115,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_copy_buffer: unsafe {
-                extern "system" fn cmd_copy_buffer(
+                unsafe extern "system" fn cmd_copy_buffer(
                     _command_buffer: CommandBuffer,
                     _src_buffer: Buffer,
                     _dst_buffer: Buffer,
@@ -4056,7 +4133,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_copy_image: unsafe {
-                extern "system" fn cmd_copy_image(
+                unsafe extern "system" fn cmd_copy_image(
                     _command_buffer: CommandBuffer,
                     _src_image: Image,
                     _src_image_layout: ImageLayout,
@@ -4076,7 +4153,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_blit_image: unsafe {
-                extern "system" fn cmd_blit_image(
+                unsafe extern "system" fn cmd_blit_image(
                     _command_buffer: CommandBuffer,
                     _src_image: Image,
                     _src_image_layout: ImageLayout,
@@ -4097,7 +4174,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_copy_buffer_to_image: unsafe {
-                extern "system" fn cmd_copy_buffer_to_image(
+                unsafe extern "system" fn cmd_copy_buffer_to_image(
                     _command_buffer: CommandBuffer,
                     _src_buffer: Buffer,
                     _dst_image: Image,
@@ -4120,7 +4197,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_copy_image_to_buffer: unsafe {
-                extern "system" fn cmd_copy_image_to_buffer(
+                unsafe extern "system" fn cmd_copy_image_to_buffer(
                     _command_buffer: CommandBuffer,
                     _src_image: Image,
                     _src_image_layout: ImageLayout,
@@ -4143,7 +4220,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_update_buffer: unsafe {
-                extern "system" fn cmd_update_buffer(
+                unsafe extern "system" fn cmd_update_buffer(
                     _command_buffer: CommandBuffer,
                     _dst_buffer: Buffer,
                     _dst_offset: DeviceSize,
@@ -4161,7 +4238,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_fill_buffer: unsafe {
-                extern "system" fn cmd_fill_buffer(
+                unsafe extern "system" fn cmd_fill_buffer(
                     _command_buffer: CommandBuffer,
                     _dst_buffer: Buffer,
                     _dst_offset: DeviceSize,
@@ -4179,7 +4256,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_clear_color_image: unsafe {
-                extern "system" fn cmd_clear_color_image(
+                unsafe extern "system" fn cmd_clear_color_image(
                     _command_buffer: CommandBuffer,
                     _image: Image,
                     _image_layout: ImageLayout,
@@ -4202,7 +4279,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_clear_depth_stencil_image: unsafe {
-                extern "system" fn cmd_clear_depth_stencil_image(
+                unsafe extern "system" fn cmd_clear_depth_stencil_image(
                     _command_buffer: CommandBuffer,
                     _image: Image,
                     _image_layout: ImageLayout,
@@ -4226,7 +4303,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_clear_attachments: unsafe {
-                extern "system" fn cmd_clear_attachments(
+                unsafe extern "system" fn cmd_clear_attachments(
                     _command_buffer: CommandBuffer,
                     _attachment_count: u32,
                     _p_attachments: *const ClearAttachment,
@@ -4248,7 +4325,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_resolve_image: unsafe {
-                extern "system" fn cmd_resolve_image(
+                unsafe extern "system" fn cmd_resolve_image(
                     _command_buffer: CommandBuffer,
                     _src_image: Image,
                     _src_image_layout: ImageLayout,
@@ -4268,7 +4345,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_set_event: unsafe {
-                extern "system" fn cmd_set_event(
+                unsafe extern "system" fn cmd_set_event(
                     _command_buffer: CommandBuffer,
                     _event: Event,
                     _stage_mask: PipelineStageFlags,
@@ -4284,7 +4361,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_reset_event: unsafe {
-                extern "system" fn cmd_reset_event(
+                unsafe extern "system" fn cmd_reset_event(
                     _command_buffer: CommandBuffer,
                     _event: Event,
                     _stage_mask: PipelineStageFlags,
@@ -4300,7 +4377,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_wait_events: unsafe {
-                extern "system" fn cmd_wait_events(
+                unsafe extern "system" fn cmd_wait_events(
                     _command_buffer: CommandBuffer,
                     _event_count: u32,
                     _p_events: *const Event,
@@ -4324,7 +4401,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_pipeline_barrier: unsafe {
-                extern "system" fn cmd_pipeline_barrier(
+                unsafe extern "system" fn cmd_pipeline_barrier(
                     _command_buffer: CommandBuffer,
                     _src_stage_mask: PipelineStageFlags,
                     _dst_stage_mask: PipelineStageFlags,
@@ -4348,7 +4425,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_begin_query: unsafe {
-                extern "system" fn cmd_begin_query(
+                unsafe extern "system" fn cmd_begin_query(
                     _command_buffer: CommandBuffer,
                     _query_pool: QueryPool,
                     _query: u32,
@@ -4365,7 +4442,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_end_query: unsafe {
-                extern "system" fn cmd_end_query(
+                unsafe extern "system" fn cmd_end_query(
                     _command_buffer: CommandBuffer,
                     _query_pool: QueryPool,
                     _query: u32,
@@ -4381,7 +4458,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_reset_query_pool: unsafe {
-                extern "system" fn cmd_reset_query_pool(
+                unsafe extern "system" fn cmd_reset_query_pool(
                     _command_buffer: CommandBuffer,
                     _query_pool: QueryPool,
                     _first_query: u32,
@@ -4399,7 +4476,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_write_timestamp: unsafe {
-                extern "system" fn cmd_write_timestamp(
+                unsafe extern "system" fn cmd_write_timestamp(
                     _command_buffer: CommandBuffer,
                     _pipeline_stage: PipelineStageFlags,
                     _query_pool: QueryPool,
@@ -4417,7 +4494,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_copy_query_pool_results: unsafe {
-                extern "system" fn cmd_copy_query_pool_results(
+                unsafe extern "system" fn cmd_copy_query_pool_results(
                     _command_buffer: CommandBuffer,
                     _query_pool: QueryPool,
                     _first_query: u32,
@@ -4442,7 +4519,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_push_constants: unsafe {
-                extern "system" fn cmd_push_constants(
+                unsafe extern "system" fn cmd_push_constants(
                     _command_buffer: CommandBuffer,
                     _layout: PipelineLayout,
                     _stage_flags: ShaderStageFlags,
@@ -4462,7 +4539,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_begin_render_pass: unsafe {
-                extern "system" fn cmd_begin_render_pass(
+                unsafe extern "system" fn cmd_begin_render_pass(
                     _command_buffer: CommandBuffer,
                     _p_render_pass_begin: *const RenderPassBeginInfo,
                     _contents: SubpassContents,
@@ -4482,7 +4559,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_next_subpass: unsafe {
-                extern "system" fn cmd_next_subpass(
+                unsafe extern "system" fn cmd_next_subpass(
                     _command_buffer: CommandBuffer,
                     _contents: SubpassContents,
                 ) {
@@ -4497,7 +4574,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_end_render_pass: unsafe {
-                extern "system" fn cmd_end_render_pass(_command_buffer: CommandBuffer) {
+                unsafe extern "system" fn cmd_end_render_pass(_command_buffer: CommandBuffer) {
                     panic!(concat!("Unable to load ", stringify!(cmd_end_render_pass)))
                 }
                 let cname =
@@ -4510,7 +4587,7 @@ impl DeviceFnV1_0 {
                 }
             },
             cmd_execute_commands: unsafe {
-                extern "system" fn cmd_execute_commands(
+                unsafe extern "system" fn cmd_execute_commands(
                     _command_buffer: CommandBuffer,
                     _command_buffer_count: u32,
                     _p_command_buffers: *const CommandBuffer,
@@ -5852,9 +5929,10 @@ impl DeviceFnV1_0 {
     }
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkEnumerateInstanceVersion = extern "system" fn(p_api_version: *mut u32) -> Result;
+pub type PFN_vkEnumerateInstanceVersion =
+    unsafe extern "system" fn(p_api_version: *mut u32) -> Result;
 pub struct EntryFnV1_1 {
-    pub enumerate_instance_version: extern "system" fn(p_api_version: *mut u32) -> Result,
+    pub enumerate_instance_version: unsafe extern "system" fn(p_api_version: *mut u32) -> Result,
 }
 unsafe impl Send for EntryFnV1_1 {}
 unsafe impl Sync for EntryFnV1_1 {}
@@ -5872,7 +5950,9 @@ impl EntryFnV1_1 {
     {
         EntryFnV1_1 {
             enumerate_instance_version: unsafe {
-                extern "system" fn enumerate_instance_version(_p_api_version: *mut u32) -> Result {
+                unsafe extern "system" fn enumerate_instance_version(
+                    _p_api_version: *mut u32,
+                ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
                         stringify!(enumerate_instance_version)
@@ -5896,55 +5976,55 @@ impl EntryFnV1_1 {
     }
 }
 pub struct InstanceFnV1_1 {
-    pub enumerate_physical_device_groups: extern "system" fn(
+    pub enumerate_physical_device_groups: unsafe extern "system" fn(
         instance: Instance,
         p_physical_device_group_count: *mut u32,
         p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties,
     ) -> Result,
-    pub get_physical_device_features2: extern "system" fn(
+    pub get_physical_device_features2: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_features: *mut PhysicalDeviceFeatures2,
     ),
-    pub get_physical_device_properties2: extern "system" fn(
+    pub get_physical_device_properties2: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_properties: *mut PhysicalDeviceProperties2,
     ),
-    pub get_physical_device_format_properties2: extern "system" fn(
+    pub get_physical_device_format_properties2: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         format: Format,
         p_format_properties: *mut FormatProperties2,
     ),
-    pub get_physical_device_image_format_properties2: extern "system" fn(
+    pub get_physical_device_image_format_properties2: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_image_format_info: *const PhysicalDeviceImageFormatInfo2,
         p_image_format_properties: *mut ImageFormatProperties2,
     ) -> Result,
-    pub get_physical_device_queue_family_properties2: extern "system" fn(
+    pub get_physical_device_queue_family_properties2: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_queue_family_property_count: *mut u32,
         p_queue_family_properties: *mut QueueFamilyProperties2,
     ),
-    pub get_physical_device_memory_properties2: extern "system" fn(
+    pub get_physical_device_memory_properties2: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_memory_properties: *mut PhysicalDeviceMemoryProperties2,
     ),
-    pub get_physical_device_sparse_image_format_properties2: extern "system" fn(
+    pub get_physical_device_sparse_image_format_properties2: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_format_info: *const PhysicalDeviceSparseImageFormatInfo2,
         p_property_count: *mut u32,
         p_properties: *mut SparseImageFormatProperties2,
     ),
-    pub get_physical_device_external_buffer_properties: extern "system" fn(
+    pub get_physical_device_external_buffer_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo,
         p_external_buffer_properties: *mut ExternalBufferProperties,
     ),
-    pub get_physical_device_external_fence_properties: extern "system" fn(
+    pub get_physical_device_external_fence_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_external_fence_info: *const PhysicalDeviceExternalFenceInfo,
         p_external_fence_properties: *mut ExternalFenceProperties,
     ),
-    pub get_physical_device_external_semaphore_properties: extern "system" fn(
+    pub get_physical_device_external_semaphore_properties: unsafe extern "system" fn(
         physical_device: PhysicalDevice,
         p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo,
         p_external_semaphore_properties: *mut ExternalSemaphoreProperties,
@@ -5982,7 +6062,7 @@ impl InstanceFnV1_1 {
     {
         InstanceFnV1_1 {
             enumerate_physical_device_groups: unsafe {
-                extern "system" fn enumerate_physical_device_groups(
+                unsafe extern "system" fn enumerate_physical_device_groups(
                     _instance: Instance,
                     _p_physical_device_group_count: *mut u32,
                     _p_physical_device_group_properties: *mut PhysicalDeviceGroupProperties,
@@ -6003,7 +6083,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_features2: unsafe {
-                extern "system" fn get_physical_device_features2(
+                unsafe extern "system" fn get_physical_device_features2(
                     _physical_device: PhysicalDevice,
                     _p_features: *mut PhysicalDeviceFeatures2,
                 ) {
@@ -6023,7 +6103,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_properties2: unsafe {
-                extern "system" fn get_physical_device_properties2(
+                unsafe extern "system" fn get_physical_device_properties2(
                     _physical_device: PhysicalDevice,
                     _p_properties: *mut PhysicalDeviceProperties2,
                 ) {
@@ -6043,7 +6123,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_format_properties2: unsafe {
-                extern "system" fn get_physical_device_format_properties2(
+                unsafe extern "system" fn get_physical_device_format_properties2(
                     _physical_device: PhysicalDevice,
                     _format: Format,
                     _p_format_properties: *mut FormatProperties2,
@@ -6064,7 +6144,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_image_format_properties2: unsafe {
-                extern "system" fn get_physical_device_image_format_properties2(
+                unsafe extern "system" fn get_physical_device_image_format_properties2(
                     _physical_device: PhysicalDevice,
                     _p_image_format_info: *const PhysicalDeviceImageFormatInfo2,
                     _p_image_format_properties: *mut ImageFormatProperties2,
@@ -6085,7 +6165,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_queue_family_properties2: unsafe {
-                extern "system" fn get_physical_device_queue_family_properties2(
+                unsafe extern "system" fn get_physical_device_queue_family_properties2(
                     _physical_device: PhysicalDevice,
                     _p_queue_family_property_count: *mut u32,
                     _p_queue_family_properties: *mut QueueFamilyProperties2,
@@ -6106,7 +6186,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_memory_properties2: unsafe {
-                extern "system" fn get_physical_device_memory_properties2(
+                unsafe extern "system" fn get_physical_device_memory_properties2(
                     _physical_device: PhysicalDevice,
                     _p_memory_properties: *mut PhysicalDeviceMemoryProperties2,
                 ) {
@@ -6126,7 +6206,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_sparse_image_format_properties2: unsafe {
-                extern "system" fn get_physical_device_sparse_image_format_properties2(
+                unsafe extern "system" fn get_physical_device_sparse_image_format_properties2(
                     _physical_device: PhysicalDevice,
                     _p_format_info: *const PhysicalDeviceSparseImageFormatInfo2,
                     _p_property_count: *mut u32,
@@ -6148,7 +6228,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_external_buffer_properties: unsafe {
-                extern "system" fn get_physical_device_external_buffer_properties(
+                unsafe extern "system" fn get_physical_device_external_buffer_properties(
                     _physical_device: PhysicalDevice,
                     _p_external_buffer_info: *const PhysicalDeviceExternalBufferInfo,
                     _p_external_buffer_properties: *mut ExternalBufferProperties,
@@ -6169,7 +6249,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_external_fence_properties: unsafe {
-                extern "system" fn get_physical_device_external_fence_properties(
+                unsafe extern "system" fn get_physical_device_external_fence_properties(
                     _physical_device: PhysicalDevice,
                     _p_external_fence_info: *const PhysicalDeviceExternalFenceInfo,
                     _p_external_fence_properties: *mut ExternalFenceProperties,
@@ -6190,7 +6270,7 @@ impl InstanceFnV1_1 {
                 }
             },
             get_physical_device_external_semaphore_properties: unsafe {
-                extern "system" fn get_physical_device_external_semaphore_properties(
+                unsafe extern "system" fn get_physical_device_external_semaphore_properties(
                     _physical_device: PhysicalDevice,
                     _p_external_semaphore_info: *const PhysicalDeviceExternalSemaphoreInfo,
                     _p_external_semaphore_properties: *mut ExternalSemaphoreProperties,
@@ -6340,31 +6420,32 @@ impl InstanceFnV1_1 {
     }
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceQueue2 = extern "system" fn(
+pub type PFN_vkGetDeviceQueue2 = unsafe extern "system" fn(
     device: Device,
     bind_info_count: u32,
     p_bind_infos: *const BindBufferMemoryInfo,
 ) -> Result;
 pub struct DeviceFnV1_1 {
-    pub bind_buffer_memory2: extern "system" fn(
+    pub bind_buffer_memory2: unsafe extern "system" fn(
         device: Device,
         bind_info_count: u32,
         p_bind_infos: *const BindBufferMemoryInfo,
     ) -> Result,
-    pub bind_image_memory2: extern "system" fn(
+    pub bind_image_memory2: unsafe extern "system" fn(
         device: Device,
         bind_info_count: u32,
         p_bind_infos: *const BindImageMemoryInfo,
     ) -> Result,
-    pub get_device_group_peer_memory_features: extern "system" fn(
+    pub get_device_group_peer_memory_features: unsafe extern "system" fn(
         device: Device,
         heap_index: u32,
         local_device_index: u32,
         remote_device_index: u32,
         p_peer_memory_features: *mut PeerMemoryFeatureFlags,
     ),
-    pub cmd_set_device_mask: extern "system" fn(command_buffer: CommandBuffer, device_mask: u32),
-    pub cmd_dispatch_base: extern "system" fn(
+    pub cmd_set_device_mask:
+        unsafe extern "system" fn(command_buffer: CommandBuffer, device_mask: u32),
+    pub cmd_dispatch_base: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         base_group_x: u32,
         base_group_y: u32,
@@ -6373,58 +6454,61 @@ pub struct DeviceFnV1_1 {
         group_count_y: u32,
         group_count_z: u32,
     ),
-    pub get_image_memory_requirements2: extern "system" fn(
+    pub get_image_memory_requirements2: unsafe extern "system" fn(
         device: Device,
         p_info: *const ImageMemoryRequirementsInfo2,
         p_memory_requirements: *mut MemoryRequirements2,
     ),
-    pub get_buffer_memory_requirements2: extern "system" fn(
+    pub get_buffer_memory_requirements2: unsafe extern "system" fn(
         device: Device,
         p_info: *const BufferMemoryRequirementsInfo2,
         p_memory_requirements: *mut MemoryRequirements2,
     ),
-    pub get_image_sparse_memory_requirements2: extern "system" fn(
+    pub get_image_sparse_memory_requirements2: unsafe extern "system" fn(
         device: Device,
         p_info: *const ImageSparseMemoryRequirementsInfo2,
         p_sparse_memory_requirement_count: *mut u32,
         p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
     ),
-    pub trim_command_pool:
-        extern "system" fn(device: Device, command_pool: CommandPool, flags: CommandPoolTrimFlags),
-    pub get_device_queue2: extern "system" fn(
+    pub trim_command_pool: unsafe extern "system" fn(
+        device: Device,
+        command_pool: CommandPool,
+        flags: CommandPoolTrimFlags,
+    ),
+    pub get_device_queue2: unsafe extern "system" fn(
         device: Device,
         p_queue_info: *const DeviceQueueInfo2,
         p_queue: *mut Queue,
     ),
-    pub create_sampler_ycbcr_conversion: extern "system" fn(
+    pub create_sampler_ycbcr_conversion: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const SamplerYcbcrConversionCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_ycbcr_conversion: *mut SamplerYcbcrConversion,
     ) -> Result,
-    pub destroy_sampler_ycbcr_conversion: extern "system" fn(
+    pub destroy_sampler_ycbcr_conversion: unsafe extern "system" fn(
         device: Device,
         ycbcr_conversion: SamplerYcbcrConversion,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub create_descriptor_update_template: extern "system" fn(
+    pub create_descriptor_update_template: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const DescriptorUpdateTemplateCreateInfo,
         p_allocator: *const AllocationCallbacks,
         p_descriptor_update_template: *mut DescriptorUpdateTemplate,
     ) -> Result,
-    pub destroy_descriptor_update_template: extern "system" fn(
+    pub destroy_descriptor_update_template: unsafe extern "system" fn(
         device: Device,
         descriptor_update_template: DescriptorUpdateTemplate,
         p_allocator: *const AllocationCallbacks,
     ),
-    pub update_descriptor_set_with_template: extern "system" fn(
+    pub update_descriptor_set_with_template: unsafe extern "system" fn(
         device: Device,
         descriptor_set: DescriptorSet,
         descriptor_update_template: DescriptorUpdateTemplate,
         p_data: *const c_void,
     ),
-    pub get_descriptor_set_layout_support: extern "system" fn(
+    pub get_descriptor_set_layout_support: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const DescriptorSetLayoutCreateInfo,
         p_support: *mut DescriptorSetLayoutSupport,
@@ -6461,7 +6545,7 @@ impl DeviceFnV1_1 {
     {
         DeviceFnV1_1 {
             bind_buffer_memory2: unsafe {
-                extern "system" fn bind_buffer_memory2(
+                unsafe extern "system" fn bind_buffer_memory2(
                     _device: Device,
                     _bind_info_count: u32,
                     _p_bind_infos: *const BindBufferMemoryInfo,
@@ -6478,7 +6562,7 @@ impl DeviceFnV1_1 {
                 }
             },
             bind_image_memory2: unsafe {
-                extern "system" fn bind_image_memory2(
+                unsafe extern "system" fn bind_image_memory2(
                     _device: Device,
                     _bind_info_count: u32,
                     _p_bind_infos: *const BindImageMemoryInfo,
@@ -6495,7 +6579,7 @@ impl DeviceFnV1_1 {
                 }
             },
             get_device_group_peer_memory_features: unsafe {
-                extern "system" fn get_device_group_peer_memory_features(
+                unsafe extern "system" fn get_device_group_peer_memory_features(
                     _device: Device,
                     _heap_index: u32,
                     _local_device_index: u32,
@@ -6518,7 +6602,7 @@ impl DeviceFnV1_1 {
                 }
             },
             cmd_set_device_mask: unsafe {
-                extern "system" fn cmd_set_device_mask(
+                unsafe extern "system" fn cmd_set_device_mask(
                     _command_buffer: CommandBuffer,
                     _device_mask: u32,
                 ) {
@@ -6534,7 +6618,7 @@ impl DeviceFnV1_1 {
                 }
             },
             cmd_dispatch_base: unsafe {
-                extern "system" fn cmd_dispatch_base(
+                unsafe extern "system" fn cmd_dispatch_base(
                     _command_buffer: CommandBuffer,
                     _base_group_x: u32,
                     _base_group_y: u32,
@@ -6554,7 +6638,7 @@ impl DeviceFnV1_1 {
                 }
             },
             get_image_memory_requirements2: unsafe {
-                extern "system" fn get_image_memory_requirements2(
+                unsafe extern "system" fn get_image_memory_requirements2(
                     _device: Device,
                     _p_info: *const ImageMemoryRequirementsInfo2,
                     _p_memory_requirements: *mut MemoryRequirements2,
@@ -6575,7 +6659,7 @@ impl DeviceFnV1_1 {
                 }
             },
             get_buffer_memory_requirements2: unsafe {
-                extern "system" fn get_buffer_memory_requirements2(
+                unsafe extern "system" fn get_buffer_memory_requirements2(
                     _device: Device,
                     _p_info: *const BufferMemoryRequirementsInfo2,
                     _p_memory_requirements: *mut MemoryRequirements2,
@@ -6596,7 +6680,7 @@ impl DeviceFnV1_1 {
                 }
             },
             get_image_sparse_memory_requirements2: unsafe {
-                extern "system" fn get_image_sparse_memory_requirements2(
+                unsafe extern "system" fn get_image_sparse_memory_requirements2(
                     _device: Device,
                     _p_info: *const ImageSparseMemoryRequirementsInfo2,
                     _p_sparse_memory_requirement_count: *mut u32,
@@ -6618,7 +6702,7 @@ impl DeviceFnV1_1 {
                 }
             },
             trim_command_pool: unsafe {
-                extern "system" fn trim_command_pool(
+                unsafe extern "system" fn trim_command_pool(
                     _device: Device,
                     _command_pool: CommandPool,
                     _flags: CommandPoolTrimFlags,
@@ -6634,7 +6718,7 @@ impl DeviceFnV1_1 {
                 }
             },
             get_device_queue2: unsafe {
-                extern "system" fn get_device_queue2(
+                unsafe extern "system" fn get_device_queue2(
                     _device: Device,
                     _p_queue_info: *const DeviceQueueInfo2,
                     _p_queue: *mut Queue,
@@ -6650,7 +6734,7 @@ impl DeviceFnV1_1 {
                 }
             },
             create_sampler_ycbcr_conversion: unsafe {
-                extern "system" fn create_sampler_ycbcr_conversion(
+                unsafe extern "system" fn create_sampler_ycbcr_conversion(
                     _device: Device,
                     _p_create_info: *const SamplerYcbcrConversionCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -6672,7 +6756,7 @@ impl DeviceFnV1_1 {
                 }
             },
             destroy_sampler_ycbcr_conversion: unsafe {
-                extern "system" fn destroy_sampler_ycbcr_conversion(
+                unsafe extern "system" fn destroy_sampler_ycbcr_conversion(
                     _device: Device,
                     _ycbcr_conversion: SamplerYcbcrConversion,
                     _p_allocator: *const AllocationCallbacks,
@@ -6693,7 +6777,7 @@ impl DeviceFnV1_1 {
                 }
             },
             create_descriptor_update_template: unsafe {
-                extern "system" fn create_descriptor_update_template(
+                unsafe extern "system" fn create_descriptor_update_template(
                     _device: Device,
                     _p_create_info: *const DescriptorUpdateTemplateCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
@@ -6715,7 +6799,7 @@ impl DeviceFnV1_1 {
                 }
             },
             destroy_descriptor_update_template: unsafe {
-                extern "system" fn destroy_descriptor_update_template(
+                unsafe extern "system" fn destroy_descriptor_update_template(
                     _device: Device,
                     _descriptor_update_template: DescriptorUpdateTemplate,
                     _p_allocator: *const AllocationCallbacks,
@@ -6736,7 +6820,7 @@ impl DeviceFnV1_1 {
                 }
             },
             update_descriptor_set_with_template: unsafe {
-                extern "system" fn update_descriptor_set_with_template(
+                unsafe extern "system" fn update_descriptor_set_with_template(
                     _device: Device,
                     _descriptor_set: DescriptorSet,
                     _descriptor_update_template: DescriptorUpdateTemplate,
@@ -6758,7 +6842,7 @@ impl DeviceFnV1_1 {
                 }
             },
             get_descriptor_set_layout_support: unsafe {
-                extern "system" fn get_descriptor_set_layout_support(
+                unsafe extern "system" fn get_descriptor_set_layout_support(
                     _device: Device,
                     _p_create_info: *const DescriptorSetLayoutCreateInfo,
                     _p_support: *mut DescriptorSetLayoutSupport,
@@ -6997,7 +7081,7 @@ impl InstanceFnV1_2 {
     }
 }
 pub struct DeviceFnV1_2 {
-    pub cmd_draw_indirect_count: extern "system" fn(
+    pub cmd_draw_indirect_count: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
@@ -7006,7 +7090,7 @@ pub struct DeviceFnV1_2 {
         max_draw_count: u32,
         stride: u32,
     ),
-    pub cmd_draw_indexed_indirect_count: extern "system" fn(
+    pub cmd_draw_indexed_indirect_count: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         buffer: Buffer,
         offset: DeviceSize,
@@ -7015,46 +7099,53 @@ pub struct DeviceFnV1_2 {
         max_draw_count: u32,
         stride: u32,
     ),
-    pub create_render_pass2: extern "system" fn(
+    pub create_render_pass2: unsafe extern "system" fn(
         device: Device,
         p_create_info: *const RenderPassCreateInfo2,
         p_allocator: *const AllocationCallbacks,
         p_render_pass: *mut RenderPass,
     ) -> Result,
-    pub cmd_begin_render_pass2: extern "system" fn(
+    pub cmd_begin_render_pass2: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_render_pass_begin: *const RenderPassBeginInfo,
         p_subpass_begin_info: *const SubpassBeginInfo,
     ),
-    pub cmd_next_subpass2: extern "system" fn(
+    pub cmd_next_subpass2: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_subpass_begin_info: *const SubpassBeginInfo,
         p_subpass_end_info: *const SubpassEndInfo,
     ),
-    pub cmd_end_render_pass2: extern "system" fn(
+    pub cmd_end_render_pass2: unsafe extern "system" fn(
         command_buffer: CommandBuffer,
         p_subpass_end_info: *const SubpassEndInfo,
     ),
-    pub reset_query_pool: extern "system" fn(
+    pub reset_query_pool: unsafe extern "system" fn(
         device: Device,
         query_pool: QueryPool,
         first_query: u32,
         query_count: u32,
     ),
-    pub get_semaphore_counter_value:
-        extern "system" fn(device: Device, semaphore: Semaphore, p_value: *mut u64) -> Result,
-    pub wait_semaphores: extern "system" fn(
+    pub get_semaphore_counter_value: unsafe extern "system" fn(
+        device: Device,
+        semaphore: Semaphore,
+        p_value: *mut u64,
+    ) -> Result,
+    pub wait_semaphores: unsafe extern "system" fn(
         device: Device,
         p_wait_info: *const SemaphoreWaitInfo,
         timeout: u64,
     ) -> Result,
-    pub signal_semaphore:
-        extern "system" fn(device: Device, p_signal_info: *const SemaphoreSignalInfo) -> Result,
-    pub get_buffer_device_address:
-        extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> DeviceAddress,
+    pub signal_semaphore: unsafe extern "system" fn(
+        device: Device,
+        p_signal_info: *const SemaphoreSignalInfo,
+    ) -> Result,
+    pub get_buffer_device_address: unsafe extern "system" fn(
+        device: Device,
+        p_info: *const BufferDeviceAddressInfo,
+    ) -> DeviceAddress,
     pub get_buffer_opaque_capture_address:
-        extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> u64,
-    pub get_device_memory_opaque_capture_address: extern "system" fn(
+        unsafe extern "system" fn(device: Device, p_info: *const BufferDeviceAddressInfo) -> u64,
+    pub get_device_memory_opaque_capture_address: unsafe extern "system" fn(
         device: Device,
         p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
     ) -> u64,
@@ -7087,7 +7178,7 @@ impl DeviceFnV1_2 {
     {
         DeviceFnV1_2 {
             cmd_draw_indirect_count: unsafe {
-                extern "system" fn cmd_draw_indirect_count(
+                unsafe extern "system" fn cmd_draw_indirect_count(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -7111,7 +7202,7 @@ impl DeviceFnV1_2 {
                 }
             },
             cmd_draw_indexed_indirect_count: unsafe {
-                extern "system" fn cmd_draw_indexed_indirect_count(
+                unsafe extern "system" fn cmd_draw_indexed_indirect_count(
                     _command_buffer: CommandBuffer,
                     _buffer: Buffer,
                     _offset: DeviceSize,
@@ -7136,7 +7227,7 @@ impl DeviceFnV1_2 {
                 }
             },
             create_render_pass2: unsafe {
-                extern "system" fn create_render_pass2(
+                unsafe extern "system" fn create_render_pass2(
                     _device: Device,
                     _p_create_info: *const RenderPassCreateInfo2,
                     _p_allocator: *const AllocationCallbacks,
@@ -7154,7 +7245,7 @@ impl DeviceFnV1_2 {
                 }
             },
             cmd_begin_render_pass2: unsafe {
-                extern "system" fn cmd_begin_render_pass2(
+                unsafe extern "system" fn cmd_begin_render_pass2(
                     _command_buffer: CommandBuffer,
                     _p_render_pass_begin: *const RenderPassBeginInfo,
                     _p_subpass_begin_info: *const SubpassBeginInfo,
@@ -7174,7 +7265,7 @@ impl DeviceFnV1_2 {
                 }
             },
             cmd_next_subpass2: unsafe {
-                extern "system" fn cmd_next_subpass2(
+                unsafe extern "system" fn cmd_next_subpass2(
                     _command_buffer: CommandBuffer,
                     _p_subpass_begin_info: *const SubpassBeginInfo,
                     _p_subpass_end_info: *const SubpassEndInfo,
@@ -7190,7 +7281,7 @@ impl DeviceFnV1_2 {
                 }
             },
             cmd_end_render_pass2: unsafe {
-                extern "system" fn cmd_end_render_pass2(
+                unsafe extern "system" fn cmd_end_render_pass2(
                     _command_buffer: CommandBuffer,
                     _p_subpass_end_info: *const SubpassEndInfo,
                 ) {
@@ -7206,7 +7297,7 @@ impl DeviceFnV1_2 {
                 }
             },
             reset_query_pool: unsafe {
-                extern "system" fn reset_query_pool(
+                unsafe extern "system" fn reset_query_pool(
                     _device: Device,
                     _query_pool: QueryPool,
                     _first_query: u32,
@@ -7223,7 +7314,7 @@ impl DeviceFnV1_2 {
                 }
             },
             get_semaphore_counter_value: unsafe {
-                extern "system" fn get_semaphore_counter_value(
+                unsafe extern "system" fn get_semaphore_counter_value(
                     _device: Device,
                     _semaphore: Semaphore,
                     _p_value: *mut u64,
@@ -7244,7 +7335,7 @@ impl DeviceFnV1_2 {
                 }
             },
             wait_semaphores: unsafe {
-                extern "system" fn wait_semaphores(
+                unsafe extern "system" fn wait_semaphores(
                     _device: Device,
                     _p_wait_info: *const SemaphoreWaitInfo,
                     _timeout: u64,
@@ -7260,7 +7351,7 @@ impl DeviceFnV1_2 {
                 }
             },
             signal_semaphore: unsafe {
-                extern "system" fn signal_semaphore(
+                unsafe extern "system" fn signal_semaphore(
                     _device: Device,
                     _p_signal_info: *const SemaphoreSignalInfo,
                 ) -> Result {
@@ -7275,7 +7366,7 @@ impl DeviceFnV1_2 {
                 }
             },
             get_buffer_device_address: unsafe {
-                extern "system" fn get_buffer_device_address(
+                unsafe extern "system" fn get_buffer_device_address(
                     _device: Device,
                     _p_info: *const BufferDeviceAddressInfo,
                 ) -> DeviceAddress {
@@ -7294,7 +7385,7 @@ impl DeviceFnV1_2 {
                 }
             },
             get_buffer_opaque_capture_address: unsafe {
-                extern "system" fn get_buffer_opaque_capture_address(
+                unsafe extern "system" fn get_buffer_opaque_capture_address(
                     _device: Device,
                     _p_info: *const BufferDeviceAddressInfo,
                 ) -> u64 {
@@ -7314,7 +7405,7 @@ impl DeviceFnV1_2 {
                 }
             },
             get_device_memory_opaque_capture_address: unsafe {
-                extern "system" fn get_device_memory_opaque_capture_address(
+                unsafe extern "system" fn get_device_memory_opaque_capture_address(
                     _device: Device,
                     _p_info: *const DeviceMemoryOpaqueCaptureAddressInfo,
                 ) -> u64 {

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -969,12 +969,12 @@ fn generate_function_pointers<'a>(
     quote! {
         #(
             #[allow(non_camel_case_types)]
-            pub type #pfn_names_ref = extern "system" fn(#(#signature_params_ref),*) #return_types_ref;
+            pub type #pfn_names_ref = unsafe extern "system" fn(#(#signature_params_ref),*) #return_types_ref;
         )*
 
         pub struct #ident {
             #(
-                pub #names_ref: extern "system" fn(#expanded_params_ref) #return_types_ref,
+                pub #names_ref: unsafe extern "system" fn(#expanded_params_ref) #return_types_ref,
             )*
         }
 
@@ -996,7 +996,7 @@ fn generate_function_pointers<'a>(
                     #(
                         #names_ref: unsafe {
 
-                            extern "system" fn #names_ref (#expanded_params_unused) #return_types_ref {
+                            unsafe extern "system" fn #names_ref (#expanded_params_unused) #return_types_ref {
                                 panic!(concat!("Unable to load ", stringify!(#names_ref)))
                             }
                             let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(#raw_names_ref);


### PR DESCRIPTION
Depends on #439

Rusty wrappers are already marked `unsafe`, and by definition the raw Vulkan function pointers used under the hood are `unsafe` too.  Not needing `unsafe` when going directly through `self.fp_v1_x()` is odd at best.
