### PR TITLE
ash-window: Require at least `raw-window-handle 0.3.4` for 0.4 interop

### DIFF
--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -15,7 +15,7 @@ workspace = ".."
 
 [dependencies]
 ash = { path = "../ash", version = "0.35", default-features = false }
-raw-window-handle = "0.3"
+raw-window-handle = "0.3.4"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 raw-window-metal = "0.1"


### PR DESCRIPTION
`raw-window-handle 0.3.4` was pushed as a "semver-trick-like" patch release, implementing the `0.3` trait for the `0.4` crate release [74].  This allows `ash-window` as a window-handle "consumer" crate to accept both `0.3` and i`0.4` handles from consumer crates simultaneously.  To ensure this patch release is available even when users omit regular `cargo update` or build with `-Z minimal-versions`, set the minimal patch version in `Cargo.toml` to it.

[74]: https://github.com/rust-windowing/raw-window-handle/pull/74
CC @dvc94ch, https://github.com/MaikKlein/ash/pull/505#issuecomment-1009181013
