### PR TITLE
example: Refactor event loop handling for continuous redraw

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -185,23 +185,23 @@ impl ExampleBase {
             .borrow_mut()
             .run_return(|event, _, control_flow| {
                 *control_flow = ControlFlow::Wait;
-                f();
-                if let Event::WindowEvent {
-                    event:
-                        WindowEvent::CloseRequested
-                        | WindowEvent::KeyboardInput {
-                            input:
-                                KeyboardInput {
-                                    state: ElementState::Pressed,
-                                    virtual_keycode: Some(VirtualKeyCode::Escape),
-                                    ..
-                                },
-                            ..
-                        },
-                    ..
-                } = event
-                {
-                    *control_flow = ControlFlow::Exit
+                match event {
+                    Event::WindowEvent {
+                        event:
+                            WindowEvent::CloseRequested
+                            | WindowEvent::KeyboardInput {
+                                input:
+                                    KeyboardInput {
+                                        state: ElementState::Pressed,
+                                        virtual_keycode: Some(VirtualKeyCode::Escape),
+                                        ..
+                                    },
+                                ..
+                            },
+                        ..
+                    } => *control_flow = ControlFlow::Exit,
+                    Event::RedrawRequested(_) => f(),
+                    _ => (),
                 }
             });
     }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -184,7 +184,7 @@ impl ExampleBase {
         self.event_loop
             .borrow_mut()
             .run_return(|event, _, control_flow| {
-                *control_flow = ControlFlow::Wait;
+                *control_flow = ControlFlow::Poll;
                 match event {
                     Event::WindowEvent {
                         event:
@@ -200,7 +200,7 @@ impl ExampleBase {
                             },
                         ..
                     } => *control_flow = ControlFlow::Exit,
-                    Event::RedrawRequested(_) => f(),
+                    Event::MainEventsCleared => f(),
                     _ => (),
                 }
             });


### PR DESCRIPTION
Fixes hangs in case of non-mailbox present modes. I assume acquiring an image from the swapchain hangs when redrawing unconditionally on each incoming event. See https://github.com/rust-windowing/winit/issues/2127 and https://github.com/MaikKlein/ash/issues/541

Tested on Windows with Nvidia gpu