### PR TITLE
Assert that Vulkan array-getters return the same length

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -328,6 +328,7 @@ impl Device {
             &mut count,
             out.as_mut_ptr(),
         );
+        assert_eq!(count as usize, out.len());
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkTrimCommandPool.html>"]

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -70,6 +70,7 @@ impl GetMemoryRequirements2 {
             &mut count,
             out.as_mut_ptr(),
         );
+        assert_eq!(count as usize, out.len());
     }
 
     pub fn name() -> &'static CStr {

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -107,6 +107,7 @@ impl GetPhysicalDeviceProperties2 {
             &mut count,
             out.as_mut_ptr(),
         );
+        assert_eq!(count as usize, out.len());
     }
 
     /// Retrieve the number of elements to pass to [`Self::get_physical_device_sparse_image_format_properties2()`]
@@ -144,6 +145,7 @@ impl GetPhysicalDeviceProperties2 {
                 &mut count,
                 out.as_mut_ptr(),
             );
+        assert_eq!(count as usize, out.len());
     }
 
     pub fn name() -> &'static CStr {

--- a/ash/src/extensions/khr/get_surface_capabilities2.rs
+++ b/ash/src/extensions/khr/get_surface_capabilities2.rs
@@ -66,7 +66,7 @@ impl GetSurfaceCapabilities2 {
             &mut count,
             out.as_mut_ptr(),
         );
-        assert_eq!(count, out.len() as u32);
+        assert_eq!(count as usize, out.len());
         err_code.result()
     }
 

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -69,7 +69,7 @@ impl Maintenance4 {
             &mut count,
             out.as_mut_ptr(),
         );
-        assert_eq!(count, out.len() as u32);
+        assert_eq!(count as usize, out.len());
     }
 
     pub fn name() -> &'static CStr {

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -67,10 +67,12 @@ impl Instance {
         &self,
         out: &mut [vk::PhysicalDeviceGroupProperties],
     ) -> VkResult<()> {
-        let mut group_count = out.len() as u32;
+        let mut count = out.len() as u32;
         self.instance_fn_1_1
-            .enumerate_physical_device_groups(self.handle(), &mut group_count, out.as_mut_ptr())
-            .result()
+            .enumerate_physical_device_groups(self.handle(), &mut count, out.as_mut_ptr())
+            .result()?;
+        assert_eq!(count as usize, out.len());
+        Ok(())
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceFeatures2.html>"]
@@ -144,13 +146,14 @@ impl Instance {
         physical_device: vk::PhysicalDevice,
         out: &mut [vk::QueueFamilyProperties2],
     ) {
-        let mut queue_count = out.len() as u32;
+        let mut count = out.len() as u32;
         self.instance_fn_1_1
             .get_physical_device_queue_family_properties2(
                 physical_device,
-                &mut queue_count,
+                &mut count,
                 out.as_mut_ptr(),
             );
+        assert_eq!(count as usize, out.len());
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceMemoryProperties2.html>"]
@@ -190,14 +193,15 @@ impl Instance {
         format_info: &vk::PhysicalDeviceSparseImageFormatInfo2,
         out: &mut [vk::SparseImageFormatProperties2],
     ) {
-        let mut format_count = out.len() as u32;
+        let mut count = out.len() as u32;
         self.instance_fn_1_1
             .get_physical_device_sparse_image_format_properties2(
                 physical_device,
                 format_info,
-                &mut format_count,
+                &mut count,
                 out.as_mut_ptr(),
             );
+        assert_eq!(count as usize, out.len());
     }
 
     #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceExternalBufferProperties.html>"]


### PR DESCRIPTION
Originally introduced in [#489] this inserts the array-length equality check everywhere else: in the supposedly invalid and inexistant event where Vulkan suddenly returns less items (`count` has been modified) than were originally queried through respective `_len()` functions (or more likely: a slice of invalid length passed by the user) and some elements at the end of the slice are left uninitialized, panic.

Wherever there is valid concern or possibility for this to happen - or to circumvent assertions and panics altogether - mutable references to mutable slices should be passed allowing the length to be promptly updated.

[#489]: https://github.com/MaikKlein/ash/pull/489#discussion_r753020089
