### PR TITLE
Add conversions between Extent2D, Extent3D and Rect2D

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Added conversions from `Extent2D` to `Extent3D` and `Rect2D` (#557)
+
 ## [0.35.1] - 2022-01-18
 
 ### Added

--- a/ash/src/vk/prelude.rs
+++ b/ash/src/vk/prelude.rs
@@ -1,3 +1,5 @@
+use crate::vk;
+
 /// Holds 24 bits in the least significant bits of memory,
 /// and 8 bytes in the most significant bits of that memory,
 /// occupying a single [`u32`] in total. This is commonly used in
@@ -30,4 +32,23 @@ impl Packed24_8 {
 impl super::ColorComponentFlags {
     /// Contraction of [`Self::R`] | [`Self::G`] | [`Self::B`] | [`Self::A`]
     pub const RGBA: Self = Self(Self::R.0 | Self::G.0 | Self::B.0 | Self::A.0);
+}
+
+impl From<vk::Extent2D> for vk::Extent3D {
+    fn from(value: vk::Extent2D) -> Self {
+        Self {
+            width: value.width,
+            height: value.height,
+            depth: 1,
+        }
+    }
+}
+
+impl From<vk::Extent2D> for vk::Rect2D {
+    fn from(extent: vk::Extent2D) -> Self {
+        Self {
+            offset: Default::default(),
+            extent,
+        }
+    }
 }

--- a/examples/src/bin/texture.rs
+++ b/examples/src/bin/texture.rs
@@ -264,7 +264,8 @@ fn main() {
         let image = image::load_from_memory(include_bytes!("../../assets/rust.png"))
             .unwrap()
             .to_rgba8();
-        let image_dimensions = image.dimensions();
+        let (width, height) = image.dimensions();
+        let image_extent = vk::Extent2D { width, height };
         let image_data = image.into_raw();
         let image_buffer_info = vk::BufferCreateInfo {
             size: (std::mem::size_of::<u8>() * image_data.len()) as u64,
@@ -313,11 +314,7 @@ fn main() {
         let texture_create_info = vk::ImageCreateInfo {
             image_type: vk::ImageType::TYPE_2D,
             format: vk::Format::R8G8B8A8_UNORM,
-            extent: vk::Extent3D {
-                width: image_dimensions.0,
-                height: image_dimensions.1,
-                depth: 1,
-            },
+            extent: image_extent.into(),
             mip_levels: 1,
             array_layers: 1,
             samples: vk::SampleCountFlags::TYPE_1,
@@ -388,11 +385,7 @@ fn main() {
                             .layer_count(1)
                             .build(),
                     )
-                    .image_extent(vk::Extent3D {
-                        width: image_dimensions.0,
-                        height: image_dimensions.1,
-                        depth: 1,
-                    });
+                    .image_extent(image_extent.into());
 
                 device.cmd_copy_buffer_to_image(
                     texture_command_buffer,
@@ -623,10 +616,7 @@ fn main() {
             min_depth: 0.0,
             max_depth: 1.0,
         }];
-        let scissors = [vk::Rect2D {
-            extent: base.surface_resolution,
-            ..Default::default()
-        }];
+        let scissors = [base.surface_resolution.into()];
         let viewport_state_info = vk::PipelineViewportStateCreateInfo::builder()
             .scissors(&scissors)
             .viewports(&viewports);
@@ -727,10 +717,7 @@ fn main() {
             let render_pass_begin_info = vk::RenderPassBeginInfo::builder()
                 .render_pass(renderpass)
                 .framebuffer(framebuffers[present_index as usize])
-                .render_area(vk::Rect2D {
-                    offset: vk::Offset2D { x: 0, y: 0 },
-                    extent: base.surface_resolution,
-                })
+                .render_area(base.surface_resolution.into())
                 .clear_values(&clear_values);
 
             record_submit_commandbuffer(

--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -277,10 +277,7 @@ fn main() {
             min_depth: 0.0,
             max_depth: 1.0,
         }];
-        let scissors = [vk::Rect2D {
-            offset: vk::Offset2D { x: 0, y: 0 },
-            extent: base.surface_resolution,
-        }];
+        let scissors = [base.surface_resolution.into()];
         let viewport_state_info = vk::PipelineViewportStateCreateInfo::builder()
             .scissors(&scissors)
             .viewports(&viewports);
@@ -380,10 +377,7 @@ fn main() {
             let render_pass_begin_info = vk::RenderPassBeginInfo::builder()
                 .render_pass(renderpass)
                 .framebuffer(framebuffers[present_index as usize])
-                .render_area(vk::Rect2D {
-                    offset: vk::Offset2D { x: 0, y: 0 },
-                    extent: base.surface_resolution,
-                })
+                .render_area(base.surface_resolution.into())
                 .clear_values(&clear_values);
 
             record_submit_commandbuffer(

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -425,11 +425,7 @@ impl ExampleBase {
             let depth_image_create_info = vk::ImageCreateInfo::builder()
                 .image_type(vk::ImageType::TYPE_2D)
                 .format(vk::Format::D16_UNORM)
-                .extent(vk::Extent3D {
-                    width: surface_resolution.width,
-                    height: surface_resolution.height,
-                    depth: 1,
-                })
+                .extent(surface_resolution.into())
                 .mip_levels(1)
                 .array_layers(1)
                 .samples(vk::SampleCountFlags::TYPE_1)


### PR DESCRIPTION
When using `ash`, I frequently find myself wishing that converting between 2D/3D extents was less verbose, since it's so common. Likewise, you need to convert from an `Extent2D` to a `Rect2D` any time you want to start a render pass that affects an entire framebuffer.