### PR TITLE
Convert `vk_bitflags_wrapped!` methods to `const fn`

### DIFF
--- a/ash/src/vk/macros.rs
+++ b/ash/src/vk/macros.rs
@@ -32,18 +32,6 @@ macro_rules! vk_bitflags_wrapped {
             pub const fn contains(self, other: Self) -> bool {
                 self.0 & other.0 == other.0
             }
-            #[inline]
-            pub const fn intersection(self, other: Self) -> Self {
-                Self(self.0 & other.0)
-            }
-            #[inline]
-            pub const fn union(self, other: Self) -> Self {
-                Self(self.0 | other.0)
-            }
-            #[inline]
-            pub const fn difference(self, other: Self) -> Self {
-                Self(self.0 & !other.0)
-            }
         }
         impl ::std::ops::BitOr for $name {
             type Output = Self;

--- a/ash/src/vk/macros.rs
+++ b/ash/src/vk/macros.rs
@@ -20,17 +20,29 @@ macro_rules! vk_bitflags_wrapped {
                 self.0
             }
             #[inline]
-            pub fn is_empty(self) -> bool {
-                self == Self::empty()
+            pub const fn is_empty(self) -> bool {
+                self.0 == Self::empty().0
             }
             #[inline]
-            pub fn intersects(self, other: Self) -> bool {
-                self & other != Self::empty()
+            pub const fn intersects(self, other: Self) -> bool {
+                !Self(self.0 & other.0).is_empty()
             }
             #[doc = r" Returns whether `other` is a subset of `self`"]
             #[inline]
-            pub fn contains(self, other: Self) -> bool {
-                self & other == other
+            pub const fn contains(self, other: Self) -> bool {
+                self.0 & other.0 == other.0
+            }
+            #[inline]
+            pub const fn intersection(self, other: Self) -> Self {
+                Self(self.0 & other.0)
+            }
+            #[inline]
+            pub const fn union(self, other: Self) -> Self {
+                Self(self.0 | other.0)
+            }
+            #[inline]
+            pub const fn difference(self, other: Self) -> Self {
+                Self(self.0 & !other.0)
             }
         }
         impl ::std::ops::BitOr for $name {


### PR DESCRIPTION
Closes #546

So that vk_bitflags may be used directly in const contexts more ergonomically, similar to bitflags: https://docs.rs/bitflags/1.3.2/bitflags/example_generated/struct.Flags.html