### PR TITLE
Fix new clippy warnings since Rust 1.57

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1049,10 +1049,10 @@ fn generate_function_pointers<'a>(
     let pfn_typedefs = commands
         .iter()
         .filter(|pfn| pfn.type_needs_defining)
-        .map(|pfn| CommandToType(pfn));
-    let members = commands.iter().map(|pfn| CommandToMember(pfn));
-    let loaders = commands.iter().map(|pfn| CommandToLoader(pfn));
-    let bodies = commands.iter().map(|pfn| CommandToBody(pfn));
+        .map(CommandToType);
+    let members = commands.iter().map(CommandToMember);
+    let loaders = commands.iter().map(CommandToLoader);
+    let bodies = commands.iter().map(CommandToBody);
 
     quote! {
         #(#pfn_typedefs)*


### PR DESCRIPTION
The removal of `handle` from `DrawIndirectCount` will slightly interfere with #494, but it remains to be seen which PR lands first.
