### PR TITLE
Use link text in docs to omit `Self::` prefix in rendered docs

### DIFF
--- a/ash/src/device.rs
+++ b/ash/src/device.rs
@@ -297,7 +297,7 @@ impl Device {
             .get_buffer_memory_requirements2(self.handle(), info, out);
     }
 
-    /// Retrieve the number of elements to pass to [`Self::get_image_sparse_memory_requirements2()`]
+    /// Retrieve the number of elements to pass to [`get_image_sparse_memory_requirements2()`][Self::get_image_sparse_memory_requirements2()]
     pub unsafe fn get_image_sparse_memory_requirements2_len(
         &self,
         info: &vk::ImageSparseMemoryRequirementsInfo2,
@@ -314,7 +314,7 @@ impl Device {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageSparseMemoryRequirements2.html>
     ///
-    /// Call [`Self::get_image_sparse_memory_requirements2_len()`] to query the number of elements to pass to `out`.
+    /// Call [`get_image_sparse_memory_requirements2_len()`][Self::get_image_sparse_memory_requirements2_len()] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn get_image_sparse_memory_requirements2(
         &self,

--- a/ash/src/entry.rs
+++ b/ash/src/entry.rs
@@ -264,10 +264,10 @@ impl Entry {
         &self.entry_fn_1_1
     }
 
-    #[deprecated = "This function is unavailable and therefore panics on Vulkan 1.0, please use `try_enumerate_instance_version` instead"]
+    #[deprecated = "This function is unavailable and therefore panics on Vulkan 1.0, please use `try_enumerate_instance_version()` instead"]
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumerateInstanceVersion.html>
     ///
-    /// Please use [`Self::try_enumerate_instance_version`] instead.
+    /// Please use [`try_enumerate_instance_version()`][Self::try_enumerate_instance_version()] instead.
     pub fn enumerate_instance_version(&self) -> VkResult<u32> {
         unsafe {
             let mut api_version = 0;

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -39,7 +39,7 @@ impl GetMemoryRequirements2 {
             .get_image_memory_requirements2_khr(self.handle, info, memory_requirements);
     }
 
-    /// Retrieve the number of elements to pass to [`Self::get_image_sparse_memory_requirements2()`]
+    /// Retrieve the number of elements to pass to [`get_image_sparse_memory_requirements2()`][Self::get_image_sparse_memory_requirements2()]
     pub unsafe fn get_image_sparse_memory_requirements2_len(
         &self,
         info: &vk::ImageSparseMemoryRequirementsInfo2KHR,
@@ -56,7 +56,7 @@ impl GetMemoryRequirements2 {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetImageSparseMemoryRequirements2KHR.html>
     ///
-    /// Call [`Self::get_image_sparse_memory_requirements2_len()`] to query the number of elements to pass to `out`.
+    /// Call [`get_image_sparse_memory_requirements2_len()`][Self::get_image_sparse_memory_requirements2_len()] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn get_image_sparse_memory_requirements2(
         &self,

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -78,7 +78,7 @@ impl GetPhysicalDeviceProperties2 {
             .get_physical_device_properties2_khr(physical_device, properties);
     }
 
-    /// Retrieve the number of elements to pass to [`Self::get_physical_device_queue_family_properties2()`]
+    /// Retrieve the number of elements to pass to [`get_physical_device_queue_family_properties2()`][Self::get_physical_device_queue_family_properties2()]
     pub unsafe fn get_physical_device_queue_family_properties2_len(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -94,7 +94,7 @@ impl GetPhysicalDeviceProperties2 {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceQueueFamilyProperties2KHR.html>
     ///
-    /// Call [`Self::get_physical_device_queue_family_properties2_len()`] to query the number of elements to pass to `out`.
+    /// Call [`get_physical_device_queue_family_properties2_len()`][Self::get_physical_device_queue_family_properties2_len()] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn get_physical_device_queue_family_properties2(
         &self,
@@ -110,7 +110,7 @@ impl GetPhysicalDeviceProperties2 {
         assert_eq!(count as usize, out.len());
     }
 
-    /// Retrieve the number of elements to pass to [`Self::get_physical_device_sparse_image_format_properties2()`]
+    /// Retrieve the number of elements to pass to [`get_physical_device_sparse_image_format_properties2()`][Self::get_physical_device_sparse_image_format_properties2()]
     pub unsafe fn get_physical_device_sparse_image_format_properties2_len(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -129,7 +129,7 @@ impl GetPhysicalDeviceProperties2 {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSparseImageFormatProperties2KHR.html>
     ///
-    /// Call [`Self::get_physical_device_sparse_image_format_properties2_len()`] to query the number of elements to pass to `out`.
+    /// Call [`get_physical_device_sparse_image_format_properties2_len()`][Self::get_physical_device_sparse_image_format_properties2_len()] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn get_physical_device_sparse_image_format_properties2(
         &self,

--- a/ash/src/extensions/khr/get_surface_capabilities2.rs
+++ b/ash/src/extensions/khr/get_surface_capabilities2.rs
@@ -33,7 +33,7 @@ impl GetSurfaceCapabilities2 {
             .result_with_success(surface_capabilities)
     }
 
-    /// Retrieve the number of elements to pass to [`Self::get_physical_device_surface_formats2()`]
+    /// Retrieve the number of elements to pass to [`get_physical_device_surface_formats2()`][Self::get_physical_device_surface_formats2()]
     pub unsafe fn get_physical_device_surface_formats2_len(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -51,7 +51,7 @@ impl GetSurfaceCapabilities2 {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceFormats2KHR.html>
     ///
-    /// Call [`Self::get_physical_device_surface_formats2_len()`] to query the number of elements to pass to `out`.
+    /// Call [`get_physical_device_surface_formats2_len()`][Self::get_physical_device_surface_formats2_len()] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn get_physical_device_surface_formats2(
         &self,

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -38,7 +38,7 @@ impl Maintenance4 {
             .get_device_image_memory_requirements_khr(self.handle, create_info, out)
     }
 
-    /// Retrieve the number of elements to pass to [`Self::get_device_image_sparse_memory_requirements()`]
+    /// Retrieve the number of elements to pass to [`get_device_image_sparse_memory_requirements()`][Self::get_device_image_sparse_memory_requirements()]
     pub unsafe fn get_device_image_sparse_memory_requirements_len(
         &self,
         create_info: &vk::DeviceImageMemoryRequirementsKHR,
@@ -55,7 +55,7 @@ impl Maintenance4 {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetDeviceImageSparseMemoryRequirementsKHR.html>
     ///
-    /// Call [`Self::get_device_image_sparse_memory_requirements_len()`] to query the number of elements to pass to `out`.
+    /// Call [`get_device_image_sparse_memory_requirements_len()`][Self::get_device_image_sparse_memory_requirements_len()] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn get_device_image_sparse_memory_requirements(
         &self,

--- a/ash/src/instance.rs
+++ b/ash/src/instance.rs
@@ -51,7 +51,7 @@ impl Instance {
         &self.instance_fn_1_1
     }
 
-    /// Retrieve the number of elements to pass to [`Self::enumerate_physical_device_groups()`]
+    /// Retrieve the number of elements to pass to [`enumerate_physical_device_groups()`][Self::enumerate_physical_device_groups()]
     pub unsafe fn enumerate_physical_device_groups_len(&self) -> VkResult<usize> {
         let mut group_count = 0;
         self.instance_fn_1_1
@@ -61,7 +61,7 @@ impl Instance {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkEnumeratePhysicalDeviceGroups.html>
     ///
-    /// Call [`Self::enumerate_physical_device_groups_len()`] to query the number of elements to pass to `out`.
+    /// Call [`enumerate_physical_device_groups_len()`][Self::enumerate_physical_device_groups_len()] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn enumerate_physical_device_groups(
         &self,
@@ -122,7 +122,7 @@ impl Instance {
             .result()
     }
 
-    /// Retrieve the number of elements to pass to [`Self::get_physical_device_queue_family_properties2()`]
+    /// Retrieve the number of elements to pass to [`get_physical_device_queue_family_properties2()`][Self::get_physical_device_queue_family_properties2()]
     pub unsafe fn get_physical_device_queue_family_properties2_len(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -139,7 +139,7 @@ impl Instance {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceQueueFamilyProperties2.html>
     ///
-    /// Call [`Self::get_physical_device_queue_family_properties2_len()`] to query the number of elements to pass to `out`.
+    /// Call [`get_physical_device_queue_family_properties2_len()`][Self::get_physical_device_queue_family_properties2_len()] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn get_physical_device_queue_family_properties2(
         &self,
@@ -166,7 +166,7 @@ impl Instance {
             .get_physical_device_memory_properties2(physical_device, out);
     }
 
-    /// Retrieve the number of elements to pass to [`Self::get_physical_device_sparse_image_format_properties2()`]
+    /// Retrieve the number of elements to pass to [`get_physical_device_sparse_image_format_properties2()`][Self::get_physical_device_sparse_image_format_properties2()]
     pub unsafe fn get_physical_device_sparse_image_format_properties2_len(
         &self,
         physical_device: vk::PhysicalDevice,
@@ -185,7 +185,7 @@ impl Instance {
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSparseImageFormatProperties2.html>
     ///
-    /// Call [`Self::get_physical_device_sparse_image_format_properties2_len()`] to query the number of elements to pass to `out`.
+    /// Call [`get_physical_device_sparse_image_format_properties2_len()`][Self::get_physical_device_sparse_image_format_properties2_len()] to query the number of elements to pass to `out`.
     /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
     pub unsafe fn get_physical_device_sparse_image_format_properties2(
         &self,

--- a/ash/src/vk/prelude.rs
+++ b/ash/src/vk/prelude.rs
@@ -34,7 +34,7 @@ impl Packed24_8 {
 use vk::ColorComponentFlags;
 
 impl ColorComponentFlags {
-    /// Contraction of [`Self::R`] | [`Self::G`] | [`Self::B`] | [`Self::A`]
+    /// Contraction of [`R`][Self::R] | [`G`][Self::G] | [`B`][Self::B] | [`A`][Self::A]
     pub const RGBA: Self = Self(Self::R.0 | Self::G.0 | Self::B.0 | Self::A.0);
 }
 


### PR DESCRIPTION
Suggestion from [#559].

[#559]: https://github.com/MaikKlein/ash/pull/559#discussion_r790178735

~Note that `Self::` in `_len()` function docs hasn't been replaced (yet?) as the longer function names make this format rather verbose.  However, we should probably prefer docs readability over code readability?~