### PR TITLE
Give users direct access to bitflags and enumeration constants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Give users direct access to bitflags and enumeration constants (#554)
 - example: Refactor event loop handling for continuous redraw (#542)
 - Generate `RGBA=R|G|B|A` helper constant for `ColorComponentFlags` (#537)
 - Remove remaining `CString` allocations on string literals in examples and hand-written AMD extension (#533)

--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -2,13 +2,13 @@ use crate::vk::definitions::*;
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCacheCreateFlagBits.html>"]
-pub struct PipelineCacheCreateFlags(pub(crate) Flags);
+pub struct PipelineCacheCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineCacheCreateFlags, Flags);
 impl PipelineCacheCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueueFlagBits.html>"]
-pub struct QueueFlags(pub(crate) Flags);
+pub struct QueueFlags(pub Flags);
 vk_bitflags_wrapped!(QueueFlags, Flags);
 impl QueueFlags {
     #[doc = "Queue supports graphics operations"]
@@ -23,7 +23,7 @@ impl QueueFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCullModeFlagBits.html>"]
-pub struct CullModeFlags(pub(crate) Flags);
+pub struct CullModeFlags(pub Flags);
 vk_bitflags_wrapped!(CullModeFlags, Flags);
 impl CullModeFlags {
     pub const NONE: Self = Self(0);
@@ -34,19 +34,19 @@ impl CullModeFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderPassCreateFlagBits.html>"]
-pub struct RenderPassCreateFlags(pub(crate) Flags);
+pub struct RenderPassCreateFlags(pub Flags);
 vk_bitflags_wrapped!(RenderPassCreateFlags, Flags);
 impl RenderPassCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceQueueCreateFlagBits.html>"]
-pub struct DeviceQueueCreateFlags(pub(crate) Flags);
+pub struct DeviceQueueCreateFlags(pub Flags);
 vk_bitflags_wrapped!(DeviceQueueCreateFlags, Flags);
 impl DeviceQueueCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryPropertyFlagBits.html>"]
-pub struct MemoryPropertyFlags(pub(crate) Flags);
+pub struct MemoryPropertyFlags(pub Flags);
 vk_bitflags_wrapped!(MemoryPropertyFlags, Flags);
 impl MemoryPropertyFlags {
     #[doc = "If otherwise stated, then allocate memory on device"]
@@ -63,7 +63,7 @@ impl MemoryPropertyFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryHeapFlagBits.html>"]
-pub struct MemoryHeapFlags(pub(crate) Flags);
+pub struct MemoryHeapFlags(pub Flags);
 vk_bitflags_wrapped!(MemoryHeapFlags, Flags);
 impl MemoryHeapFlags {
     #[doc = "If set, heap represents device memory"]
@@ -72,7 +72,7 @@ impl MemoryHeapFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccessFlagBits.html>"]
-pub struct AccessFlags(pub(crate) Flags);
+pub struct AccessFlags(pub Flags);
 vk_bitflags_wrapped!(AccessFlags, Flags);
 impl AccessFlags {
     #[doc = "Controls coherency of indirect command reads"]
@@ -113,7 +113,7 @@ impl AccessFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferUsageFlagBits.html>"]
-pub struct BufferUsageFlags(pub(crate) Flags);
+pub struct BufferUsageFlags(pub Flags);
 vk_bitflags_wrapped!(BufferUsageFlags, Flags);
 impl BufferUsageFlags {
     #[doc = "Can be used as a source of transfer operations"]
@@ -138,7 +138,7 @@ impl BufferUsageFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferCreateFlagBits.html>"]
-pub struct BufferCreateFlags(pub(crate) Flags);
+pub struct BufferCreateFlags(pub Flags);
 vk_bitflags_wrapped!(BufferCreateFlags, Flags);
 impl BufferCreateFlags {
     #[doc = "Buffer should support sparse backing"]
@@ -151,7 +151,7 @@ impl BufferCreateFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderStageFlagBits.html>"]
-pub struct ShaderStageFlags(pub(crate) Flags);
+pub struct ShaderStageFlags(pub Flags);
 vk_bitflags_wrapped!(ShaderStageFlags, Flags);
 impl ShaderStageFlags {
     pub const VERTEX: Self = Self(0b1);
@@ -166,7 +166,7 @@ impl ShaderStageFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageUsageFlagBits.html>"]
-pub struct ImageUsageFlags(pub(crate) Flags);
+pub struct ImageUsageFlags(pub Flags);
 vk_bitflags_wrapped!(ImageUsageFlags, Flags);
 impl ImageUsageFlags {
     #[doc = "Can be used as a source of transfer operations"]
@@ -189,7 +189,7 @@ impl ImageUsageFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageCreateFlagBits.html>"]
-pub struct ImageCreateFlags(pub(crate) Flags);
+pub struct ImageCreateFlags(pub Flags);
 vk_bitflags_wrapped!(ImageCreateFlags, Flags);
 impl ImageCreateFlags {
     #[doc = "Image should support sparse backing"]
@@ -206,19 +206,19 @@ impl ImageCreateFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageViewCreateFlagBits.html>"]
-pub struct ImageViewCreateFlags(pub(crate) Flags);
+pub struct ImageViewCreateFlags(pub Flags);
 vk_bitflags_wrapped!(ImageViewCreateFlags, Flags);
 impl ImageViewCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerCreateFlagBits.html>"]
-pub struct SamplerCreateFlags(pub(crate) Flags);
+pub struct SamplerCreateFlags(pub Flags);
 vk_bitflags_wrapped!(SamplerCreateFlags, Flags);
 impl SamplerCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCreateFlagBits.html>"]
-pub struct PipelineCreateFlags(pub(crate) Flags);
+pub struct PipelineCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineCreateFlags, Flags);
 impl PipelineCreateFlags {
     pub const DISABLE_OPTIMIZATION: Self = Self(0b1);
@@ -228,13 +228,13 @@ impl PipelineCreateFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineShaderStageCreateFlagBits.html>"]
-pub struct PipelineShaderStageCreateFlags(pub(crate) Flags);
+pub struct PipelineShaderStageCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineShaderStageCreateFlags, Flags);
 impl PipelineShaderStageCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkColorComponentFlagBits.html>"]
-pub struct ColorComponentFlags(pub(crate) Flags);
+pub struct ColorComponentFlags(pub Flags);
 vk_bitflags_wrapped!(ColorComponentFlags, Flags);
 impl ColorComponentFlags {
     pub const R: Self = Self(0b1);
@@ -245,7 +245,7 @@ impl ColorComponentFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFenceCreateFlagBits.html>"]
-pub struct FenceCreateFlags(pub(crate) Flags);
+pub struct FenceCreateFlags(pub Flags);
 vk_bitflags_wrapped!(FenceCreateFlags, Flags);
 impl FenceCreateFlags {
     pub const SIGNALED: Self = Self(0b1);
@@ -253,13 +253,13 @@ impl FenceCreateFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreCreateFlagBits.html>"]
-pub struct SemaphoreCreateFlags(pub(crate) Flags);
+pub struct SemaphoreCreateFlags(pub Flags);
 vk_bitflags_wrapped!(SemaphoreCreateFlags, Flags);
 impl SemaphoreCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFormatFeatureFlagBits.html>"]
-pub struct FormatFeatureFlags(pub(crate) Flags);
+pub struct FormatFeatureFlags(pub Flags);
 vk_bitflags_wrapped!(FormatFeatureFlags, Flags);
 impl FormatFeatureFlags {
     #[doc = "Format can be used for sampled images (SAMPLED_IMAGE and COMBINED_IMAGE_SAMPLER descriptor types)"]
@@ -292,7 +292,7 @@ impl FormatFeatureFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryControlFlagBits.html>"]
-pub struct QueryControlFlags(pub(crate) Flags);
+pub struct QueryControlFlags(pub Flags);
 vk_bitflags_wrapped!(QueryControlFlags, Flags);
 impl QueryControlFlags {
     #[doc = "Require precise results to be collected by the query"]
@@ -301,7 +301,7 @@ impl QueryControlFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryResultFlagBits.html>"]
-pub struct QueryResultFlags(pub(crate) Flags);
+pub struct QueryResultFlags(pub Flags);
 vk_bitflags_wrapped!(QueryResultFlags, Flags);
 impl QueryResultFlags {
     #[doc = "Results of the queries are written to the destination buffer as 64-bit values"]
@@ -316,7 +316,7 @@ impl QueryResultFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferUsageFlagBits.html>"]
-pub struct CommandBufferUsageFlags(pub(crate) Flags);
+pub struct CommandBufferUsageFlags(pub Flags);
 vk_bitflags_wrapped!(CommandBufferUsageFlags, Flags);
 impl CommandBufferUsageFlags {
     pub const ONE_TIME_SUBMIT: Self = Self(0b1);
@@ -327,7 +327,7 @@ impl CommandBufferUsageFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPipelineStatisticFlagBits.html>"]
-pub struct QueryPipelineStatisticFlags(pub(crate) Flags);
+pub struct QueryPipelineStatisticFlags(pub Flags);
 vk_bitflags_wrapped!(QueryPipelineStatisticFlags, Flags);
 impl QueryPipelineStatisticFlags {
     #[doc = "Optional"]
@@ -356,7 +356,7 @@ impl QueryPipelineStatisticFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageAspectFlagBits.html>"]
-pub struct ImageAspectFlags(pub(crate) Flags);
+pub struct ImageAspectFlags(pub Flags);
 vk_bitflags_wrapped!(ImageAspectFlags, Flags);
 impl ImageAspectFlags {
     pub const COLOR: Self = Self(0b1);
@@ -367,7 +367,7 @@ impl ImageAspectFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseImageFormatFlagBits.html>"]
-pub struct SparseImageFormatFlags(pub(crate) Flags);
+pub struct SparseImageFormatFlags(pub Flags);
 vk_bitflags_wrapped!(SparseImageFormatFlags, Flags);
 impl SparseImageFormatFlags {
     #[doc = "Image uses a single mip tail region for all array layers"]
@@ -380,7 +380,7 @@ impl SparseImageFormatFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSparseMemoryBindFlagBits.html>"]
-pub struct SparseMemoryBindFlags(pub(crate) Flags);
+pub struct SparseMemoryBindFlags(pub Flags);
 vk_bitflags_wrapped!(SparseMemoryBindFlags, Flags);
 impl SparseMemoryBindFlags {
     #[doc = "Operation binds resource metadata to memory"]
@@ -389,7 +389,7 @@ impl SparseMemoryBindFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineStageFlagBits.html>"]
-pub struct PipelineStageFlags(pub(crate) Flags);
+pub struct PipelineStageFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineStageFlags, Flags);
 impl PipelineStageFlags {
     #[doc = "Before subsequent commands are processed"]
@@ -430,7 +430,7 @@ impl PipelineStageFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandPoolCreateFlagBits.html>"]
-pub struct CommandPoolCreateFlags(pub(crate) Flags);
+pub struct CommandPoolCreateFlags(pub Flags);
 vk_bitflags_wrapped!(CommandPoolCreateFlags, Flags);
 impl CommandPoolCreateFlags {
     #[doc = "Command buffers have a short lifetime"]
@@ -441,7 +441,7 @@ impl CommandPoolCreateFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandPoolResetFlagBits.html>"]
-pub struct CommandPoolResetFlags(pub(crate) Flags);
+pub struct CommandPoolResetFlags(pub Flags);
 vk_bitflags_wrapped!(CommandPoolResetFlags, Flags);
 impl CommandPoolResetFlags {
     #[doc = "Release resources owned by the pool"]
@@ -450,7 +450,7 @@ impl CommandPoolResetFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferResetFlagBits.html>"]
-pub struct CommandBufferResetFlags(pub(crate) Flags);
+pub struct CommandBufferResetFlags(pub Flags);
 vk_bitflags_wrapped!(CommandBufferResetFlags, Flags);
 impl CommandBufferResetFlags {
     #[doc = "Release resources owned by the buffer"]
@@ -459,7 +459,7 @@ impl CommandBufferResetFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSampleCountFlagBits.html>"]
-pub struct SampleCountFlags(pub(crate) Flags);
+pub struct SampleCountFlags(pub Flags);
 vk_bitflags_wrapped!(SampleCountFlags, Flags);
 impl SampleCountFlags {
     #[doc = "Sample count 1 supported"]
@@ -480,7 +480,7 @@ impl SampleCountFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentDescriptionFlagBits.html>"]
-pub struct AttachmentDescriptionFlags(pub(crate) Flags);
+pub struct AttachmentDescriptionFlags(pub Flags);
 vk_bitflags_wrapped!(AttachmentDescriptionFlags, Flags);
 impl AttachmentDescriptionFlags {
     #[doc = "The attachment may alias physical memory of another attachment in the same render pass"]
@@ -489,7 +489,7 @@ impl AttachmentDescriptionFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStencilFaceFlagBits.html>"]
-pub struct StencilFaceFlags(pub(crate) Flags);
+pub struct StencilFaceFlags(pub Flags);
 vk_bitflags_wrapped!(StencilFaceFlags, Flags);
 impl StencilFaceFlags {
     #[doc = "Front face"]
@@ -502,7 +502,7 @@ impl StencilFaceFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorPoolCreateFlagBits.html>"]
-pub struct DescriptorPoolCreateFlags(pub(crate) Flags);
+pub struct DescriptorPoolCreateFlags(pub Flags);
 vk_bitflags_wrapped!(DescriptorPoolCreateFlags, Flags);
 impl DescriptorPoolCreateFlags {
     #[doc = "Descriptor sets may be freed individually"]
@@ -511,7 +511,7 @@ impl DescriptorPoolCreateFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDependencyFlagBits.html>"]
-pub struct DependencyFlags(pub(crate) Flags);
+pub struct DependencyFlags(pub Flags);
 vk_bitflags_wrapped!(DependencyFlags, Flags);
 impl DependencyFlags {
     #[doc = "Dependency is per pixel region "]
@@ -520,7 +520,7 @@ impl DependencyFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreWaitFlagBits.html>"]
-pub struct SemaphoreWaitFlags(pub(crate) Flags);
+pub struct SemaphoreWaitFlags(pub Flags);
 vk_bitflags_wrapped!(SemaphoreWaitFlags, Flags);
 impl SemaphoreWaitFlags {
     pub const ANY: Self = Self(0b1);
@@ -528,7 +528,7 @@ impl SemaphoreWaitFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPlaneAlphaFlagBitsKHR.html>"]
-pub struct DisplayPlaneAlphaFlagsKHR(pub(crate) Flags);
+pub struct DisplayPlaneAlphaFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(DisplayPlaneAlphaFlagsKHR, Flags);
 impl DisplayPlaneAlphaFlagsKHR {
     pub const OPAQUE: Self = Self(0b1);
@@ -539,7 +539,7 @@ impl DisplayPlaneAlphaFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCompositeAlphaFlagBitsKHR.html>"]
-pub struct CompositeAlphaFlagsKHR(pub(crate) Flags);
+pub struct CompositeAlphaFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(CompositeAlphaFlagsKHR, Flags);
 impl CompositeAlphaFlagsKHR {
     pub const OPAQUE: Self = Self(0b1);
@@ -550,7 +550,7 @@ impl CompositeAlphaFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceTransformFlagBitsKHR.html>"]
-pub struct SurfaceTransformFlagsKHR(pub(crate) Flags);
+pub struct SurfaceTransformFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(SurfaceTransformFlagsKHR, Flags);
 impl SurfaceTransformFlagsKHR {
     pub const IDENTITY: Self = Self(0b1);
@@ -566,7 +566,7 @@ impl SurfaceTransformFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSwapchainImageUsageFlagBitsANDROID.html>"]
-pub struct SwapchainImageUsageFlagsANDROID(pub(crate) Flags);
+pub struct SwapchainImageUsageFlagsANDROID(pub Flags);
 vk_bitflags_wrapped!(SwapchainImageUsageFlagsANDROID, Flags);
 impl SwapchainImageUsageFlagsANDROID {
     pub const SHARED: Self = Self(0b1);
@@ -574,7 +574,7 @@ impl SwapchainImageUsageFlagsANDROID {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugReportFlagBitsEXT.html>"]
-pub struct DebugReportFlagsEXT(pub(crate) Flags);
+pub struct DebugReportFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(DebugReportFlagsEXT, Flags);
 impl DebugReportFlagsEXT {
     pub const INFORMATION: Self = Self(0b1);
@@ -586,7 +586,7 @@ impl DebugReportFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryHandleTypeFlagBitsNV.html>"]
-pub struct ExternalMemoryHandleTypeFlagsNV(pub(crate) Flags);
+pub struct ExternalMemoryHandleTypeFlagsNV(pub Flags);
 vk_bitflags_wrapped!(ExternalMemoryHandleTypeFlagsNV, Flags);
 impl ExternalMemoryHandleTypeFlagsNV {
     pub const OPAQUE_WIN32: Self = Self(0b1);
@@ -597,7 +597,7 @@ impl ExternalMemoryHandleTypeFlagsNV {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryFeatureFlagBitsNV.html>"]
-pub struct ExternalMemoryFeatureFlagsNV(pub(crate) Flags);
+pub struct ExternalMemoryFeatureFlagsNV(pub Flags);
 vk_bitflags_wrapped!(ExternalMemoryFeatureFlagsNV, Flags);
 impl ExternalMemoryFeatureFlagsNV {
     pub const DEDICATED_ONLY: Self = Self(0b1);
@@ -607,7 +607,7 @@ impl ExternalMemoryFeatureFlagsNV {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubgroupFeatureFlagBits.html>"]
-pub struct SubgroupFeatureFlags(pub(crate) Flags);
+pub struct SubgroupFeatureFlags(pub Flags);
 vk_bitflags_wrapped!(SubgroupFeatureFlags, Flags);
 impl SubgroupFeatureFlags {
     #[doc = "Basic subgroup operations"]
@@ -630,7 +630,7 @@ impl SubgroupFeatureFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndirectCommandsLayoutUsageFlagBitsNV.html>"]
-pub struct IndirectCommandsLayoutUsageFlagsNV(pub(crate) Flags);
+pub struct IndirectCommandsLayoutUsageFlagsNV(pub Flags);
 vk_bitflags_wrapped!(IndirectCommandsLayoutUsageFlagsNV, Flags);
 impl IndirectCommandsLayoutUsageFlagsNV {
     pub const EXPLICIT_PREPROCESS: Self = Self(0b1);
@@ -640,7 +640,7 @@ impl IndirectCommandsLayoutUsageFlagsNV {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndirectStateFlagBitsNV.html>"]
-pub struct IndirectStateFlagsNV(pub(crate) Flags);
+pub struct IndirectStateFlagsNV(pub Flags);
 vk_bitflags_wrapped!(IndirectStateFlagsNV, Flags);
 impl IndirectStateFlagsNV {
     pub const FLAG_FRONTFACE: Self = Self(0b1);
@@ -648,19 +648,19 @@ impl IndirectStateFlagsNV {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPrivateDataSlotCreateFlagBitsEXT.html>"]
-pub struct PrivateDataSlotCreateFlagsEXT(pub(crate) Flags);
+pub struct PrivateDataSlotCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(PrivateDataSlotCreateFlagsEXT, Flags);
 impl PrivateDataSlotCreateFlagsEXT {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorSetLayoutCreateFlagBits.html>"]
-pub struct DescriptorSetLayoutCreateFlags(pub(crate) Flags);
+pub struct DescriptorSetLayoutCreateFlags(pub Flags);
 vk_bitflags_wrapped!(DescriptorSetLayoutCreateFlags, Flags);
 impl DescriptorSetLayoutCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryHandleTypeFlagBits.html>"]
-pub struct ExternalMemoryHandleTypeFlags(pub(crate) Flags);
+pub struct ExternalMemoryHandleTypeFlags(pub Flags);
 vk_bitflags_wrapped!(ExternalMemoryHandleTypeFlags, Flags);
 impl ExternalMemoryHandleTypeFlags {
     pub const OPAQUE_FD: Self = Self(0b1);
@@ -674,7 +674,7 @@ impl ExternalMemoryHandleTypeFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalMemoryFeatureFlagBits.html>"]
-pub struct ExternalMemoryFeatureFlags(pub(crate) Flags);
+pub struct ExternalMemoryFeatureFlags(pub Flags);
 vk_bitflags_wrapped!(ExternalMemoryFeatureFlags, Flags);
 impl ExternalMemoryFeatureFlags {
     pub const DEDICATED_ONLY: Self = Self(0b1);
@@ -684,7 +684,7 @@ impl ExternalMemoryFeatureFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalSemaphoreHandleTypeFlagBits.html>"]
-pub struct ExternalSemaphoreHandleTypeFlags(pub(crate) Flags);
+pub struct ExternalSemaphoreHandleTypeFlags(pub Flags);
 vk_bitflags_wrapped!(ExternalSemaphoreHandleTypeFlags, Flags);
 impl ExternalSemaphoreHandleTypeFlags {
     pub const OPAQUE_FD: Self = Self(0b1);
@@ -697,7 +697,7 @@ impl ExternalSemaphoreHandleTypeFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalSemaphoreFeatureFlagBits.html>"]
-pub struct ExternalSemaphoreFeatureFlags(pub(crate) Flags);
+pub struct ExternalSemaphoreFeatureFlags(pub Flags);
 vk_bitflags_wrapped!(ExternalSemaphoreFeatureFlags, Flags);
 impl ExternalSemaphoreFeatureFlags {
     pub const EXPORTABLE: Self = Self(0b1);
@@ -706,7 +706,7 @@ impl ExternalSemaphoreFeatureFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreImportFlagBits.html>"]
-pub struct SemaphoreImportFlags(pub(crate) Flags);
+pub struct SemaphoreImportFlags(pub Flags);
 vk_bitflags_wrapped!(SemaphoreImportFlags, Flags);
 impl SemaphoreImportFlags {
     pub const TEMPORARY: Self = Self(0b1);
@@ -714,7 +714,7 @@ impl SemaphoreImportFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalFenceHandleTypeFlagBits.html>"]
-pub struct ExternalFenceHandleTypeFlags(pub(crate) Flags);
+pub struct ExternalFenceHandleTypeFlags(pub Flags);
 vk_bitflags_wrapped!(ExternalFenceHandleTypeFlags, Flags);
 impl ExternalFenceHandleTypeFlags {
     pub const OPAQUE_FD: Self = Self(0b1);
@@ -725,7 +725,7 @@ impl ExternalFenceHandleTypeFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkExternalFenceFeatureFlagBits.html>"]
-pub struct ExternalFenceFeatureFlags(pub(crate) Flags);
+pub struct ExternalFenceFeatureFlags(pub Flags);
 vk_bitflags_wrapped!(ExternalFenceFeatureFlags, Flags);
 impl ExternalFenceFeatureFlags {
     pub const EXPORTABLE: Self = Self(0b1);
@@ -734,7 +734,7 @@ impl ExternalFenceFeatureFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFenceImportFlagBits.html>"]
-pub struct FenceImportFlags(pub(crate) Flags);
+pub struct FenceImportFlags(pub Flags);
 vk_bitflags_wrapped!(FenceImportFlags, Flags);
 impl FenceImportFlags {
     pub const TEMPORARY: Self = Self(0b1);
@@ -742,7 +742,7 @@ impl FenceImportFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSurfaceCounterFlagBitsEXT.html>"]
-pub struct SurfaceCounterFlagsEXT(pub(crate) Flags);
+pub struct SurfaceCounterFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(SurfaceCounterFlagsEXT, Flags);
 impl SurfaceCounterFlagsEXT {
     pub const VBLANK: Self = Self(0b1);
@@ -750,7 +750,7 @@ impl SurfaceCounterFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPeerMemoryFeatureFlagBits.html>"]
-pub struct PeerMemoryFeatureFlags(pub(crate) Flags);
+pub struct PeerMemoryFeatureFlags(pub Flags);
 vk_bitflags_wrapped!(PeerMemoryFeatureFlags, Flags);
 impl PeerMemoryFeatureFlags {
     #[doc = "Can read with vkCmdCopy commands"]
@@ -765,7 +765,7 @@ impl PeerMemoryFeatureFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryAllocateFlagBits.html>"]
-pub struct MemoryAllocateFlags(pub(crate) Flags);
+pub struct MemoryAllocateFlags(pub Flags);
 vk_bitflags_wrapped!(MemoryAllocateFlags, Flags);
 impl MemoryAllocateFlags {
     #[doc = "Force allocation on specific devices"]
@@ -774,7 +774,7 @@ impl MemoryAllocateFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceGroupPresentModeFlagBitsKHR.html>"]
-pub struct DeviceGroupPresentModeFlagsKHR(pub(crate) Flags);
+pub struct DeviceGroupPresentModeFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(DeviceGroupPresentModeFlagsKHR, Flags);
 impl DeviceGroupPresentModeFlagsKHR {
     #[doc = "Present from local memory"]
@@ -789,19 +789,19 @@ impl DeviceGroupPresentModeFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSwapchainCreateFlagBitsKHR.html>"]
-pub struct SwapchainCreateFlagsKHR(pub(crate) Flags);
+pub struct SwapchainCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(SwapchainCreateFlagsKHR, Flags);
 impl SwapchainCreateFlagsKHR {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassDescriptionFlagBits.html>"]
-pub struct SubpassDescriptionFlags(pub(crate) Flags);
+pub struct SubpassDescriptionFlags(pub Flags);
 vk_bitflags_wrapped!(SubpassDescriptionFlags, Flags);
 impl SubpassDescriptionFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessageSeverityFlagBitsEXT.html>"]
-pub struct DebugUtilsMessageSeverityFlagsEXT(pub(crate) Flags);
+pub struct DebugUtilsMessageSeverityFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(DebugUtilsMessageSeverityFlagsEXT, Flags);
 impl DebugUtilsMessageSeverityFlagsEXT {
     pub const VERBOSE: Self = Self(0b1);
@@ -812,7 +812,7 @@ impl DebugUtilsMessageSeverityFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessageTypeFlagBitsEXT.html>"]
-pub struct DebugUtilsMessageTypeFlagsEXT(pub(crate) Flags);
+pub struct DebugUtilsMessageTypeFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(DebugUtilsMessageTypeFlagsEXT, Flags);
 impl DebugUtilsMessageTypeFlagsEXT {
     pub const GENERAL: Self = Self(0b1);
@@ -822,7 +822,7 @@ impl DebugUtilsMessageTypeFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorBindingFlagBits.html>"]
-pub struct DescriptorBindingFlags(pub(crate) Flags);
+pub struct DescriptorBindingFlags(pub Flags);
 vk_bitflags_wrapped!(DescriptorBindingFlags, Flags);
 impl DescriptorBindingFlags {
     pub const UPDATE_AFTER_BIND: Self = Self(0b1);
@@ -833,7 +833,7 @@ impl DescriptorBindingFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkConditionalRenderingFlagBitsEXT.html>"]
-pub struct ConditionalRenderingFlagsEXT(pub(crate) Flags);
+pub struct ConditionalRenderingFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(ConditionalRenderingFlagsEXT, Flags);
 impl ConditionalRenderingFlagsEXT {
     pub const INVERTED: Self = Self(0b1);
@@ -841,7 +841,7 @@ impl ConditionalRenderingFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkResolveModeFlagBits.html>"]
-pub struct ResolveModeFlags(pub(crate) Flags);
+pub struct ResolveModeFlags(pub Flags);
 vk_bitflags_wrapped!(ResolveModeFlags, Flags);
 impl ResolveModeFlags {
     pub const NONE: Self = Self(0);
@@ -853,7 +853,7 @@ impl ResolveModeFlags {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryInstanceFlagBitsKHR.html>"]
-pub struct GeometryInstanceFlagsKHR(pub(crate) Flags);
+pub struct GeometryInstanceFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(GeometryInstanceFlagsKHR, Flags);
 impl GeometryInstanceFlagsKHR {
     pub const TRIANGLE_FACING_CULL_DISABLE: Self = Self(0b1);
@@ -865,7 +865,7 @@ impl GeometryInstanceFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryFlagBitsKHR.html>"]
-pub struct GeometryFlagsKHR(pub(crate) Flags);
+pub struct GeometryFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(GeometryFlagsKHR, Flags);
 impl GeometryFlagsKHR {
     pub const OPAQUE: Self = Self(0b1);
@@ -874,7 +874,7 @@ impl GeometryFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBuildAccelerationStructureFlagBitsKHR.html>"]
-pub struct BuildAccelerationStructureFlagsKHR(pub(crate) Flags);
+pub struct BuildAccelerationStructureFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(BuildAccelerationStructureFlagsKHR, Flags);
 impl BuildAccelerationStructureFlagsKHR {
     pub const ALLOW_UPDATE: Self = Self(0b1);
@@ -886,7 +886,7 @@ impl BuildAccelerationStructureFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureCreateFlagBitsKHR.html>"]
-pub struct AccelerationStructureCreateFlagsKHR(pub(crate) Flags);
+pub struct AccelerationStructureCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(AccelerationStructureCreateFlagsKHR, Flags);
 impl AccelerationStructureCreateFlagsKHR {
     pub const DEVICE_ADDRESS_CAPTURE_REPLAY: Self = Self(0b1);
@@ -894,13 +894,13 @@ impl AccelerationStructureCreateFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFramebufferCreateFlagBits.html>"]
-pub struct FramebufferCreateFlags(pub(crate) Flags);
+pub struct FramebufferCreateFlags(pub Flags);
 vk_bitflags_wrapped!(FramebufferCreateFlags, Flags);
 impl FramebufferCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceDiagnosticsConfigFlagBitsNV.html>"]
-pub struct DeviceDiagnosticsConfigFlagsNV(pub(crate) Flags);
+pub struct DeviceDiagnosticsConfigFlagsNV(pub Flags);
 vk_bitflags_wrapped!(DeviceDiagnosticsConfigFlagsNV, Flags);
 impl DeviceDiagnosticsConfigFlagsNV {
     pub const ENABLE_SHADER_DEBUG_INFO: Self = Self(0b1);
@@ -910,7 +910,7 @@ impl DeviceDiagnosticsConfigFlagsNV {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCreationFeedbackFlagBitsEXT.html>"]
-pub struct PipelineCreationFeedbackFlagsEXT(pub(crate) Flags);
+pub struct PipelineCreationFeedbackFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(PipelineCreationFeedbackFlagsEXT, Flags);
 impl PipelineCreationFeedbackFlagsEXT {
     pub const VALID: Self = Self(0b1);
@@ -920,7 +920,7 @@ impl PipelineCreationFeedbackFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterDescriptionFlagBitsKHR.html>"]
-pub struct PerformanceCounterDescriptionFlagsKHR(pub(crate) Flags);
+pub struct PerformanceCounterDescriptionFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(PerformanceCounterDescriptionFlagsKHR, Flags);
 impl PerformanceCounterDescriptionFlagsKHR {
     pub const PERFORMANCE_IMPACTING: Self = Self(0b1);
@@ -929,31 +929,31 @@ impl PerformanceCounterDescriptionFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAcquireProfilingLockFlagBitsKHR.html>"]
-pub struct AcquireProfilingLockFlagsKHR(pub(crate) Flags);
+pub struct AcquireProfilingLockFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(AcquireProfilingLockFlagsKHR, Flags);
 impl AcquireProfilingLockFlagsKHR {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderCorePropertiesFlagBitsAMD.html>"]
-pub struct ShaderCorePropertiesFlagsAMD(pub(crate) Flags);
+pub struct ShaderCorePropertiesFlagsAMD(pub Flags);
 vk_bitflags_wrapped!(ShaderCorePropertiesFlagsAMD, Flags);
 impl ShaderCorePropertiesFlagsAMD {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderModuleCreateFlagBits.html>"]
-pub struct ShaderModuleCreateFlags(pub(crate) Flags);
+pub struct ShaderModuleCreateFlags(pub Flags);
 vk_bitflags_wrapped!(ShaderModuleCreateFlags, Flags);
 impl ShaderModuleCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCompilerControlFlagBitsAMD.html>"]
-pub struct PipelineCompilerControlFlagsAMD(pub(crate) Flags);
+pub struct PipelineCompilerControlFlagsAMD(pub Flags);
 vk_bitflags_wrapped!(PipelineCompilerControlFlagsAMD, Flags);
 impl PipelineCompilerControlFlagsAMD {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkToolPurposeFlagBitsEXT.html>"]
-pub struct ToolPurposeFlagsEXT(pub(crate) Flags);
+pub struct ToolPurposeFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(ToolPurposeFlagsEXT, Flags);
 impl ToolPurposeFlagsEXT {
     pub const VALIDATION: Self = Self(0b1);
@@ -965,7 +965,7 @@ impl ToolPurposeFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccessFlagBits2KHR.html>"]
-pub struct AccessFlags2KHR(pub(crate) Flags64);
+pub struct AccessFlags2KHR(pub Flags64);
 vk_bitflags_wrapped!(AccessFlags2KHR, Flags64);
 impl AccessFlags2KHR {
     pub const NONE: Self = Self(0);
@@ -993,7 +993,7 @@ impl AccessFlags2KHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineStageFlagBits2KHR.html>"]
-pub struct PipelineStageFlags2KHR(pub(crate) Flags64);
+pub struct PipelineStageFlags2KHR(pub Flags64);
 vk_bitflags_wrapped!(PipelineStageFlags2KHR, Flags64);
 impl PipelineStageFlags2KHR {
     pub const NONE: Self = Self(0);
@@ -1028,7 +1028,7 @@ impl PipelineStageFlags2KHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubmitFlagBitsKHR.html>"]
-pub struct SubmitFlagsKHR(pub(crate) Flags);
+pub struct SubmitFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(SubmitFlagsKHR, Flags);
 impl SubmitFlagsKHR {
     pub const PROTECTED: Self = Self(0b1);
@@ -1036,31 +1036,31 @@ impl SubmitFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkEventCreateFlagBits.html>"]
-pub struct EventCreateFlags(pub(crate) Flags);
+pub struct EventCreateFlags(pub Flags);
 vk_bitflags_wrapped!(EventCreateFlags, Flags);
 impl EventCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineLayoutCreateFlagBits.html>"]
-pub struct PipelineLayoutCreateFlags(pub(crate) Flags);
+pub struct PipelineLayoutCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineLayoutCreateFlags, Flags);
 impl PipelineLayoutCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineColorBlendStateCreateFlagBits.html>"]
-pub struct PipelineColorBlendStateCreateFlags(pub(crate) Flags);
+pub struct PipelineColorBlendStateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineColorBlendStateCreateFlags, Flags);
 impl PipelineColorBlendStateCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDepthStencilStateCreateFlagBits.html>"]
-pub struct PipelineDepthStencilStateCreateFlags(pub(crate) Flags);
+pub struct PipelineDepthStencilStateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineDepthStencilStateCreateFlags, Flags);
 impl PipelineDepthStencilStateCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoCodecOperationFlagBitsKHR.html>"]
-pub struct VideoCodecOperationFlagsKHR(pub(crate) Flags);
+pub struct VideoCodecOperationFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoCodecOperationFlagsKHR, Flags);
 impl VideoCodecOperationFlagsKHR {
     pub const INVALID: Self = Self(0);
@@ -1068,7 +1068,7 @@ impl VideoCodecOperationFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoChromaSubsamplingFlagBitsKHR.html>"]
-pub struct VideoChromaSubsamplingFlagsKHR(pub(crate) Flags);
+pub struct VideoChromaSubsamplingFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoChromaSubsamplingFlagsKHR, Flags);
 impl VideoChromaSubsamplingFlagsKHR {
     pub const INVALID: Self = Self(0);
@@ -1080,7 +1080,7 @@ impl VideoChromaSubsamplingFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoComponentBitDepthFlagBitsKHR.html>"]
-pub struct VideoComponentBitDepthFlagsKHR(pub(crate) Flags);
+pub struct VideoComponentBitDepthFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoComponentBitDepthFlagsKHR, Flags);
 impl VideoComponentBitDepthFlagsKHR {
     pub const INVALID: Self = Self(0);
@@ -1091,7 +1091,7 @@ impl VideoComponentBitDepthFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoCapabilityFlagBitsKHR.html>"]
-pub struct VideoCapabilityFlagsKHR(pub(crate) Flags);
+pub struct VideoCapabilityFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoCapabilityFlagsKHR, Flags);
 impl VideoCapabilityFlagsKHR {
     pub const PROTECTED_CONTENT: Self = Self(0b1);
@@ -1100,7 +1100,7 @@ impl VideoCapabilityFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoSessionCreateFlagBitsKHR.html>"]
-pub struct VideoSessionCreateFlagsKHR(pub(crate) Flags);
+pub struct VideoSessionCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoSessionCreateFlagsKHR, Flags);
 impl VideoSessionCreateFlagsKHR {
     pub const DEFAULT: Self = Self(0);
@@ -1109,7 +1109,7 @@ impl VideoSessionCreateFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoCodingQualityPresetFlagBitsKHR.html>"]
-pub struct VideoCodingQualityPresetFlagsKHR(pub(crate) Flags);
+pub struct VideoCodingQualityPresetFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoCodingQualityPresetFlagsKHR, Flags);
 impl VideoCodingQualityPresetFlagsKHR {
     pub const NORMAL: Self = Self(0b1);
@@ -1119,7 +1119,7 @@ impl VideoCodingQualityPresetFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoDecodeH264PictureLayoutFlagBitsEXT.html>"]
-pub struct VideoDecodeH264PictureLayoutFlagsEXT(pub(crate) Flags);
+pub struct VideoDecodeH264PictureLayoutFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoDecodeH264PictureLayoutFlagsEXT, Flags);
 impl VideoDecodeH264PictureLayoutFlagsEXT {
     pub const PROGRESSIVE: Self = Self(0);
@@ -1129,7 +1129,7 @@ impl VideoDecodeH264PictureLayoutFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoCodingControlFlagBitsKHR.html>"]
-pub struct VideoCodingControlFlagsKHR(pub(crate) Flags);
+pub struct VideoCodingControlFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoCodingControlFlagsKHR, Flags);
 impl VideoCodingControlFlagsKHR {
     pub const DEFAULT: Self = Self(0);
@@ -1138,7 +1138,7 @@ impl VideoCodingControlFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoDecodeFlagBitsKHR.html>"]
-pub struct VideoDecodeFlagsKHR(pub(crate) Flags);
+pub struct VideoDecodeFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoDecodeFlagsKHR, Flags);
 impl VideoDecodeFlagsKHR {
     pub const DEFAULT: Self = Self(0);
@@ -1147,7 +1147,7 @@ impl VideoDecodeFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeFlagBitsKHR.html>"]
-pub struct VideoEncodeFlagsKHR(pub(crate) Flags);
+pub struct VideoEncodeFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeFlagsKHR, Flags);
 impl VideoEncodeFlagsKHR {
     pub const DEFAULT: Self = Self(0);
@@ -1156,7 +1156,7 @@ impl VideoEncodeFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeRateControlFlagBitsKHR.html>"]
-pub struct VideoEncodeRateControlFlagsKHR(pub(crate) Flags);
+pub struct VideoEncodeRateControlFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeRateControlFlagsKHR, Flags);
 impl VideoEncodeRateControlFlagsKHR {
     pub const DEFAULT: Self = Self(0);
@@ -1165,7 +1165,7 @@ impl VideoEncodeRateControlFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeRateControlModeFlagBitsKHR.html>"]
-pub struct VideoEncodeRateControlModeFlagsKHR(pub(crate) Flags);
+pub struct VideoEncodeRateControlModeFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeRateControlModeFlagsKHR, Flags);
 impl VideoEncodeRateControlModeFlagsKHR {
     pub const NONE: Self = Self(0);
@@ -1175,7 +1175,7 @@ impl VideoEncodeRateControlModeFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH264CapabilityFlagBitsEXT.html>"]
-pub struct VideoEncodeH264CapabilityFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH264CapabilityFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH264CapabilityFlagsEXT, Flags);
 impl VideoEncodeH264CapabilityFlagsEXT {
     pub const CABAC: Self = Self(0b1);
@@ -1193,7 +1193,7 @@ impl VideoEncodeH264CapabilityFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH264InputModeFlagBitsEXT.html>"]
-pub struct VideoEncodeH264InputModeFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH264InputModeFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH264InputModeFlagsEXT, Flags);
 impl VideoEncodeH264InputModeFlagsEXT {
     pub const FRAME: Self = Self(0b1);
@@ -1203,7 +1203,7 @@ impl VideoEncodeH264InputModeFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH264OutputModeFlagBitsEXT.html>"]
-pub struct VideoEncodeH264OutputModeFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH264OutputModeFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH264OutputModeFlagsEXT, Flags);
 impl VideoEncodeH264OutputModeFlagsEXT {
     pub const FRAME: Self = Self(0b1);
@@ -1213,7 +1213,7 @@ impl VideoEncodeH264OutputModeFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH264CreateFlagBitsEXT.html>"]
-pub struct VideoEncodeH264CreateFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH264CreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH264CreateFlagsEXT, Flags);
 impl VideoEncodeH264CreateFlagsEXT {
     pub const DEFAULT: Self = Self(0);
@@ -1222,7 +1222,7 @@ impl VideoEncodeH264CreateFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH264RateControlStructureFlagBitsEXT.html>"]
-pub struct VideoEncodeH264RateControlStructureFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH264RateControlStructureFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH264RateControlStructureFlagsEXT, Flags);
 impl VideoEncodeH264RateControlStructureFlagsEXT {
     pub const UNKNOWN: Self = Self(0);
@@ -1232,13 +1232,13 @@ impl VideoEncodeH264RateControlStructureFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageFormatConstraintsFlagBitsFUCHSIA.html>"]
-pub struct ImageFormatConstraintsFlagsFUCHSIA(pub(crate) Flags);
+pub struct ImageFormatConstraintsFlagsFUCHSIA(pub Flags);
 vk_bitflags_wrapped!(ImageFormatConstraintsFlagsFUCHSIA, Flags);
 impl ImageFormatConstraintsFlagsFUCHSIA {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageConstraintsInfoFlagBitsFUCHSIA.html>"]
-pub struct ImageConstraintsInfoFlagsFUCHSIA(pub(crate) Flags);
+pub struct ImageConstraintsInfoFlagsFUCHSIA(pub Flags);
 vk_bitflags_wrapped!(ImageConstraintsInfoFlagsFUCHSIA, Flags);
 impl ImageConstraintsInfoFlagsFUCHSIA {
     pub const CPU_READ_RARELY: Self = Self(0b1);
@@ -1250,7 +1250,7 @@ impl ImageConstraintsInfoFlagsFUCHSIA {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFormatFeatureFlagBits2KHR.html>"]
-pub struct FormatFeatureFlags2KHR(pub(crate) Flags64);
+pub struct FormatFeatureFlags2KHR(pub Flags64);
 vk_bitflags_wrapped!(FormatFeatureFlags2KHR, Flags64);
 impl FormatFeatureFlags2KHR {
     pub const SAMPLED_IMAGE: Self = Self(0b1);
@@ -1289,7 +1289,7 @@ impl FormatFeatureFlags2KHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH265InputModeFlagBitsEXT.html>"]
-pub struct VideoEncodeH265InputModeFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH265InputModeFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH265InputModeFlagsEXT, Flags);
 impl VideoEncodeH265InputModeFlagsEXT {
     pub const FRAME: Self = Self(0b1);
@@ -1299,7 +1299,7 @@ impl VideoEncodeH265InputModeFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH265OutputModeFlagBitsEXT.html>"]
-pub struct VideoEncodeH265OutputModeFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH265OutputModeFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH265OutputModeFlagsEXT, Flags);
 impl VideoEncodeH265OutputModeFlagsEXT {
     pub const FRAME: Self = Self(0b1);
@@ -1309,7 +1309,7 @@ impl VideoEncodeH265OutputModeFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH265CtbSizeFlagBitsEXT.html>"]
-pub struct VideoEncodeH265CtbSizeFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH265CtbSizeFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH265CtbSizeFlagsEXT, Flags);
 impl VideoEncodeH265CtbSizeFlagsEXT {
     pub const TYPE_8: Self = Self(0b1);
@@ -1320,7 +1320,7 @@ impl VideoEncodeH265CtbSizeFlagsEXT {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRenderingFlagBitsKHR.html>"]
-pub struct RenderingFlagsKHR(pub(crate) Flags);
+pub struct RenderingFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(RenderingFlagsKHR, Flags);
 impl RenderingFlagsKHR {
     pub const CONTENTS_SECONDARY_COMMAND_BUFFERS: Self = Self(0b1);
@@ -1330,7 +1330,7 @@ impl RenderingFlagsKHR {
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH265RateControlStructureFlagBitsEXT.html>"]
-pub struct VideoEncodeH265RateControlStructureFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH265RateControlStructureFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH265RateControlStructureFlagsEXT, Flags);
 impl VideoEncodeH265RateControlStructureFlagsEXT {
     pub const UNKNOWN: Self = Self(0);

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -72,257 +72,257 @@ pub type DeviceAddress = u64;
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPoolCreateFlags.html>"]
-pub struct QueryPoolCreateFlags(pub(crate) Flags);
+pub struct QueryPoolCreateFlags(pub Flags);
 vk_bitflags_wrapped!(QueryPoolCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDynamicStateCreateFlags.html>"]
-pub struct PipelineDynamicStateCreateFlags(pub(crate) Flags);
+pub struct PipelineDynamicStateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineDynamicStateCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineMultisampleStateCreateFlags.html>"]
-pub struct PipelineMultisampleStateCreateFlags(pub(crate) Flags);
+pub struct PipelineMultisampleStateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineMultisampleStateCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationStateCreateFlags.html>"]
-pub struct PipelineRasterizationStateCreateFlags(pub(crate) Flags);
+pub struct PipelineRasterizationStateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineRasterizationStateCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportStateCreateFlags.html>"]
-pub struct PipelineViewportStateCreateFlags(pub(crate) Flags);
+pub struct PipelineViewportStateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineViewportStateCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineTessellationStateCreateFlags.html>"]
-pub struct PipelineTessellationStateCreateFlags(pub(crate) Flags);
+pub struct PipelineTessellationStateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineTessellationStateCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineInputAssemblyStateCreateFlags.html>"]
-pub struct PipelineInputAssemblyStateCreateFlags(pub(crate) Flags);
+pub struct PipelineInputAssemblyStateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineInputAssemblyStateCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineVertexInputStateCreateFlags.html>"]
-pub struct PipelineVertexInputStateCreateFlags(pub(crate) Flags);
+pub struct PipelineVertexInputStateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(PipelineVertexInputStateCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBufferViewCreateFlags.html>"]
-pub struct BufferViewCreateFlags(pub(crate) Flags);
+pub struct BufferViewCreateFlags(pub Flags);
 vk_bitflags_wrapped!(BufferViewCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkInstanceCreateFlags.html>"]
-pub struct InstanceCreateFlags(pub(crate) Flags);
+pub struct InstanceCreateFlags(pub Flags);
 vk_bitflags_wrapped!(InstanceCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceCreateFlags.html>"]
-pub struct DeviceCreateFlags(pub(crate) Flags);
+pub struct DeviceCreateFlags(pub Flags);
 vk_bitflags_wrapped!(DeviceCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryMapFlags.html>"]
-pub struct MemoryMapFlags(pub(crate) Flags);
+pub struct MemoryMapFlags(pub Flags);
 vk_bitflags_wrapped!(MemoryMapFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorPoolResetFlags.html>"]
-pub struct DescriptorPoolResetFlags(pub(crate) Flags);
+pub struct DescriptorPoolResetFlags(pub Flags);
 vk_bitflags_wrapped!(DescriptorPoolResetFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorUpdateTemplateCreateFlags.html>"]
-pub struct DescriptorUpdateTemplateCreateFlags(pub(crate) Flags);
+pub struct DescriptorUpdateTemplateCreateFlags(pub Flags);
 vk_bitflags_wrapped!(DescriptorUpdateTemplateCreateFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureMotionInfoFlagsNV.html>"]
-pub struct AccelerationStructureMotionInfoFlagsNV(pub(crate) Flags);
+pub struct AccelerationStructureMotionInfoFlagsNV(pub Flags);
 vk_bitflags_wrapped!(AccelerationStructureMotionInfoFlagsNV, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureMotionInstanceFlagsNV.html>"]
-pub struct AccelerationStructureMotionInstanceFlagsNV(pub(crate) Flags);
+pub struct AccelerationStructureMotionInstanceFlagsNV(pub Flags);
 vk_bitflags_wrapped!(AccelerationStructureMotionInstanceFlagsNV, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayModeCreateFlagsKHR.html>"]
-pub struct DisplayModeCreateFlagsKHR(pub(crate) Flags);
+pub struct DisplayModeCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(DisplayModeCreateFlagsKHR, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplaySurfaceCreateFlagsKHR.html>"]
-pub struct DisplaySurfaceCreateFlagsKHR(pub(crate) Flags);
+pub struct DisplaySurfaceCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(DisplaySurfaceCreateFlagsKHR, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAndroidSurfaceCreateFlagsKHR.html>"]
-pub struct AndroidSurfaceCreateFlagsKHR(pub(crate) Flags);
+pub struct AndroidSurfaceCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(AndroidSurfaceCreateFlagsKHR, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkViSurfaceCreateFlagsNN.html>"]
-pub struct ViSurfaceCreateFlagsNN(pub(crate) Flags);
+pub struct ViSurfaceCreateFlagsNN(pub Flags);
 vk_bitflags_wrapped!(ViSurfaceCreateFlagsNN, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWaylandSurfaceCreateFlagsKHR.html>"]
-pub struct WaylandSurfaceCreateFlagsKHR(pub(crate) Flags);
+pub struct WaylandSurfaceCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(WaylandSurfaceCreateFlagsKHR, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkWin32SurfaceCreateFlagsKHR.html>"]
-pub struct Win32SurfaceCreateFlagsKHR(pub(crate) Flags);
+pub struct Win32SurfaceCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(Win32SurfaceCreateFlagsKHR, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkXlibSurfaceCreateFlagsKHR.html>"]
-pub struct XlibSurfaceCreateFlagsKHR(pub(crate) Flags);
+pub struct XlibSurfaceCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(XlibSurfaceCreateFlagsKHR, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkXcbSurfaceCreateFlagsKHR.html>"]
-pub struct XcbSurfaceCreateFlagsKHR(pub(crate) Flags);
+pub struct XcbSurfaceCreateFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(XcbSurfaceCreateFlagsKHR, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDirectFBSurfaceCreateFlagsEXT.html>"]
-pub struct DirectFBSurfaceCreateFlagsEXT(pub(crate) Flags);
+pub struct DirectFBSurfaceCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(DirectFBSurfaceCreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIOSSurfaceCreateFlagsMVK.html>"]
-pub struct IOSSurfaceCreateFlagsMVK(pub(crate) Flags);
+pub struct IOSSurfaceCreateFlagsMVK(pub Flags);
 vk_bitflags_wrapped!(IOSSurfaceCreateFlagsMVK, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMacOSSurfaceCreateFlagsMVK.html>"]
-pub struct MacOSSurfaceCreateFlagsMVK(pub(crate) Flags);
+pub struct MacOSSurfaceCreateFlagsMVK(pub Flags);
 vk_bitflags_wrapped!(MacOSSurfaceCreateFlagsMVK, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMetalSurfaceCreateFlagsEXT.html>"]
-pub struct MetalSurfaceCreateFlagsEXT(pub(crate) Flags);
+pub struct MetalSurfaceCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(MetalSurfaceCreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImagePipeSurfaceCreateFlagsFUCHSIA.html>"]
-pub struct ImagePipeSurfaceCreateFlagsFUCHSIA(pub(crate) Flags);
+pub struct ImagePipeSurfaceCreateFlagsFUCHSIA(pub Flags);
 vk_bitflags_wrapped!(ImagePipeSurfaceCreateFlagsFUCHSIA, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStreamDescriptorSurfaceCreateFlagsGGP.html>"]
-pub struct StreamDescriptorSurfaceCreateFlagsGGP(pub(crate) Flags);
+pub struct StreamDescriptorSurfaceCreateFlagsGGP(pub Flags);
 vk_bitflags_wrapped!(StreamDescriptorSurfaceCreateFlagsGGP, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkHeadlessSurfaceCreateFlagsEXT.html>"]
-pub struct HeadlessSurfaceCreateFlagsEXT(pub(crate) Flags);
+pub struct HeadlessSurfaceCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(HeadlessSurfaceCreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkScreenSurfaceCreateFlagsQNX.html>"]
-pub struct ScreenSurfaceCreateFlagsQNX(pub(crate) Flags);
+pub struct ScreenSurfaceCreateFlagsQNX(pub Flags);
 vk_bitflags_wrapped!(ScreenSurfaceCreateFlagsQNX, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandPoolTrimFlags.html>"]
-pub struct CommandPoolTrimFlags(pub(crate) Flags);
+pub struct CommandPoolTrimFlags(pub Flags);
 vk_bitflags_wrapped!(CommandPoolTrimFlags, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineViewportSwizzleStateCreateFlagsNV.html>"]
-pub struct PipelineViewportSwizzleStateCreateFlagsNV(pub(crate) Flags);
+pub struct PipelineViewportSwizzleStateCreateFlagsNV(pub Flags);
 vk_bitflags_wrapped!(PipelineViewportSwizzleStateCreateFlagsNV, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineDiscardRectangleStateCreateFlagsEXT.html>"]
-pub struct PipelineDiscardRectangleStateCreateFlagsEXT(pub(crate) Flags);
+pub struct PipelineDiscardRectangleStateCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(PipelineDiscardRectangleStateCreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCoverageToColorStateCreateFlagsNV.html>"]
-pub struct PipelineCoverageToColorStateCreateFlagsNV(pub(crate) Flags);
+pub struct PipelineCoverageToColorStateCreateFlagsNV(pub Flags);
 vk_bitflags_wrapped!(PipelineCoverageToColorStateCreateFlagsNV, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCoverageModulationStateCreateFlagsNV.html>"]
-pub struct PipelineCoverageModulationStateCreateFlagsNV(pub(crate) Flags);
+pub struct PipelineCoverageModulationStateCreateFlagsNV(pub Flags);
 vk_bitflags_wrapped!(PipelineCoverageModulationStateCreateFlagsNV, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCoverageReductionStateCreateFlagsNV.html>"]
-pub struct PipelineCoverageReductionStateCreateFlagsNV(pub(crate) Flags);
+pub struct PipelineCoverageReductionStateCreateFlagsNV(pub Flags);
 vk_bitflags_wrapped!(PipelineCoverageReductionStateCreateFlagsNV, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationCacheCreateFlagsEXT.html>"]
-pub struct ValidationCacheCreateFlagsEXT(pub(crate) Flags);
+pub struct ValidationCacheCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(ValidationCacheCreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessengerCreateFlagsEXT.html>"]
-pub struct DebugUtilsMessengerCreateFlagsEXT(pub(crate) Flags);
+pub struct DebugUtilsMessengerCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(DebugUtilsMessengerCreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugUtilsMessengerCallbackDataFlagsEXT.html>"]
-pub struct DebugUtilsMessengerCallbackDataFlagsEXT(pub(crate) Flags);
+pub struct DebugUtilsMessengerCallbackDataFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(DebugUtilsMessengerCallbackDataFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceMemoryReportFlagsEXT.html>"]
-pub struct DeviceMemoryReportFlagsEXT(pub(crate) Flags);
+pub struct DeviceMemoryReportFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(DeviceMemoryReportFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationConservativeStateCreateFlagsEXT.html>"]
-pub struct PipelineRasterizationConservativeStateCreateFlagsEXT(pub(crate) Flags);
+pub struct PipelineRasterizationConservativeStateCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(PipelineRasterizationConservativeStateCreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationStateStreamCreateFlagsEXT.html>"]
-pub struct PipelineRasterizationStateStreamCreateFlagsEXT(pub(crate) Flags);
+pub struct PipelineRasterizationStateStreamCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(PipelineRasterizationStateStreamCreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationDepthClipStateCreateFlagsEXT.html>"]
-pub struct PipelineRasterizationDepthClipStateCreateFlagsEXT(pub(crate) Flags);
+pub struct PipelineRasterizationDepthClipStateCreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(PipelineRasterizationDepthClipStateCreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoBeginCodingFlagsKHR.html>"]
-pub struct VideoBeginCodingFlagsKHR(pub(crate) Flags);
+pub struct VideoBeginCodingFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoBeginCodingFlagsKHR, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEndCodingFlagsKHR.html>"]
-pub struct VideoEndCodingFlagsKHR(pub(crate) Flags);
+pub struct VideoEndCodingFlagsKHR(pub Flags);
 vk_bitflags_wrapped!(VideoEndCodingFlagsKHR, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoDecodeH264CreateFlagsEXT.html>"]
-pub struct VideoDecodeH264CreateFlagsEXT(pub(crate) Flags);
+pub struct VideoDecodeH264CreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoDecodeH264CreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoDecodeH265CreateFlagsEXT.html>"]
-pub struct VideoDecodeH265CreateFlagsEXT(pub(crate) Flags);
+pub struct VideoDecodeH265CreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoDecodeH265CreateFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH265CapabilityFlagsEXT.html>"]
-pub struct VideoEncodeH265CapabilityFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH265CapabilityFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH265CapabilityFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVideoEncodeH265CreateFlagsEXT.html>"]
-pub struct VideoEncodeH265CreateFlagsEXT(pub(crate) Flags);
+pub struct VideoEncodeH265CreateFlagsEXT(pub Flags);
 vk_bitflags_wrapped!(VideoEncodeH265CreateFlagsEXT, Flags);
 define_handle!(
     Instance,

--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -2,11 +2,13 @@ use std::fmt;
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageLayout.html>"]
-pub struct ImageLayout(pub(crate) i32);
+pub struct ImageLayout(pub i32);
 impl ImageLayout {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -34,11 +36,13 @@ impl ImageLayout {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentLoadOp.html>"]
-pub struct AttachmentLoadOp(pub(crate) i32);
+pub struct AttachmentLoadOp(pub i32);
 impl AttachmentLoadOp {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -51,11 +55,13 @@ impl AttachmentLoadOp {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAttachmentStoreOp.html>"]
-pub struct AttachmentStoreOp(pub(crate) i32);
+pub struct AttachmentStoreOp(pub i32);
 impl AttachmentStoreOp {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -67,11 +73,13 @@ impl AttachmentStoreOp {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageType.html>"]
-pub struct ImageType(pub(crate) i32);
+pub struct ImageType(pub i32);
 impl ImageType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -84,11 +92,13 @@ impl ImageType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageTiling.html>"]
-pub struct ImageTiling(pub(crate) i32);
+pub struct ImageTiling(pub i32);
 impl ImageTiling {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -100,11 +110,13 @@ impl ImageTiling {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkImageViewType.html>"]
-pub struct ImageViewType(pub(crate) i32);
+pub struct ImageViewType(pub i32);
 impl ImageViewType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -121,11 +133,13 @@ impl ImageViewType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandBufferLevel.html>"]
-pub struct CommandBufferLevel(pub(crate) i32);
+pub struct CommandBufferLevel(pub i32);
 impl CommandBufferLevel {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -137,11 +151,13 @@ impl CommandBufferLevel {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkComponentSwizzle.html>"]
-pub struct ComponentSwizzle(pub(crate) i32);
+pub struct ComponentSwizzle(pub i32);
 impl ComponentSwizzle {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -158,11 +174,13 @@ impl ComponentSwizzle {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorType.html>"]
-pub struct DescriptorType(pub(crate) i32);
+pub struct DescriptorType(pub i32);
 impl DescriptorType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -183,11 +201,13 @@ impl DescriptorType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryType.html>"]
-pub struct QueryType(pub(crate) i32);
+pub struct QueryType(pub i32);
 impl QueryType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -201,11 +221,13 @@ impl QueryType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBorderColor.html>"]
-pub struct BorderColor(pub(crate) i32);
+pub struct BorderColor(pub i32);
 impl BorderColor {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -221,11 +243,13 @@ impl BorderColor {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineBindPoint.html>"]
-pub struct PipelineBindPoint(pub(crate) i32);
+pub struct PipelineBindPoint(pub i32);
 impl PipelineBindPoint {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -237,11 +261,13 @@ impl PipelineBindPoint {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineCacheHeaderVersion.html>"]
-pub struct PipelineCacheHeaderVersion(pub(crate) i32);
+pub struct PipelineCacheHeaderVersion(pub i32);
 impl PipelineCacheHeaderVersion {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -252,11 +278,13 @@ impl PipelineCacheHeaderVersion {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPrimitiveTopology.html>"]
-pub struct PrimitiveTopology(pub(crate) i32);
+pub struct PrimitiveTopology(pub i32);
 impl PrimitiveTopology {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -277,11 +305,13 @@ impl PrimitiveTopology {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSharingMode.html>"]
-pub struct SharingMode(pub(crate) i32);
+pub struct SharingMode(pub i32);
 impl SharingMode {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -293,11 +323,13 @@ impl SharingMode {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndexType.html>"]
-pub struct IndexType(pub(crate) i32);
+pub struct IndexType(pub i32);
 impl IndexType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -309,11 +341,13 @@ impl IndexType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFilter.html>"]
-pub struct Filter(pub(crate) i32);
+pub struct Filter(pub i32);
 impl Filter {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -325,11 +359,13 @@ impl Filter {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerMipmapMode.html>"]
-pub struct SamplerMipmapMode(pub(crate) i32);
+pub struct SamplerMipmapMode(pub i32);
 impl SamplerMipmapMode {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -343,11 +379,13 @@ impl SamplerMipmapMode {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerAddressMode.html>"]
-pub struct SamplerAddressMode(pub(crate) i32);
+pub struct SamplerAddressMode(pub i32);
 impl SamplerAddressMode {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -361,11 +399,13 @@ impl SamplerAddressMode {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCompareOp.html>"]
-pub struct CompareOp(pub(crate) i32);
+pub struct CompareOp(pub i32);
 impl CompareOp {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -383,11 +423,13 @@ impl CompareOp {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPolygonMode.html>"]
-pub struct PolygonMode(pub(crate) i32);
+pub struct PolygonMode(pub i32);
 impl PolygonMode {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -400,11 +442,13 @@ impl PolygonMode {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFrontFace.html>"]
-pub struct FrontFace(pub(crate) i32);
+pub struct FrontFace(pub i32);
 impl FrontFace {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -416,11 +460,13 @@ impl FrontFace {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBlendFactor.html>"]
-pub struct BlendFactor(pub(crate) i32);
+pub struct BlendFactor(pub i32);
 impl BlendFactor {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -449,11 +495,13 @@ impl BlendFactor {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBlendOp.html>"]
-pub struct BlendOp(pub(crate) i32);
+pub struct BlendOp(pub i32);
 impl BlendOp {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -468,11 +516,13 @@ impl BlendOp {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStencilOp.html>"]
-pub struct StencilOp(pub(crate) i32);
+pub struct StencilOp(pub i32);
 impl StencilOp {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -490,11 +540,13 @@ impl StencilOp {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkLogicOp.html>"]
-pub struct LogicOp(pub(crate) i32);
+pub struct LogicOp(pub i32);
 impl LogicOp {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -520,11 +572,13 @@ impl LogicOp {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkInternalAllocationType.html>"]
-pub struct InternalAllocationType(pub(crate) i32);
+pub struct InternalAllocationType(pub i32);
 impl InternalAllocationType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -535,11 +589,13 @@ impl InternalAllocationType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSystemAllocationScope.html>"]
-pub struct SystemAllocationScope(pub(crate) i32);
+pub struct SystemAllocationScope(pub i32);
 impl SystemAllocationScope {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -554,11 +610,13 @@ impl SystemAllocationScope {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceType.html>"]
-pub struct PhysicalDeviceType(pub(crate) i32);
+pub struct PhysicalDeviceType(pub i32);
 impl PhysicalDeviceType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -573,11 +631,13 @@ impl PhysicalDeviceType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVertexInputRate.html>"]
-pub struct VertexInputRate(pub(crate) i32);
+pub struct VertexInputRate(pub i32);
 impl VertexInputRate {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -589,11 +649,13 @@ impl VertexInputRate {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFormat.html>"]
-pub struct Format(pub(crate) i32);
+pub struct Format(pub i32);
 impl Format {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -788,11 +850,13 @@ impl Format {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkStructureType.html>"]
-pub struct StructureType(pub(crate) i32);
+pub struct StructureType(pub i32);
 impl StructureType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -853,11 +917,13 @@ impl StructureType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSubpassContents.html>"]
-pub struct SubpassContents(pub(crate) i32);
+pub struct SubpassContents(pub i32);
 impl SubpassContents {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -870,11 +936,13 @@ impl SubpassContents {
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkResult.html>"]
 #[must_use]
-pub struct Result(pub(crate) i32);
+pub struct Result(pub i32);
 impl Result {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -966,11 +1034,13 @@ impl fmt::Display for Result {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDynamicState.html>"]
-pub struct DynamicState(pub(crate) i32);
+pub struct DynamicState(pub i32);
 impl DynamicState {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -989,11 +1059,13 @@ impl DynamicState {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDescriptorUpdateTemplateType.html>"]
-pub struct DescriptorUpdateTemplateType(pub(crate) i32);
+pub struct DescriptorUpdateTemplateType(pub i32);
 impl DescriptorUpdateTemplateType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1005,11 +1077,13 @@ impl DescriptorUpdateTemplateType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkObjectType.html>"]
-pub struct ObjectType(pub(crate) i32);
+pub struct ObjectType(pub i32);
 impl ObjectType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1045,11 +1119,13 @@ impl ObjectType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSemaphoreType.html>"]
-pub struct SemaphoreType(pub(crate) i32);
+pub struct SemaphoreType(pub i32);
 impl SemaphoreType {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1061,11 +1137,13 @@ impl SemaphoreType {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPresentModeKHR.html>"]
-pub struct PresentModeKHR(pub(crate) i32);
+pub struct PresentModeKHR(pub i32);
 impl PresentModeKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1079,11 +1157,13 @@ impl PresentModeKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkColorSpaceKHR.html>"]
-pub struct ColorSpaceKHR(pub(crate) i32);
+pub struct ColorSpaceKHR(pub i32);
 impl ColorSpaceKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1094,11 +1174,13 @@ impl ColorSpaceKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkTimeDomainEXT.html>"]
-pub struct TimeDomainEXT(pub(crate) i32);
+pub struct TimeDomainEXT(pub i32);
 impl TimeDomainEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1112,11 +1194,13 @@ impl TimeDomainEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDebugReportObjectTypeEXT.html>"]
-pub struct DebugReportObjectTypeEXT(pub(crate) i32);
+pub struct DebugReportObjectTypeEXT(pub i32);
 impl DebugReportObjectTypeEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1158,11 +1242,13 @@ impl DebugReportObjectTypeEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceMemoryReportEventTypeEXT.html>"]
-pub struct DeviceMemoryReportEventTypeEXT(pub(crate) i32);
+pub struct DeviceMemoryReportEventTypeEXT(pub i32);
 impl DeviceMemoryReportEventTypeEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1177,11 +1263,13 @@ impl DeviceMemoryReportEventTypeEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRasterizationOrderAMD.html>"]
-pub struct RasterizationOrderAMD(pub(crate) i32);
+pub struct RasterizationOrderAMD(pub i32);
 impl RasterizationOrderAMD {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1193,11 +1281,13 @@ impl RasterizationOrderAMD {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationCheckEXT.html>"]
-pub struct ValidationCheckEXT(pub(crate) i32);
+pub struct ValidationCheckEXT(pub i32);
 impl ValidationCheckEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1209,11 +1299,13 @@ impl ValidationCheckEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationFeatureEnableEXT.html>"]
-pub struct ValidationFeatureEnableEXT(pub(crate) i32);
+pub struct ValidationFeatureEnableEXT(pub i32);
 impl ValidationFeatureEnableEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1228,11 +1320,13 @@ impl ValidationFeatureEnableEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationFeatureDisableEXT.html>"]
-pub struct ValidationFeatureDisableEXT(pub(crate) i32);
+pub struct ValidationFeatureDisableEXT(pub i32);
 impl ValidationFeatureDisableEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1250,11 +1344,13 @@ impl ValidationFeatureDisableEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkIndirectCommandsTokenTypeNV.html>"]
-pub struct IndirectCommandsTokenTypeNV(pub(crate) i32);
+pub struct IndirectCommandsTokenTypeNV(pub i32);
 impl IndirectCommandsTokenTypeNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1272,11 +1368,13 @@ impl IndirectCommandsTokenTypeNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayPowerStateEXT.html>"]
-pub struct DisplayPowerStateEXT(pub(crate) i32);
+pub struct DisplayPowerStateEXT(pub i32);
 impl DisplayPowerStateEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1289,11 +1387,13 @@ impl DisplayPowerStateEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDeviceEventTypeEXT.html>"]
-pub struct DeviceEventTypeEXT(pub(crate) i32);
+pub struct DeviceEventTypeEXT(pub i32);
 impl DeviceEventTypeEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1304,11 +1404,13 @@ impl DeviceEventTypeEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDisplayEventTypeEXT.html>"]
-pub struct DisplayEventTypeEXT(pub(crate) i32);
+pub struct DisplayEventTypeEXT(pub i32);
 impl DisplayEventTypeEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1319,11 +1421,13 @@ impl DisplayEventTypeEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkViewportCoordinateSwizzleNV.html>"]
-pub struct ViewportCoordinateSwizzleNV(pub(crate) i32);
+pub struct ViewportCoordinateSwizzleNV(pub i32);
 impl ViewportCoordinateSwizzleNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1341,11 +1445,13 @@ impl ViewportCoordinateSwizzleNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDiscardRectangleModeEXT.html>"]
-pub struct DiscardRectangleModeEXT(pub(crate) i32);
+pub struct DiscardRectangleModeEXT(pub i32);
 impl DiscardRectangleModeEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1357,11 +1463,13 @@ impl DiscardRectangleModeEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPointClippingBehavior.html>"]
-pub struct PointClippingBehavior(pub(crate) i32);
+pub struct PointClippingBehavior(pub i32);
 impl PointClippingBehavior {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1373,11 +1481,13 @@ impl PointClippingBehavior {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerReductionMode.html>"]
-pub struct SamplerReductionMode(pub(crate) i32);
+pub struct SamplerReductionMode(pub i32);
 impl SamplerReductionMode {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1390,11 +1500,13 @@ impl SamplerReductionMode {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkTessellationDomainOrigin.html>"]
-pub struct TessellationDomainOrigin(pub(crate) i32);
+pub struct TessellationDomainOrigin(pub i32);
 impl TessellationDomainOrigin {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1406,11 +1518,13 @@ impl TessellationDomainOrigin {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerYcbcrModelConversion.html>"]
-pub struct SamplerYcbcrModelConversion(pub(crate) i32);
+pub struct SamplerYcbcrModelConversion(pub i32);
 impl SamplerYcbcrModelConversion {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1429,11 +1543,13 @@ impl SamplerYcbcrModelConversion {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkSamplerYcbcrRange.html>"]
-pub struct SamplerYcbcrRange(pub(crate) i32);
+pub struct SamplerYcbcrRange(pub i32);
 impl SamplerYcbcrRange {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1447,11 +1563,13 @@ impl SamplerYcbcrRange {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkChromaLocation.html>"]
-pub struct ChromaLocation(pub(crate) i32);
+pub struct ChromaLocation(pub i32);
 impl ChromaLocation {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1463,11 +1581,13 @@ impl ChromaLocation {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBlendOverlapEXT.html>"]
-pub struct BlendOverlapEXT(pub(crate) i32);
+pub struct BlendOverlapEXT(pub i32);
 impl BlendOverlapEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1480,11 +1600,13 @@ impl BlendOverlapEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCoverageModulationModeNV.html>"]
-pub struct CoverageModulationModeNV(pub(crate) i32);
+pub struct CoverageModulationModeNV(pub i32);
 impl CoverageModulationModeNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1498,11 +1620,13 @@ impl CoverageModulationModeNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCoverageReductionModeNV.html>"]
-pub struct CoverageReductionModeNV(pub(crate) i32);
+pub struct CoverageReductionModeNV(pub i32);
 impl CoverageReductionModeNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1514,11 +1638,13 @@ impl CoverageReductionModeNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkValidationCacheHeaderVersionEXT.html>"]
-pub struct ValidationCacheHeaderVersionEXT(pub(crate) i32);
+pub struct ValidationCacheHeaderVersionEXT(pub i32);
 impl ValidationCacheHeaderVersionEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1529,11 +1655,13 @@ impl ValidationCacheHeaderVersionEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderInfoTypeAMD.html>"]
-pub struct ShaderInfoTypeAMD(pub(crate) i32);
+pub struct ShaderInfoTypeAMD(pub i32);
 impl ShaderInfoTypeAMD {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1546,11 +1674,13 @@ impl ShaderInfoTypeAMD {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueueGlobalPriorityEXT.html>"]
-pub struct QueueGlobalPriorityEXT(pub(crate) i32);
+pub struct QueueGlobalPriorityEXT(pub i32);
 impl QueueGlobalPriorityEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1564,11 +1694,13 @@ impl QueueGlobalPriorityEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkConservativeRasterizationModeEXT.html>"]
-pub struct ConservativeRasterizationModeEXT(pub(crate) i32);
+pub struct ConservativeRasterizationModeEXT(pub i32);
 impl ConservativeRasterizationModeEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1581,11 +1713,13 @@ impl ConservativeRasterizationModeEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkVendorId.html>"]
-pub struct VendorId(pub(crate) i32);
+pub struct VendorId(pub i32);
 impl VendorId {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1607,11 +1741,13 @@ impl VendorId {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkDriverId.html>"]
-pub struct DriverId(pub(crate) i32);
+pub struct DriverId(pub i32);
 impl DriverId {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1663,11 +1799,13 @@ impl DriverId {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShadingRatePaletteEntryNV.html>"]
-pub struct ShadingRatePaletteEntryNV(pub(crate) i32);
+pub struct ShadingRatePaletteEntryNV(pub i32);
 impl ShadingRatePaletteEntryNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1689,11 +1827,13 @@ impl ShadingRatePaletteEntryNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCoarseSampleOrderTypeNV.html>"]
-pub struct CoarseSampleOrderTypeNV(pub(crate) i32);
+pub struct CoarseSampleOrderTypeNV(pub i32);
 impl CoarseSampleOrderTypeNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1707,11 +1847,13 @@ impl CoarseSampleOrderTypeNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCopyAccelerationStructureModeKHR.html>"]
-pub struct CopyAccelerationStructureModeKHR(pub(crate) i32);
+pub struct CopyAccelerationStructureModeKHR(pub i32);
 impl CopyAccelerationStructureModeKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1725,11 +1867,13 @@ impl CopyAccelerationStructureModeKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkBuildAccelerationStructureModeKHR.html>"]
-pub struct BuildAccelerationStructureModeKHR(pub(crate) i32);
+pub struct BuildAccelerationStructureModeKHR(pub i32);
 impl BuildAccelerationStructureModeKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1741,11 +1885,13 @@ impl BuildAccelerationStructureModeKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureTypeKHR.html>"]
-pub struct AccelerationStructureTypeKHR(pub(crate) i32);
+pub struct AccelerationStructureTypeKHR(pub i32);
 impl AccelerationStructureTypeKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1758,11 +1904,13 @@ impl AccelerationStructureTypeKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkGeometryTypeKHR.html>"]
-pub struct GeometryTypeKHR(pub(crate) i32);
+pub struct GeometryTypeKHR(pub i32);
 impl GeometryTypeKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1775,11 +1923,13 @@ impl GeometryTypeKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureMemoryRequirementsTypeNV.html>"]
-pub struct AccelerationStructureMemoryRequirementsTypeNV(pub(crate) i32);
+pub struct AccelerationStructureMemoryRequirementsTypeNV(pub i32);
 impl AccelerationStructureMemoryRequirementsTypeNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1792,11 +1942,13 @@ impl AccelerationStructureMemoryRequirementsTypeNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureBuildTypeKHR.html>"]
-pub struct AccelerationStructureBuildTypeKHR(pub(crate) i32);
+pub struct AccelerationStructureBuildTypeKHR(pub i32);
 impl AccelerationStructureBuildTypeKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1809,11 +1961,13 @@ impl AccelerationStructureBuildTypeKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkRayTracingShaderGroupTypeKHR.html>"]
-pub struct RayTracingShaderGroupTypeKHR(pub(crate) i32);
+pub struct RayTracingShaderGroupTypeKHR(pub i32);
 impl RayTracingShaderGroupTypeKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1826,11 +1980,13 @@ impl RayTracingShaderGroupTypeKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureCompatibilityKHR.html>"]
-pub struct AccelerationStructureCompatibilityKHR(pub(crate) i32);
+pub struct AccelerationStructureCompatibilityKHR(pub i32);
 impl AccelerationStructureCompatibilityKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1842,11 +1998,13 @@ impl AccelerationStructureCompatibilityKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderGroupShaderKHR.html>"]
-pub struct ShaderGroupShaderKHR(pub(crate) i32);
+pub struct ShaderGroupShaderKHR(pub i32);
 impl ShaderGroupShaderKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1860,11 +2018,13 @@ impl ShaderGroupShaderKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkMemoryOverallocationBehaviorAMD.html>"]
-pub struct MemoryOverallocationBehaviorAMD(pub(crate) i32);
+pub struct MemoryOverallocationBehaviorAMD(pub i32);
 impl MemoryOverallocationBehaviorAMD {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1877,11 +2037,13 @@ impl MemoryOverallocationBehaviorAMD {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkScopeNV.html>"]
-pub struct ScopeNV(pub(crate) i32);
+pub struct ScopeNV(pub i32);
 impl ScopeNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1895,11 +2057,13 @@ impl ScopeNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkComponentTypeNV.html>"]
-pub struct ComponentTypeNV(pub(crate) i32);
+pub struct ComponentTypeNV(pub i32);
 impl ComponentTypeNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1920,11 +2084,13 @@ impl ComponentTypeNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFullScreenExclusiveEXT.html>"]
-pub struct FullScreenExclusiveEXT(pub(crate) i32);
+pub struct FullScreenExclusiveEXT(pub i32);
 impl FullScreenExclusiveEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1938,11 +2104,13 @@ impl FullScreenExclusiveEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterScopeKHR.html>"]
-pub struct PerformanceCounterScopeKHR(pub(crate) i32);
+pub struct PerformanceCounterScopeKHR(pub i32);
 impl PerformanceCounterScopeKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1955,11 +2123,13 @@ impl PerformanceCounterScopeKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterUnitKHR.html>"]
-pub struct PerformanceCounterUnitKHR(pub(crate) i32);
+pub struct PerformanceCounterUnitKHR(pub i32);
 impl PerformanceCounterUnitKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -1980,11 +2150,13 @@ impl PerformanceCounterUnitKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceCounterStorageKHR.html>"]
-pub struct PerformanceCounterStorageKHR(pub(crate) i32);
+pub struct PerformanceCounterStorageKHR(pub i32);
 impl PerformanceCounterStorageKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2000,11 +2172,13 @@ impl PerformanceCounterStorageKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceConfigurationTypeINTEL.html>"]
-pub struct PerformanceConfigurationTypeINTEL(pub(crate) i32);
+pub struct PerformanceConfigurationTypeINTEL(pub i32);
 impl PerformanceConfigurationTypeINTEL {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2015,11 +2189,13 @@ impl PerformanceConfigurationTypeINTEL {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryPoolSamplingModeINTEL.html>"]
-pub struct QueryPoolSamplingModeINTEL(pub(crate) i32);
+pub struct QueryPoolSamplingModeINTEL(pub i32);
 impl QueryPoolSamplingModeINTEL {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2030,11 +2206,13 @@ impl QueryPoolSamplingModeINTEL {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceOverrideTypeINTEL.html>"]
-pub struct PerformanceOverrideTypeINTEL(pub(crate) i32);
+pub struct PerformanceOverrideTypeINTEL(pub i32);
 impl PerformanceOverrideTypeINTEL {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2046,11 +2224,13 @@ impl PerformanceOverrideTypeINTEL {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceParameterTypeINTEL.html>"]
-pub struct PerformanceParameterTypeINTEL(pub(crate) i32);
+pub struct PerformanceParameterTypeINTEL(pub i32);
 impl PerformanceParameterTypeINTEL {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2062,11 +2242,13 @@ impl PerformanceParameterTypeINTEL {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPerformanceValueTypeINTEL.html>"]
-pub struct PerformanceValueTypeINTEL(pub(crate) i32);
+pub struct PerformanceValueTypeINTEL(pub i32);
 impl PerformanceValueTypeINTEL {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2081,11 +2263,13 @@ impl PerformanceValueTypeINTEL {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkShaderFloatControlsIndependence.html>"]
-pub struct ShaderFloatControlsIndependence(pub(crate) i32);
+pub struct ShaderFloatControlsIndependence(pub i32);
 impl ShaderFloatControlsIndependence {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2098,11 +2282,13 @@ impl ShaderFloatControlsIndependence {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineExecutableStatisticFormatKHR.html>"]
-pub struct PipelineExecutableStatisticFormatKHR(pub(crate) i32);
+pub struct PipelineExecutableStatisticFormatKHR(pub i32);
 impl PipelineExecutableStatisticFormatKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2116,11 +2302,13 @@ impl PipelineExecutableStatisticFormatKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkLineRasterizationModeEXT.html>"]
-pub struct LineRasterizationModeEXT(pub(crate) i32);
+pub struct LineRasterizationModeEXT(pub i32);
 impl LineRasterizationModeEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2134,11 +2322,13 @@ impl LineRasterizationModeEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFragmentShadingRateCombinerOpKHR.html>"]
-pub struct FragmentShadingRateCombinerOpKHR(pub(crate) i32);
+pub struct FragmentShadingRateCombinerOpKHR(pub i32);
 impl FragmentShadingRateCombinerOpKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2153,11 +2343,13 @@ impl FragmentShadingRateCombinerOpKHR {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFragmentShadingRateNV.html>"]
-pub struct FragmentShadingRateNV(pub(crate) i32);
+pub struct FragmentShadingRateNV(pub i32);
 impl FragmentShadingRateNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2179,11 +2371,13 @@ impl FragmentShadingRateNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkFragmentShadingRateTypeNV.html>"]
-pub struct FragmentShadingRateTypeNV(pub(crate) i32);
+pub struct FragmentShadingRateTypeNV(pub i32);
 impl FragmentShadingRateTypeNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2195,11 +2389,13 @@ impl FragmentShadingRateTypeNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkProvokingVertexModeEXT.html>"]
-pub struct ProvokingVertexModeEXT(pub(crate) i32);
+pub struct ProvokingVertexModeEXT(pub i32);
 impl ProvokingVertexModeEXT {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2211,11 +2407,13 @@ impl ProvokingVertexModeEXT {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureMotionInstanceTypeNV.html>"]
-pub struct AccelerationStructureMotionInstanceTypeNV(pub(crate) i32);
+pub struct AccelerationStructureMotionInstanceTypeNV(pub i32);
 impl AccelerationStructureMotionInstanceTypeNV {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }
@@ -2228,11 +2426,13 @@ impl AccelerationStructureMotionInstanceTypeNV {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkQueryResultStatusKHR.html>"]
-pub struct QueryResultStatusKHR(pub(crate) i32);
+pub struct QueryResultStatusKHR(pub i32);
 impl QueryResultStatusKHR {
+    #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
+    #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
     pub const fn as_raw(self) -> i32 {
         self.0
     }

--- a/ash/src/vk/macros.rs
+++ b/ash/src/vk/macros.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! vk_bitflags_wrapped {
-    ($ name : ident , $ flag_type : ty) => {
+    ($name:ident, $flag_type:ty) => {
         impl Default for $name {
             fn default() -> Self {
                 Self(0)
@@ -11,10 +11,12 @@ macro_rules! vk_bitflags_wrapped {
             pub const fn empty() -> Self {
                 Self(0)
             }
+            #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
             #[inline]
             pub const fn from_raw(x: $flag_type) -> Self {
                 Self(x)
             }
+            #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
             #[inline]
             pub const fn as_raw(self) -> $flag_type {
                 self.0
@@ -81,12 +83,13 @@ macro_rules! vk_bitflags_wrapped {
         }
     };
 }
+
 #[macro_export]
 macro_rules! handle_nondispatchable {
-    ($ name : ident , $ ty : ident) => {
+    ($name:ident, $ty:ident) => {
         handle_nondispatchable!($name, $ty, doc = "");
     };
-    ($ name : ident , $ ty : ident , $ doc_link : meta) => {
+    ($name:ident, $ty:ident, $doc_link:meta) => {
         #[repr(transparent)]
         #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Default)]
         #[$doc_link]
@@ -117,12 +120,13 @@ macro_rules! handle_nondispatchable {
         }
     };
 }
+
 #[macro_export]
 macro_rules! define_handle {
-    ($ name : ident , $ ty : ident) => {
+    ($name:ident, $ty:ident) => {
         define_handle!($name, $ty, doc = "");
     };
-    ($ name : ident , $ ty : ident , $ doc_link : meta) => {
+    ($name:ident, $ty:ident, $doc_link:meta) => {
         #[repr(transparent)]
         #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash)]
         #[$doc_link]

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1177,7 +1177,7 @@ pub fn generate_bitmask(
         #[repr(transparent)]
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[doc = #khronos_link]
-        pub struct #ident(pub(crate) #type_);
+        pub struct #ident(pub #type_);
         vk_bitflags_wrapped!(#ident, #type_);
     })
 }
@@ -1326,7 +1326,7 @@ pub fn generate_enum<'a>(
                 #[repr(transparent)]
                 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
                 #[doc = #khronos_link]
-                pub struct #ident(pub(crate) #type_);
+                pub struct #ident(pub #type_);
                 vk_bitflags_wrapped!(#ident, #type_);
                 #impl_bitflags
             };
@@ -1345,9 +1345,11 @@ pub fn generate_enum<'a>(
             #[repr(transparent)]
             #[doc = #khronos_link]
             #struct_attribute
-            pub struct #ident(pub(crate) i32);
+            pub struct #ident(pub i32);
             impl #ident {
+                #[deprecated = "The newtype constructor is now directly available and preferred. This function will be removed in Ash 0.36."]
                 pub const fn from_raw(x: i32) -> Self { Self(x) }
+                #[deprecated = "The newtype `.0` member is now directly available and preferred. This function will be removed in Ash 0.36."]
                 pub const fn as_raw(self) -> i32 { self.0 }
             }
             #impl_block


### PR DESCRIPTION
Nothing special happens when converting to and from these constants, and its API is found to be more concise yet ever so slightly (0.1s) faster to compile than having separate `to_raw` and `from_raw` functions for each [1], that it makes sense to drop these entirely.  Ash is still on a nonbreaking contribution streak so these functions are marked `deprecated` for now and will be removed at the next breaking crate release.

[1]: https://github.com/MaikKlein/ash/pull/549#discussion_r781402363
