### PR TITLE
maintenance4: Fix documented output parameter now named `out`

### DIFF
--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -57,7 +57,7 @@ impl Maintenance4 {
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceImageSparseMemoryRequirementsKHR.html>"]
     ///
-    /// Call [`Self::get_device_image_sparse_memory_requirements_len()`] to query the number of elements to pass to `sparse_memory_requirements`.
+    /// Call [`Self::get_device_image_sparse_memory_requirements_len()`] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn get_device_image_sparse_memory_requirements(
         &self,


### PR DESCRIPTION
This naming was changed at the last resort across the other `_len()` variant calls to be consistent, but the maintenance4 PR didn't have its documentation updated (probably some rust-analyzer "rename symbol" action).

Fixes: 50d58fd ("extensions: Add VK_KHR_maintenance4")
