### PR TITLE
generator: Use "Backwards-compatible" comment to detect deprecated alias

### DIFF
--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -498,8 +498,6 @@ impl StencilFaceFlags {
     pub const BACK: Self = Self(0b10);
     #[doc = "Front and back faces"]
     pub const FRONT_AND_BACK: Self = Self(0x0000_0003);
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const STENCIL_FRONT_AND_BACK: Self = Self::FRONT_AND_BACK;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -1090,8 +1090,6 @@ impl ColorSpaceKHR {
 }
 impl ColorSpaceKHR {
     pub const SRGB_NONLINEAR: Self = Self(0);
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const COLORSPACE_SRGB_NONLINEAR: Self = Self::SRGB_NONLINEAR;
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -1153,13 +1151,9 @@ impl DebugReportObjectTypeEXT {
     pub const SURFACE_KHR: Self = Self(26);
     pub const SWAPCHAIN_KHR: Self = Self(27);
     pub const DEBUG_REPORT_CALLBACK_EXT: Self = Self(28);
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const DEBUG_REPORT: Self = Self::DEBUG_REPORT_CALLBACK_EXT;
     pub const DISPLAY_KHR: Self = Self(29);
     pub const DISPLAY_MODE_KHR: Self = Self(30);
     pub const VALIDATION_CACHE_EXT: Self = Self(33);
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const VALIDATION_CACHE: Self = Self::VALIDATION_CACHE_EXT;
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -1957,12 +1951,6 @@ impl PerformanceCounterScopeKHR {
     pub const COMMAND_BUFFER: Self = Self(0);
     pub const RENDER_PASS: Self = Self(1);
     pub const COMMAND: Self = Self(2);
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const QUERY_SCOPE_COMMAND_BUFFER: Self = Self::COMMAND_BUFFER;
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const QUERY_SCOPE_RENDER_PASS: Self = Self::RENDER_PASS;
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const QUERY_SCOPE_COMMAND: Self = Self::COMMAND;
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -1972,11 +1972,6 @@ impl StructureType {
     pub const DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT: Self = Self(1_000_011_000);
 }
 #[doc = "Generated from 'VK_EXT_debug_report'"]
-impl StructureType {
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const DEBUG_REPORT_CREATE_INFO_EXT: Self = Self::DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
-}
-#[doc = "Generated from 'VK_EXT_debug_report'"]
 impl Result {
     pub const ERROR_VALIDATION_FAILED_EXT: Self = Self(-1_000_011_001);
 }
@@ -4479,12 +4474,6 @@ impl PipelineCreateFlags {
         Self(0b10_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_dynamic_rendering'"]
-impl PipelineCreateFlags {
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const RASTERIZATION_STATE_FRAGMENT_SHADING_RATE_ATTACHMENT_KHR: Self =
-        Self::RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_KHR;
-}
-#[doc = "Generated from 'VK_KHR_dynamic_rendering'"]
 impl StructureType {
     pub const RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR: Self = Self(1_000_044_006);
 }
@@ -4492,12 +4481,6 @@ impl StructureType {
 impl PipelineCreateFlags {
     pub const RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_EXT: Self =
         Self(0b100_0000_0000_0000_0000_0000);
-}
-#[doc = "Generated from 'VK_KHR_dynamic_rendering'"]
-impl PipelineCreateFlags {
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const RASTERIZATION_STATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_EXT: Self =
-        Self::RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_EXT;
 }
 #[doc = "Generated from 'VK_KHR_dynamic_rendering'"]
 impl StructureType {
@@ -7691,11 +7674,6 @@ impl ExtDisplaySurfaceCounterFn {
 impl StructureType {
     pub const SURFACE_CAPABILITIES_2_EXT: Self = Self(1_000_090_000);
 }
-#[doc = "Generated from 'VK_EXT_display_surface_counter'"]
-impl StructureType {
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const SURFACE_CAPABILITIES2_EXT: Self = Self::SURFACE_CAPABILITIES_2_EXT;
-}
 impl ExtDisplayControlFn {
     pub fn name() -> &'static ::std::ffi::CStr {
         ::std::ffi::CStr::from_bytes_with_nul(b"VK_EXT_display_control\0")
@@ -8358,11 +8336,6 @@ impl ColorSpaceKHR {
 #[doc = "Generated from 'VK_EXT_swapchain_colorspace'"]
 impl ColorSpaceKHR {
     pub const EXTENDED_SRGB_NONLINEAR_EXT: Self = Self(1_000_104_014);
-}
-#[doc = "Generated from 'VK_EXT_swapchain_colorspace'"]
-impl ColorSpaceKHR {
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const DCI_P3_LINEAR_EXT: Self = Self::DISPLAY_P3_LINEAR_EXT;
 }
 impl ExtHdrMetadataFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -16896,12 +16869,6 @@ impl IntelPerformanceQueryFn {
 #[doc = "Generated from 'VK_INTEL_performance_query'"]
 impl StructureType {
     pub const QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL: Self = Self(1_000_210_000);
-}
-#[doc = "Generated from 'VK_INTEL_performance_query'"]
-impl StructureType {
-    #[deprecated = "Backwards-compatible alias containing a typo"]
-    pub const QUERY_POOL_CREATE_INFO_INTEL: Self =
-        Self::QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL;
 }
 #[doc = "Generated from 'VK_INTEL_performance_query'"]
 impl StructureType {


### PR DESCRIPTION
vk.xml now contains the comment text "Backwards-compatible alias containing a typo" which we can use to detect intentional renames, without needing to specify explicit overrides/exceptions in the generator anymore.

These deprecated constants exist for the sole reason of backwards compatibility which Vulkan cannot permit itself to remove in the C headers, but are unreasonable for crate authors to use anyway due to their `#[deprecated]` annotation whose cargo-check warnings are easy to fix by just using the non-deprecated variant instead.  Furthermore, Ash is still allowing itself to perform breaking changes in its releases making this the perfect time to get rid of all these useless variants and the generator support code that comes with it.  No need to come up with a "more proper" variant name if we don't generate those that "intentionally" fail to adhere to the "enum variant name" specification in the first place.

---

~Perhaps we should reach a point where we just stop generating any variants with this discrepancy at all, given that we're releasing ash where breaking changes are allowed and `#[deprecated]` triggers check/clippy warnings already anyway.  I doubt anyone uses these (EDIT: Bar all the missing `#[deprecated]` annotations from https://github.com/MaikKlein/ash/pull/501/files... :sweat_smile:).~ Done!