### PR TITLE
Updated winit, fixed examples

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["maik klein <maikklein@googlemail.com>"]
 edition = "2018"
 
 [dependencies]
-winit = "0.19.5"
+winit = "0.25.0"
 image = "0.10.4"
 ash = { path = "../ash" }
 ash-window = { path = "../ash-window" }

--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -1,3 +1,4 @@
+use std::rc::Rc;
 use std::default::Default;
 use std::ffi::CString;
 use std::io::Cursor;
@@ -25,7 +26,8 @@ pub struct Vector3 {
 
 fn main() {
     unsafe {
-        let base = ExampleBase::new(1920, 1080);
+        let (event_loop, window) = ExampleBase::build_window(1920, 1080);
+        let base = ExampleBase::new(&window);
 
         let renderpass_attachments = [
             vk::AttachmentDescription {
@@ -704,13 +706,19 @@ fn main() {
 
         let graphic_pipeline = graphics_pipelines[0];
 
-        base.render_loop(|| {
-            let (present_index, _) = base
+        let rc_base = Rc::new(base);
+        let event_base = Rc::clone(&rc_base);
+
+        let rc_frame_buffs = Rc::new(framebuffers);
+        let event_frame_buffs = Rc::clone(&rc_frame_buffs);
+
+        ExampleBase::render_loop(event_loop, move || {
+            let (present_index, _) = event_base
                 .swapchain_loader
                 .acquire_next_image(
-                    base.swapchain,
+                    event_base.swapchain,
                     std::u64::MAX,
-                    base.present_complete_semaphore,
+                    event_base.present_complete_semaphore,
                     vk::Fence::null(),
                 )
                 .unwrap();
@@ -730,21 +738,21 @@ fn main() {
 
             let render_pass_begin_info = vk::RenderPassBeginInfo::builder()
                 .render_pass(renderpass)
-                .framebuffer(framebuffers[present_index as usize])
+                .framebuffer(event_frame_buffs[present_index as usize])
                 .render_area(vk::Rect2D {
                     offset: vk::Offset2D { x: 0, y: 0 },
-                    extent: base.surface_resolution,
+                    extent: event_base.surface_resolution,
                 })
                 .clear_values(&clear_values);
 
             record_submit_commandbuffer(
-                &base.device,
-                base.draw_command_buffer,
-                base.draw_commands_reuse_fence,
-                base.present_queue,
+                &event_base.device,
+                event_base.draw_command_buffer,
+                event_base.draw_commands_reuse_fence,
+                event_base.present_queue,
                 &[vk::PipelineStageFlags::BOTTOM_OF_PIPE],
-                &[base.present_complete_semaphore],
-                &[base.rendering_complete_semaphore],
+                &[event_base.present_complete_semaphore],
+                &[event_base.rendering_complete_semaphore],
                 |device, draw_command_buffer| {
                     device.cmd_begin_render_pass(
                         draw_command_buffer,
@@ -794,46 +802,47 @@ fn main() {
             //let mut present_info_err = mem::zeroed();
             let present_info = vk::PresentInfoKHR {
                 wait_semaphore_count: 1,
-                p_wait_semaphores: &base.rendering_complete_semaphore,
+                p_wait_semaphores: &event_base.rendering_complete_semaphore,
                 swapchain_count: 1,
-                p_swapchains: &base.swapchain,
+                p_swapchains: &event_base.swapchain,
                 p_image_indices: &present_index,
                 ..Default::default()
             };
-            base.swapchain_loader
-                .queue_present(base.present_queue, &present_info)
+            event_base.swapchain_loader
+                .queue_present(event_base.present_queue, &present_info)
                 .unwrap();
         });
-        base.device.device_wait_idle().unwrap();
+
+        rc_base.device.device_wait_idle().unwrap();
 
         for pipeline in graphics_pipelines {
-            base.device.destroy_pipeline(pipeline, None);
+            rc_base.device.destroy_pipeline(pipeline, None);
         }
-        base.device.destroy_pipeline_layout(pipeline_layout, None);
-        base.device
+        rc_base.device.destroy_pipeline_layout(pipeline_layout, None);
+        rc_base.device
             .destroy_shader_module(vertex_shader_module, None);
-        base.device
+        rc_base.device
             .destroy_shader_module(fragment_shader_module, None);
-        base.device.free_memory(image_buffer_memory, None);
-        base.device.destroy_buffer(image_buffer, None);
-        base.device.free_memory(texture_memory, None);
-        base.device.destroy_image_view(tex_image_view, None);
-        base.device.destroy_image(texture_image, None);
-        base.device.free_memory(index_buffer_memory, None);
-        base.device.destroy_buffer(index_buffer, None);
-        base.device.free_memory(uniform_color_buffer_memory, None);
-        base.device.destroy_buffer(uniform_color_buffer, None);
-        base.device.free_memory(vertex_input_buffer_memory, None);
-        base.device.destroy_buffer(vertex_input_buffer, None);
+        rc_base.device.free_memory(image_buffer_memory, None);
+        rc_base.device.destroy_buffer(image_buffer, None);
+        rc_base.device.free_memory(texture_memory, None);
+        rc_base.device.destroy_image_view(tex_image_view, None);
+        rc_base.device.destroy_image(texture_image, None);
+        rc_base.device.free_memory(index_buffer_memory, None);
+        rc_base.device.destroy_buffer(index_buffer, None);
+        rc_base.device.free_memory(uniform_color_buffer_memory, None);
+        rc_base.device.destroy_buffer(uniform_color_buffer, None);
+        rc_base.device.free_memory(vertex_input_buffer_memory, None);
+        rc_base.device.destroy_buffer(vertex_input_buffer, None);
         for &descriptor_set_layout in desc_set_layouts.iter() {
-            base.device
+            rc_base.device
                 .destroy_descriptor_set_layout(descriptor_set_layout, None);
         }
-        base.device.destroy_descriptor_pool(descriptor_pool, None);
-        base.device.destroy_sampler(sampler, None);
-        for framebuffer in framebuffers {
-            base.device.destroy_framebuffer(framebuffer, None);
+        rc_base.device.destroy_descriptor_pool(descriptor_pool, None);
+        rc_base.device.destroy_sampler(sampler, None);
+        for framebuffer in rc_frame_buffs.as_ref() {
+            rc_base.device.destroy_framebuffer(*framebuffer, None);
         }
-        base.device.destroy_render_pass(renderpass, None);
+        rc_base.device.destroy_render_pass(renderpass, None);
     }
 }


### PR DESCRIPTION
The version of the `winit` library being used by the examples does not compile on my M1 Mac.

I bumped `winit` to the newest version and updated the examples to work with the newer API requirements.

The examples now successfully compile and run on my M1 MacBook.