### PR TITLE
examples: Update winit to 0.26 and image to 0.23

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["maik klein <maikklein@googlemail.com>"]
 edition = "2018"
 
 [dependencies]
-winit = "0.25.0"
-image = "0.10.4"
+winit = "0.26"
+image = "0.23"
 # The examples require the validation layers, which means the SDK or
 # equivalent development packages should be present, so we can link
 # directly and benefit from the infallible `Entry` constructor.

--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -263,7 +263,7 @@ fn main() {
 
         let image = image::load_from_memory(include_bytes!("../../assets/rust.png"))
             .unwrap()
-            .to_rgba();
+            .to_rgba8();
         let image_dimensions = image.dimensions();
         let image_data = image.into_raw();
         let image_buffer_info = vk::BufferCreateInfo {


### PR DESCRIPTION
Examples-only excerpt of #547, as the generator and ash-window example changes need more work.  Fixes #550.
