### PR TITLE
extensions: make naming and layout consistent accross all extensions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,11 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `VK_KHR_present_wait` extension (#493)
+- Added `VK_KHR_present_wait` device extension (#493)
 
 ### Changed
 
-- Removed `instance` function from `extensions::ext::ExtendedDynamicState` and `extensions::khr::PushDescriptor` (#494)
+- Device extension `ext::ExtendedDynamicState`, `khr::PushDescriptor`, `khr::PipelineExecutableProperties` and `khr::TimelineSemaphore` now expose `fn device()` instead of `fn instance()` (#494, #499)
+- Changed `khr::PipelineExecutableProperties::new()` and `khr::TimelineSemaphore::new()` to take `instance` and `device` as arguments (#499)
+
+### Removed
+
+- Removed `From<vk::Result>` trait for `VkResult` (#495)
+- Removed `device` argument from `ext::DebugMarkers::debug_marker_set_object_name` function (#494)
+- Removed `instance` argument from `ext::DebugUtils::submit_debug_utils_message` function (#499)
 
 ## [0.33.3] - 2021-09-08
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `VK_KHR_present_wait` extension (#493)
 
+### Changed
+
+- Removed `instance` function from `extensions::ext::ExtendedDynamicState` and `extensions::khr::PushDescriptor` (#494)
+
 ## [0.33.3] - 2021-09-08
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,13 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Device extension `ext::ExtendedDynamicState`, `khr::PushDescriptor`, `khr::PipelineExecutableProperties` and `khr::TimelineSemaphore` now expose `fn device()` instead of `fn instance()` (#494, #499)
+- Device extension `khr::PipelineExecutableProperties` and `khr::TimelineSemaphore` now expose `fn device()` instead of `fn instance()` (#499)
 - Changed `khr::PipelineExecutableProperties::new()` and `khr::TimelineSemaphore::new()` to take `instance` and `device` as arguments (#499)
 
 ### Removed
 
-- Removed `From<vk::Result>` trait for `VkResult` (#495)
+- Removed `device()` function from `khr::Synchronization2` device extension (#494)
+- Removed `instance()` function from `ext::ExtendedDynamicState`, `khr::PushDescriptor`, `ext::ToolingInfo` and `khr::GetPhysicalDeviceProperties2` instance extensions (#494)
 - Removed `device` argument from `ext::DebugMarkers::debug_marker_set_object_name` function (#494)
+- Removed `From<vk::Result>` trait for `VkResult` (#495)
 - Removed `instance` argument from `ext::DebugUtils::submit_debug_utils_message` function (#499)
 
 ## [0.33.3] - 2021-09-08

--- a/ash/src/extensions/ext/buffer_device_address.rs
+++ b/ash/src/extensions/ext/buffer_device_address.rs
@@ -6,16 +6,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct BufferDeviceAddress {
     handle: vk::Device,
-    fns: vk::ExtBufferDeviceAddressFn,
+    fp: vk::ExtBufferDeviceAddressFn,
 }
 
 impl BufferDeviceAddress {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::ExtBufferDeviceAddressFn::load(|name| unsafe {
+        let fp = vk::ExtBufferDeviceAddressFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferDeviceAddressEXT.html>"]
@@ -23,7 +23,7 @@ impl BufferDeviceAddress {
         &self,
         info: &vk::BufferDeviceAddressInfoEXT,
     ) -> vk::DeviceAddress {
-        self.fns.get_buffer_device_address_ext(self.handle, info)
+        self.fp.get_buffer_device_address_ext(self.handle, info)
     }
 
     pub fn name() -> &'static CStr {
@@ -31,7 +31,7 @@ impl BufferDeviceAddress {
     }
 
     pub fn fp(&self) -> &vk::ExtBufferDeviceAddressFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/ext/buffer_device_address.rs
+++ b/ash/src/extensions/ext/buffer_device_address.rs
@@ -11,13 +11,11 @@ pub struct BufferDeviceAddress {
 
 impl BufferDeviceAddress {
     pub fn new(instance: &Instance, device: &Device) -> Self {
+        let handle = device.handle();
         let fns = vk::ExtBufferDeviceAddressFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            fns,
-        }
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferDeviceAddressEXT.html>"]

--- a/ash/src/extensions/ext/debug_marker.rs
+++ b/ash/src/extensions/ext/debug_marker.rs
@@ -7,16 +7,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct DebugMarker {
     handle: vk::Device,
-    fns: vk::ExtDebugMarkerFn,
+    fp: vk::ExtDebugMarkerFn,
 }
 
 impl DebugMarker {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::ExtDebugMarkerFn::load(|name| unsafe {
+        let fp = vk::ExtDebugMarkerFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDebugMarkerSetObjectNameEXT.html>"]
@@ -24,7 +24,7 @@ impl DebugMarker {
         &self,
         name_info: &vk::DebugMarkerObjectNameInfoEXT,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .debug_marker_set_object_name_ext(self.handle, name_info)
             .result()
     }
@@ -35,13 +35,13 @@ impl DebugMarker {
         command_buffer: vk::CommandBuffer,
         marker_info: &vk::DebugMarkerMarkerInfoEXT,
     ) {
-        self.fns
+        self.fp
             .cmd_debug_marker_begin_ext(command_buffer, marker_info);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDebugMarkerEndEXT.html>"]
     pub unsafe fn cmd_debug_marker_end(&self, command_buffer: vk::CommandBuffer) {
-        self.fns.cmd_debug_marker_end_ext(command_buffer);
+        self.fp.cmd_debug_marker_end_ext(command_buffer);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDebugMarkerInsertEXT.html>"]
@@ -50,7 +50,7 @@ impl DebugMarker {
         command_buffer: vk::CommandBuffer,
         marker_info: &vk::DebugMarkerMarkerInfoEXT,
     ) {
-        self.fns
+        self.fp
             .cmd_debug_marker_insert_ext(command_buffer, marker_info);
     }
 
@@ -59,7 +59,7 @@ impl DebugMarker {
     }
 
     pub fn fp(&self) -> &vk::ExtDebugMarkerFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/ext/debug_marker.rs
+++ b/ash/src/extensions/ext/debug_marker.rs
@@ -22,11 +22,10 @@ impl DebugMarker {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDebugMarkerSetObjectNameEXT.html>"]
     pub unsafe fn debug_marker_set_object_name(
         &self,
-        device: vk::Device,
         name_info: &vk::DebugMarkerObjectNameInfoEXT,
     ) -> VkResult<()> {
         self.fns
-            .debug_marker_set_object_name_ext(device, name_info)
+            .debug_marker_set_object_name_ext(self.handle, name_info)
             .result()
     }
 

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct DebugReport {
     handle: vk::Instance,
-    fns: vk::ExtDebugReportFn,
+    fp: vk::ExtDebugReportFn,
 }
 
 impl DebugReport {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::ExtDebugReportFn::load(|name| unsafe {
+        let fp = vk::ExtDebugReportFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDebugReportCallbackEXT.html>"]
@@ -26,7 +26,7 @@ impl DebugReport {
         debug: vk::DebugReportCallbackEXT,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.fns.destroy_debug_report_callback_ext(
+        self.fp.destroy_debug_report_callback_ext(
             self.handle,
             debug,
             allocation_callbacks.as_raw_ptr(),
@@ -40,7 +40,7 @@ impl DebugReport {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DebugReportCallbackEXT> {
         let mut debug_cb = mem::zeroed();
-        self.fns
+        self.fp
             .create_debug_report_callback_ext(
                 self.handle,
                 create_info,
@@ -55,7 +55,7 @@ impl DebugReport {
     }
 
     pub fn fp(&self) -> &vk::ExtDebugReportFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct DebugReport {
     handle: vk::Instance,
-    debug_report_fn: vk::ExtDebugReportFn,
+    fns: vk::ExtDebugReportFn,
 }
 
 impl DebugReport {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let debug_report_fn = vk::ExtDebugReportFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::ExtDebugReportFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            debug_report_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::ExtDebugReportFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroyDebugReportCallbackEXT.html>"]
@@ -32,7 +26,7 @@ impl DebugReport {
         debug: vk::DebugReportCallbackEXT,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.debug_report_fn.destroy_debug_report_callback_ext(
+        self.fns.destroy_debug_report_callback_ext(
             self.handle,
             debug,
             allocation_callbacks.as_raw_ptr(),
@@ -46,7 +40,7 @@ impl DebugReport {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DebugReportCallbackEXT> {
         let mut debug_cb = mem::zeroed();
-        self.debug_report_fn
+        self.fns
             .create_debug_report_callback_ext(
                 self.handle,
                 create_info,
@@ -56,8 +50,12 @@ impl DebugReport {
             .result_with_success(debug_cb)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::ExtDebugReportFn::name()
+    }
+
     pub fn fp(&self) -> &vk::ExtDebugReportFn {
-        &self.debug_report_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -7,16 +7,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct DebugUtils {
     handle: vk::Instance,
-    fns: vk::ExtDebugUtilsFn,
+    fp: vk::ExtDebugUtilsFn,
 }
 
 impl DebugUtils {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::ExtDebugUtilsFn::load(|name| unsafe {
+        let fp = vk::ExtDebugUtilsFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html>"]
@@ -25,7 +25,7 @@ impl DebugUtils {
         device: vk::Device,
         name_info: &vk::DebugUtilsObjectNameInfoEXT,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .set_debug_utils_object_name_ext(device, name_info)
             .result()
     }
@@ -36,7 +36,7 @@ impl DebugUtils {
         device: vk::Device,
         tag_info: &vk::DebugUtilsObjectTagInfoEXT,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .set_debug_utils_object_tag_ext(device, tag_info)
             .result()
     }
@@ -47,13 +47,13 @@ impl DebugUtils {
         command_buffer: vk::CommandBuffer,
         label: &vk::DebugUtilsLabelEXT,
     ) {
-        self.fns
+        self.fp
             .cmd_begin_debug_utils_label_ext(command_buffer, label);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndDebugUtilsLabelEXT.html>"]
     pub unsafe fn cmd_end_debug_utils_label(&self, command_buffer: vk::CommandBuffer) {
-        self.fns.cmd_end_debug_utils_label_ext(command_buffer);
+        self.fp.cmd_end_debug_utils_label_ext(command_buffer);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdInsertDebugUtilsLabelEXT.html>"]
@@ -62,7 +62,7 @@ impl DebugUtils {
         command_buffer: vk::CommandBuffer,
         label: &vk::DebugUtilsLabelEXT,
     ) {
-        self.fns
+        self.fp
             .cmd_insert_debug_utils_label_ext(command_buffer, label);
     }
 
@@ -72,12 +72,12 @@ impl DebugUtils {
         queue: vk::Queue,
         label: &vk::DebugUtilsLabelEXT,
     ) {
-        self.fns.queue_begin_debug_utils_label_ext(queue, label);
+        self.fp.queue_begin_debug_utils_label_ext(queue, label);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueEndDebugUtilsLabelEXT.html>"]
     pub unsafe fn queue_end_debug_utils_label(&self, queue: vk::Queue) {
-        self.fns.queue_end_debug_utils_label_ext(queue);
+        self.fp.queue_end_debug_utils_label_ext(queue);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkQueueInsertDebugUtilsLabelEXT.html>"]
@@ -86,7 +86,7 @@ impl DebugUtils {
         queue: vk::Queue,
         label: &vk::DebugUtilsLabelEXT,
     ) {
-        self.fns.queue_insert_debug_utils_label_ext(queue, label);
+        self.fp.queue_insert_debug_utils_label_ext(queue, label);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDebugUtilsMessengerEXT.html>"]
@@ -96,7 +96,7 @@ impl DebugUtils {
         allocator: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DebugUtilsMessengerEXT> {
         let mut messenger = mem::zeroed();
-        self.fns
+        self.fp
             .create_debug_utils_messenger_ext(
                 self.handle,
                 create_info,
@@ -112,7 +112,7 @@ impl DebugUtils {
         messenger: vk::DebugUtilsMessengerEXT,
         allocator: Option<&vk::AllocationCallbacks>,
     ) {
-        self.fns
+        self.fp
             .destroy_debug_utils_messenger_ext(self.handle, messenger, allocator.as_raw_ptr());
     }
 
@@ -123,7 +123,7 @@ impl DebugUtils {
         message_types: vk::DebugUtilsMessageTypeFlagsEXT,
         callback_data: &vk::DebugUtilsMessengerCallbackDataEXT,
     ) {
-        self.fns.submit_debug_utils_message_ext(
+        self.fp.submit_debug_utils_message_ext(
             self.handle,
             message_severity,
             message_types,
@@ -136,7 +136,7 @@ impl DebugUtils {
     }
 
     pub fn fp(&self) -> &vk::ExtDebugUtilsFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/ext/extended_dynamic_state.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state.rs
@@ -6,15 +6,15 @@ use std::ptr;
 
 #[derive(Clone)]
 pub struct ExtendedDynamicState {
-    fns: vk::ExtExtendedDynamicStateFn,
+    fp: vk::ExtExtendedDynamicStateFn,
 }
 
 impl ExtendedDynamicState {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let fns = vk::ExtExtendedDynamicStateFn::load(|name| unsafe {
+        let fp = vk::ExtExtendedDynamicStateFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { fns }
+        Self { fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetCullModeEXT.html>"]
@@ -23,7 +23,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         cull_mode: vk::CullModeFlags,
     ) {
-        self.fns.cmd_set_cull_mode_ext(command_buffer, cull_mode)
+        self.fp.cmd_set_cull_mode_ext(command_buffer, cull_mode)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetFrontFaceEXT.html>"]
@@ -32,7 +32,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         front_face: vk::FrontFace,
     ) {
-        self.fns.cmd_set_front_face_ext(command_buffer, front_face)
+        self.fp.cmd_set_front_face_ext(command_buffer, front_face)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetPrimitiveTopologyEXT.html>"]
@@ -41,7 +41,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         primitive_topology: vk::PrimitiveTopology,
     ) {
-        self.fns
+        self.fp
             .cmd_set_primitive_topology_ext(command_buffer, primitive_topology)
     }
 
@@ -51,7 +51,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         viewports: &[vk::Viewport],
     ) {
-        self.fns.cmd_set_viewport_with_count_ext(
+        self.fp.cmd_set_viewport_with_count_ext(
             command_buffer,
             viewports.len() as u32,
             viewports.as_ptr(),
@@ -64,7 +64,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         scissors: &[vk::Rect2D],
     ) {
-        self.fns.cmd_set_scissor_with_count_ext(
+        self.fp.cmd_set_scissor_with_count_ext(
             command_buffer,
             scissors.len() as u32,
             scissors.as_ptr(),
@@ -94,7 +94,7 @@ impl ExtendedDynamicState {
         } else {
             ptr::null()
         };
-        self.fns.cmd_bind_vertex_buffers2_ext(
+        self.fp.cmd_bind_vertex_buffers2_ext(
             command_buffer,
             first_binding,
             buffers.len() as u32,
@@ -111,7 +111,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         depth_test_enable: bool,
     ) {
-        self.fns
+        self.fp
             .cmd_set_depth_test_enable_ext(command_buffer, depth_test_enable.into())
     }
 
@@ -121,7 +121,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         depth_write_enable: bool,
     ) {
-        self.fns
+        self.fp
             .cmd_set_depth_write_enable_ext(command_buffer, depth_write_enable.into())
     }
 
@@ -131,7 +131,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         depth_compare_op: vk::CompareOp,
     ) {
-        self.fns
+        self.fp
             .cmd_set_depth_compare_op_ext(command_buffer, depth_compare_op)
     }
 
@@ -141,7 +141,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         depth_bounds_test_enable: bool,
     ) {
-        self.fns
+        self.fp
             .cmd_set_depth_bounds_test_enable_ext(command_buffer, depth_bounds_test_enable.into())
     }
 
@@ -151,7 +151,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         stencil_test_enable: bool,
     ) {
-        self.fns
+        self.fp
             .cmd_set_stencil_test_enable_ext(command_buffer, stencil_test_enable.into())
     }
 
@@ -165,7 +165,7 @@ impl ExtendedDynamicState {
         depth_fail_op: vk::StencilOp,
         compare_op: vk::CompareOp,
     ) {
-        self.fns.cmd_set_stencil_op_ext(
+        self.fp.cmd_set_stencil_op_ext(
             command_buffer,
             face_mask,
             fail_op,
@@ -180,6 +180,6 @@ impl ExtendedDynamicState {
     }
 
     pub fn fp(&self) -> &vk::ExtExtendedDynamicStateFn {
-        &self.fns
+        &self.fp
     }
 }

--- a/ash/src/extensions/ext/extended_dynamic_state.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state.rs
@@ -6,17 +6,15 @@ use std::ptr;
 
 #[derive(Clone)]
 pub struct ExtendedDynamicState {
-    handle: vk::Device,
     fns: vk::ExtExtendedDynamicStateFn,
 }
 
 impl ExtendedDynamicState {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let handle = device.handle();
         let fns = vk::ExtExtendedDynamicStateFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetCullModeEXT.html>"]
@@ -183,9 +181,5 @@ impl ExtendedDynamicState {
 
     pub fn fp(&self) -> &vk::ExtExtendedDynamicStateFn {
         &self.fns
-    }
-
-    pub fn device(&self) -> vk::Device {
-        self.handle
     }
 }

--- a/ash/src/extensions/ext/extended_dynamic_state.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state.rs
@@ -6,23 +6,17 @@ use std::ptr;
 
 #[derive(Clone)]
 pub struct ExtendedDynamicState {
-    handle: vk::Instance,
-    extended_dynamic_state_fn: vk::ExtExtendedDynamicStateFn,
+    handle: vk::Device,
+    fns: vk::ExtExtendedDynamicStateFn,
 }
 
 impl ExtendedDynamicState {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let extended_dynamic_state_fn = vk::ExtExtendedDynamicStateFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::ExtExtendedDynamicStateFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            extended_dynamic_state_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::ExtExtendedDynamicStateFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetCullModeEXT.html>"]
@@ -31,8 +25,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         cull_mode: vk::CullModeFlags,
     ) {
-        self.extended_dynamic_state_fn
-            .cmd_set_cull_mode_ext(command_buffer, cull_mode)
+        self.fns.cmd_set_cull_mode_ext(command_buffer, cull_mode)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetFrontFaceEXT.html>"]
@@ -41,8 +34,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         front_face: vk::FrontFace,
     ) {
-        self.extended_dynamic_state_fn
-            .cmd_set_front_face_ext(command_buffer, front_face)
+        self.fns.cmd_set_front_face_ext(command_buffer, front_face)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetPrimitiveTopologyEXT.html>"]
@@ -51,7 +43,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         primitive_topology: vk::PrimitiveTopology,
     ) {
-        self.extended_dynamic_state_fn
+        self.fns
             .cmd_set_primitive_topology_ext(command_buffer, primitive_topology)
     }
 
@@ -61,12 +53,11 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         viewports: &[vk::Viewport],
     ) {
-        self.extended_dynamic_state_fn
-            .cmd_set_viewport_with_count_ext(
-                command_buffer,
-                viewports.len() as u32,
-                viewports.as_ptr(),
-            )
+        self.fns.cmd_set_viewport_with_count_ext(
+            command_buffer,
+            viewports.len() as u32,
+            viewports.as_ptr(),
+        )
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetScissorWithCountEXT.html>"]
@@ -75,12 +66,11 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         scissors: &[vk::Rect2D],
     ) {
-        self.extended_dynamic_state_fn
-            .cmd_set_scissor_with_count_ext(
-                command_buffer,
-                scissors.len() as u32,
-                scissors.as_ptr(),
-            )
+        self.fns.cmd_set_scissor_with_count_ext(
+            command_buffer,
+            scissors.len() as u32,
+            scissors.as_ptr(),
+        )
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBindVertexBuffers2EXT.html>"]
@@ -106,7 +96,7 @@ impl ExtendedDynamicState {
         } else {
             ptr::null()
         };
-        self.extended_dynamic_state_fn.cmd_bind_vertex_buffers2_ext(
+        self.fns.cmd_bind_vertex_buffers2_ext(
             command_buffer,
             first_binding,
             buffers.len() as u32,
@@ -123,7 +113,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         depth_test_enable: bool,
     ) {
-        self.extended_dynamic_state_fn
+        self.fns
             .cmd_set_depth_test_enable_ext(command_buffer, depth_test_enable.into())
     }
 
@@ -133,7 +123,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         depth_write_enable: bool,
     ) {
-        self.extended_dynamic_state_fn
+        self.fns
             .cmd_set_depth_write_enable_ext(command_buffer, depth_write_enable.into())
     }
 
@@ -143,7 +133,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         depth_compare_op: vk::CompareOp,
     ) {
-        self.extended_dynamic_state_fn
+        self.fns
             .cmd_set_depth_compare_op_ext(command_buffer, depth_compare_op)
     }
 
@@ -153,7 +143,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         depth_bounds_test_enable: bool,
     ) {
-        self.extended_dynamic_state_fn
+        self.fns
             .cmd_set_depth_bounds_test_enable_ext(command_buffer, depth_bounds_test_enable.into())
     }
 
@@ -163,7 +153,7 @@ impl ExtendedDynamicState {
         command_buffer: vk::CommandBuffer,
         stencil_test_enable: bool,
     ) {
-        self.extended_dynamic_state_fn
+        self.fns
             .cmd_set_stencil_test_enable_ext(command_buffer, stencil_test_enable.into())
     }
 
@@ -177,7 +167,7 @@ impl ExtendedDynamicState {
         depth_fail_op: vk::StencilOp,
         compare_op: vk::CompareOp,
     ) {
-        self.extended_dynamic_state_fn.cmd_set_stencil_op_ext(
+        self.fns.cmd_set_stencil_op_ext(
             command_buffer,
             face_mask,
             fail_op,
@@ -187,11 +177,15 @@ impl ExtendedDynamicState {
         )
     }
 
-    pub fn fp(&self) -> &vk::ExtExtendedDynamicStateFn {
-        &self.extended_dynamic_state_fn
+    pub fn name() -> &'static CStr {
+        vk::ExtExtendedDynamicStateFn::name()
     }
 
-    pub fn instance(&self) -> vk::Instance {
+    pub fn fp(&self) -> &vk::ExtExtendedDynamicStateFn {
+        &self.fns
+    }
+
+    pub fn device(&self) -> vk::Device {
         self.handle
     }
 }

--- a/ash/src/extensions/ext/full_screen_exclusive.rs
+++ b/ash/src/extensions/ext/full_screen_exclusive.rs
@@ -7,22 +7,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct FullScreenExclusive {
     handle: vk::Device,
-    full_screen_exclusive_fn: vk::ExtFullScreenExclusiveFn,
+    fns: vk::ExtFullScreenExclusiveFn,
 }
 
 impl FullScreenExclusive {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let full_screen_exclusive_fn = vk::ExtFullScreenExclusiveFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::ExtFullScreenExclusiveFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            full_screen_exclusive_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::ExtFullScreenExclusiveFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAcquireFullScreenExclusiveModeEXT.html>"]
@@ -30,7 +24,7 @@ impl FullScreenExclusive {
         &self,
         swapchain: vk::SwapchainKHR,
     ) -> VkResult<()> {
-        self.full_screen_exclusive_fn
+        self.fns
             .acquire_full_screen_exclusive_mode_ext(self.handle, swapchain)
             .result()
     }
@@ -42,13 +36,12 @@ impl FullScreenExclusive {
         surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.full_screen_exclusive_fn
-                .get_physical_device_surface_present_modes2_ext(
-                    physical_device,
-                    surface_info,
-                    count,
-                    data,
-                )
+            self.fns.get_physical_device_surface_present_modes2_ext(
+                physical_device,
+                surface_info,
+                count,
+                data,
+            )
         })
     }
 
@@ -57,7 +50,7 @@ impl FullScreenExclusive {
         &self,
         swapchain: vk::SwapchainKHR,
     ) -> VkResult<()> {
-        self.full_screen_exclusive_fn
+        self.fns
             .release_full_screen_exclusive_mode_ext(self.handle, swapchain)
             .result()
     }
@@ -68,7 +61,7 @@ impl FullScreenExclusive {
         surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
     ) -> VkResult<vk::DeviceGroupPresentModeFlagsKHR> {
         let mut present_modes = mem::zeroed();
-        self.full_screen_exclusive_fn
+        self.fns
             .get_device_group_surface_present_modes2_ext(
                 self.handle,
                 surface_info,
@@ -77,8 +70,12 @@ impl FullScreenExclusive {
             .result_with_success(present_modes)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::ExtFullScreenExclusiveFn::name()
+    }
+
     pub fn fp(&self) -> &vk::ExtFullScreenExclusiveFn {
-        &self.full_screen_exclusive_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/ext/full_screen_exclusive.rs
+++ b/ash/src/extensions/ext/full_screen_exclusive.rs
@@ -7,16 +7,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct FullScreenExclusive {
     handle: vk::Device,
-    fns: vk::ExtFullScreenExclusiveFn,
+    fp: vk::ExtFullScreenExclusiveFn,
 }
 
 impl FullScreenExclusive {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::ExtFullScreenExclusiveFn::load(|name| unsafe {
+        let fp = vk::ExtFullScreenExclusiveFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkAcquireFullScreenExclusiveModeEXT.html>"]
@@ -24,7 +24,7 @@ impl FullScreenExclusive {
         &self,
         swapchain: vk::SwapchainKHR,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .acquire_full_screen_exclusive_mode_ext(self.handle, swapchain)
             .result()
     }
@@ -36,7 +36,7 @@ impl FullScreenExclusive {
         surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.fns.get_physical_device_surface_present_modes2_ext(
+            self.fp.get_physical_device_surface_present_modes2_ext(
                 physical_device,
                 surface_info,
                 count,
@@ -50,7 +50,7 @@ impl FullScreenExclusive {
         &self,
         swapchain: vk::SwapchainKHR,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .release_full_screen_exclusive_mode_ext(self.handle, swapchain)
             .result()
     }
@@ -61,7 +61,7 @@ impl FullScreenExclusive {
         surface_info: &vk::PhysicalDeviceSurfaceInfo2KHR,
     ) -> VkResult<vk::DeviceGroupPresentModeFlagsKHR> {
         let mut present_modes = mem::zeroed();
-        self.fns
+        self.fp
             .get_device_group_surface_present_modes2_ext(
                 self.handle,
                 surface_info,
@@ -75,7 +75,7 @@ impl FullScreenExclusive {
     }
 
     pub fn fp(&self) -> &vk::ExtFullScreenExclusiveFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/ext/metal_surface.rs
+++ b/ash/src/extensions/ext/metal_surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct MetalSurface {
     handle: vk::Instance,
-    fns: vk::ExtMetalSurfaceFn,
+    fp: vk::ExtMetalSurfaceFn,
 }
 
 impl MetalSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::ExtMetalSurfaceFn::load(|name| unsafe {
+        let fp = vk::ExtMetalSurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateMetalSurfaceEXT.html>"]
@@ -27,7 +27,7 @@ impl MetalSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.fns
+        self.fp
             .create_metal_surface_ext(
                 self.handle,
                 create_info,
@@ -42,7 +42,7 @@ impl MetalSurface {
     }
 
     pub fn fp(&self) -> &vk::ExtMetalSurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/ext/metal_surface.rs
+++ b/ash/src/extensions/ext/metal_surface.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct MetalSurface {
     handle: vk::Instance,
-    metal_surface_fn: vk::ExtMetalSurfaceFn,
+    fns: vk::ExtMetalSurfaceFn,
 }
 
 impl MetalSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let surface_fn = vk::ExtMetalSurfaceFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::ExtMetalSurfaceFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            metal_surface_fn: surface_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::ExtMetalSurfaceFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateMetalSurfaceEXT.html>"]
@@ -33,7 +27,7 @@ impl MetalSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.metal_surface_fn
+        self.fns
             .create_metal_surface_ext(
                 self.handle,
                 create_info,
@@ -43,8 +37,12 @@ impl MetalSurface {
             .result_with_success(surface)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::ExtMetalSurfaceFn::name()
+    }
+
     pub fn fp(&self) -> &vk::ExtMetalSurfaceFn {
-        &self.metal_surface_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/ext/tooling_info.rs
+++ b/ash/src/extensions/ext/tooling_info.rs
@@ -6,15 +6,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct ToolingInfo {
-    fns: vk::ExtToolingInfoFn,
+    fp: vk::ExtToolingInfoFn,
 }
 
 impl ToolingInfo {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let fns = vk::ExtToolingInfoFn::load(|name| unsafe {
+        let fp = vk::ExtToolingInfoFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
         });
-        Self { fns }
+        Self { fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceToolPropertiesEXT.html>"]
@@ -23,7 +23,7 @@ impl ToolingInfo {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::PhysicalDeviceToolPropertiesEXT>> {
         read_into_defaulted_vector(|count, data| {
-            self.fns
+            self.fp
                 .get_physical_device_tool_properties_ext(physical_device, count, data)
         })
     }
@@ -33,6 +33,6 @@ impl ToolingInfo {
     }
 
     pub fn fp(&self) -> &vk::ExtToolingInfoFn {
-        &self.fns
+        &self.fp
     }
 }

--- a/ash/src/extensions/ext/tooling_info.rs
+++ b/ash/src/extensions/ext/tooling_info.rs
@@ -6,17 +6,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct ToolingInfo {
-    handle: vk::Instance,
     fns: vk::ExtToolingInfoFn,
 }
 
 impl ToolingInfo {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let handle = instance.handle();
         let fns = vk::ExtToolingInfoFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
+            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceToolPropertiesEXT.html>"]
@@ -36,9 +34,5 @@ impl ToolingInfo {
 
     pub fn fp(&self) -> &vk::ExtToolingInfoFn {
         &self.fns
-    }
-
-    pub fn instance(&self) -> vk::Instance {
-        self.handle
     }
 }

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct AccelerationStructure {
     handle: vk::Device,
-    fns: vk::KhrAccelerationStructureFn,
+    fp: vk::KhrAccelerationStructureFn,
 }
 
 impl AccelerationStructure {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrAccelerationStructureFn::load(|name| unsafe {
+        let fp = vk::KhrAccelerationStructureFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     pub unsafe fn get_properties(
@@ -39,7 +39,7 @@ impl AccelerationStructure {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::AccelerationStructureKHR> {
         let mut accel_struct = mem::zeroed();
-        self.fns
+        self.fp
             .create_acceleration_structure_khr(
                 self.handle,
                 create_info,
@@ -55,7 +55,7 @@ impl AccelerationStructure {
         accel_struct: vk::AccelerationStructureKHR,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.fns.destroy_acceleration_structure_khr(
+        self.fp.destroy_acceleration_structure_khr(
             self.handle,
             accel_struct,
             allocation_callbacks.as_raw_ptr(),
@@ -80,7 +80,7 @@ impl AccelerationStructure {
             })
             .collect::<Vec<_>>();
 
-        self.fns.cmd_build_acceleration_structures_khr(
+        self.fp.cmd_build_acceleration_structures_khr(
             command_buffer,
             infos.len() as _,
             infos.as_ptr(),
@@ -110,7 +110,7 @@ impl AccelerationStructure {
             })
             .collect::<Vec<_>>();
 
-        self.fns.cmd_build_acceleration_structures_indirect_khr(
+        self.fp.cmd_build_acceleration_structures_indirect_khr(
             command_buffer,
             infos.len() as _,
             infos.as_ptr(),
@@ -138,7 +138,7 @@ impl AccelerationStructure {
             })
             .collect::<Vec<_>>();
 
-        self.fns
+        self.fp
             .build_acceleration_structures_khr(
                 self.handle,
                 deferred_operation,
@@ -155,7 +155,7 @@ impl AccelerationStructure {
         deferred_operation: vk::DeferredOperationKHR,
         info: &vk::CopyAccelerationStructureInfoKHR,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .copy_acceleration_structure_khr(self.handle, deferred_operation, info as *const _)
             .result()
     }
@@ -166,7 +166,7 @@ impl AccelerationStructure {
         deferred_operation: vk::DeferredOperationKHR,
         info: &vk::CopyAccelerationStructureToMemoryInfoKHR,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .copy_acceleration_structure_to_memory_khr(
                 self.handle,
                 deferred_operation,
@@ -181,7 +181,7 @@ impl AccelerationStructure {
         deferred_operation: vk::DeferredOperationKHR,
         info: &vk::CopyMemoryToAccelerationStructureInfoKHR,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .copy_memory_to_acceleration_structure_khr(
                 self.handle,
                 deferred_operation,
@@ -198,7 +198,7 @@ impl AccelerationStructure {
         data: &mut [u8],
         stride: usize,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .write_acceleration_structures_properties_khr(
                 self.handle,
                 acceleration_structures.len() as _,
@@ -217,7 +217,7 @@ impl AccelerationStructure {
         command_buffer: vk::CommandBuffer,
         info: &vk::CopyAccelerationStructureInfoKHR,
     ) {
-        self.fns
+        self.fp
             .cmd_copy_acceleration_structure_khr(command_buffer, info);
     }
 
@@ -227,7 +227,7 @@ impl AccelerationStructure {
         command_buffer: vk::CommandBuffer,
         info: &vk::CopyAccelerationStructureToMemoryInfoKHR,
     ) {
-        self.fns
+        self.fp
             .cmd_copy_acceleration_structure_to_memory_khr(command_buffer, info as *const _);
     }
 
@@ -237,7 +237,7 @@ impl AccelerationStructure {
         command_buffer: vk::CommandBuffer,
         info: &vk::CopyMemoryToAccelerationStructureInfoKHR,
     ) {
-        self.fns
+        self.fp
             .cmd_copy_memory_to_acceleration_structure_khr(command_buffer, info as *const _);
     }
 
@@ -246,7 +246,7 @@ impl AccelerationStructure {
         &self,
         info: &vk::AccelerationStructureDeviceAddressInfoKHR,
     ) -> vk::DeviceAddress {
-        self.fns
+        self.fp
             .get_acceleration_structure_device_address_khr(self.handle, info as *const _)
     }
 
@@ -259,7 +259,7 @@ impl AccelerationStructure {
         query_pool: vk::QueryPool,
         first_query: u32,
     ) {
-        self.fns.cmd_write_acceleration_structures_properties_khr(
+        self.fp.cmd_write_acceleration_structures_properties_khr(
             command_buffer,
             structures.len() as _,
             structures.as_ptr(),
@@ -276,12 +276,11 @@ impl AccelerationStructure {
     ) -> vk::AccelerationStructureCompatibilityKHR {
         let mut compatibility = vk::AccelerationStructureCompatibilityKHR::default();
 
-        self.fns
-            .get_device_acceleration_structure_compatibility_khr(
-                self.handle,
-                version,
-                &mut compatibility as *mut _,
-            );
+        self.fp.get_device_acceleration_structure_compatibility_khr(
+            self.handle,
+            version,
+            &mut compatibility as *mut _,
+        );
 
         compatibility
     }
@@ -297,7 +296,7 @@ impl AccelerationStructure {
 
         let mut size_info = vk::AccelerationStructureBuildSizesInfoKHR::default();
 
-        self.fns.get_acceleration_structure_build_sizes_khr(
+        self.fp.get_acceleration_structure_build_sizes_khr(
             self.handle,
             build_type,
             build_info as *const _,
@@ -313,7 +312,7 @@ impl AccelerationStructure {
     }
 
     pub fn fp(&self) -> &vk::KhrAccelerationStructureFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -8,18 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct AccelerationStructure {
     handle: vk::Device,
-    acceleration_structure_fn: vk::KhrAccelerationStructureFn,
+    fns: vk::KhrAccelerationStructureFn,
 }
 
 impl AccelerationStructure {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let acceleration_structure_fn = vk::KhrAccelerationStructureFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrAccelerationStructureFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            acceleration_structure_fn,
-        }
+        Self { handle, fns }
     }
 
     pub unsafe fn get_properties(
@@ -41,7 +39,7 @@ impl AccelerationStructure {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::AccelerationStructureKHR> {
         let mut accel_struct = mem::zeroed();
-        self.acceleration_structure_fn
+        self.fns
             .create_acceleration_structure_khr(
                 self.handle,
                 create_info,
@@ -57,12 +55,11 @@ impl AccelerationStructure {
         accel_struct: vk::AccelerationStructureKHR,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.acceleration_structure_fn
-            .destroy_acceleration_structure_khr(
-                self.handle,
-                accel_struct,
-                allocation_callbacks.as_raw_ptr(),
-            );
+        self.fns.destroy_acceleration_structure_khr(
+            self.handle,
+            accel_struct,
+            allocation_callbacks.as_raw_ptr(),
+        );
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBuildAccelerationStructuresKHR.html>"]
@@ -83,13 +80,12 @@ impl AccelerationStructure {
             })
             .collect::<Vec<_>>();
 
-        self.acceleration_structure_fn
-            .cmd_build_acceleration_structures_khr(
-                command_buffer,
-                infos.len() as _,
-                infos.as_ptr(),
-                build_range_infos.as_ptr(),
-            );
+        self.fns.cmd_build_acceleration_structures_khr(
+            command_buffer,
+            infos.len() as _,
+            infos.as_ptr(),
+            build_range_infos.as_ptr(),
+        );
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBuildAccelerationStructuresIndirectKHR.html>"]
@@ -114,15 +110,14 @@ impl AccelerationStructure {
             })
             .collect::<Vec<_>>();
 
-        self.acceleration_structure_fn
-            .cmd_build_acceleration_structures_indirect_khr(
-                command_buffer,
-                infos.len() as _,
-                infos.as_ptr(),
-                indirect_device_addresses.as_ptr(),
-                indirect_strides.as_ptr(),
-                max_primitive_counts.as_ptr(),
-            );
+        self.fns.cmd_build_acceleration_structures_indirect_khr(
+            command_buffer,
+            infos.len() as _,
+            infos.as_ptr(),
+            indirect_device_addresses.as_ptr(),
+            indirect_strides.as_ptr(),
+            max_primitive_counts.as_ptr(),
+        );
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkBuildAccelerationStructuresKHR.html>"]
@@ -143,7 +138,7 @@ impl AccelerationStructure {
             })
             .collect::<Vec<_>>();
 
-        self.acceleration_structure_fn
+        self.fns
             .build_acceleration_structures_khr(
                 self.handle,
                 deferred_operation,
@@ -160,7 +155,7 @@ impl AccelerationStructure {
         deferred_operation: vk::DeferredOperationKHR,
         info: &vk::CopyAccelerationStructureInfoKHR,
     ) -> VkResult<()> {
-        self.acceleration_structure_fn
+        self.fns
             .copy_acceleration_structure_khr(self.handle, deferred_operation, info as *const _)
             .result()
     }
@@ -171,7 +166,7 @@ impl AccelerationStructure {
         deferred_operation: vk::DeferredOperationKHR,
         info: &vk::CopyAccelerationStructureToMemoryInfoKHR,
     ) -> VkResult<()> {
-        self.acceleration_structure_fn
+        self.fns
             .copy_acceleration_structure_to_memory_khr(
                 self.handle,
                 deferred_operation,
@@ -186,7 +181,7 @@ impl AccelerationStructure {
         deferred_operation: vk::DeferredOperationKHR,
         info: &vk::CopyMemoryToAccelerationStructureInfoKHR,
     ) -> VkResult<()> {
-        self.acceleration_structure_fn
+        self.fns
             .copy_memory_to_acceleration_structure_khr(
                 self.handle,
                 deferred_operation,
@@ -203,7 +198,7 @@ impl AccelerationStructure {
         data: &mut [u8],
         stride: usize,
     ) -> VkResult<()> {
-        self.acceleration_structure_fn
+        self.fns
             .write_acceleration_structures_properties_khr(
                 self.handle,
                 acceleration_structures.len() as _,
@@ -222,7 +217,7 @@ impl AccelerationStructure {
         command_buffer: vk::CommandBuffer,
         info: &vk::CopyAccelerationStructureInfoKHR,
     ) {
-        self.acceleration_structure_fn
+        self.fns
             .cmd_copy_acceleration_structure_khr(command_buffer, info);
     }
 
@@ -232,7 +227,7 @@ impl AccelerationStructure {
         command_buffer: vk::CommandBuffer,
         info: &vk::CopyAccelerationStructureToMemoryInfoKHR,
     ) {
-        self.acceleration_structure_fn
+        self.fns
             .cmd_copy_acceleration_structure_to_memory_khr(command_buffer, info as *const _);
     }
 
@@ -242,7 +237,7 @@ impl AccelerationStructure {
         command_buffer: vk::CommandBuffer,
         info: &vk::CopyMemoryToAccelerationStructureInfoKHR,
     ) {
-        self.acceleration_structure_fn
+        self.fns
             .cmd_copy_memory_to_acceleration_structure_khr(command_buffer, info as *const _);
     }
 
@@ -251,7 +246,7 @@ impl AccelerationStructure {
         &self,
         info: &vk::AccelerationStructureDeviceAddressInfoKHR,
     ) -> vk::DeviceAddress {
-        self.acceleration_structure_fn
+        self.fns
             .get_acceleration_structure_device_address_khr(self.handle, info as *const _)
     }
 
@@ -264,15 +259,14 @@ impl AccelerationStructure {
         query_pool: vk::QueryPool,
         first_query: u32,
     ) {
-        self.acceleration_structure_fn
-            .cmd_write_acceleration_structures_properties_khr(
-                command_buffer,
-                structures.len() as _,
-                structures.as_ptr(),
-                query_type,
-                query_pool,
-                first_query,
-            );
+        self.fns.cmd_write_acceleration_structures_properties_khr(
+            command_buffer,
+            structures.len() as _,
+            structures.as_ptr(),
+            query_type,
+            query_pool,
+            first_query,
+        );
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceAccelerationStructureCompatibilityKHR.html>"]
@@ -282,7 +276,7 @@ impl AccelerationStructure {
     ) -> vk::AccelerationStructureCompatibilityKHR {
         let mut compatibility = vk::AccelerationStructureCompatibilityKHR::default();
 
-        self.acceleration_structure_fn
+        self.fns
             .get_device_acceleration_structure_compatibility_khr(
                 self.handle,
                 version,
@@ -303,14 +297,13 @@ impl AccelerationStructure {
 
         let mut size_info = vk::AccelerationStructureBuildSizesInfoKHR::default();
 
-        self.acceleration_structure_fn
-            .get_acceleration_structure_build_sizes_khr(
-                self.handle,
-                build_type,
-                build_info as *const _,
-                max_primitive_counts.as_ptr(),
-                &mut size_info as *mut _,
-            );
+        self.fns.get_acceleration_structure_build_sizes_khr(
+            self.handle,
+            build_type,
+            build_info as *const _,
+            max_primitive_counts.as_ptr(),
+            &mut size_info as *mut _,
+        );
 
         size_info
     }
@@ -320,7 +313,7 @@ impl AccelerationStructure {
     }
 
     pub fn fp(&self) -> &vk::KhrAccelerationStructureFn {
-        &self.acceleration_structure_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct AndroidSurface {
     handle: vk::Instance,
-    android_surface_fn: vk::KhrAndroidSurfaceFn,
+    fns: vk::KhrAndroidSurfaceFn,
 }
 
 impl AndroidSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let surface_fn = vk::KhrAndroidSurfaceFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::KhrAndroidSurfaceFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            android_surface_fn: surface_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrAndroidSurfaceFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateAndroidSurfaceKHR.html>"]
@@ -33,7 +27,7 @@ impl AndroidSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.android_surface_fn
+        self.fns
             .create_android_surface_khr(
                 self.handle,
                 create_info,
@@ -43,8 +37,12 @@ impl AndroidSurface {
             .result_with_success(surface)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrAndroidSurfaceFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrAndroidSurfaceFn {
-        &self.android_surface_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct AndroidSurface {
     handle: vk::Instance,
-    fns: vk::KhrAndroidSurfaceFn,
+    fp: vk::KhrAndroidSurfaceFn,
 }
 
 impl AndroidSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::KhrAndroidSurfaceFn::load(|name| unsafe {
+        let fp = vk::KhrAndroidSurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateAndroidSurfaceKHR.html>"]
@@ -27,7 +27,7 @@ impl AndroidSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.fns
+        self.fp
             .create_android_surface_khr(
                 self.handle,
                 create_info,
@@ -42,7 +42,7 @@ impl AndroidSurface {
     }
 
     pub fn fp(&self) -> &vk::KhrAndroidSurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/buffer_device_address.rs
+++ b/ash/src/extensions/khr/buffer_device_address.rs
@@ -6,16 +6,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct BufferDeviceAddress {
     handle: vk::Device,
-    fns: vk::KhrBufferDeviceAddressFn,
+    fp: vk::KhrBufferDeviceAddressFn,
 }
 
 impl BufferDeviceAddress {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrBufferDeviceAddressFn::load(|name| unsafe {
+        let fp = vk::KhrBufferDeviceAddressFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferDeviceAddressKHR.html>"]
@@ -23,7 +23,7 @@ impl BufferDeviceAddress {
         &self,
         info: &vk::BufferDeviceAddressInfoKHR,
     ) -> vk::DeviceAddress {
-        self.fns.get_buffer_device_address_khr(self.handle, info)
+        self.fp.get_buffer_device_address_khr(self.handle, info)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferOpaqueCaptureAddressKHR.html>"]
@@ -31,7 +31,7 @@ impl BufferDeviceAddress {
         &self,
         info: &vk::BufferDeviceAddressInfoKHR,
     ) -> u64 {
-        self.fns
+        self.fp
             .get_buffer_opaque_capture_address_khr(self.handle, info)
     }
 
@@ -40,7 +40,7 @@ impl BufferDeviceAddress {
         &self,
         info: &vk::DeviceMemoryOpaqueCaptureAddressInfoKHR,
     ) -> u64 {
-        self.fns
+        self.fp
             .get_device_memory_opaque_capture_address_khr(self.handle, info)
     }
 
@@ -49,7 +49,7 @@ impl BufferDeviceAddress {
     }
 
     pub fn fp(&self) -> &vk::KhrBufferDeviceAddressFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/buffer_device_address.rs
+++ b/ash/src/extensions/khr/buffer_device_address.rs
@@ -11,13 +11,11 @@ pub struct BufferDeviceAddress {
 
 impl BufferDeviceAddress {
     pub fn new(instance: &Instance, device: &Device) -> Self {
+        let handle = device.handle();
         let fns = vk::KhrBufferDeviceAddressFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            fns,
-        }
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferDeviceAddressKHR.html>"]

--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct CreateRenderPass2 {
     handle: vk::Device,
-    fns: vk::KhrCreateRenderpass2Fn,
+    fp: vk::KhrCreateRenderpass2Fn,
 }
 
 impl CreateRenderPass2 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrCreateRenderpass2Fn::load(|name| unsafe {
+        let fp = vk::KhrCreateRenderpass2Fn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateRenderPass2.html>"]
@@ -27,7 +27,7 @@ impl CreateRenderPass2 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::zeroed();
-        self.fns
+        self.fp
             .create_render_pass2_khr(
                 self.handle,
                 create_info,
@@ -44,7 +44,7 @@ impl CreateRenderPass2 {
         render_pass_begin_info: &vk::RenderPassBeginInfo,
         subpass_begin_info: &vk::SubpassBeginInfo,
     ) {
-        self.fns.cmd_begin_render_pass2_khr(
+        self.fp.cmd_begin_render_pass2_khr(
             command_buffer,
             render_pass_begin_info,
             subpass_begin_info,
@@ -58,7 +58,7 @@ impl CreateRenderPass2 {
         subpass_begin_info: &vk::SubpassBeginInfo,
         subpass_end_info: &vk::SubpassEndInfo,
     ) {
-        self.fns
+        self.fp
             .cmd_next_subpass2_khr(command_buffer, subpass_begin_info, subpass_end_info);
     }
 
@@ -68,7 +68,7 @@ impl CreateRenderPass2 {
         command_buffer: vk::CommandBuffer,
         subpass_end_info: &vk::SubpassEndInfo,
     ) {
-        self.fns
+        self.fp
             .cmd_end_render_pass2_khr(command_buffer, subpass_end_info);
     }
 
@@ -77,7 +77,7 @@ impl CreateRenderPass2 {
     }
 
     pub fn fp(&self) -> &vk::KhrCreateRenderpass2Fn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct CreateRenderPass2 {
     handle: vk::Device,
-    khr_create_renderpass2_fn: vk::KhrCreateRenderpass2Fn,
+    fns: vk::KhrCreateRenderpass2Fn,
 }
 
 impl CreateRenderPass2 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let khr_create_renderpass2_fn = vk::KhrCreateRenderpass2Fn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrCreateRenderpass2Fn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            khr_create_renderpass2_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrCreateRenderpass2Fn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateRenderPass2.html>"]
@@ -33,7 +27,7 @@ impl CreateRenderPass2 {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::RenderPass> {
         let mut renderpass = mem::zeroed();
-        self.khr_create_renderpass2_fn
+        self.fns
             .create_render_pass2_khr(
                 self.handle,
                 create_info,
@@ -50,7 +44,7 @@ impl CreateRenderPass2 {
         render_pass_begin_info: &vk::RenderPassBeginInfo,
         subpass_begin_info: &vk::SubpassBeginInfo,
     ) {
-        self.khr_create_renderpass2_fn.cmd_begin_render_pass2_khr(
+        self.fns.cmd_begin_render_pass2_khr(
             command_buffer,
             render_pass_begin_info,
             subpass_begin_info,
@@ -64,11 +58,8 @@ impl CreateRenderPass2 {
         subpass_begin_info: &vk::SubpassBeginInfo,
         subpass_end_info: &vk::SubpassEndInfo,
     ) {
-        self.khr_create_renderpass2_fn.cmd_next_subpass2_khr(
-            command_buffer,
-            subpass_begin_info,
-            subpass_end_info,
-        );
+        self.fns
+            .cmd_next_subpass2_khr(command_buffer, subpass_begin_info, subpass_end_info);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndRenderPass2.html>"]
@@ -77,12 +68,16 @@ impl CreateRenderPass2 {
         command_buffer: vk::CommandBuffer,
         subpass_end_info: &vk::SubpassEndInfo,
     ) {
-        self.khr_create_renderpass2_fn
+        self.fns
             .cmd_end_render_pass2_khr(command_buffer, subpass_end_info);
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrCreateRenderpass2Fn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrCreateRenderpass2Fn {
-        &self.khr_create_renderpass2_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -8,18 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct DeferredHostOperations {
     handle: vk::Device,
-    deferred_host_operations_fn: vk::KhrDeferredHostOperationsFn,
+    fns: vk::KhrDeferredHostOperationsFn,
 }
 
 impl DeferredHostOperations {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let deferred_host_operations_fn = vk::KhrDeferredHostOperationsFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrDeferredHostOperationsFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            deferred_host_operations_fn,
-        }
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDeferredOperationKHR.html>"]
@@ -28,7 +26,7 @@ impl DeferredHostOperations {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DeferredOperationKHR> {
         let mut operation = mem::zeroed();
-        self.deferred_host_operations_fn
+        self.fns
             .create_deferred_operation_khr(
                 self.handle,
                 allocation_callbacks.as_raw_ptr(),
@@ -42,7 +40,7 @@ impl DeferredHostOperations {
         &self,
         operation: vk::DeferredOperationKHR,
     ) -> VkResult<()> {
-        self.deferred_host_operations_fn
+        self.fns
             .deferred_operation_join_khr(self.handle, operation)
             .result()
     }
@@ -53,12 +51,11 @@ impl DeferredHostOperations {
         operation: vk::DeferredOperationKHR,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.deferred_host_operations_fn
-            .destroy_deferred_operation_khr(
-                self.handle,
-                operation,
-                allocation_callbacks.as_raw_ptr(),
-            );
+        self.fns.destroy_deferred_operation_khr(
+            self.handle,
+            operation,
+            allocation_callbacks.as_raw_ptr(),
+        );
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeferredOperationMaxConcurrencyKHR.html>"]
@@ -66,7 +63,7 @@ impl DeferredHostOperations {
         &self,
         operation: vk::DeferredOperationKHR,
     ) -> u32 {
-        self.deferred_host_operations_fn
+        self.fns
             .get_deferred_operation_max_concurrency_khr(self.handle, operation)
     }
 
@@ -75,7 +72,7 @@ impl DeferredHostOperations {
         &self,
         operation: vk::DeferredOperationKHR,
     ) -> VkResult<()> {
-        self.deferred_host_operations_fn
+        self.fns
             .get_deferred_operation_result_khr(self.handle, operation)
             .result()
     }
@@ -85,7 +82,7 @@ impl DeferredHostOperations {
     }
 
     pub fn fp(&self) -> &vk::KhrDeferredHostOperationsFn {
-        &self.deferred_host_operations_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct DeferredHostOperations {
     handle: vk::Device,
-    fns: vk::KhrDeferredHostOperationsFn,
+    fp: vk::KhrDeferredHostOperationsFn,
 }
 
 impl DeferredHostOperations {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrDeferredHostOperationsFn::load(|name| unsafe {
+        let fp = vk::KhrDeferredHostOperationsFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDeferredOperationKHR.html>"]
@@ -26,7 +26,7 @@ impl DeferredHostOperations {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DeferredOperationKHR> {
         let mut operation = mem::zeroed();
-        self.fns
+        self.fp
             .create_deferred_operation_khr(
                 self.handle,
                 allocation_callbacks.as_raw_ptr(),
@@ -40,7 +40,7 @@ impl DeferredHostOperations {
         &self,
         operation: vk::DeferredOperationKHR,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .deferred_operation_join_khr(self.handle, operation)
             .result()
     }
@@ -51,7 +51,7 @@ impl DeferredHostOperations {
         operation: vk::DeferredOperationKHR,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.fns.destroy_deferred_operation_khr(
+        self.fp.destroy_deferred_operation_khr(
             self.handle,
             operation,
             allocation_callbacks.as_raw_ptr(),
@@ -63,7 +63,7 @@ impl DeferredHostOperations {
         &self,
         operation: vk::DeferredOperationKHR,
     ) -> u32 {
-        self.fns
+        self.fp
             .get_deferred_operation_max_concurrency_khr(self.handle, operation)
     }
 
@@ -72,7 +72,7 @@ impl DeferredHostOperations {
         &self,
         operation: vk::DeferredOperationKHR,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .get_deferred_operation_result_khr(self.handle, operation)
             .result()
     }
@@ -82,7 +82,7 @@ impl DeferredHostOperations {
     }
 
     pub fn fp(&self) -> &vk::KhrDeferredHostOperationsFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Display {
     handle: vk::Instance,
-    fns: vk::KhrDisplayFn,
+    fp: vk::KhrDisplayFn,
 }
 
 impl Display {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::KhrDisplayFn::load(|name| unsafe {
+        let fp = vk::KhrDisplayFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceDisplayPropertiesKHR.html>"]
@@ -26,7 +26,7 @@ impl Display {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::DisplayPropertiesKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.fns
+            self.fp
                 .get_physical_device_display_properties_khr(physical_device, count, data)
         })
     }
@@ -37,7 +37,7 @@ impl Display {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::DisplayPlanePropertiesKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.fns
+            self.fp
                 .get_physical_device_display_plane_properties_khr(physical_device, count, data)
         })
     }
@@ -49,7 +49,7 @@ impl Display {
         plane_index: u32,
     ) -> VkResult<Vec<vk::DisplayKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.fns.get_display_plane_supported_displays_khr(
+            self.fp.get_display_plane_supported_displays_khr(
                 physical_device,
                 plane_index,
                 count,
@@ -65,7 +65,7 @@ impl Display {
         display: vk::DisplayKHR,
     ) -> VkResult<Vec<vk::DisplayModePropertiesKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.fns
+            self.fp
                 .get_display_mode_properties_khr(physical_device, display, count, data)
         })
     }
@@ -79,7 +79,7 @@ impl Display {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DisplayModeKHR> {
         let mut display_mode = mem::MaybeUninit::zeroed();
-        self.fns
+        self.fp
             .create_display_mode_khr(
                 physical_device,
                 display,
@@ -98,7 +98,7 @@ impl Display {
         plane_index: u32,
     ) -> VkResult<vk::DisplayPlaneCapabilitiesKHR> {
         let mut display_plane_capabilities = mem::MaybeUninit::zeroed();
-        self.fns
+        self.fp
             .get_display_plane_capabilities_khr(
                 physical_device,
                 mode,
@@ -115,7 +115,7 @@ impl Display {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::zeroed();
-        self.fns
+        self.fp
             .create_display_plane_surface_khr(
                 self.handle,
                 create_info,
@@ -130,7 +130,7 @@ impl Display {
     }
 
     pub fn fp(&self) -> &vk::KhrDisplayFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Display {
     handle: vk::Instance,
-    display_fn: vk::KhrDisplayFn,
+    fns: vk::KhrDisplayFn,
 }
 
 impl Display {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let display_fn = vk::KhrDisplayFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::KhrDisplayFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            display_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrDisplayFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceDisplayPropertiesKHR.html>"]
@@ -32,7 +26,7 @@ impl Display {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::DisplayPropertiesKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.display_fn
+            self.fns
                 .get_physical_device_display_properties_khr(physical_device, count, data)
         })
     }
@@ -43,7 +37,7 @@ impl Display {
         physical_device: vk::PhysicalDevice,
     ) -> VkResult<Vec<vk::DisplayPlanePropertiesKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.display_fn
+            self.fns
                 .get_physical_device_display_plane_properties_khr(physical_device, count, data)
         })
     }
@@ -55,7 +49,7 @@ impl Display {
         plane_index: u32,
     ) -> VkResult<Vec<vk::DisplayKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.display_fn.get_display_plane_supported_displays_khr(
+            self.fns.get_display_plane_supported_displays_khr(
                 physical_device,
                 plane_index,
                 count,
@@ -71,7 +65,7 @@ impl Display {
         display: vk::DisplayKHR,
     ) -> VkResult<Vec<vk::DisplayModePropertiesKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.display_fn
+            self.fns
                 .get_display_mode_properties_khr(physical_device, display, count, data)
         })
     }
@@ -85,7 +79,7 @@ impl Display {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::DisplayModeKHR> {
         let mut display_mode = mem::MaybeUninit::zeroed();
-        self.display_fn
+        self.fns
             .create_display_mode_khr(
                 physical_device,
                 display,
@@ -104,7 +98,7 @@ impl Display {
         plane_index: u32,
     ) -> VkResult<vk::DisplayPlaneCapabilitiesKHR> {
         let mut display_plane_capabilities = mem::MaybeUninit::zeroed();
-        self.display_fn
+        self.fns
             .get_display_plane_capabilities_khr(
                 physical_device,
                 mode,
@@ -121,7 +115,7 @@ impl Display {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::MaybeUninit::zeroed();
-        self.display_fn
+        self.fns
             .create_display_plane_surface_khr(
                 self.handle,
                 create_info,
@@ -131,8 +125,12 @@ impl Display {
             .result_with_success(surface.assume_init())
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrDisplayFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrDisplayFn {
-        &self.display_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct DisplaySwapchain {
     handle: vk::Device,
-    swapchain_fn: vk::KhrDisplaySwapchainFn,
+    fns: vk::KhrDisplaySwapchainFn,
 }
 
 impl DisplaySwapchain {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let swapchain_fn = vk::KhrDisplaySwapchainFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrDisplaySwapchainFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            swapchain_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrDisplaySwapchainFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateSharedSwapchainsKHR.html>"]
@@ -33,7 +27,7 @@ impl DisplaySwapchain {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Vec<vk::SwapchainKHR>> {
         let mut swapchains = Vec::with_capacity(create_infos.len());
-        let err_code = self.swapchain_fn.create_shared_swapchains_khr(
+        let err_code = self.fns.create_shared_swapchains_khr(
             self.handle,
             create_infos.len() as u32,
             create_infos.as_ptr(),
@@ -44,8 +38,12 @@ impl DisplaySwapchain {
         err_code.result_with_success(swapchains)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrDisplaySwapchainFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrDisplaySwapchainFn {
-        &self.swapchain_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct DisplaySwapchain {
     handle: vk::Device,
-    fns: vk::KhrDisplaySwapchainFn,
+    fp: vk::KhrDisplaySwapchainFn,
 }
 
 impl DisplaySwapchain {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrDisplaySwapchainFn::load(|name| unsafe {
+        let fp = vk::KhrDisplaySwapchainFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateSharedSwapchainsKHR.html>"]
@@ -27,7 +27,7 @@ impl DisplaySwapchain {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Vec<vk::SwapchainKHR>> {
         let mut swapchains = Vec::with_capacity(create_infos.len());
-        let err_code = self.fns.create_shared_swapchains_khr(
+        let err_code = self.fp.create_shared_swapchains_khr(
             self.handle,
             create_infos.len() as u32,
             create_infos.as_ptr(),
@@ -43,7 +43,7 @@ impl DisplaySwapchain {
     }
 
     pub fn fp(&self) -> &vk::KhrDisplaySwapchainFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/draw_indirect_count.rs
+++ b/ash/src/extensions/khr/draw_indirect_count.rs
@@ -6,22 +6,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct DrawIndirectCount {
     handle: vk::Device,
-    draw_indirect_count_fn: vk::KhrDrawIndirectCountFn,
+    fns: vk::KhrDrawIndirectCountFn,
 }
 
 impl DrawIndirectCount {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let draw_indirect_count_fn = vk::KhrDrawIndirectCountFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrDrawIndirectCountFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            draw_indirect_count_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrDrawIndirectCountFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndexedIndirectCountKHR.html>"]
@@ -35,16 +29,15 @@ impl DrawIndirectCount {
         max_draw_count: u32,
         stride: u32,
     ) {
-        self.draw_indirect_count_fn
-            .cmd_draw_indexed_indirect_count_khr(
-                command_buffer,
-                buffer,
-                offset,
-                count_buffer,
-                count_buffer_offset,
-                max_draw_count,
-                stride,
-            );
+        self.fns.cmd_draw_indexed_indirect_count_khr(
+            command_buffer,
+            buffer,
+            offset,
+            count_buffer,
+            count_buffer_offset,
+            max_draw_count,
+            stride,
+        );
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndirectCountKHR.html>"]
@@ -58,15 +51,26 @@ impl DrawIndirectCount {
         max_draw_count: u32,
         stride: u32,
     ) {
-        self.draw_indirect_count_fn
-            .cmd_draw_indexed_indirect_count_khr(
-                command_buffer,
-                buffer,
-                offset,
-                count_buffer,
-                count_buffer_offset,
-                max_draw_count,
-                stride,
-            );
+        self.fns.cmd_draw_indexed_indirect_count_khr(
+            command_buffer,
+            buffer,
+            offset,
+            count_buffer,
+            count_buffer_offset,
+            max_draw_count,
+            stride,
+        );
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrDrawIndirectCountFn::name()
+    }
+
+    pub fn fp(&self) -> &vk::KhrDrawIndirectCountFn {
+        &self.fns
+    }
+
+    pub fn device(&self) -> vk::Device {
+        self.handle
     }
 }

--- a/ash/src/extensions/khr/draw_indirect_count.rs
+++ b/ash/src/extensions/khr/draw_indirect_count.rs
@@ -5,15 +5,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct DrawIndirectCount {
-    fns: vk::KhrDrawIndirectCountFn,
+    fp: vk::KhrDrawIndirectCountFn,
 }
 
 impl DrawIndirectCount {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let fns = vk::KhrDrawIndirectCountFn::load(|name| unsafe {
+        let fp = vk::KhrDrawIndirectCountFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { fns }
+        Self { fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndexedIndirectCountKHR.html>"]
@@ -27,7 +27,7 @@ impl DrawIndirectCount {
         max_draw_count: u32,
         stride: u32,
     ) {
-        self.fns.cmd_draw_indexed_indirect_count_khr(
+        self.fp.cmd_draw_indexed_indirect_count_khr(
             command_buffer,
             buffer,
             offset,
@@ -49,7 +49,7 @@ impl DrawIndirectCount {
         max_draw_count: u32,
         stride: u32,
     ) {
-        self.fns.cmd_draw_indexed_indirect_count_khr(
+        self.fp.cmd_draw_indexed_indirect_count_khr(
             command_buffer,
             buffer,
             offset,
@@ -65,6 +65,6 @@ impl DrawIndirectCount {
     }
 
     pub fn fp(&self) -> &vk::KhrDrawIndirectCountFn {
-        &self.fns
+        &self.fp
     }
 }

--- a/ash/src/extensions/khr/draw_indirect_count.rs
+++ b/ash/src/extensions/khr/draw_indirect_count.rs
@@ -5,17 +5,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct DrawIndirectCount {
-    handle: vk::Device,
     fns: vk::KhrDrawIndirectCountFn,
 }
 
 impl DrawIndirectCount {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let handle = device.handle();
         let fns = vk::KhrDrawIndirectCountFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCmdDrawIndexedIndirectCountKHR.html>"]
@@ -68,9 +66,5 @@ impl DrawIndirectCount {
 
     pub fn fp(&self) -> &vk::KhrDrawIndirectCountFn {
         &self.fns
-    }
-
-    pub fn device(&self) -> vk::Device {
-        self.handle
     }
 }

--- a/ash/src/extensions/khr/dynamic_rendering.rs
+++ b/ash/src/extensions/khr/dynamic_rendering.rs
@@ -5,25 +5,17 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct DynamicRendering {
+    handle: vk::Device,
     fns: vk::KhrDynamicRenderingFn,
 }
 
 impl DynamicRendering {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let dynamic_rendering_fn = vk::KhrDynamicRenderingFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrDynamicRenderingFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            fns: dynamic_rendering_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrDynamicRenderingFn::name()
-    }
-
-    pub fn fp(&self) -> &vk::KhrDynamicRenderingFn {
-        &self.fns
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginRenderingKHR.html>"]
@@ -39,5 +31,17 @@ impl DynamicRendering {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndRenderingKHR.html>"]
     pub unsafe fn cmd_end_rendering(&self, command_buffer: vk::CommandBuffer) {
         self.fns.cmd_end_rendering_khr(command_buffer)
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrDynamicRenderingFn::name()
+    }
+
+    pub fn fp(&self) -> &vk::KhrDynamicRenderingFn {
+        &self.fns
+    }
+
+    pub fn device(&self) -> vk::Device {
+        self.handle
     }
 }

--- a/ash/src/extensions/khr/dynamic_rendering.rs
+++ b/ash/src/extensions/khr/dynamic_rendering.rs
@@ -5,17 +5,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct DynamicRendering {
-    handle: vk::Device,
     fns: vk::KhrDynamicRenderingFn,
 }
 
 impl DynamicRendering {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let handle = device.handle();
         let fns = vk::KhrDynamicRenderingFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginRenderingKHR.html>"]
@@ -39,9 +37,5 @@ impl DynamicRendering {
 
     pub fn fp(&self) -> &vk::KhrDynamicRenderingFn {
         &self.fns
-    }
-
-    pub fn device(&self) -> vk::Device {
-        self.handle
     }
 }

--- a/ash/src/extensions/khr/dynamic_rendering.rs
+++ b/ash/src/extensions/khr/dynamic_rendering.rs
@@ -5,15 +5,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct DynamicRendering {
-    fns: vk::KhrDynamicRenderingFn,
+    fp: vk::KhrDynamicRenderingFn,
 }
 
 impl DynamicRendering {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let fns = vk::KhrDynamicRenderingFn::load(|name| unsafe {
+        let fp = vk::KhrDynamicRenderingFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { fns }
+        Self { fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBeginRenderingKHR.html>"]
@@ -22,13 +22,13 @@ impl DynamicRendering {
         command_buffer: vk::CommandBuffer,
         rendering_info: &vk::RenderingInfoKHR,
     ) {
-        self.fns
+        self.fp
             .cmd_begin_rendering_khr(command_buffer, rendering_info)
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdEndRenderingKHR.html>"]
     pub unsafe fn cmd_end_rendering(&self, command_buffer: vk::CommandBuffer) {
-        self.fns.cmd_end_rendering_khr(command_buffer)
+        self.fp.cmd_end_rendering_khr(command_buffer)
     }
 
     pub fn name() -> &'static CStr {
@@ -36,6 +36,6 @@ impl DynamicRendering {
     }
 
     pub fn fp(&self) -> &vk::KhrDynamicRenderingFn {
-        &self.fns
+        &self.fp
     }
 }

--- a/ash/src/extensions/khr/external_fence_fd.rs
+++ b/ash/src/extensions/khr/external_fence_fd.rs
@@ -7,27 +7,21 @@ use std::mem;
 #[derive(Clone)]
 pub struct ExternalFenceFd {
     handle: vk::Device,
-    external_fence_fd_fn: vk::KhrExternalFenceFdFn,
+    fns: vk::KhrExternalFenceFdFn,
 }
 
 impl ExternalFenceFd {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let external_fence_fd_fn = vk::KhrExternalFenceFdFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrExternalFenceFdFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            external_fence_fd_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrExternalFenceFdFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkImportFenceFdKHR.html>"]
     pub unsafe fn import_fence_fd(&self, import_info: &vk::ImportFenceFdInfoKHR) -> VkResult<()> {
-        self.external_fence_fd_fn
+        self.fns
             .import_fence_fd_khr(self.handle, import_info)
             .result()
     }
@@ -35,14 +29,17 @@ impl ExternalFenceFd {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetFenceFdKHR.html>"]
     pub unsafe fn get_fence_fd(&self, get_info: &vk::FenceGetFdInfoKHR) -> VkResult<i32> {
         let mut fd = -1;
-
-        self.external_fence_fd_fn
+        self.fns
             .get_fence_fd_khr(self.handle, get_info, &mut fd)
             .result_with_success(fd)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrExternalFenceFdFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrExternalFenceFdFn {
-        &self.external_fence_fd_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/external_fence_fd.rs
+++ b/ash/src/extensions/khr/external_fence_fd.rs
@@ -7,21 +7,21 @@ use std::mem;
 #[derive(Clone)]
 pub struct ExternalFenceFd {
     handle: vk::Device,
-    fns: vk::KhrExternalFenceFdFn,
+    fp: vk::KhrExternalFenceFdFn,
 }
 
 impl ExternalFenceFd {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrExternalFenceFdFn::load(|name| unsafe {
+        let fp = vk::KhrExternalFenceFdFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkImportFenceFdKHR.html>"]
     pub unsafe fn import_fence_fd(&self, import_info: &vk::ImportFenceFdInfoKHR) -> VkResult<()> {
-        self.fns
+        self.fp
             .import_fence_fd_khr(self.handle, import_info)
             .result()
     }
@@ -29,7 +29,7 @@ impl ExternalFenceFd {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetFenceFdKHR.html>"]
     pub unsafe fn get_fence_fd(&self, get_info: &vk::FenceGetFdInfoKHR) -> VkResult<i32> {
         let mut fd = -1;
-        self.fns
+        self.fp
             .get_fence_fd_khr(self.handle, get_info, &mut fd)
             .result_with_success(fd)
     }
@@ -39,7 +39,7 @@ impl ExternalFenceFd {
     }
 
     pub fn fp(&self) -> &vk::KhrExternalFenceFdFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -7,29 +7,22 @@ use std::mem;
 #[derive(Clone)]
 pub struct ExternalMemoryFd {
     handle: vk::Device,
-    external_memory_fd_fn: vk::KhrExternalMemoryFdFn,
+    fns: vk::KhrExternalMemoryFdFn,
 }
 
 impl ExternalMemoryFd {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let external_memory_fd_fn = vk::KhrExternalMemoryFdFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrExternalMemoryFdFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            external_memory_fd_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrExternalMemoryFdFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryFdKHR.html>"]
     pub unsafe fn get_memory_fd(&self, create_info: &vk::MemoryGetFdInfoKHR) -> VkResult<i32> {
         let mut fd = -1;
-
-        self.external_memory_fd_fn
+        self.fns
             .get_memory_fd_khr(self.handle, create_info, &mut fd)
             .result_with_success(fd)
     }
@@ -41,13 +34,17 @@ impl ExternalMemoryFd {
         fd: i32,
     ) -> VkResult<vk::MemoryFdPropertiesKHR> {
         let mut memory_fd_properties = Default::default();
-        self.external_memory_fd_fn
+        self.fns
             .get_memory_fd_properties_khr(self.handle, handle_type, fd, &mut memory_fd_properties)
             .result_with_success(memory_fd_properties)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrExternalMemoryFdFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrExternalMemoryFdFn {
-        &self.external_memory_fd_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -7,22 +7,22 @@ use std::mem;
 #[derive(Clone)]
 pub struct ExternalMemoryFd {
     handle: vk::Device,
-    fns: vk::KhrExternalMemoryFdFn,
+    fp: vk::KhrExternalMemoryFdFn,
 }
 
 impl ExternalMemoryFd {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrExternalMemoryFdFn::load(|name| unsafe {
+        let fp = vk::KhrExternalMemoryFdFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetMemoryFdKHR.html>"]
     pub unsafe fn get_memory_fd(&self, create_info: &vk::MemoryGetFdInfoKHR) -> VkResult<i32> {
         let mut fd = -1;
-        self.fns
+        self.fp
             .get_memory_fd_khr(self.handle, create_info, &mut fd)
             .result_with_success(fd)
     }
@@ -34,7 +34,7 @@ impl ExternalMemoryFd {
         fd: i32,
     ) -> VkResult<vk::MemoryFdPropertiesKHR> {
         let mut memory_fd_properties = Default::default();
-        self.fns
+        self.fp
             .get_memory_fd_properties_khr(self.handle, handle_type, fd, &mut memory_fd_properties)
             .result_with_success(memory_fd_properties)
     }
@@ -44,7 +44,7 @@ impl ExternalMemoryFd {
     }
 
     pub fn fp(&self) -> &vk::KhrExternalMemoryFdFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/external_semaphore_fd.rs
+++ b/ash/src/extensions/khr/external_semaphore_fd.rs
@@ -7,16 +7,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct ExternalSemaphoreFd {
     handle: vk::Device,
-    fns: vk::KhrExternalSemaphoreFdFn,
+    fp: vk::KhrExternalSemaphoreFdFn,
 }
 
 impl ExternalSemaphoreFd {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrExternalSemaphoreFdFn::load(|name| unsafe {
+        let fp = vk::KhrExternalSemaphoreFdFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkImportSemaphoreFdKHR.html>"]
@@ -24,7 +24,7 @@ impl ExternalSemaphoreFd {
         &self,
         import_info: &vk::ImportSemaphoreFdInfoKHR,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .import_semaphore_fd_khr(self.handle, import_info)
             .result()
     }
@@ -32,7 +32,7 @@ impl ExternalSemaphoreFd {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSemaphoreFdKHR.html>"]
     pub unsafe fn get_semaphore_fd(&self, get_info: &vk::SemaphoreGetFdInfoKHR) -> VkResult<i32> {
         let mut fd = -1;
-        self.fns
+        self.fp
             .get_semaphore_fd_khr(self.handle, get_info, &mut fd)
             .result_with_success(fd)
     }
@@ -42,7 +42,7 @@ impl ExternalSemaphoreFd {
     }
 
     pub fn fp(&self) -> &vk::KhrExternalSemaphoreFdFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/external_semaphore_fd.rs
+++ b/ash/src/extensions/khr/external_semaphore_fd.rs
@@ -7,22 +7,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct ExternalSemaphoreFd {
     handle: vk::Device,
-    external_semaphore_fd_fn: vk::KhrExternalSemaphoreFdFn,
+    fns: vk::KhrExternalSemaphoreFdFn,
 }
 
 impl ExternalSemaphoreFd {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let external_semaphore_fd_fn = vk::KhrExternalSemaphoreFdFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrExternalSemaphoreFdFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            external_semaphore_fd_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrExternalSemaphoreFdFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkImportSemaphoreFdKHR.html>"]
@@ -30,7 +24,7 @@ impl ExternalSemaphoreFd {
         &self,
         import_info: &vk::ImportSemaphoreFdInfoKHR,
     ) -> VkResult<()> {
-        self.external_semaphore_fd_fn
+        self.fns
             .import_semaphore_fd_khr(self.handle, import_info)
             .result()
     }
@@ -38,14 +32,17 @@ impl ExternalSemaphoreFd {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSemaphoreFdKHR.html>"]
     pub unsafe fn get_semaphore_fd(&self, get_info: &vk::SemaphoreGetFdInfoKHR) -> VkResult<i32> {
         let mut fd = -1;
-
-        self.external_semaphore_fd_fn
+        self.fns
             .get_semaphore_fd_khr(self.handle, get_info, &mut fd)
             .result_with_success(fd)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrExternalSemaphoreFdFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrExternalSemaphoreFdFn {
-        &self.external_semaphore_fd_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -7,22 +7,16 @@ use std::ptr;
 #[derive(Clone)]
 pub struct GetMemoryRequirements2 {
     handle: vk::Device,
-    get_memory_requirements2_fn: vk::KhrGetMemoryRequirements2Fn,
+    fns: vk::KhrGetMemoryRequirements2Fn,
 }
 
 impl GetMemoryRequirements2 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let get_memory_requirements2_fn = vk::KhrGetMemoryRequirements2Fn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrGetMemoryRequirements2Fn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            get_memory_requirements2_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrGetMemoryRequirements2Fn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferMemoryRequirements2KHR.html>"]
@@ -31,7 +25,7 @@ impl GetMemoryRequirements2 {
         info: &vk::BufferMemoryRequirementsInfo2KHR,
         memory_requirements: &mut vk::MemoryRequirements2KHR,
     ) {
-        self.get_memory_requirements2_fn
+        self.fns
             .get_buffer_memory_requirements2_khr(self.handle, info, memory_requirements);
     }
 
@@ -41,7 +35,7 @@ impl GetMemoryRequirements2 {
         info: &vk::ImageMemoryRequirementsInfo2KHR,
         memory_requirements: &mut vk::MemoryRequirements2KHR,
     ) {
-        self.get_memory_requirements2_fn
+        self.fns
             .get_image_memory_requirements2_khr(self.handle, info, memory_requirements);
     }
 
@@ -51,13 +45,12 @@ impl GetMemoryRequirements2 {
         info: &vk::ImageSparseMemoryRequirementsInfo2KHR,
     ) -> usize {
         let mut count = 0;
-        self.get_memory_requirements2_fn
-            .get_image_sparse_memory_requirements2_khr(
-                self.handle,
-                info,
-                &mut count,
-                ptr::null_mut(),
-            );
+        self.fns.get_image_sparse_memory_requirements2_khr(
+            self.handle,
+            info,
+            &mut count,
+            ptr::null_mut(),
+        );
         count as usize
     }
 
@@ -71,17 +64,20 @@ impl GetMemoryRequirements2 {
         out: &mut [vk::SparseImageMemoryRequirements2KHR],
     ) {
         let mut count = out.len() as u32;
-        self.get_memory_requirements2_fn
-            .get_image_sparse_memory_requirements2_khr(
-                self.handle,
-                info,
-                &mut count,
-                out.as_mut_ptr(),
-            );
+        self.fns.get_image_sparse_memory_requirements2_khr(
+            self.handle,
+            info,
+            &mut count,
+            out.as_mut_ptr(),
+        );
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrGetMemoryRequirements2Fn::name()
     }
 
     pub fn fp(&self) -> &vk::KhrGetMemoryRequirements2Fn {
-        &self.get_memory_requirements2_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -7,16 +7,16 @@ use std::ptr;
 #[derive(Clone)]
 pub struct GetMemoryRequirements2 {
     handle: vk::Device,
-    fns: vk::KhrGetMemoryRequirements2Fn,
+    fp: vk::KhrGetMemoryRequirements2Fn,
 }
 
 impl GetMemoryRequirements2 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrGetMemoryRequirements2Fn::load(|name| unsafe {
+        let fp = vk::KhrGetMemoryRequirements2Fn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetBufferMemoryRequirements2KHR.html>"]
@@ -25,7 +25,7 @@ impl GetMemoryRequirements2 {
         info: &vk::BufferMemoryRequirementsInfo2KHR,
         memory_requirements: &mut vk::MemoryRequirements2KHR,
     ) {
-        self.fns
+        self.fp
             .get_buffer_memory_requirements2_khr(self.handle, info, memory_requirements);
     }
 
@@ -35,7 +35,7 @@ impl GetMemoryRequirements2 {
         info: &vk::ImageMemoryRequirementsInfo2KHR,
         memory_requirements: &mut vk::MemoryRequirements2KHR,
     ) {
-        self.fns
+        self.fp
             .get_image_memory_requirements2_khr(self.handle, info, memory_requirements);
     }
 
@@ -45,7 +45,7 @@ impl GetMemoryRequirements2 {
         info: &vk::ImageSparseMemoryRequirementsInfo2KHR,
     ) -> usize {
         let mut count = 0;
-        self.fns.get_image_sparse_memory_requirements2_khr(
+        self.fp.get_image_sparse_memory_requirements2_khr(
             self.handle,
             info,
             &mut count,
@@ -64,7 +64,7 @@ impl GetMemoryRequirements2 {
         out: &mut [vk::SparseImageMemoryRequirements2KHR],
     ) {
         let mut count = out.len() as u32;
-        self.fns.get_image_sparse_memory_requirements2_khr(
+        self.fp.get_image_sparse_memory_requirements2_khr(
             self.handle,
             info,
             &mut count,
@@ -77,7 +77,7 @@ impl GetMemoryRequirements2 {
     }
 
     pub fn fp(&self) -> &vk::KhrGetMemoryRequirements2Fn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -7,15 +7,15 @@ use std::ptr;
 
 #[derive(Clone)]
 pub struct GetPhysicalDeviceProperties2 {
-    fns: vk::KhrGetPhysicalDeviceProperties2Fn,
+    fp: vk::KhrGetPhysicalDeviceProperties2Fn,
 }
 
 impl GetPhysicalDeviceProperties2 {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let fns = vk::KhrGetPhysicalDeviceProperties2Fn::load(|name| unsafe {
+        let fp = vk::KhrGetPhysicalDeviceProperties2Fn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
         });
-        Self { fns }
+        Self { fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceFeatures2KHR.html>"]
@@ -24,7 +24,7 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
         features: &mut vk::PhysicalDeviceFeatures2KHR,
     ) {
-        self.fns
+        self.fp
             .get_physical_device_features2_khr(physical_device, features);
     }
 
@@ -35,7 +35,7 @@ impl GetPhysicalDeviceProperties2 {
         format: vk::Format,
         format_properties: &mut vk::FormatProperties2KHR,
     ) {
-        self.fns.get_physical_device_format_properties2_khr(
+        self.fp.get_physical_device_format_properties2_khr(
             physical_device,
             format,
             format_properties,
@@ -49,7 +49,7 @@ impl GetPhysicalDeviceProperties2 {
         image_format_info: &vk::PhysicalDeviceImageFormatInfo2KHR,
         image_format_properties: &mut vk::ImageFormatProperties2KHR,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .get_physical_device_image_format_properties2_khr(
                 physical_device,
                 image_format_info,
@@ -64,7 +64,7 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
         memory_properties: &mut vk::PhysicalDeviceMemoryProperties2KHR,
     ) {
-        self.fns
+        self.fp
             .get_physical_device_memory_properties2_khr(physical_device, memory_properties);
     }
 
@@ -74,7 +74,7 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
         properties: &mut vk::PhysicalDeviceProperties2KHR,
     ) {
-        self.fns
+        self.fp
             .get_physical_device_properties2_khr(physical_device, properties);
     }
 
@@ -84,7 +84,7 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
     ) -> usize {
         let mut count = 0;
-        self.fns.get_physical_device_queue_family_properties2_khr(
+        self.fp.get_physical_device_queue_family_properties2_khr(
             physical_device,
             &mut count,
             ptr::null_mut(),
@@ -102,7 +102,7 @@ impl GetPhysicalDeviceProperties2 {
         out: &mut [vk::QueueFamilyProperties2KHR],
     ) {
         let mut count = out.len() as u32;
-        self.fns.get_physical_device_queue_family_properties2_khr(
+        self.fp.get_physical_device_queue_family_properties2_khr(
             physical_device,
             &mut count,
             out.as_mut_ptr(),
@@ -116,7 +116,7 @@ impl GetPhysicalDeviceProperties2 {
         format_info: &vk::PhysicalDeviceSparseImageFormatInfo2KHR,
     ) -> usize {
         let mut count = 0;
-        self.fns
+        self.fp
             .get_physical_device_sparse_image_format_properties2_khr(
                 physical_device,
                 format_info,
@@ -137,7 +137,7 @@ impl GetPhysicalDeviceProperties2 {
         out: &mut [vk::SparseImageFormatProperties2KHR],
     ) {
         let mut count = out.len() as u32;
-        self.fns
+        self.fp
             .get_physical_device_sparse_image_format_properties2_khr(
                 physical_device,
                 format_info,
@@ -151,6 +151,6 @@ impl GetPhysicalDeviceProperties2 {
     }
 
     pub fn fp(&self) -> &vk::KhrGetPhysicalDeviceProperties2Fn {
-        &self.fns
+        &self.fp
     }
 }

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -8,23 +8,16 @@ use std::ptr;
 #[derive(Clone)]
 pub struct GetPhysicalDeviceProperties2 {
     handle: vk::Instance,
-    get_physical_device_properties2_fn: vk::KhrGetPhysicalDeviceProperties2Fn,
+    fns: vk::KhrGetPhysicalDeviceProperties2Fn,
 }
 
 impl GetPhysicalDeviceProperties2 {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let get_physical_device_properties2_fn =
-            vk::KhrGetPhysicalDeviceProperties2Fn::load(|name| unsafe {
-                mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
-            });
-        Self {
-            handle: instance.handle(),
-            get_physical_device_properties2_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrGetPhysicalDeviceProperties2Fn::name()
+        let handle = instance.handle();
+        let fns = vk::KhrGetPhysicalDeviceProperties2Fn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
+        });
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceFeatures2KHR.html>"]
@@ -33,7 +26,7 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
         features: &mut vk::PhysicalDeviceFeatures2KHR,
     ) {
-        self.get_physical_device_properties2_fn
+        self.fns
             .get_physical_device_features2_khr(physical_device, features);
     }
 
@@ -44,8 +37,11 @@ impl GetPhysicalDeviceProperties2 {
         format: vk::Format,
         format_properties: &mut vk::FormatProperties2KHR,
     ) {
-        self.get_physical_device_properties2_fn
-            .get_physical_device_format_properties2_khr(physical_device, format, format_properties);
+        self.fns.get_physical_device_format_properties2_khr(
+            physical_device,
+            format,
+            format_properties,
+        );
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceImageFormatProperties2KHR.html>"]
@@ -55,7 +51,7 @@ impl GetPhysicalDeviceProperties2 {
         image_format_info: &vk::PhysicalDeviceImageFormatInfo2KHR,
         image_format_properties: &mut vk::ImageFormatProperties2KHR,
     ) -> VkResult<()> {
-        self.get_physical_device_properties2_fn
+        self.fns
             .get_physical_device_image_format_properties2_khr(
                 physical_device,
                 image_format_info,
@@ -70,7 +66,7 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
         memory_properties: &mut vk::PhysicalDeviceMemoryProperties2KHR,
     ) {
-        self.get_physical_device_properties2_fn
+        self.fns
             .get_physical_device_memory_properties2_khr(physical_device, memory_properties);
     }
 
@@ -80,7 +76,7 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
         properties: &mut vk::PhysicalDeviceProperties2KHR,
     ) {
-        self.get_physical_device_properties2_fn
+        self.fns
             .get_physical_device_properties2_khr(physical_device, properties);
     }
 
@@ -90,12 +86,11 @@ impl GetPhysicalDeviceProperties2 {
         physical_device: vk::PhysicalDevice,
     ) -> usize {
         let mut count = 0;
-        self.get_physical_device_properties2_fn
-            .get_physical_device_queue_family_properties2_khr(
-                physical_device,
-                &mut count,
-                ptr::null_mut(),
-            );
+        self.fns.get_physical_device_queue_family_properties2_khr(
+            physical_device,
+            &mut count,
+            ptr::null_mut(),
+        );
         count as usize
     }
 
@@ -109,12 +104,11 @@ impl GetPhysicalDeviceProperties2 {
         out: &mut [vk::QueueFamilyProperties2KHR],
     ) {
         let mut count = out.len() as u32;
-        self.get_physical_device_properties2_fn
-            .get_physical_device_queue_family_properties2_khr(
-                physical_device,
-                &mut count,
-                out.as_mut_ptr(),
-            );
+        self.fns.get_physical_device_queue_family_properties2_khr(
+            physical_device,
+            &mut count,
+            out.as_mut_ptr(),
+        );
     }
 
     /// Retrieve the number of elements to pass to [`Self::get_physical_device_sparse_image_format_properties2()`]
@@ -124,7 +118,7 @@ impl GetPhysicalDeviceProperties2 {
         format_info: &vk::PhysicalDeviceSparseImageFormatInfo2KHR,
     ) -> usize {
         let mut count = 0;
-        self.get_physical_device_properties2_fn
+        self.fns
             .get_physical_device_sparse_image_format_properties2_khr(
                 physical_device,
                 format_info,
@@ -145,7 +139,7 @@ impl GetPhysicalDeviceProperties2 {
         out: &mut [vk::SparseImageFormatProperties2KHR],
     ) {
         let mut count = out.len() as u32;
-        self.get_physical_device_properties2_fn
+        self.fns
             .get_physical_device_sparse_image_format_properties2_khr(
                 physical_device,
                 format_info,
@@ -154,8 +148,12 @@ impl GetPhysicalDeviceProperties2 {
             );
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrGetPhysicalDeviceProperties2Fn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrGetPhysicalDeviceProperties2Fn {
-        &self.get_physical_device_properties2_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -7,17 +7,15 @@ use std::ptr;
 
 #[derive(Clone)]
 pub struct GetPhysicalDeviceProperties2 {
-    handle: vk::Instance,
     fns: vk::KhrGetPhysicalDeviceProperties2Fn,
 }
 
 impl GetPhysicalDeviceProperties2 {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let handle = instance.handle();
         let fns = vk::KhrGetPhysicalDeviceProperties2Fn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
+            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceFeatures2KHR.html>"]
@@ -154,9 +152,5 @@ impl GetPhysicalDeviceProperties2 {
 
     pub fn fp(&self) -> &vk::KhrGetPhysicalDeviceProperties2Fn {
         &self.fns
-    }
-
-    pub fn instance(&self) -> vk::Instance {
-        self.handle
     }
 }

--- a/ash/src/extensions/khr/maintenance1.rs
+++ b/ash/src/extensions/khr/maintenance1.rs
@@ -6,16 +6,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Maintenance1 {
     handle: vk::Device,
-    fns: vk::KhrMaintenance1Fn,
+    fp: vk::KhrMaintenance1Fn,
 }
 
 impl Maintenance1 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrMaintenance1Fn::load(|name| unsafe {
+        let fp = vk::KhrMaintenance1Fn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkTrimCommandPoolKHR.html>"]
@@ -24,7 +24,7 @@ impl Maintenance1 {
         command_pool: vk::CommandPool,
         flags: vk::CommandPoolTrimFlagsKHR,
     ) {
-        self.fns
+        self.fp
             .trim_command_pool_khr(self.handle, command_pool, flags);
     }
 
@@ -33,7 +33,7 @@ impl Maintenance1 {
     }
 
     pub fn fp(&self) -> &vk::KhrMaintenance1Fn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/maintenance1.rs
+++ b/ash/src/extensions/khr/maintenance1.rs
@@ -11,17 +11,11 @@ pub struct Maintenance1 {
 
 impl Maintenance1 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
+        let handle = device.handle();
         let fns = vk::KhrMaintenance1Fn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            fns,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrMaintenance1Fn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkTrimCommandPoolKHR.html>"]
@@ -32,6 +26,10 @@ impl Maintenance1 {
     ) {
         self.fns
             .trim_command_pool_khr(self.handle, command_pool, flags);
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrMaintenance1Fn::name()
     }
 
     pub fn fp(&self) -> &vk::KhrMaintenance1Fn {

--- a/ash/src/extensions/khr/maintenance3.rs
+++ b/ash/src/extensions/khr/maintenance3.rs
@@ -11,17 +11,11 @@ pub struct Maintenance3 {
 
 impl Maintenance3 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
+        let handle = device.handle();
         let fns = vk::KhrMaintenance3Fn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            fns,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrMaintenance3Fn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDescriptorSetLayoutSupportKHR.html>"]
@@ -32,6 +26,10 @@ impl Maintenance3 {
     ) {
         self.fns
             .get_descriptor_set_layout_support_khr(self.handle, create_info, out);
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrMaintenance3Fn::name()
     }
 
     pub fn fp(&self) -> &vk::KhrMaintenance3Fn {

--- a/ash/src/extensions/khr/maintenance3.rs
+++ b/ash/src/extensions/khr/maintenance3.rs
@@ -6,16 +6,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Maintenance3 {
     handle: vk::Device,
-    fns: vk::KhrMaintenance3Fn,
+    fp: vk::KhrMaintenance3Fn,
 }
 
 impl Maintenance3 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrMaintenance3Fn::load(|name| unsafe {
+        let fp = vk::KhrMaintenance3Fn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDescriptorSetLayoutSupportKHR.html>"]
@@ -24,7 +24,7 @@ impl Maintenance3 {
         create_info: &vk::DescriptorSetLayoutCreateInfo,
         out: &mut vk::DescriptorSetLayoutSupportKHR,
     ) {
-        self.fns
+        self.fp
             .get_descriptor_set_layout_support_khr(self.handle, create_info, out);
     }
 
@@ -33,7 +33,7 @@ impl Maintenance3 {
     }
 
     pub fn fp(&self) -> &vk::KhrMaintenance3Fn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -11,13 +11,11 @@ pub struct Maintenance4 {
 
 impl Maintenance4 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
+        let handle = device.handle();
         let fns = vk::KhrMaintenance4Fn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            fns,
-        }
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceBufferMemoryRequirementsKHR.html>"]

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -6,16 +6,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Maintenance4 {
     handle: vk::Device,
-    fns: vk::KhrMaintenance4Fn,
+    fp: vk::KhrMaintenance4Fn,
 }
 
 impl Maintenance4 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrMaintenance4Fn::load(|name| unsafe {
+        let fp = vk::KhrMaintenance4Fn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceBufferMemoryRequirementsKHR.html>"]
@@ -24,7 +24,7 @@ impl Maintenance4 {
         create_info: &vk::DeviceBufferMemoryRequirementsKHR,
         out: &mut vk::MemoryRequirements2,
     ) {
-        self.fns
+        self.fp
             .get_device_buffer_memory_requirements_khr(self.handle, create_info, out)
     }
 
@@ -34,7 +34,7 @@ impl Maintenance4 {
         create_info: &vk::DeviceImageMemoryRequirementsKHR,
         out: &mut vk::MemoryRequirements2,
     ) {
-        self.fns
+        self.fp
             .get_device_image_memory_requirements_khr(self.handle, create_info, out)
     }
 
@@ -44,7 +44,7 @@ impl Maintenance4 {
         create_info: &vk::DeviceImageMemoryRequirementsKHR,
     ) -> usize {
         let mut count = 0;
-        self.fns.get_device_image_sparse_memory_requirements_khr(
+        self.fp.get_device_image_sparse_memory_requirements_khr(
             self.handle,
             create_info,
             &mut count,
@@ -63,7 +63,7 @@ impl Maintenance4 {
         out: &mut [vk::SparseImageMemoryRequirements2],
     ) {
         let mut count = out.len() as u32;
-        self.fns.get_device_image_sparse_memory_requirements_khr(
+        self.fp.get_device_image_sparse_memory_requirements_khr(
             self.handle,
             create_info,
             &mut count,
@@ -77,7 +77,7 @@ impl Maintenance4 {
     }
 
     pub fn fp(&self) -> &vk::KhrMaintenance4Fn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/pipeline_executable_properties.rs
+++ b/ash/src/extensions/khr/pipeline_executable_properties.rs
@@ -7,16 +7,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct PipelineExecutableProperties {
     handle: vk::Device,
-    fns: vk::KhrPipelineExecutablePropertiesFn,
+    fp: vk::KhrPipelineExecutablePropertiesFn,
 }
 
 impl PipelineExecutableProperties {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrPipelineExecutablePropertiesFn::load(|name| unsafe {
+        let fp = vk::KhrPipelineExecutablePropertiesFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineExecutableInternalRepresentationsKHR.html>"]
@@ -25,7 +25,7 @@ impl PipelineExecutableProperties {
         executable_info: &vk::PipelineExecutableInfoKHR,
     ) -> VkResult<Vec<vk::PipelineExecutableInternalRepresentationKHR>> {
         read_into_defaulted_vector(|count, data| {
-            self.fns
+            self.fp
                 .get_pipeline_executable_internal_representations_khr(
                     self.handle,
                     executable_info,
@@ -41,7 +41,7 @@ impl PipelineExecutableProperties {
         pipeline_info: &vk::PipelineInfoKHR,
     ) -> VkResult<Vec<vk::PipelineExecutablePropertiesKHR>> {
         read_into_defaulted_vector(|count, data| {
-            self.fns
+            self.fp
                 .get_pipeline_executable_properties_khr(self.handle, pipeline_info, count, data)
         })
     }
@@ -52,7 +52,7 @@ impl PipelineExecutableProperties {
         executable_info: &vk::PipelineExecutableInfoKHR,
     ) -> VkResult<Vec<vk::PipelineExecutableStatisticKHR>> {
         read_into_defaulted_vector(|count, data| {
-            self.fns.get_pipeline_executable_statistics_khr(
+            self.fp.get_pipeline_executable_statistics_khr(
                 self.handle,
                 executable_info,
                 count,
@@ -66,7 +66,7 @@ impl PipelineExecutableProperties {
     }
 
     pub fn fp(&self) -> &vk::KhrPipelineExecutablePropertiesFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/present_wait.rs
+++ b/ash/src/extensions/khr/present_wait.rs
@@ -7,16 +7,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct PresentWait {
     handle: vk::Device,
-    fns: vk::KhrPresentWaitFn,
+    fp: vk::KhrPresentWaitFn,
 }
 
 impl PresentWait {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrPresentWaitFn::load(|name| unsafe {
+        let fp = vk::KhrPresentWaitFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkWaitForPresentKHR.html>"]
@@ -26,7 +26,7 @@ impl PresentWait {
         present_id: u64,
         timeout: u64,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .wait_for_present_khr(self.handle, swapchain, present_id, timeout)
             .result()
     }
@@ -36,7 +36,7 @@ impl PresentWait {
     }
 
     pub fn fp(&self) -> &vk::KhrPresentWaitFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/push_descriptor.rs
+++ b/ash/src/extensions/khr/push_descriptor.rs
@@ -6,17 +6,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct PushDescriptor {
-    handle: vk::Device,
     fns: vk::KhrPushDescriptorFn,
 }
 
 impl PushDescriptor {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let handle = device.handle();
         let fns = vk::KhrPushDescriptorFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdPushDescriptorSetKHR.html>"]
@@ -62,9 +60,5 @@ impl PushDescriptor {
 
     pub fn fp(&self) -> &vk::KhrPushDescriptorFn {
         &self.fns
-    }
-
-    pub fn device(&self) -> vk::Device {
-        self.handle
     }
 }

--- a/ash/src/extensions/khr/push_descriptor.rs
+++ b/ash/src/extensions/khr/push_descriptor.rs
@@ -6,15 +6,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct PushDescriptor {
-    fns: vk::KhrPushDescriptorFn,
+    fp: vk::KhrPushDescriptorFn,
 }
 
 impl PushDescriptor {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let fns = vk::KhrPushDescriptorFn::load(|name| unsafe {
+        let fp = vk::KhrPushDescriptorFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { fns }
+        Self { fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdPushDescriptorSetKHR.html>"]
@@ -26,7 +26,7 @@ impl PushDescriptor {
         set: u32,
         descriptor_writes: &[vk::WriteDescriptorSet],
     ) {
-        self.fns.cmd_push_descriptor_set_khr(
+        self.fp.cmd_push_descriptor_set_khr(
             command_buffer,
             pipeline_bind_point,
             layout,
@@ -45,7 +45,7 @@ impl PushDescriptor {
         set: u32,
         p_data: *const c_void,
     ) {
-        self.fns.cmd_push_descriptor_set_with_template_khr(
+        self.fp.cmd_push_descriptor_set_with_template_khr(
             command_buffer,
             descriptor_update_template,
             layout,
@@ -59,6 +59,6 @@ impl PushDescriptor {
     }
 
     pub fn fp(&self) -> &vk::KhrPushDescriptorFn {
-        &self.fns
+        &self.fp
     }
 }

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -8,18 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct RayTracingPipeline {
     handle: vk::Device,
-    ray_tracing_fn: vk::KhrRayTracingPipelineFn,
+    fns: vk::KhrRayTracingPipelineFn,
 }
 
 impl RayTracingPipeline {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let ray_tracing_fn = vk::KhrRayTracingPipelineFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrRayTracingPipelineFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            ray_tracing_fn,
-        }
+        Self { handle, fns }
     }
 
     pub unsafe fn get_properties(
@@ -46,7 +44,7 @@ impl RayTracingPipeline {
         height: u32,
         depth: u32,
     ) {
-        self.ray_tracing_fn.cmd_trace_rays_khr(
+        self.fns.cmd_trace_rays_khr(
             command_buffer,
             raygen_shader_binding_tables as *const _,
             miss_shader_binding_tables as *const _,
@@ -67,7 +65,7 @@ impl RayTracingPipeline {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Vec<vk::Pipeline>> {
         let mut pipelines = vec![mem::zeroed(); create_info.len()];
-        self.ray_tracing_fn
+        self.fns
             .create_ray_tracing_pipelines_khr(
                 self.handle,
                 deferred_operation,
@@ -89,16 +87,14 @@ impl RayTracingPipeline {
         data_size: usize,
     ) -> VkResult<Vec<u8>> {
         let mut data = Vec::<u8>::with_capacity(data_size);
-        let err_code = self
-            .ray_tracing_fn
-            .get_ray_tracing_shader_group_handles_khr(
-                self.handle,
-                pipeline,
-                first_group,
-                group_count,
-                data_size,
-                data.as_mut_ptr() as *mut std::ffi::c_void,
-            );
+        let err_code = self.fns.get_ray_tracing_shader_group_handles_khr(
+            self.handle,
+            pipeline,
+            first_group,
+            group_count,
+            data_size,
+            data.as_mut_ptr() as *mut std::ffi::c_void,
+        );
         data.set_len(data_size);
         err_code.result_with_success(data)
     }
@@ -113,7 +109,7 @@ impl RayTracingPipeline {
     ) -> VkResult<Vec<u8>> {
         let mut data: Vec<u8> = Vec::with_capacity(data_size);
 
-        self.ray_tracing_fn
+        self.fns
             .get_ray_tracing_capture_replay_shader_group_handles_khr(
                 self.handle,
                 pipeline,
@@ -135,7 +131,7 @@ impl RayTracingPipeline {
         callable_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
         indirect_device_address: vk::DeviceAddress,
     ) {
-        self.ray_tracing_fn.cmd_trace_rays_indirect_khr(
+        self.fns.cmd_trace_rays_indirect_khr(
             command_buffer,
             raygen_shader_binding_table.as_ptr(),
             miss_shader_binding_table.as_ptr(),
@@ -152,8 +148,12 @@ impl RayTracingPipeline {
         group: u32,
         group_shader: vk::ShaderGroupShaderKHR,
     ) -> vk::DeviceSize {
-        self.ray_tracing_fn
-            .get_ray_tracing_shader_group_stack_size_khr(self.handle, pipeline, group, group_shader)
+        self.fns.get_ray_tracing_shader_group_stack_size_khr(
+            self.handle,
+            pipeline,
+            group,
+            group_shader,
+        )
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetRayTracingPipelineStackSizeKHR.html>"]
@@ -162,7 +162,7 @@ impl RayTracingPipeline {
         command_buffer: vk::CommandBuffer,
         pipeline_stack_size: u32,
     ) {
-        self.ray_tracing_fn
+        self.fns
             .cmd_set_ray_tracing_pipeline_stack_size_khr(command_buffer, pipeline_stack_size);
     }
 
@@ -171,7 +171,7 @@ impl RayTracingPipeline {
     }
 
     pub fn fp(&self) -> &vk::KhrRayTracingPipelineFn {
-        &self.ray_tracing_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct RayTracingPipeline {
     handle: vk::Device,
-    fns: vk::KhrRayTracingPipelineFn,
+    fp: vk::KhrRayTracingPipelineFn,
 }
 
 impl RayTracingPipeline {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrRayTracingPipelineFn::load(|name| unsafe {
+        let fp = vk::KhrRayTracingPipelineFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     pub unsafe fn get_properties(
@@ -44,7 +44,7 @@ impl RayTracingPipeline {
         height: u32,
         depth: u32,
     ) {
-        self.fns.cmd_trace_rays_khr(
+        self.fp.cmd_trace_rays_khr(
             command_buffer,
             raygen_shader_binding_tables as *const _,
             miss_shader_binding_tables as *const _,
@@ -65,7 +65,7 @@ impl RayTracingPipeline {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Vec<vk::Pipeline>> {
         let mut pipelines = vec![mem::zeroed(); create_info.len()];
-        self.fns
+        self.fp
             .create_ray_tracing_pipelines_khr(
                 self.handle,
                 deferred_operation,
@@ -87,7 +87,7 @@ impl RayTracingPipeline {
         data_size: usize,
     ) -> VkResult<Vec<u8>> {
         let mut data = Vec::<u8>::with_capacity(data_size);
-        let err_code = self.fns.get_ray_tracing_shader_group_handles_khr(
+        let err_code = self.fp.get_ray_tracing_shader_group_handles_khr(
             self.handle,
             pipeline,
             first_group,
@@ -109,7 +109,7 @@ impl RayTracingPipeline {
     ) -> VkResult<Vec<u8>> {
         let mut data: Vec<u8> = Vec::with_capacity(data_size);
 
-        self.fns
+        self.fp
             .get_ray_tracing_capture_replay_shader_group_handles_khr(
                 self.handle,
                 pipeline,
@@ -131,7 +131,7 @@ impl RayTracingPipeline {
         callable_shader_binding_table: &[vk::StridedDeviceAddressRegionKHR],
         indirect_device_address: vk::DeviceAddress,
     ) {
-        self.fns.cmd_trace_rays_indirect_khr(
+        self.fp.cmd_trace_rays_indirect_khr(
             command_buffer,
             raygen_shader_binding_table.as_ptr(),
             miss_shader_binding_table.as_ptr(),
@@ -148,7 +148,7 @@ impl RayTracingPipeline {
         group: u32,
         group_shader: vk::ShaderGroupShaderKHR,
     ) -> vk::DeviceSize {
-        self.fns.get_ray_tracing_shader_group_stack_size_khr(
+        self.fp.get_ray_tracing_shader_group_stack_size_khr(
             self.handle,
             pipeline,
             group,
@@ -162,7 +162,7 @@ impl RayTracingPipeline {
         command_buffer: vk::CommandBuffer,
         pipeline_stack_size: u32,
     ) {
-        self.fns
+        self.fp
             .cmd_set_ray_tracing_pipeline_stack_size_khr(command_buffer, pipeline_stack_size);
     }
 
@@ -171,7 +171,7 @@ impl RayTracingPipeline {
     }
 
     pub fn fp(&self) -> &vk::KhrRayTracingPipelineFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Surface {
     handle: vk::Instance,
-    fns: vk::KhrSurfaceFn,
+    fp: vk::KhrSurfaceFn,
 }
 
 impl Surface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::KhrSurfaceFn::load(|name| unsafe {
+        let fp = vk::KhrSurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceSupportKHR.html>"]
@@ -28,7 +28,7 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<bool> {
         let mut b = 0;
-        self.fns
+        self.fp
             .get_physical_device_surface_support_khr(
                 physical_device,
                 queue_family_index,
@@ -45,7 +45,7 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.fns.get_physical_device_surface_present_modes_khr(
+            self.fp.get_physical_device_surface_present_modes_khr(
                 physical_device,
                 surface,
                 count,
@@ -61,7 +61,7 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<vk::SurfaceCapabilitiesKHR> {
         let mut surface_capabilities = mem::zeroed();
-        self.fns
+        self.fp
             .get_physical_device_surface_capabilities_khr(
                 physical_device,
                 surface,
@@ -77,7 +77,7 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::SurfaceFormatKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.fns
+            self.fp
                 .get_physical_device_surface_formats_khr(physical_device, surface, count, data)
         })
     }
@@ -88,7 +88,7 @@ impl Surface {
         surface: vk::SurfaceKHR,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.fns
+        self.fp
             .destroy_surface_khr(self.handle, surface, allocation_callbacks.as_raw_ptr());
     }
 
@@ -97,7 +97,7 @@ impl Surface {
     }
 
     pub fn fp(&self) -> &vk::KhrSurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Surface {
     handle: vk::Instance,
-    surface_fn: vk::KhrSurfaceFn,
+    fns: vk::KhrSurfaceFn,
 }
 
 impl Surface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let surface_fn = vk::KhrSurfaceFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::KhrSurfaceFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            surface_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrSurfaceFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceSupportKHR.html>"]
@@ -34,7 +28,7 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<bool> {
         let mut b = 0;
-        self.surface_fn
+        self.fns
             .get_physical_device_surface_support_khr(
                 physical_device,
                 queue_family_index,
@@ -51,13 +45,12 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::PresentModeKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.surface_fn
-                .get_physical_device_surface_present_modes_khr(
-                    physical_device,
-                    surface,
-                    count,
-                    data,
-                )
+            self.fns.get_physical_device_surface_present_modes_khr(
+                physical_device,
+                surface,
+                count,
+                data,
+            )
         })
     }
 
@@ -68,7 +61,7 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<vk::SurfaceCapabilitiesKHR> {
         let mut surface_capabilities = mem::zeroed();
-        self.surface_fn
+        self.fns
             .get_physical_device_surface_capabilities_khr(
                 physical_device,
                 surface,
@@ -84,12 +77,8 @@ impl Surface {
         surface: vk::SurfaceKHR,
     ) -> VkResult<Vec<vk::SurfaceFormatKHR>> {
         read_into_uninitialized_vector(|count, data| {
-            self.surface_fn.get_physical_device_surface_formats_khr(
-                physical_device,
-                surface,
-                count,
-                data,
-            )
+            self.fns
+                .get_physical_device_surface_formats_khr(physical_device, surface, count, data)
         })
     }
 
@@ -99,15 +88,16 @@ impl Surface {
         surface: vk::SurfaceKHR,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.surface_fn.destroy_surface_khr(
-            self.handle,
-            surface,
-            allocation_callbacks.as_raw_ptr(),
-        );
+        self.fns
+            .destroy_surface_khr(self.handle, surface, allocation_callbacks.as_raw_ptr());
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrSurfaceFn::name()
     }
 
     pub fn fp(&self) -> &vk::KhrSurfaceFn {
-        &self.surface_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Swapchain {
     handle: vk::Device,
-    swapchain_fn: vk::KhrSwapchainFn,
+    fns: vk::KhrSwapchainFn,
 }
 
 impl Swapchain {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let swapchain_fn = vk::KhrSwapchainFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrSwapchainFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            swapchain_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrSwapchainFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkDestroySwapchainKHR.html>"]
@@ -32,11 +26,8 @@ impl Swapchain {
         swapchain: vk::SwapchainKHR,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.swapchain_fn.destroy_swapchain_khr(
-            self.handle,
-            swapchain,
-            allocation_callbacks.as_raw_ptr(),
-        );
+        self.fns
+            .destroy_swapchain_khr(self.handle, swapchain, allocation_callbacks.as_raw_ptr());
     }
 
     /// On success, returns the next image's index and whether the swapchain is suboptimal for the surface.
@@ -49,7 +40,7 @@ impl Swapchain {
         fence: vk::Fence,
     ) -> VkResult<(u32, bool)> {
         let mut index = 0;
-        let err_code = self.swapchain_fn.acquire_next_image_khr(
+        let err_code = self.fns.acquire_next_image_khr(
             self.handle,
             swapchain,
             timeout,
@@ -71,7 +62,7 @@ impl Swapchain {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SwapchainKHR> {
         let mut swapchain = mem::zeroed();
-        self.swapchain_fn
+        self.fns
             .create_swapchain_khr(
                 self.handle,
                 create_info,
@@ -86,9 +77,9 @@ impl Swapchain {
     pub unsafe fn queue_present(
         &self,
         queue: vk::Queue,
-        create_info: &vk::PresentInfoKHR,
+        present_info: &vk::PresentInfoKHR,
     ) -> VkResult<bool> {
-        let err_code = self.swapchain_fn.queue_present_khr(queue, create_info);
+        let err_code = self.fns.queue_present_khr(queue, present_info);
         match err_code {
             vk::Result::SUCCESS => Ok(false),
             vk::Result::SUBOPTIMAL_KHR => Ok(true),
@@ -102,13 +93,17 @@ impl Swapchain {
         swapchain: vk::SwapchainKHR,
     ) -> VkResult<Vec<vk::Image>> {
         read_into_uninitialized_vector(|count, data| {
-            self.swapchain_fn
+            self.fns
                 .get_swapchain_images_khr(self.handle, swapchain, count, data)
         })
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrSwapchainFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrSwapchainFn {
-        &self.swapchain_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/synchronization2.rs
+++ b/ash/src/extensions/khr/synchronization2.rs
@@ -6,17 +6,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct Synchronization2 {
-    handle: vk::Device,
     fns: vk::KhrSynchronization2Fn,
 }
 
 impl Synchronization2 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let handle = device.handle();
         let fns = vk::KhrSynchronization2Fn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdPipelineBarrier2KHR.html>"]
@@ -97,9 +95,5 @@ impl Synchronization2 {
 
     pub fn fp(&self) -> &vk::KhrSynchronization2Fn {
         &self.fns
-    }
-
-    pub fn device(&self) -> vk::Device {
-        self.handle
     }
 }

--- a/ash/src/extensions/khr/synchronization2.rs
+++ b/ash/src/extensions/khr/synchronization2.rs
@@ -6,15 +6,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct Synchronization2 {
-    fns: vk::KhrSynchronization2Fn,
+    fp: vk::KhrSynchronization2Fn,
 }
 
 impl Synchronization2 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let fns = vk::KhrSynchronization2Fn::load(|name| unsafe {
+        let fp = vk::KhrSynchronization2Fn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { fns }
+        Self { fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdPipelineBarrier2KHR.html>"]
@@ -23,7 +23,7 @@ impl Synchronization2 {
         command_buffer: vk::CommandBuffer,
         dependency_info: &vk::DependencyInfoKHR,
     ) {
-        self.fns
+        self.fp
             .cmd_pipeline_barrier2_khr(command_buffer, dependency_info)
     }
 
@@ -34,7 +34,7 @@ impl Synchronization2 {
         event: vk::Event,
         stage_mask: vk::PipelineStageFlags2KHR,
     ) {
-        self.fns
+        self.fp
             .cmd_reset_event2_khr(command_buffer, event, stage_mask)
     }
 
@@ -45,7 +45,7 @@ impl Synchronization2 {
         event: vk::Event,
         dependency_info: &vk::DependencyInfoKHR,
     ) {
-        self.fns
+        self.fp
             .cmd_set_event2_khr(command_buffer, event, dependency_info)
     }
 
@@ -57,7 +57,7 @@ impl Synchronization2 {
         dependency_infos: &[vk::DependencyInfoKHR],
     ) {
         assert_eq!(events.len(), dependency_infos.len());
-        self.fns.cmd_wait_events2_khr(
+        self.fp.cmd_wait_events2_khr(
             command_buffer,
             events.len() as u32,
             events.as_ptr(),
@@ -73,7 +73,7 @@ impl Synchronization2 {
         query_pool: vk::QueryPool,
         query: u32,
     ) {
-        self.fns
+        self.fp
             .cmd_write_timestamp2_khr(command_buffer, stage, query_pool, query)
     }
 
@@ -84,7 +84,7 @@ impl Synchronization2 {
         submits: &[vk::SubmitInfo2KHR],
         fence: vk::Fence,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .queue_submit2_khr(queue, submits.len() as u32, submits.as_ptr(), fence)
             .result()
     }
@@ -94,6 +94,6 @@ impl Synchronization2 {
     }
 
     pub fn fp(&self) -> &vk::KhrSynchronization2Fn {
-        &self.fns
+        &self.fp
     }
 }

--- a/ash/src/extensions/khr/synchronization2.rs
+++ b/ash/src/extensions/khr/synchronization2.rs
@@ -7,30 +7,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Synchronization2 {
     handle: vk::Device,
-    synchronization2_fn: vk::KhrSynchronization2Fn,
+    fns: vk::KhrSynchronization2Fn,
 }
 
 impl Synchronization2 {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let synchronization2_fn = vk::KhrSynchronization2Fn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrSynchronization2Fn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            synchronization2_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrSynchronization2Fn::name()
-    }
-
-    pub fn fp(&self) -> &vk::KhrSynchronization2Fn {
-        &self.synchronization2_fn
-    }
-
-    pub fn device(&self) -> vk::Device {
-        self.handle
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdPipelineBarrier2KHR.html>"]
@@ -39,7 +25,7 @@ impl Synchronization2 {
         command_buffer: vk::CommandBuffer,
         dependency_info: &vk::DependencyInfoKHR,
     ) {
-        self.synchronization2_fn
+        self.fns
             .cmd_pipeline_barrier2_khr(command_buffer, dependency_info)
     }
 
@@ -50,7 +36,7 @@ impl Synchronization2 {
         event: vk::Event,
         stage_mask: vk::PipelineStageFlags2KHR,
     ) {
-        self.synchronization2_fn
+        self.fns
             .cmd_reset_event2_khr(command_buffer, event, stage_mask)
     }
 
@@ -61,7 +47,7 @@ impl Synchronization2 {
         event: vk::Event,
         dependency_info: &vk::DependencyInfoKHR,
     ) {
-        self.synchronization2_fn
+        self.fns
             .cmd_set_event2_khr(command_buffer, event, dependency_info)
     }
 
@@ -73,7 +59,7 @@ impl Synchronization2 {
         dependency_infos: &[vk::DependencyInfoKHR],
     ) {
         assert_eq!(events.len(), dependency_infos.len());
-        self.synchronization2_fn.cmd_wait_events2_khr(
+        self.fns.cmd_wait_events2_khr(
             command_buffer,
             events.len() as u32,
             events.as_ptr(),
@@ -89,7 +75,7 @@ impl Synchronization2 {
         query_pool: vk::QueryPool,
         query: u32,
     ) {
-        self.synchronization2_fn
+        self.fns
             .cmd_write_timestamp2_khr(command_buffer, stage, query_pool, query)
     }
 
@@ -100,8 +86,20 @@ impl Synchronization2 {
         submits: &[vk::SubmitInfo2KHR],
         fence: vk::Fence,
     ) -> VkResult<()> {
-        self.synchronization2_fn
+        self.fns
             .queue_submit2_khr(queue, submits.len() as u32, submits.as_ptr(), fence)
             .result()
+    }
+
+    pub fn name() -> &'static CStr {
+        vk::KhrSynchronization2Fn::name()
+    }
+
+    pub fn fp(&self) -> &vk::KhrSynchronization2Fn {
+        &self.fns
+    }
+
+    pub fn device(&self) -> vk::Device {
+        self.handle
     }
 }

--- a/ash/src/extensions/khr/timeline_semaphore.rs
+++ b/ash/src/extensions/khr/timeline_semaphore.rs
@@ -7,22 +7,22 @@ use std::mem;
 #[derive(Clone)]
 pub struct TimelineSemaphore {
     handle: vk::Device,
-    fns: vk::KhrTimelineSemaphoreFn,
+    fp: vk::KhrTimelineSemaphoreFn,
 }
 
 impl TimelineSemaphore {
     pub fn new(instance: &Instance, device: &Device) -> Self {
         let handle = device.handle();
-        let fns = vk::KhrTimelineSemaphoreFn::load(|name| unsafe {
+        let fp = vk::KhrTimelineSemaphoreFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSemaphoreCounterValue.html>"]
     pub unsafe fn get_semaphore_counter_value(&self, semaphore: vk::Semaphore) -> VkResult<u64> {
         let mut value = 0;
-        self.fns
+        self.fp
             .get_semaphore_counter_value_khr(self.handle, semaphore, &mut value)
             .result_with_success(value)
     }
@@ -33,14 +33,14 @@ impl TimelineSemaphore {
         wait_info: &vk::SemaphoreWaitInfo,
         timeout: u64,
     ) -> VkResult<()> {
-        self.fns
+        self.fp
             .wait_semaphores_khr(self.handle, wait_info, timeout)
             .result()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSignalSemaphore.html>"]
     pub unsafe fn signal_semaphore(&self, signal_info: &vk::SemaphoreSignalInfo) -> VkResult<()> {
-        self.fns
+        self.fp
             .signal_semaphore_khr(self.handle, signal_info)
             .result()
     }
@@ -50,7 +50,7 @@ impl TimelineSemaphore {
     }
 
     pub fn fp(&self) -> &vk::KhrTimelineSemaphoreFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/timeline_semaphore.rs
+++ b/ash/src/extensions/khr/timeline_semaphore.rs
@@ -7,28 +7,22 @@ use std::mem;
 #[derive(Clone)]
 pub struct TimelineSemaphore {
     handle: vk::Device,
-    timeline_semaphore_fn: vk::KhrTimelineSemaphoreFn,
+    fns: vk::KhrTimelineSemaphoreFn,
 }
 
 impl TimelineSemaphore {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let timeline_semaphore_fn = vk::KhrTimelineSemaphoreFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::KhrTimelineSemaphoreFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            timeline_semaphore_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrTimelineSemaphoreFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetSemaphoreCounterValue.html>"]
     pub unsafe fn get_semaphore_counter_value(&self, semaphore: vk::Semaphore) -> VkResult<u64> {
         let mut value = 0;
-        self.timeline_semaphore_fn
+        self.fns
             .get_semaphore_counter_value_khr(self.handle, semaphore, &mut value)
             .result_with_success(value)
     }
@@ -39,20 +33,24 @@ impl TimelineSemaphore {
         wait_info: &vk::SemaphoreWaitInfo,
         timeout: u64,
     ) -> VkResult<()> {
-        self.timeline_semaphore_fn
+        self.fns
             .wait_semaphores_khr(self.handle, wait_info, timeout)
             .result()
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSignalSemaphore.html>"]
     pub unsafe fn signal_semaphore(&self, signal_info: &vk::SemaphoreSignalInfo) -> VkResult<()> {
-        self.timeline_semaphore_fn
+        self.fns
             .signal_semaphore_khr(self.handle, signal_info)
             .result()
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrTimelineSemaphoreFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrTimelineSemaphoreFn {
-        &self.timeline_semaphore_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct WaylandSurface {
     handle: vk::Instance,
-    fns: vk::KhrWaylandSurfaceFn,
+    fp: vk::KhrWaylandSurfaceFn,
 }
 
 impl WaylandSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::KhrWaylandSurfaceFn::load(|name| unsafe {
+        let fp = vk::KhrWaylandSurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateWaylandSurfaceKHR.html>"]
@@ -27,7 +27,7 @@ impl WaylandSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.fns
+        self.fp
             .create_wayland_surface_khr(
                 self.handle,
                 create_info,
@@ -45,7 +45,7 @@ impl WaylandSurface {
         wl_display: &mut vk::wl_display,
     ) -> bool {
         let b = self
-            .fns
+            .fp
             .get_physical_device_wayland_presentation_support_khr(
                 physical_device,
                 queue_family_index,
@@ -60,7 +60,7 @@ impl WaylandSurface {
     }
 
     pub fn fp(&self) -> &vk::KhrWaylandSurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct WaylandSurface {
     handle: vk::Instance,
-    wayland_surface_fn: vk::KhrWaylandSurfaceFn,
+    fns: vk::KhrWaylandSurfaceFn,
 }
 
 impl WaylandSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let surface_fn = vk::KhrWaylandSurfaceFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::KhrWaylandSurfaceFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            wayland_surface_fn: surface_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrWaylandSurfaceFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateWaylandSurfaceKHR.html>"]
@@ -33,7 +27,7 @@ impl WaylandSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.wayland_surface_fn
+        self.fns
             .create_wayland_surface_khr(
                 self.handle,
                 create_info,
@@ -51,7 +45,7 @@ impl WaylandSurface {
         wl_display: &mut vk::wl_display,
     ) -> bool {
         let b = self
-            .wayland_surface_fn
+            .fns
             .get_physical_device_wayland_presentation_support_khr(
                 physical_device,
                 queue_family_index,
@@ -61,8 +55,12 @@ impl WaylandSurface {
         b > 0
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrWaylandSurfaceFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrWaylandSurfaceFn {
-        &self.wayland_surface_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Win32Surface {
     handle: vk::Instance,
-    win32_surface_fn: vk::KhrWin32SurfaceFn,
+    fns: vk::KhrWin32SurfaceFn,
 }
 
 impl Win32Surface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let surface_fn = vk::KhrWin32SurfaceFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::KhrWin32SurfaceFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            win32_surface_fn: surface_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::KhrWin32SurfaceFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateWin32SurfaceKHR.html>"]
@@ -33,7 +27,7 @@ impl Win32Surface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.win32_surface_fn
+        self.fns
             .create_win32_surface_khr(
                 self.handle,
                 create_info,
@@ -49,18 +43,20 @@ impl Win32Surface {
         physical_device: vk::PhysicalDevice,
         queue_family_index: u32,
     ) -> bool {
-        let b = self
-            .win32_surface_fn
-            .get_physical_device_win32_presentation_support_khr(
-                physical_device,
-                queue_family_index,
-            );
+        let b = self.fns.get_physical_device_win32_presentation_support_khr(
+            physical_device,
+            queue_family_index,
+        );
 
         b > 0
     }
 
+    pub fn name() -> &'static CStr {
+        vk::KhrWin32SurfaceFn::name()
+    }
+
     pub fn fp(&self) -> &vk::KhrWin32SurfaceFn {
-        &self.win32_surface_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct Win32Surface {
     handle: vk::Instance,
-    fns: vk::KhrWin32SurfaceFn,
+    fp: vk::KhrWin32SurfaceFn,
 }
 
 impl Win32Surface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::KhrWin32SurfaceFn::load(|name| unsafe {
+        let fp = vk::KhrWin32SurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateWin32SurfaceKHR.html>"]
@@ -27,7 +27,7 @@ impl Win32Surface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.fns
+        self.fp
             .create_win32_surface_khr(
                 self.handle,
                 create_info,
@@ -43,7 +43,7 @@ impl Win32Surface {
         physical_device: vk::PhysicalDevice,
         queue_family_index: u32,
     ) -> bool {
-        let b = self.fns.get_physical_device_win32_presentation_support_khr(
+        let b = self.fp.get_physical_device_win32_presentation_support_khr(
             physical_device,
             queue_family_index,
         );
@@ -56,7 +56,7 @@ impl Win32Surface {
     }
 
     pub fn fp(&self) -> &vk::KhrWin32SurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct XcbSurface {
     handle: vk::Instance,
-    fns: vk::KhrXcbSurfaceFn,
+    fp: vk::KhrXcbSurfaceFn,
 }
 
 impl XcbSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::KhrXcbSurfaceFn::load(|name| unsafe {
+        let fp = vk::KhrXcbSurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateXcbSurfaceKHR.html>"]
@@ -27,7 +27,7 @@ impl XcbSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.fns
+        self.fp
             .create_xcb_surface_khr(
                 self.handle,
                 create_info,
@@ -45,7 +45,7 @@ impl XcbSurface {
         connection: &mut vk::xcb_connection_t,
         visual_id: vk::xcb_visualid_t,
     ) -> bool {
-        let b = self.fns.get_physical_device_xcb_presentation_support_khr(
+        let b = self.fp.get_physical_device_xcb_presentation_support_khr(
             physical_device,
             queue_family_index,
             connection,
@@ -60,7 +60,7 @@ impl XcbSurface {
     }
 
     pub fn fp(&self) -> &vk::KhrXcbSurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/khr/xlib_surface.rs
+++ b/ash/src/extensions/khr/xlib_surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct XlibSurface {
     handle: vk::Instance,
-    fns: vk::KhrXlibSurfaceFn,
+    fp: vk::KhrXlibSurfaceFn,
 }
 
 impl XlibSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::KhrXlibSurfaceFn::load(|name| unsafe {
+        let fp = vk::KhrXlibSurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateXlibSurfaceKHR.html>"]
@@ -27,7 +27,7 @@ impl XlibSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.fns
+        self.fp
             .create_xlib_surface_khr(
                 self.handle,
                 create_info,
@@ -45,7 +45,7 @@ impl XlibSurface {
         display: &mut vk::Display,
         visual_id: vk::VisualID,
     ) -> bool {
-        let b = self.fns.get_physical_device_xlib_presentation_support_khr(
+        let b = self.fp.get_physical_device_xlib_presentation_support_khr(
             physical_device,
             queue_family_index,
             display,
@@ -60,7 +60,7 @@ impl XlibSurface {
     }
 
     pub fn fp(&self) -> &vk::KhrXlibSurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct IOSSurface {
     handle: vk::Instance,
-    ios_surface_fn: vk::MvkIosSurfaceFn,
+    fns: vk::MvkIosSurfaceFn,
 }
 
 impl IOSSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let surface_fn = vk::MvkIosSurfaceFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::MvkIosSurfaceFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            ios_surface_fn: surface_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::MvkIosSurfaceFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateIOSSurfaceMVK.html>"]
@@ -33,7 +27,7 @@ impl IOSSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.ios_surface_fn
+        self.fns
             .create_ios_surface_mvk(
                 self.handle,
                 create_info,
@@ -43,8 +37,12 @@ impl IOSSurface {
             .result_with_success(surface)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::MvkIosSurfaceFn::name()
+    }
+
     pub fn fp(&self) -> &vk::MvkIosSurfaceFn {
-        &self.ios_surface_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct IOSSurface {
     handle: vk::Instance,
-    fns: vk::MvkIosSurfaceFn,
+    fp: vk::MvkIosSurfaceFn,
 }
 
 impl IOSSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::MvkIosSurfaceFn::load(|name| unsafe {
+        let fp = vk::MvkIosSurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateIOSSurfaceMVK.html>"]
@@ -27,7 +27,7 @@ impl IOSSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.fns
+        self.fp
             .create_ios_surface_mvk(
                 self.handle,
                 create_info,
@@ -42,7 +42,7 @@ impl IOSSurface {
     }
 
     pub fn fp(&self) -> &vk::MvkIosSurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct MacOSSurface {
     handle: vk::Instance,
-    fns: vk::MvkMacosSurfaceFn,
+    fp: vk::MvkMacosSurfaceFn,
 }
 
 impl MacOSSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::MvkMacosSurfaceFn::load(|name| unsafe {
+        let fp = vk::MvkMacosSurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateMacOSSurfaceMVK.html>"]
@@ -27,7 +27,7 @@ impl MacOSSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.fns
+        self.fp
             .create_mac_os_surface_mvk(
                 self.handle,
                 create_info,
@@ -42,7 +42,7 @@ impl MacOSSurface {
     }
 
     pub fn fp(&self) -> &vk::MvkMacosSurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct MacOSSurface {
     handle: vk::Instance,
-    macos_surface_fn: vk::MvkMacosSurfaceFn,
+    fns: vk::MvkMacosSurfaceFn,
 }
 
 impl MacOSSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let surface_fn = vk::MvkMacosSurfaceFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::MvkMacosSurfaceFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            macos_surface_fn: surface_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::MvkMacosSurfaceFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateMacOSSurfaceMVK.html>"]
@@ -33,7 +27,7 @@ impl MacOSSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.macos_surface_fn
+        self.fns
             .create_mac_os_surface_mvk(
                 self.handle,
                 create_info,
@@ -43,8 +37,12 @@ impl MacOSSurface {
             .result_with_success(surface)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::MvkMacosSurfaceFn::name()
+    }
+
     pub fn fp(&self) -> &vk::MvkMacosSurfaceFn {
-        &self.macos_surface_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/nn/vi_surface.rs
+++ b/ash/src/extensions/nn/vi_surface.rs
@@ -8,22 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct ViSurface {
     handle: vk::Instance,
-    vi_surface_fn: vk::NnViSurfaceFn,
+    fns: vk::NnViSurfaceFn,
 }
 
 impl ViSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
-        let surface_fn = vk::NnViSurfaceFn::load(|name| unsafe {
-            mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+        let handle = instance.handle();
+        let fns = vk::NnViSurfaceFn::load(|name| unsafe {
+            mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: instance.handle(),
-            vi_surface_fn: surface_fn,
-        }
-    }
-
-    pub fn name() -> &'static CStr {
-        vk::NnViSurfaceFn::name()
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateViSurfaceNN.html>"]
@@ -33,7 +27,7 @@ impl ViSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.vi_surface_fn
+        self.fns
             .create_vi_surface_nn(
                 self.handle,
                 create_info,
@@ -43,8 +37,12 @@ impl ViSurface {
             .result_with_success(surface)
     }
 
+    pub fn name() -> &'static CStr {
+        vk::NnViSurfaceFn::name()
+    }
+
     pub fn fp(&self) -> &vk::NnViSurfaceFn {
-        &self.vi_surface_fn
+        &self.fns
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/nn/vi_surface.rs
+++ b/ash/src/extensions/nn/vi_surface.rs
@@ -8,16 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct ViSurface {
     handle: vk::Instance,
-    fns: vk::NnViSurfaceFn,
+    fp: vk::NnViSurfaceFn,
 }
 
 impl ViSurface {
     pub fn new(entry: &Entry, instance: &Instance) -> Self {
         let handle = instance.handle();
-        let fns = vk::NnViSurfaceFn::load(|name| unsafe {
+        let fp = vk::NnViSurfaceFn::load(|name| unsafe {
             mem::transmute(entry.get_instance_proc_addr(handle, name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { handle, fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateViSurfaceNN.html>"]
@@ -27,7 +27,7 @@ impl ViSurface {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::SurfaceKHR> {
         let mut surface = mem::zeroed();
-        self.fns
+        self.fp
             .create_vi_surface_nn(
                 self.handle,
                 create_info,
@@ -42,7 +42,7 @@ impl ViSurface {
     }
 
     pub fn fp(&self) -> &vk::NnViSurfaceFn {
-        &self.fns
+        &self.fp
     }
 
     pub fn instance(&self) -> vk::Instance {

--- a/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
+++ b/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
@@ -6,17 +6,15 @@ use std::os::raw::c_void;
 
 #[derive(Clone)]
 pub struct DeviceDiagnosticCheckpoints {
-    handle: vk::Device,
     fns: vk::NvDeviceDiagnosticCheckpointsFn,
 }
 
 impl DeviceDiagnosticCheckpoints {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let handle = device.handle();
         let fns = vk::NvDeviceDiagnosticCheckpointsFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetCheckpointNV.html>"]
@@ -53,9 +51,5 @@ impl DeviceDiagnosticCheckpoints {
 
     pub fn fp(&self) -> &vk::NvDeviceDiagnosticCheckpointsFn {
         &self.fns
-    }
-
-    pub fn device(&self) -> vk::Device {
-        self.handle
     }
 }

--- a/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
+++ b/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
@@ -6,15 +6,15 @@ use std::os::raw::c_void;
 
 #[derive(Clone)]
 pub struct DeviceDiagnosticCheckpoints {
-    fns: vk::NvDeviceDiagnosticCheckpointsFn,
+    fp: vk::NvDeviceDiagnosticCheckpointsFn,
 }
 
 impl DeviceDiagnosticCheckpoints {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let fns = vk::NvDeviceDiagnosticCheckpointsFn::load(|name| unsafe {
+        let fp = vk::NvDeviceDiagnosticCheckpointsFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { fns }
+        Self { fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetCheckpointNV.html>"]
@@ -23,21 +23,21 @@ impl DeviceDiagnosticCheckpoints {
         command_buffer: vk::CommandBuffer,
         p_checkpoint_marker: *const c_void,
     ) {
-        self.fns
+        self.fp
             .cmd_set_checkpoint_nv(command_buffer, p_checkpoint_marker);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetQueueCheckpointDataNV.html>"]
     pub unsafe fn get_queue_checkpoint_data(&self, queue: vk::Queue) -> Vec<vk::CheckpointDataNV> {
         let mut checkpoint_data_count: u32 = 0;
-        self.fns.get_queue_checkpoint_data_nv(
+        self.fp.get_queue_checkpoint_data_nv(
             queue,
             &mut checkpoint_data_count,
             std::ptr::null_mut(),
         );
         let mut checkpoint_data: Vec<vk::CheckpointDataNV> =
             vec![vk::CheckpointDataNV::default(); checkpoint_data_count as _];
-        self.fns.get_queue_checkpoint_data_nv(
+        self.fp.get_queue_checkpoint_data_nv(
             queue,
             &mut checkpoint_data_count,
             checkpoint_data.as_mut_ptr(),
@@ -50,6 +50,6 @@ impl DeviceDiagnosticCheckpoints {
     }
 
     pub fn fp(&self) -> &vk::NvDeviceDiagnosticCheckpointsFn {
-        &self.fns
+        &self.fp
     }
 }

--- a/ash/src/extensions/nv/mesh_shader.rs
+++ b/ash/src/extensions/nv/mesh_shader.rs
@@ -5,15 +5,17 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct MeshShader {
-    mesh_shader_fn: vk::NvMeshShaderFn,
+    handle: vk::Device,
+    fns: vk::NvMeshShaderFn,
 }
 
 impl MeshShader {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let mesh_shader_fn = vk::NvMeshShaderFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::NvMeshShaderFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self { mesh_shader_fn }
+        Self { handle, fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawMeshTasksNV.html>"]
@@ -23,7 +25,7 @@ impl MeshShader {
         task_count: u32,
         first_task: u32,
     ) {
-        self.mesh_shader_fn
+        self.fns
             .cmd_draw_mesh_tasks_nv(command_buffer, task_count, first_task);
     }
 
@@ -36,7 +38,7 @@ impl MeshShader {
         draw_count: u32,
         stride: u32,
     ) {
-        self.mesh_shader_fn.cmd_draw_mesh_tasks_indirect_nv(
+        self.fns.cmd_draw_mesh_tasks_indirect_nv(
             command_buffer,
             buffer,
             offset,
@@ -56,7 +58,7 @@ impl MeshShader {
         max_draw_count: u32,
         stride: u32,
     ) {
-        self.mesh_shader_fn.cmd_draw_mesh_tasks_indirect_count_nv(
+        self.fns.cmd_draw_mesh_tasks_indirect_count_nv(
             command_buffer,
             buffer,
             offset,
@@ -72,6 +74,10 @@ impl MeshShader {
     }
 
     pub fn fp(&self) -> &vk::NvMeshShaderFn {
-        &self.mesh_shader_fn
+        &self.fns
+    }
+
+    pub fn device(&self) -> vk::Device {
+        self.handle
     }
 }

--- a/ash/src/extensions/nv/mesh_shader.rs
+++ b/ash/src/extensions/nv/mesh_shader.rs
@@ -5,15 +5,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct MeshShader {
-    fns: vk::NvMeshShaderFn,
+    fp: vk::NvMeshShaderFn,
 }
 
 impl MeshShader {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let fns = vk::NvMeshShaderFn::load(|name| unsafe {
+        let fp = vk::NvMeshShaderFn::load(|name| unsafe {
             mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { fns }
+        Self { fp }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawMeshTasksNV.html>"]
@@ -23,7 +23,7 @@ impl MeshShader {
         task_count: u32,
         first_task: u32,
     ) {
-        self.fns
+        self.fp
             .cmd_draw_mesh_tasks_nv(command_buffer, task_count, first_task);
     }
 
@@ -36,13 +36,8 @@ impl MeshShader {
         draw_count: u32,
         stride: u32,
     ) {
-        self.fns.cmd_draw_mesh_tasks_indirect_nv(
-            command_buffer,
-            buffer,
-            offset,
-            draw_count,
-            stride,
-        );
+        self.fp
+            .cmd_draw_mesh_tasks_indirect_nv(command_buffer, buffer, offset, draw_count, stride);
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawMeshTasksIndirectCountNV.html>"]
@@ -56,7 +51,7 @@ impl MeshShader {
         max_draw_count: u32,
         stride: u32,
     ) {
-        self.fns.cmd_draw_mesh_tasks_indirect_count_nv(
+        self.fp.cmd_draw_mesh_tasks_indirect_count_nv(
             command_buffer,
             buffer,
             offset,
@@ -72,6 +67,6 @@ impl MeshShader {
     }
 
     pub fn fp(&self) -> &vk::NvMeshShaderFn {
-        &self.fns
+        &self.fp
     }
 }

--- a/ash/src/extensions/nv/mesh_shader.rs
+++ b/ash/src/extensions/nv/mesh_shader.rs
@@ -5,17 +5,15 @@ use std::mem;
 
 #[derive(Clone)]
 pub struct MeshShader {
-    handle: vk::Device,
     fns: vk::NvMeshShaderFn,
 }
 
 impl MeshShader {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let handle = device.handle();
         let fns = vk::NvMeshShaderFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
+            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
         });
-        Self { handle, fns }
+        Self { fns }
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdDrawMeshTasksNV.html>"]
@@ -75,9 +73,5 @@ impl MeshShader {
 
     pub fn fp(&self) -> &vk::NvMeshShaderFn {
         &self.fns
-    }
-
-    pub fn device(&self) -> vk::Device {
-        self.handle
     }
 }

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -8,18 +8,16 @@ use std::mem;
 #[derive(Clone)]
 pub struct RayTracing {
     handle: vk::Device,
-    ray_tracing_fn: vk::NvRayTracingFn,
+    fns: vk::NvRayTracingFn,
 }
 
 impl RayTracing {
     pub fn new(instance: &Instance, device: &Device) -> Self {
-        let ray_tracing_fn = vk::NvRayTracingFn::load(|name| unsafe {
-            mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
+        let handle = device.handle();
+        let fns = vk::NvRayTracingFn::load(|name| unsafe {
+            mem::transmute(instance.get_device_proc_addr(handle, name.as_ptr()))
         });
-        Self {
-            handle: device.handle(),
-            ray_tracing_fn,
-        }
+        Self { handle, fns }
     }
 
     pub unsafe fn get_properties(
@@ -41,7 +39,7 @@ impl RayTracing {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<vk::AccelerationStructureNV> {
         let mut accel_struct = mem::zeroed();
-        self.ray_tracing_fn
+        self.fns
             .create_acceleration_structure_nv(
                 self.handle,
                 create_info,
@@ -57,7 +55,7 @@ impl RayTracing {
         accel_struct: vk::AccelerationStructureNV,
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) {
-        self.ray_tracing_fn.destroy_acceleration_structure_nv(
+        self.fns.destroy_acceleration_structure_nv(
             self.handle,
             accel_struct,
             allocation_callbacks.as_raw_ptr(),
@@ -70,12 +68,11 @@ impl RayTracing {
         info: &vk::AccelerationStructureMemoryRequirementsInfoNV,
     ) -> vk::MemoryRequirements2KHR {
         let mut requirements = mem::zeroed();
-        self.ray_tracing_fn
-            .get_acceleration_structure_memory_requirements_nv(
-                self.handle,
-                info,
-                &mut requirements,
-            );
+        self.fns.get_acceleration_structure_memory_requirements_nv(
+            self.handle,
+            info,
+            &mut requirements,
+        );
         requirements
     }
 
@@ -84,7 +81,7 @@ impl RayTracing {
         &self,
         bind_info: &[vk::BindAccelerationStructureMemoryInfoNV],
     ) -> VkResult<()> {
-        self.ray_tracing_fn
+        self.fns
             .bind_acceleration_structure_memory_nv(
                 self.handle,
                 bind_info.len() as u32,
@@ -106,7 +103,7 @@ impl RayTracing {
         scratch: vk::Buffer,
         scratch_offset: vk::DeviceSize,
     ) {
-        self.ray_tracing_fn.cmd_build_acceleration_structure_nv(
+        self.fns.cmd_build_acceleration_structure_nv(
             command_buffer,
             info,
             instance_data,
@@ -127,7 +124,7 @@ impl RayTracing {
         src: vk::AccelerationStructureNV,
         mode: vk::CopyAccelerationStructureModeNV,
     ) {
-        self.ray_tracing_fn
+        self.fns
             .cmd_copy_acceleration_structure_nv(command_buffer, dst, src, mode);
     }
 
@@ -150,7 +147,7 @@ impl RayTracing {
         height: u32,
         depth: u32,
     ) {
-        self.ray_tracing_fn.cmd_trace_rays_nv(
+        self.fns.cmd_trace_rays_nv(
             command_buffer,
             raygen_shader_binding_table_buffer,
             raygen_shader_binding_offset,
@@ -177,7 +174,7 @@ impl RayTracing {
         allocation_callbacks: Option<&vk::AllocationCallbacks>,
     ) -> VkResult<Vec<vk::Pipeline>> {
         let mut pipelines = vec![mem::zeroed(); create_info.len()];
-        self.ray_tracing_fn
+        self.fns
             .create_ray_tracing_pipelines_nv(
                 self.handle,
                 pipeline_cache,
@@ -197,7 +194,7 @@ impl RayTracing {
         group_count: u32,
         data: &mut [u8],
     ) -> VkResult<()> {
-        self.ray_tracing_fn
+        self.fns
             .get_ray_tracing_shader_group_handles_nv(
                 self.handle,
                 pipeline,
@@ -216,7 +213,7 @@ impl RayTracing {
     ) -> VkResult<u64> {
         let mut handle: u64 = 0;
         let handle_ptr: *mut u64 = &mut handle;
-        self.ray_tracing_fn
+        self.fns
             .get_acceleration_structure_handle_nv(
                 self.handle,
                 accel_struct,
@@ -235,20 +232,19 @@ impl RayTracing {
         query_pool: vk::QueryPool,
         first_query: u32,
     ) {
-        self.ray_tracing_fn
-            .cmd_write_acceleration_structures_properties_nv(
-                command_buffer,
-                structures.len() as u32,
-                structures.as_ptr(),
-                query_type,
-                query_pool,
-                first_query,
-            );
+        self.fns.cmd_write_acceleration_structures_properties_nv(
+            command_buffer,
+            structures.len() as u32,
+            structures.as_ptr(),
+            query_type,
+            query_pool,
+            first_query,
+        );
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCompileDeferredNV.html>"]
     pub unsafe fn compile_deferred(&self, pipeline: vk::Pipeline, shader: u32) -> VkResult<()> {
-        self.ray_tracing_fn
+        self.fns
             .compile_deferred_nv(self.handle, pipeline, shader)
             .result()
     }
@@ -258,7 +254,7 @@ impl RayTracing {
     }
 
     pub fn fp(&self) -> &vk::NvRayTracingFn {
-        &self.ray_tracing_fn
+        &self.fns
     }
 
     pub fn device(&self) -> vk::Device {


### PR DESCRIPTION
breaking change:
- some extensions were exposing instance() instead of device()

includes:
- renaming function pointer member to fns
- moving name(), fp(), device()/instance() functions at end of file
- adding missing device()/instance() functions
- ~~using result() instead of into()~~