### PR TITLE
Unify readme between Ash and Ash-window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# Ash
+Ash
+=
 
 A very lightweight wrapper around Vulkan
+-
 
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
-[![LICENSE](https://img.shields.io/badge/license-apache-blue.svg)](LICENSE-APACHE)
+[![Crates.io Version](https://img.shields.io/crates/v/ash.svg)](https://crates.io/crates/ash)
 [![Documentation](https://docs.rs/ash/badge.svg)](https://docs.rs/ash)
 [![Build Status](https://github.com/MaikKlein/ash/workflows/CI/badge.svg)](https://github.com/MaikKlein/ash/actions?workflow=CI)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
+[![LICENSE](https://img.shields.io/badge/license-apache-blue.svg)](LICENSE-APACHE)
 [![Join the chat at https://gitter.im/MaikKlein/ash](https://badges.gitter.im/MaikKlein/ash.svg)](https://gitter.im/MaikKlein/ash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Crates.io Version](https://img.shields.io/crates/v/ash.svg)](https://crates.io/crates/ash)
 
 ## Overview
 - [x] A true Vulkan API without compromises
@@ -72,7 +74,7 @@ let desc_alloc_info = vk::DescriptorSetAllocateInfo {
 ### Builder pattern
 
 ```rust
-// We lose all lifetime information when we call `.build()`. Be carefull!
+// We lose all lifetime information when we call `.build()`. Be careful!
 let queue_info = [vk::DeviceQueueCreateInfo::builder()
     .queue_family_index(queue_family_index)
     .queue_priorities(&priorities)
@@ -259,7 +261,7 @@ cargo run --bin texture
 ### Utility libraries
 * [vk-sync](https://github.com/gwihlidal/vk-sync-rs) - Simplified Vulkan synchronization logic, written in rust.
 * [vk-mem-rs](https://github.com/gwihlidal/vk-mem-rs) - This crate provides an FFI layer and idiomatic rust wrappers for the excellent AMD Vulkan Memory Allocator (VMA) C/C++ library.
-* [gpu-alloactor](https://github.com/Traverse-Research/gpu-allocator) - Memory allocator written in pure Rust for GPU memory in Vulkan and in the future DirectX 12
+* [gpu-allocator](https://github.com/Traverse-Research/gpu-allocator) - Memory allocator written in pure Rust for GPU memory in Vulkan and in the future DirectX 12
 * [lahar](https://github.com/Ralith/lahar) - Tools for asynchronously uploading data to a Vulkan device.
 
 ### Libraries that use ash

--- a/ash-window/README.md
+++ b/ash-window/README.md
@@ -1,45 +1,39 @@
-
-<h1 align="center">ash-window</h1>
-<p align="center">
-    <a href="https://crates.io/crates/ash-window">
-      <img src="https://img.shields.io/crates/v/ash-window?style=flat-square" alt = "crates.io">
-    </a>
-    <a href="https://docs.rs/ash-window">
-      <img src="https://docs.rs/ash-window/badge.svg?style=flat-square" alt="docs">
-    </a>
-    <a href="https://github.com/MaikKlein/ash/actions">
-      <img src="https://github.com/MaikKlein/ash/workflows/CI/badge.svg?style=flat" alt="ci">
-    </a>
-    <br>
-    <a href="LICENSE-MIT">
-      <img src="https://img.shields.io/badge/license-MIT-green.svg?style=flat-square" alt="License - MIT">
-    </a>
-    <a href="LICENSE-APACHE">
-      <img src="https://img.shields.io/badge/license-APACHE2-green.svg?style=flat-square" alt="License - Apache2">
-    </a>
-</p>
+Ash-window
+=
 
 Interoperability between [`ash`](https://github.com/MaikKlein/ash) and [`raw-window-handle`](https://github.com/rust-windowing/raw-window-handle) for surface creation.
+-
 
-```toml
-ash-window = "0.4"
-```
+[![Crates.io Version](https://img.shields.io/crates/v/ash-window.svg)](https://crates.io/crates/ash-window)
+[![Documentation](https://docs.rs/ash-window/badge.svg)](https://docs.rs/ash-window)
+[![Build Status](https://github.com/MaikKlein/ash/workflows/CI/badge.svg)](https://github.com/MaikKlein/ash/actions?workflow=CI)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE-MIT)
+[![LICENSE](https://img.shields.io/badge/license-apache-blue.svg)](LICENSE-APACHE)
+[![Join the chat at https://gitter.im/MaikKlein/ash-window](https://badges.gitter.im/MaikKlein/ash-window.svg)](https://gitter.im/MaikKlein/ash-window?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Usage
 
+```toml
+ash-window = "0.6"
+```
+
 The library exposes two functions:
 
-- `enumerate_required_extensions` returns the required instance extensions needed for surface creation from a specific window handle.
+- [`enumerate_required_extensions`] returns the required instance extensions needed for surface creation from a specific window handle.
 
-- `create_surface` allows to create a surface from a type implementing `HasRawWindowHandle`
+- [`create_surface`] allows to create a surface from a type implementing [`HasRawWindowHandle`]:
 
-```rust
-ash_window::create_surface(&entry, &instance, &window, None)?;
-```
+  ```rust
+  ash_window::create_surface(&entry, &instance, &window, None)?;
+  ```
+
+[`enumerate_required_extensions`]: https://docs.rs/ash-window/latest/ash_window/fn.enumerate_required_extensions.html
+[`create_surface`]: https://docs.rs/ash-window/latest/ash_window/fn.create_surface.html
+[`HasRawWindowHandle`]: https://docs.rs/raw-window-handle/latest/raw_window_handle/trait.HasRawWindowHandle.html
 
 ## Versions
 ```toml
-ash = "0.31"
+ash = "0.32.1"
 raw-window-handle = "0.3"
 ```
 


### PR DESCRIPTION
Draft to see how it renders.  Includes some typo fixes.


We'll have to work out how to bump `toml` crate dependency versions going forward; [`cargo-release`](https://github.com/sunng87/cargo-release) is capable of bumping these before a release.
