### PR TITLE
util: Zero-initialize result to prevent possible uninit memory read

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- util: Zero-initialize result to prevent possible uninit memory read (#470)
+
 ## [0.33.0] - 2021-07-30
 
 ### Added


### PR DESCRIPTION
Fixes https://github.com/MaikKlein/ash/issues/354

`io::Read::read_exact` does not receive `MaybeUninit` memory and a trait implementation can possibly read from our uninitialized vector without `unsafe`, which is UB.  As there is no proper solution to this problem yet (see linked issue), our safest bet is to just take the perf-hit and zero-initialize this vector.
