### PR TITLE
extensions/amd: Remove unnecessary CString allocations in `fn load`

### DIFF
--- a/ash/src/extensions/experimental/amd.rs
+++ b/ash/src/extensions/experimental/amd.rs
@@ -409,9 +409,9 @@ impl AmdGpaInterfaceFn {
                         stringify!(create_gpa_session_amd)
                     ))
                 }
-                let raw_name = stringify!(vkCreateGpaSessionAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCreateGpaSessionAMD\0");
+                let val = _f(cname);
                 if val.is_null() {
                     create_gpa_session_amd
                 } else {
@@ -429,9 +429,9 @@ impl AmdGpaInterfaceFn {
                         stringify!(destroy_gpa_session_amd)
                     ))
                 }
-                let raw_name = stringify!(vkDestroyGpaSessionAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkDestroyGpaSessionAMD\0");
+                let val = _f(cname);
                 if val.is_null() {
                     destroy_gpa_session_amd
                 } else {
@@ -448,9 +448,10 @@ impl AmdGpaInterfaceFn {
                         stringify!(set_gpa_device_clock_mode_amd)
                     ))
                 }
-                let raw_name = stringify!(vkSetGpaDeviceClockModeAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkSetGpaDeviceClockModeAMD\0",
+                );
+                let val = _f(cname);
                 if val.is_null() {
                     set_gpa_device_clock_mode_amd
                 } else {
@@ -467,9 +468,9 @@ impl AmdGpaInterfaceFn {
                         stringify!(cmd_begin_gpa_session_amd)
                     ))
                 }
-                let raw_name = stringify!(vkCmdBeginGpaSessionAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdBeginGpaSessionAMD\0");
+                let val = _f(cname);
                 if val.is_null() {
                     cmd_begin_gpa_session_amd
                 } else {
@@ -486,9 +487,9 @@ impl AmdGpaInterfaceFn {
                         stringify!(cmd_end_gpa_session_amd)
                     ))
                 }
-                let raw_name = stringify!(vkCmdEndGpaSessionAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdEndGpaSessionAMD\0");
+                let val = _f(cname);
                 if val.is_null() {
                     cmd_end_gpa_session_amd
                 } else {
@@ -507,9 +508,9 @@ impl AmdGpaInterfaceFn {
                         stringify!(cmd_begin_gpa_sample_amd)
                     ))
                 }
-                let raw_name = stringify!(vkCmdBeginGpaSampleAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdBeginGpaSampleAMD\0");
+                let val = _f(cname);
                 if val.is_null() {
                     cmd_begin_gpa_sample_amd
                 } else {
@@ -527,9 +528,9 @@ impl AmdGpaInterfaceFn {
                         stringify!(cmd_end_gpa_sample_amd)
                     ))
                 }
-                let raw_name = stringify!(vkCmdEndGpaSampleAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdEndGpaSampleAMD\0");
+                let val = _f(cname);
                 if val.is_null() {
                     cmd_end_gpa_sample_amd
                 } else {
@@ -546,9 +547,9 @@ impl AmdGpaInterfaceFn {
                         stringify!(get_gpa_session_status_amd)
                     ))
                 }
-                let raw_name = stringify!(vkGetGpaSessionStatusAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkGetGpaSessionStatusAMD\0");
+                let val = _f(cname);
                 if val.is_null() {
                     get_gpa_session_status_amd
                 } else {
@@ -568,9 +569,9 @@ impl AmdGpaInterfaceFn {
                         stringify!(get_gpa_session_results_amd)
                     ))
                 }
-                let raw_name = stringify!(vkGetGpaSessionResultsAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkGetGpaSessionResultsAMD\0");
+                let val = _f(cname);
                 if val.is_null() {
                     get_gpa_session_results_amd
                 } else {
@@ -587,9 +588,9 @@ impl AmdGpaInterfaceFn {
                         stringify!(reset_gpa_session_amd)
                     ))
                 }
-                let raw_name = stringify!(vkCmdEndGpaSampleAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdEndGpaSampleAMD\0");
+                let val = _f(cname);
                 if val.is_null() {
                     reset_gpa_session_amd
                 } else {
@@ -606,9 +607,10 @@ impl AmdGpaInterfaceFn {
                         stringify!(cmd_copy_gpa_session_results_amd)
                     ))
                 }
-                let raw_name = stringify!(vkCmdCopyGpaSessionResultsAMD);
-                let cname = ::std::ffi::CString::new(raw_name).unwrap();
-                let val = _f(&cname);
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkCmdCopyGpaSessionResultsAMD\0",
+                );
+                let val = _f(cname);
                 if val.is_null() {
                     cmd_copy_gpa_session_results_amd
                 } else {

--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -1,5 +1,5 @@
 use std::default::Default;
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::io::Cursor;
 use std::mem::{self, align_of};
 use std::os::raw::c_void;
@@ -573,7 +573,7 @@ fn main() {
             .create_pipeline_layout(&layout_create_info, None)
             .unwrap();
 
-        let shader_entry_name = CString::new("main").unwrap();
+        let shader_entry_name = CStr::from_bytes_with_nul_unchecked(b"main\0");
         let shader_stage_create_infos = [
             vk::PipelineShaderStageCreateInfo {
                 module: vertex_shader_module,

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -2,7 +2,7 @@ use ash::util::*;
 use ash::vk;
 use examples::*;
 use std::default::Default;
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::io::Cursor;
 use std::mem;
 use std::mem::align_of;
@@ -226,7 +226,7 @@ fn main() {
             .create_pipeline_layout(&layout_create_info, None)
             .unwrap();
 
-        let shader_entry_name = CString::new("main").unwrap();
+        let shader_entry_name = CStr::from_bytes_with_nul_unchecked(b"main\0");
         let shader_stage_create_infos = [
             vk::PipelineShaderStageCreateInfo {
                 module: vertex_shader_module,

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -11,7 +11,7 @@ pub use ash::{Device, Instance};
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::default::Default;
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::ops::Drop;
 use std::os::raw::c_char;
 
@@ -218,7 +218,7 @@ impl ExampleBase {
                 .build(&event_loop)
                 .unwrap();
             let entry = Entry::linked();
-            let app_name = CString::new("VulkanTriangle").unwrap();
+            let app_name = CStr::from_bytes_with_nul_unchecked(b"VulkanTriangle\0");
 
             let layer_names = [CStr::from_bytes_with_nul_unchecked(
                 b"VK_LAYER_KHRONOS_validation\0",
@@ -236,9 +236,9 @@ impl ExampleBase {
             extension_names_raw.push(DebugUtils::name().as_ptr());
 
             let appinfo = vk::ApplicationInfo::builder()
-                .application_name(&app_name)
+                .application_name(app_name)
                 .application_version(0)
-                .engine_name(&app_name)
+                .engine_name(app_name)
                 .engine_version(0)
                 .api_version(vk::make_api_version(0, 1, 0, 0));
 


### PR DESCRIPTION
Following the changes in a053c6a ("Remove unnecessary CString allocation when loading functions (#379)") this addresses the remainder of string allocations in manual extension loading code.
