### PR TITLE
ash: Regenerate negative constants with `syn 1.0.81`

### DIFF
--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -236,11 +236,11 @@ impl KhrSurfaceFn {
 }
 #[doc = "Generated from 'VK_KHR_surface'"]
 impl Result {
-    pub const ERROR_SURFACE_LOST_KHR: Self = Self(-1000000000);
+    pub const ERROR_SURFACE_LOST_KHR: Self = Self(-1_000_000_000);
 }
 #[doc = "Generated from 'VK_KHR_surface'"]
 impl Result {
-    pub const ERROR_NATIVE_WINDOW_IN_USE_KHR: Self = Self(-1000000001);
+    pub const ERROR_NATIVE_WINDOW_IN_USE_KHR: Self = Self(-1_000_000_001);
 }
 #[doc = "Generated from 'VK_KHR_surface'"]
 impl ObjectType {
@@ -628,7 +628,7 @@ impl Result {
 }
 #[doc = "Generated from 'VK_KHR_swapchain'"]
 impl Result {
-    pub const ERROR_OUT_OF_DATE_KHR: Self = Self(-1000001004);
+    pub const ERROR_OUT_OF_DATE_KHR: Self = Self(-1_000_001_004);
 }
 #[doc = "Generated from 'VK_KHR_swapchain'"]
 impl ObjectType {
@@ -1078,7 +1078,7 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_KHR_display_swapchain'"]
 impl Result {
-    pub const ERROR_INCOMPATIBLE_DISPLAY_KHR: Self = Self(-1000003001);
+    pub const ERROR_INCOMPATIBLE_DISPLAY_KHR: Self = Self(-1_000_003_001);
 }
 impl KhrXlibSurfaceFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -1975,7 +1975,7 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_EXT_debug_report'"]
 impl Result {
-    pub const ERROR_VALIDATION_FAILED_EXT: Self = Self(-1000011001);
+    pub const ERROR_VALIDATION_FAILED_EXT: Self = Self(-1_000_011_001);
 }
 #[doc = "Generated from 'VK_EXT_debug_report'"]
 impl ObjectType {
@@ -2010,7 +2010,7 @@ impl NvGlslShaderFn {
 }
 #[doc = "Generated from 'VK_NV_glsl_shader'"]
 impl Result {
-    pub const ERROR_INVALID_SHADER_NV: Self = Self(-1000012000);
+    pub const ERROR_INVALID_SHADER_NV: Self = Self(-1_000_012_000);
 }
 impl ExtDepthRangeUnrestrictedFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -13137,7 +13137,7 @@ impl ExtImageDrmFormatModifierFn {
 }
 #[doc = "Generated from 'VK_EXT_image_drm_format_modifier'"]
 impl Result {
-    pub const ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT: Self = Self(-1000158000);
+    pub const ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT: Self = Self(-1_000_158_000);
 }
 #[doc = "Generated from 'VK_EXT_image_drm_format_modifier'"]
 impl StructureType {
@@ -14854,7 +14854,7 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_EXT_global_priority'"]
 impl Result {
-    pub const ERROR_NOT_PERMITTED_EXT: Self = Self(-1000174001);
+    pub const ERROR_NOT_PERMITTED_EXT: Self = Self(-1_000_174_001);
 }
 impl KhrShaderSubgroupExtendedTypesFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -18491,7 +18491,7 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_EXT_full_screen_exclusive'"]
 impl Result {
-    pub const ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT: Self = Self(-1000255000);
+    pub const ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT: Self = Self(-1_000_255_000);
 }
 #[doc = "Generated from 'VK_EXT_full_screen_exclusive'"]
 impl StructureType {

--- a/ash/src/vk/feature_extensions.rs
+++ b/ash/src/vk/feature_extensions.rs
@@ -142,7 +142,7 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_VERSION_1_1'"]
 impl Result {
-    pub const ERROR_OUT_OF_POOL_MEMORY: Self = Self(-1000069000);
+    pub const ERROR_OUT_OF_POOL_MEMORY: Self = Self(-1_000_069_000);
 }
 #[doc = "Generated from 'VK_VERSION_1_1'"]
 impl FormatFeatureFlags {
@@ -506,7 +506,7 @@ impl StructureType {
 }
 #[doc = "Generated from 'VK_VERSION_1_1'"]
 impl Result {
-    pub const ERROR_INVALID_EXTERNAL_HANDLE: Self = Self(-1000072003);
+    pub const ERROR_INVALID_EXTERNAL_HANDLE: Self = Self(-1_000_072_003);
 }
 #[doc = "Generated from 'VK_VERSION_1_1'"]
 impl StructureType {
@@ -647,7 +647,7 @@ impl DescriptorSetLayoutCreateFlags {
 }
 #[doc = "Generated from 'VK_VERSION_1_2'"]
 impl Result {
-    pub const ERROR_FRAGMENTATION: Self = Self(-1000161000);
+    pub const ERROR_FRAGMENTATION: Self = Self(-1_000_161_000);
 }
 #[doc = "Generated from 'VK_VERSION_1_2'"]
 impl StructureType {
@@ -803,5 +803,5 @@ impl MemoryAllocateFlags {
 }
 #[doc = "Generated from 'VK_VERSION_1_2'"]
 impl Result {
-    pub const ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS: Self = Self(-1000257000);
+    pub const ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS: Self = Self(-1_000_257_000);
 }


### PR DESCRIPTION
`syn` has been updated to not remove the `_` again from negative numbers, which previously disappeared in the 1.0 upgrade in 43b5058 ("Upgrade proc_macro2/syn/quote to v1.0 (#351)").

See also https://github.com/dtolnay/syn/releases/tag/1.0.81:

    Support arbitrary precision negative literal tokens on rustc 1.56+
