### PR TITLE
ci: Build-test documentation with warnings disallowed, and fix broken links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,21 @@ jobs:
         with:
           command: clippy
           args: --workspace --all-targets -- -D warnings
+
+  docs:
+    name: Build-test docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        name: Document all crates
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        with:
+          command: doc
+          args: --all --all-features --no-deps --document-private-items

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Fixed broken (intradoc) links in the prelude and `VK_KHR_get_surface_capabilities2` extension (#559)
+
 ### Added
 
 - Added conversions from `Extent2D` to `Extent3D` and `Rect2D` (#557)

--- a/ash/src/extensions/khr/get_surface_capabilities2.rs
+++ b/ash/src/extensions/khr/get_surface_capabilities2.rs
@@ -17,7 +17,7 @@ impl GetSurfaceCapabilities2 {
         Self { fp }
     }
 
-    #[doc = "https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceCapabilities2KHR.html"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceCapabilities2KHR.html>"]
     pub unsafe fn get_physical_device_surface_capabilities2(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -49,7 +49,7 @@ impl GetSurfaceCapabilities2 {
         err_code.result_with_success(count as usize)
     }
 
-    #[doc = "https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceFormats2KHR.html"]
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceFormats2KHR.html>"]
     ///
     /// Call [`Self::get_physical_device_surface_formats2_len()`] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.

--- a/ash/src/vk/prelude.rs
+++ b/ash/src/vk/prelude.rs
@@ -4,9 +4,9 @@ use crate::vk;
 /// and 8 bytes in the most significant bits of that memory,
 /// occupying a single [`u32`] in total. This is commonly used in
 /// [acceleration structure instances] such as
-/// [`vk::AccelerationStructureInstanceKHR`][super::AccelerationStructureInstanceKHR],
-/// [`vk::AccelerationStructureSRTMotionInstanceNV`][super::AccelerationStructureSRTMotionInstanceNV] and
-/// [`vk::AccelerationStructureMatrixMotionInstanceNV`][super::AccelerationStructureMatrixMotionInstanceNV].
+/// [`vk::AccelerationStructureInstanceKHR`],
+/// [`vk::AccelerationStructureSRTMotionInstanceNV`] and
+/// [`vk::AccelerationStructureMatrixMotionInstanceNV`].
 ///
 /// [acceleration structure instances]: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkAccelerationStructureInstanceKHR.html#_description
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -29,7 +29,11 @@ impl Packed24_8 {
     }
 }
 
-impl super::ColorComponentFlags {
+// Intradoc `Self::` links refuse to resolve if `ColorComponentFlags`
+// isn't directly in scope: https://github.com/rust-lang/rust/issues/93205
+use vk::ColorComponentFlags;
+
+impl ColorComponentFlags {
     /// Contraction of [`Self::R`] | [`Self::G`] | [`Self::B`] | [`Self::A`]
     pub const RGBA: Self = Self(Self::R.0 | Self::G.0 | Self::B.0 | Self::A.0);
 }


### PR DESCRIPTION
I was pretty certain our documentation was at least build-tested since that's generally one of the first things I check/PR on the crates I touch... Supposedly not here. It allowed some broken links to slip in, most recently in #530 and #537 where I _wrongly assumed_ the CI was having my back. ~Let's make sure it fails now before pushing the necessary fixes.~ CI is properly working and finding+disallowing issues: https://github.com/MaikKlein/ash/runs/4865846622?check_suite_focus=true