### PR TITLE
examples: Use c_char for pointer to raw string

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- examples: Use `c_char` for pointer to raw string (#521)
 - Device extension `khr::PipelineExecutableProperties` and `khr::TimelineSemaphore` now expose `fn device()` instead of `fn instance()` (#499)
 - Changed `khr::PipelineExecutableProperties::new()` and `khr::TimelineSemaphore::new()` to take `instance` and `device` as arguments (#499)
 

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -13,6 +13,7 @@ use std::cell::RefCell;
 use std::default::Default;
 use std::ffi::{CStr, CString};
 use std::ops::Drop;
+use std::os::raw::c_char;
 
 use winit::{
     event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
@@ -219,8 +220,10 @@ impl ExampleBase {
             let entry = Entry::new();
             let app_name = CString::new("VulkanTriangle").unwrap();
 
-            let layer_names = [CString::new("VK_LAYER_KHRONOS_validation").unwrap()];
-            let layers_names_raw: Vec<*const i8> = layer_names
+            let layer_names = [CStr::from_bytes_with_nul_unchecked(
+                b"VK_LAYER_KHRONOS_validation\0",
+            )];
+            let layers_names_raw: Vec<*const c_char> = layer_names
                 .iter()
                 .map(|raw_name| raw_name.as_ptr())
                 .collect();


### PR DESCRIPTION
On platforms like Android strings use `u8` as character-type instead of `i8` - using the appropriate `c_char` type hides this discrepancy and allows the examples to compile for all platforms.

---

Closes #315 (EDIT: GH can only link and close issues this way, not other PRs)

Opening a separate PR because that one hasn't moved for 1.5 years, even after repeated asking to replace the `s/i8/u8` (which obviously breaks all other platforms) with `c_char`.
