### PR TITLE
generator: Remove now-unnecessary alias-identical check

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1474,17 +1474,6 @@ pub fn generate_enum<'a>(
             _ => None,
         })
         .filter(|constant| constant.notation() != Some(BACKWARDS_COMPATIBLE_ALIAS_COMMENT))
-        .filter(|constant| match &constant.spec {
-            vk_parse::EnumSpec::Alias { alias, .. } => {
-                // Remove any alias whose name is identical after name de-mangling. For example
-                // the XML contains compatibility aliases for variants without _BIT postfix
-                // which are removed by the generator anyway, after which they become identical.
-                let alias_name = constant.variant_ident(name);
-                let aliases_to = variant_ident(name, alias);
-                alias_name != aliases_to
-            }
-            _ => true,
-        })
         .collect_vec();
 
     let mut values = Vec::with_capacity(constants.len());


### PR DESCRIPTION
Back when we were still trying to come up with sensible names for "deprecated" aliases (initially introduced as self-supporting constants) that don't adhere to the naming standard but only remain to exist for backwards compatibility, some of these aliases would get the same name as the enum constant they were aliasing, resulting in (compile-time) conflicts.

Now that all those aliases are simply not generated anymore (end-users should just pick the properly named variant) it is not necessary to check for and prevent these conflicts on the generator side anymore.
