### PR TITLE
generator: Don't zip the same iterator with and without filter

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1427,28 +1427,20 @@ pub fn bitflags_impl_block(
         .filter(|constant| constant.notation() != Some(BACKWARDS_COMPATIBLE_ALIAS_COMMENT))
         .map(|constant| {
             let variant_ident = constant.variant_ident(enum_name);
+            let notation = constant.doc_attribute();
             let constant = constant.constant(enum_name);
-            let tokens = if let Constant::Alias(_) = &constant {
+            let value = if let Constant::Alias(_) = &constant {
                 quote!(#constant)
             } else {
                 quote!(Self(#constant))
             };
-            (variant_ident, tokens)
-        })
-        .collect_vec();
 
-    let notations = constants.iter().map(|constant| constant.doc_attribute());
+            quote! {
+                #notation
+                pub const #variant_ident: Self = #value;
+            }
+        });
 
-    let variants =
-        variants
-            .iter()
-            .zip(notations.clone())
-            .map(|((variant_ident, value), ref notation)| {
-                quote! {
-                    #notation
-                    pub const #variant_ident: Self = #value;
-                }
-            });
     quote! {
         impl #ident {
             #(#variants)*


### PR DESCRIPTION
`constants` is iterated twice here: once with a filter, the other time without, and the results are zipped together.  Besides being able to simplify the entire execution to just one `iter()` without intermediary iterators, removing `.zip()` makes it impossible for the results in both iterators to get mismatched when the `filter` inevitably skips elements.  Fortunately no such cases seem to exist, or at least not that effect the resulting generated code.
