### PR TITLE
Generate `RGBA=R|G|B|A` helper constant for `ColorComponentFlags`

### DIFF
--- a/ash/src/vk/prelude.rs
+++ b/ash/src/vk/prelude.rs
@@ -26,3 +26,8 @@ impl Packed24_8 {
         (self.0 >> 24) as u8
     }
 }
+
+impl super::ColorComponentFlags {
+    /// Contraction of [`Self::R`] | [`Self::G`] | [`Self::B`] | [`Self::A`]
+    pub const RGBA: Self = Self(Self::R.0 | Self::G.0 | Self::B.0 | Self::A.0);
+}

--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -666,10 +666,7 @@ fn main() {
             src_alpha_blend_factor: vk::BlendFactor::ZERO,
             dst_alpha_blend_factor: vk::BlendFactor::ZERO,
             alpha_blend_op: vk::BlendOp::ADD,
-            color_write_mask: vk::ColorComponentFlags::R
-                | vk::ColorComponentFlags::G
-                | vk::ColorComponentFlags::B
-                | vk::ColorComponentFlags::A,
+            color_write_mask: vk::ColorComponentFlags::RGBA,
         }];
         let color_blend_state = vk::PipelineColorBlendStateCreateInfo::builder()
             .logic_op(vk::LogicOp::CLEAR)

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -319,10 +319,7 @@ fn main() {
             src_alpha_blend_factor: vk::BlendFactor::ZERO,
             dst_alpha_blend_factor: vk::BlendFactor::ZERO,
             alpha_blend_op: vk::BlendOp::ADD,
-            color_write_mask: vk::ColorComponentFlags::R
-                | vk::ColorComponentFlags::G
-                | vk::ColorComponentFlags::B
-                | vk::ColorComponentFlags::A,
+            color_write_mask: vk::ColorComponentFlags::RGBA,
         }];
         let color_blend_state = vk::PipelineColorBlendStateCreateInfo::builder()
             .logic_op(vk::LogicOp::CLEAR)


### PR DESCRIPTION
Fixes #536

When the misleading `all()` function was removed in #478 it also made all color components for `ColorComponentFlags` significantly more verbose to write, see #536.
