### PR TITLE
Update ash-window version in README.md

### DIFF
--- a/ash-window/README.md
+++ b/ash-window/README.md
@@ -22,7 +22,7 @@
 Interoperability between [`ash`](https://github.com/MaikKlein/ash) and [`raw-window-handle`](https://github.com/rust-windowing/raw-window-handle) for surface creation.
 
 ```toml
-ash-window = "0.4"
+ash-window = "0.6"
 ```
 
 ## Usage


### PR DESCRIPTION
Update from 0.4 to 0.6. 

I read the README.md and copied the Cargo.toml line because that is just what I saw, instead of using the latest version. So I was using 0.4, and had trouble getting `create_surface` to work. Worked after updating to 0.6 with no other changes. (Very) small change but hopefully it helps others avoid the same problem in the future.  