### PR TITLE
changelog: Add entries for recent PRs #545, #534, #553, #551, #549

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Convert `vk_bitflags_wrapped!` methods to `const fn` (#549)
+- examples: Update winit to 0.26 and image to 0.23 (#551)
+- ash-window: Require at least `raw-window-handle 0.3.4` for 0.4 interop (#553)
+- Assert that Vulkan array-getters return the same length (#534)
+- README: Correct documentation for `Entry` functions and related crate features (#545)
 - example: Refactor event loop handling for continuous redraw (#542)
 - Generate `RGBA=R|G|B|A` helper constant for `ColorComponentFlags` (#537)
 - Remove remaining `CString` allocations on string literals in examples and hand-written AMD extension (#533)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-Ash
-=
+# Ash
 
 A very lightweight wrapper around Vulkan
--
 
 [![Crates.io Version](https://img.shields.io/crates/v/ash.svg)](https://crates.io/crates/ash)
 [![Documentation](https://docs.rs/ash/badge.svg)](https://docs.rs/ash)
@@ -221,7 +219,7 @@ let pool = device.create_command_pool(&pool_create_info).unwrap();
 
 ### Optional linking
 
-The default `loaded` cargo feature will dynamically load the default Vulkan library for the current platform with `Entry::load`, meaning that the build environment does not have to have Vulkan development packages installed. 
+The default `loaded` cargo feature will dynamically load the default Vulkan library for the current platform with `Entry::load`, meaning that the build environment does not have to have Vulkan development packages installed.
 
 If, on the other hand, your application cannot handle Vulkan being missing at runtime, you can instead enable the `linked` feature, which will link your binary with the Vulkan loader directly and expose the infallible `Entry::linked`.
 

--- a/ash-window/README.md
+++ b/ash-window/README.md
@@ -1,8 +1,6 @@
-Ash-window
-=
+## Ash-window
 
 Interoperability between [`ash`](https://github.com/MaikKlein/ash) and [`raw-window-handle`](https://github.com/rust-windowing/raw-window-handle) for surface creation.
--
 
 [![Crates.io Version](https://img.shields.io/crates/v/ash-window.svg)](https://crates.io/crates/ash-window)
 [![Documentation](https://docs.rs/ash-window/badge.svg)](https://docs.rs/ash-window)


### PR DESCRIPTION
And drop the deprecated =/- markdown syntax from our readme: this is analogous to #/## for a h1/h2 header, instead of defining a title and (usually smaller font) subtitle or description.
