### PR TITLE
examples: Upgrade to winit 0.25

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["maik klein <maikklein@googlemail.com>"]
 edition = "2018"
 
 [dependencies]
-winit = "0.19.5"
+winit = "0.25.0"
 image = "0.10.4"
 ash = { path = "../ash" }
 ash-window = { path = "../ash-window" }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -147,7 +147,7 @@ pub struct ExampleBase {
     pub swapchain_loader: Swapchain,
     pub debug_utils_loader: DebugUtils,
     pub window: winit::window::Window,
-    pub events_loop: RefCell<EventLoop<()>>,
+    pub event_loop: RefCell<EventLoop<()>>,
     pub debug_call_back: vk::DebugUtilsMessengerEXT,
 
     pub pdevice: vk::PhysicalDevice,
@@ -180,7 +180,7 @@ pub struct ExampleBase {
 
 impl ExampleBase {
     pub fn render_loop<F: Fn()>(&self, f: F) {
-        self.events_loop
+        self.event_loop
             .borrow_mut()
             .run_return(|event, _, control_flow| {
                 *control_flow = ControlFlow::Wait;
@@ -207,14 +207,14 @@ impl ExampleBase {
 
     pub fn new(window_width: u32, window_height: u32) -> Self {
         unsafe {
-            let events_loop = EventLoop::new();
+            let event_loop = EventLoop::new();
             let window = WindowBuilder::new()
                 .with_title("Ash - Example")
                 .with_inner_size(winit::dpi::LogicalSize::new(
                     f64::from(window_width),
                     f64::from(window_height),
                 ))
-                .build(&events_loop)
+                .build(&event_loop)
                 .unwrap();
             let entry = Entry::new();
             let app_name = CString::new("VulkanTriangle").unwrap();
@@ -528,7 +528,7 @@ impl ExampleBase {
                 .unwrap();
 
             ExampleBase {
-                events_loop: RefCell::new(events_loop),
+                event_loop: RefCell::new(event_loop),
                 entry,
                 instance,
                 device,

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -15,7 +15,7 @@ use std::ffi::{CStr, CString};
 use std::ops::Drop;
 
 use winit::{
-    event::{DeviceEvent, ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     platform::run_return::EventLoopExtRunReturn,
     window::WindowBuilder,
@@ -187,25 +187,22 @@ impl ExampleBase {
                 f();
                 match event {
                     Event::WindowEvent {
-                        event: WindowEvent::CloseRequested,
+                        ref event,
                         window_id,
-                    } if window_id == self.window.id() => *control_flow = ControlFlow::Exit,
-
-                    Event::DeviceEvent { event, .. } => match event {
-                        DeviceEvent::Key(KeyboardInput {
-                            virtual_keycode: Some(keycode),
-                            state,
+                    } if window_id == self.window.id() => match event {
+                        WindowEvent::CloseRequested
+                        | WindowEvent::KeyboardInput {
+                            input:
+                                KeyboardInput {
+                                    state: ElementState::Pressed,
+                                    virtual_keycode: Some(VirtualKeyCode::Escape),
+                                    ..
+                                },
                             ..
-                        }) => match (keycode, state) {
-                            (VirtualKeyCode::Escape, ElementState::Released) => {
-                                *control_flow = ControlFlow::Exit
-                            }
-                            _ => (),
-                        },
-                        _ => (),
+                        } => *control_flow = ControlFlow::Exit,
+                        _ => {}
                     },
-
-                    _ => (),
+                    _ => {}
                 }
             });
     }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -185,11 +185,8 @@ impl ExampleBase {
             .run_return(|event, _, control_flow| {
                 *control_flow = ControlFlow::Wait;
                 f();
-                match event {
-                    Event::WindowEvent {
-                        ref event,
-                        window_id,
-                    } if window_id == self.window.id() => match event {
+                if let Event::WindowEvent {
+                    event:
                         WindowEvent::CloseRequested
                         | WindowEvent::KeyboardInput {
                             input:
@@ -199,10 +196,11 @@ impl ExampleBase {
                                     ..
                                 },
                             ..
-                        } => *control_flow = ControlFlow::Exit,
-                        _ => {}
-                    },
-                    _ => {}
+                        },
+                    ..
+                } = event
+                {
+                    *control_flow = ControlFlow::Exit
                 }
             });
     }


### PR DESCRIPTION
Current examples are based on old version of winint that was causing  thread panic on my system, this is well know issue that was already fixed by winint team. I updated examples to use most up to date 0.25.0 version