### PR TITLE
Expose LIB_PATH

### DIFF
--- a/ash/src/entry_libloading.rs
+++ b/ash/src/entry_libloading.rs
@@ -8,19 +8,19 @@ use std::ptr;
 use std::sync::Arc;
 
 #[cfg(windows)]
-const LIB_PATH: &str = "vulkan-1.dll";
+pub const LIB_PATH: &str = "vulkan-1.dll";
 
 #[cfg(all(
     unix,
     not(any(target_os = "macos", target_os = "ios", target_os = "android"))
 ))]
-const LIB_PATH: &str = "libvulkan.so.1";
+pub const LIB_PATH: &str = "libvulkan.so.1";
 
 #[cfg(target_os = "android")]
-const LIB_PATH: &str = "libvulkan.so";
+pub const LIB_PATH: &str = "libvulkan.so";
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-const LIB_PATH: &str = "libvulkan.dylib";
+pub const LIB_PATH: &str = "libvulkan.dylib";
 
 #[derive(Debug)]
 pub enum LoadingError {

--- a/ash/src/lib.rs
+++ b/ash/src/lib.rs
@@ -35,7 +35,7 @@
 pub use crate::device::Device;
 pub use crate::entry::{EntryCustom, InstanceError};
 #[cfg(feature = "libloading")]
-pub use crate::entry_libloading::{Entry, LoadingError};
+pub use crate::entry_libloading::{Entry, LoadingError, LIB_PATH};
 pub use crate::instance::Instance;
 
 mod device;


### PR DESCRIPTION
Objective: Construct a `EntryCustom<Option<Arc<Library>>>` used to store an either locally or externally managed entry point.

`LIB_PATH` constants are used internally by `Entry::new()`. This PR exposes these constants to be used conditionally with `EntryCustom::new_custom()`, without having to redefine them.