### PR TITLE
Use device in pipeline_executable_properties and timeline_semaphore

### DIFF
--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -131,13 +131,12 @@ impl DebugUtils {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkSubmitDebugUtilsMessageEXT.html>"]
     pub unsafe fn submit_debug_utils_message(
         &self,
-        instance: vk::Instance,
         message_severity: vk::DebugUtilsMessageSeverityFlagsEXT,
         message_types: vk::DebugUtilsMessageTypeFlagsEXT,
         callback_data: &vk::DebugUtilsMessengerCallbackDataEXT,
     ) {
         self.debug_utils_fn.submit_debug_utils_message_ext(
-            instance,
+            self.handle,
             message_severity,
             message_types,
             callback_data,

--- a/ash/src/extensions/khr/pipeline_executable_properties.rs
+++ b/ash/src/extensions/khr/pipeline_executable_properties.rs
@@ -1,23 +1,23 @@
 use crate::prelude::*;
 use crate::vk;
-use crate::{Entry, Instance};
+use crate::{Device, Instance};
 use std::ffi::CStr;
 use std::mem;
 
 #[derive(Clone)]
 pub struct PipelineExecutableProperties {
-    handle: vk::Instance,
+    handle: vk::Device,
     pipeline_executable_properties_fn: vk::KhrPipelineExecutablePropertiesFn,
 }
 
 impl PipelineExecutableProperties {
-    pub fn new(entry: &Entry, instance: &Instance) -> Self {
+    pub fn new(instance: &Instance, device: &Device) -> Self {
         let pipeline_executable_properties_fn =
             vk::KhrPipelineExecutablePropertiesFn::load(|name| unsafe {
-                mem::transmute(entry.get_instance_proc_addr(instance.handle(), name.as_ptr()))
+                mem::transmute(instance.get_device_proc_addr(device.handle(), name.as_ptr()))
             });
         Self {
-            handle: instance.handle(),
+            handle: device.handle(),
             pipeline_executable_properties_fn,
         }
     }
@@ -29,13 +29,12 @@ impl PipelineExecutableProperties {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineExecutableInternalRepresentationsKHR.html>"]
     pub unsafe fn get_pipeline_executable_internal_representations(
         &self,
-        device: vk::Device,
         executable_info: &vk::PipelineExecutableInfoKHR,
     ) -> VkResult<Vec<vk::PipelineExecutableInternalRepresentationKHR>> {
         read_into_defaulted_vector(|count, data| {
             self.pipeline_executable_properties_fn
                 .get_pipeline_executable_internal_representations_khr(
-                    device,
+                    self.handle,
                     executable_info,
                     count,
                     data,
@@ -46,24 +45,24 @@ impl PipelineExecutableProperties {
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineExecutablePropertiesKHR.html>"]
     pub unsafe fn get_pipeline_executable_properties(
         &self,
-        device: vk::Device,
+
         pipeline_info: &vk::PipelineInfoKHR,
     ) -> VkResult<Vec<vk::PipelineExecutablePropertiesKHR>> {
         read_into_defaulted_vector(|count, data| {
             self.pipeline_executable_properties_fn
-                .get_pipeline_executable_properties_khr(device, pipeline_info, count, data)
+                .get_pipeline_executable_properties_khr(self.handle, pipeline_info, count, data)
         })
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPipelineExecutableStatisticsKHR.html>"]
     pub unsafe fn get_pipeline_executable_statistics(
         &self,
-        device: vk::Device,
+
         executable_info: &vk::PipelineExecutableInfoKHR,
     ) -> VkResult<Vec<vk::PipelineExecutableStatisticKHR>> {
         read_into_defaulted_vector(|count, data| {
             self.pipeline_executable_properties_fn
-                .get_pipeline_executable_statistics_khr(device, executable_info, count, data)
+                .get_pipeline_executable_statistics_khr(self.handle, executable_info, count, data)
         })
     }
 
@@ -71,7 +70,7 @@ impl PipelineExecutableProperties {
         &self.pipeline_executable_properties_fn
     }
 
-    pub fn instance(&self) -> vk::Instance {
+    pub fn device(&self) -> vk::Device {
         self.handle
     }
 }


### PR DESCRIPTION
Of all the extensions calling get_instance_proc_addr only these two remain that should use the "optimized" device-specific function pointers, since all functions take the device as argument (a child of the device such as a command buffer or queue is also possible, but not applicable here) and may otherwise have to go through a dispatch function [1].

Only VK_EXT_debug_utils remains where all but three of the functions are device (or device-child) specific.  This however requires the autogenerated loader to be separated out into two stages (and debug utils are generally initialized before creating a logical device), making it worth to accept the dispatch function unless this extension struct is split, too.

[1]: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceProcAddr.html
