### PR TITLE
Update Vulkan-Headers to 1.3.206

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Update Vulkan-Headers to 1.3.205 (#563)
+- Update Vulkan-Headers to 1.3.206 (#563)
 
 ## [0.35.2] - 2022-02-19
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,11 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.35.2] - 2022-02-19
+## Unreleased
 
 ### Changed
 
 - extensions/khr: Drop `_khr` suffix from `get_memory_fd_properties_khr` in `ExternalMemoryFd` (#580)
+
+### Added
+
+- Update Vulkan-Headers to 1.3.205 (#563)
+
+## [0.35.2] - 2022-02-19
+
+### Changed
+
 - Replace `1.2-extensions` documentation links with `1.3-extensions` (#569)
 - Fixed broken (intradoc) links in the prelude and `VK_KHR_get_surface_capabilities2` extension (#559)
 

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ash"
-version = "0.35.2+1.3.205"
+version = "0.35.2+1.3.206"
 authors = ["maik klein <maikklein@googlemail.com>"]
 description = "Vulkan bindings for Rust"
 license = "MIT"

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ash"
-version = "0.35.2+1.2.203"
+version = "0.35.2+1.3.205"
 authors = ["maik klein <maikklein@googlemail.com>"]
 description = "Vulkan bindings for Rust"
 license = "MIT"

--- a/ash/src/vk/aliases.rs
+++ b/ash/src/vk/aliases.rs
@@ -4,8 +4,14 @@ use crate::vk::enums::*;
 pub type GeometryFlagsNV = GeometryFlagsKHR;
 pub type GeometryInstanceFlagsNV = GeometryInstanceFlagsKHR;
 pub type BuildAccelerationStructureFlagsNV = BuildAccelerationStructureFlagsKHR;
+pub type PrivateDataSlotCreateFlagsEXT = PrivateDataSlotCreateFlags;
 pub type DescriptorUpdateTemplateCreateFlagsKHR = DescriptorUpdateTemplateCreateFlags;
+pub type PipelineCreationFeedbackFlagsEXT = PipelineCreationFeedbackFlags;
 pub type SemaphoreWaitFlagsKHR = SemaphoreWaitFlags;
+pub type AccessFlags2KHR = AccessFlags2;
+pub type PipelineStageFlags2KHR = PipelineStageFlags2;
+pub type FormatFeatureFlags2KHR = FormatFeatureFlags2;
+pub type RenderingFlagsKHR = RenderingFlags;
 pub type PeerMemoryFeatureFlagsKHR = PeerMemoryFeatureFlags;
 pub type MemoryAllocateFlagsKHR = MemoryAllocateFlags;
 pub type CommandPoolTrimFlagsKHR = CommandPoolTrimFlags;
@@ -19,10 +25,14 @@ pub type ExternalFenceFeatureFlagsKHR = ExternalFenceFeatureFlags;
 pub type FenceImportFlagsKHR = FenceImportFlags;
 pub type DescriptorBindingFlagsEXT = DescriptorBindingFlags;
 pub type ResolveModeFlagsKHR = ResolveModeFlags;
+pub type ToolPurposeFlagsEXT = ToolPurposeFlags;
+pub type SubmitFlagsKHR = SubmitFlags;
 pub type DescriptorUpdateTemplateKHR = DescriptorUpdateTemplate;
 pub type SamplerYcbcrConversionKHR = SamplerYcbcrConversion;
+pub type PrivateDataSlotEXT = PrivateDataSlot;
 pub type DescriptorUpdateTemplateTypeKHR = DescriptorUpdateTemplateType;
 pub type PointClippingBehaviorKHR = PointClippingBehavior;
+pub type QueueGlobalPriorityEXT = QueueGlobalPriorityKHR;
 pub type SemaphoreTypeKHR = SemaphoreType;
 pub type CopyAccelerationStructureModeNV = CopyAccelerationStructureModeKHR;
 pub type AccelerationStructureTypeNV = AccelerationStructureTypeKHR;
@@ -35,6 +45,9 @@ pub type ChromaLocationKHR = ChromaLocation;
 pub type SamplerReductionModeEXT = SamplerReductionMode;
 pub type ShaderFloatControlsIndependenceKHR = ShaderFloatControlsIndependence;
 pub type DriverIdKHR = DriverId;
+pub type DevicePrivateDataCreateInfoEXT = DevicePrivateDataCreateInfo;
+pub type PrivateDataSlotCreateInfoEXT = PrivateDataSlotCreateInfo;
+pub type PhysicalDevicePrivateDataFeaturesEXT = PhysicalDevicePrivateDataFeatures;
 pub type PhysicalDeviceFeatures2KHR = PhysicalDeviceFeatures2;
 pub type PhysicalDeviceProperties2KHR = PhysicalDeviceProperties2;
 pub type FormatProperties2KHR = FormatProperties2;
@@ -86,8 +99,10 @@ pub type PhysicalDevice16BitStorageFeaturesKHR = PhysicalDevice16BitStorageFeatu
 pub type PhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR =
     PhysicalDeviceShaderSubgroupExtendedTypesFeatures;
 pub type BufferMemoryRequirementsInfo2KHR = BufferMemoryRequirementsInfo2;
+pub type DeviceBufferMemoryRequirementsKHR = DeviceBufferMemoryRequirements;
 pub type ImageMemoryRequirementsInfo2KHR = ImageMemoryRequirementsInfo2;
 pub type ImageSparseMemoryRequirementsInfo2KHR = ImageSparseMemoryRequirementsInfo2;
+pub type DeviceImageMemoryRequirementsKHR = DeviceImageMemoryRequirements;
 pub type MemoryRequirements2KHR = MemoryRequirements2;
 pub type SparseImageMemoryRequirements2KHR = SparseImageMemoryRequirements2;
 pub type PhysicalDevicePointClippingPropertiesKHR = PhysicalDevicePointClippingProperties;
@@ -107,14 +122,24 @@ pub type SamplerYcbcrConversionImageFormatPropertiesKHR =
 pub type PhysicalDeviceSamplerFilterMinmaxPropertiesEXT =
     PhysicalDeviceSamplerFilterMinmaxProperties;
 pub type SamplerReductionModeCreateInfoEXT = SamplerReductionModeCreateInfo;
+pub type PhysicalDeviceInlineUniformBlockFeaturesEXT = PhysicalDeviceInlineUniformBlockFeatures;
+pub type PhysicalDeviceInlineUniformBlockPropertiesEXT = PhysicalDeviceInlineUniformBlockProperties;
+pub type WriteDescriptorSetInlineUniformBlockEXT = WriteDescriptorSetInlineUniformBlock;
+pub type DescriptorPoolInlineUniformBlockCreateInfoEXT = DescriptorPoolInlineUniformBlockCreateInfo;
 pub type ImageFormatListCreateInfoKHR = ImageFormatListCreateInfo;
 pub type PhysicalDeviceMaintenance3PropertiesKHR = PhysicalDeviceMaintenance3Properties;
+pub type PhysicalDeviceMaintenance4FeaturesKHR = PhysicalDeviceMaintenance4Features;
+pub type PhysicalDeviceMaintenance4PropertiesKHR = PhysicalDeviceMaintenance4Properties;
 pub type DescriptorSetLayoutSupportKHR = DescriptorSetLayoutSupport;
 pub type PhysicalDeviceShaderDrawParameterFeatures = PhysicalDeviceShaderDrawParametersFeatures;
 pub type PhysicalDeviceShaderFloat16Int8FeaturesKHR = PhysicalDeviceShaderFloat16Int8Features;
 pub type PhysicalDeviceFloat16Int8FeaturesKHR = PhysicalDeviceShaderFloat16Int8Features;
 pub type PhysicalDeviceFloatControlsPropertiesKHR = PhysicalDeviceFloatControlsProperties;
 pub type PhysicalDeviceHostQueryResetFeaturesEXT = PhysicalDeviceHostQueryResetFeatures;
+pub type DeviceQueueGlobalPriorityCreateInfoEXT = DeviceQueueGlobalPriorityCreateInfoKHR;
+pub type PhysicalDeviceGlobalPriorityQueryFeaturesEXT =
+    PhysicalDeviceGlobalPriorityQueryFeaturesKHR;
+pub type QueueFamilyGlobalPriorityPropertiesEXT = QueueFamilyGlobalPriorityPropertiesKHR;
 pub type PhysicalDeviceDescriptorIndexingFeaturesEXT = PhysicalDeviceDescriptorIndexingFeatures;
 pub type PhysicalDeviceDescriptorIndexingPropertiesEXT = PhysicalDeviceDescriptorIndexingProperties;
 pub type DescriptorSetLayoutBindingFlagsCreateInfoEXT = DescriptorSetLayoutBindingFlagsCreateInfo;
@@ -154,14 +179,64 @@ pub type PhysicalDeviceImagelessFramebufferFeaturesKHR = PhysicalDeviceImageless
 pub type FramebufferAttachmentsCreateInfoKHR = FramebufferAttachmentsCreateInfo;
 pub type FramebufferAttachmentImageInfoKHR = FramebufferAttachmentImageInfo;
 pub type RenderPassAttachmentBeginInfoKHR = RenderPassAttachmentBeginInfo;
+pub type PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT =
+    PhysicalDeviceTextureCompressionASTCHDRFeatures;
+pub type PipelineCreationFeedbackEXT = PipelineCreationFeedback;
+pub type PipelineCreationFeedbackCreateInfoEXT = PipelineCreationFeedbackCreateInfo;
 pub type QueryPoolCreateInfoINTEL = QueryPoolPerformanceQueryCreateInfoINTEL;
 pub type PhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR =
     PhysicalDeviceSeparateDepthStencilLayoutsFeatures;
 pub type AttachmentReferenceStencilLayoutKHR = AttachmentReferenceStencilLayout;
 pub type AttachmentDescriptionStencilLayoutKHR = AttachmentDescriptionStencilLayout;
+pub type PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT =
+    PhysicalDeviceShaderDemoteToHelperInvocationFeatures;
+pub type PhysicalDeviceTexelBufferAlignmentPropertiesEXT =
+    PhysicalDeviceTexelBufferAlignmentProperties;
+pub type PhysicalDeviceSubgroupSizeControlFeaturesEXT = PhysicalDeviceSubgroupSizeControlFeatures;
+pub type PhysicalDeviceSubgroupSizeControlPropertiesEXT =
+    PhysicalDeviceSubgroupSizeControlProperties;
+pub type PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT =
+    PipelineShaderStageRequiredSubgroupSizeCreateInfo;
 pub type MemoryOpaqueCaptureAddressAllocateInfoKHR = MemoryOpaqueCaptureAddressAllocateInfo;
 pub type DeviceMemoryOpaqueCaptureAddressInfoKHR = DeviceMemoryOpaqueCaptureAddressInfo;
+pub type PhysicalDevicePipelineCreationCacheControlFeaturesEXT =
+    PhysicalDevicePipelineCreationCacheControlFeatures;
+pub type PhysicalDeviceToolPropertiesEXT = PhysicalDeviceToolProperties;
 pub type AabbPositionsNV = AabbPositionsKHR;
 pub type TransformMatrixNV = TransformMatrixKHR;
 pub type AccelerationStructureInstanceNV = AccelerationStructureInstanceKHR;
+pub type PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR =
+    PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures;
+pub type PhysicalDeviceImageRobustnessFeaturesEXT = PhysicalDeviceImageRobustnessFeatures;
+pub type BufferCopy2KHR = BufferCopy2;
+pub type ImageCopy2KHR = ImageCopy2;
+pub type ImageBlit2KHR = ImageBlit2;
+pub type BufferImageCopy2KHR = BufferImageCopy2;
+pub type ImageResolve2KHR = ImageResolve2;
+pub type CopyBufferInfo2KHR = CopyBufferInfo2;
+pub type CopyImageInfo2KHR = CopyImageInfo2;
+pub type BlitImageInfo2KHR = BlitImageInfo2;
+pub type CopyBufferToImageInfo2KHR = CopyBufferToImageInfo2;
+pub type CopyImageToBufferInfo2KHR = CopyImageToBufferInfo2;
+pub type ResolveImageInfo2KHR = ResolveImageInfo2;
+pub type PhysicalDeviceShaderTerminateInvocationFeaturesKHR =
+    PhysicalDeviceShaderTerminateInvocationFeatures;
+pub type MemoryBarrier2KHR = MemoryBarrier2;
+pub type ImageMemoryBarrier2KHR = ImageMemoryBarrier2;
+pub type BufferMemoryBarrier2KHR = BufferMemoryBarrier2;
+pub type DependencyInfoKHR = DependencyInfo;
+pub type SemaphoreSubmitInfoKHR = SemaphoreSubmitInfo;
+pub type CommandBufferSubmitInfoKHR = CommandBufferSubmitInfo;
+pub type SubmitInfo2KHR = SubmitInfo2;
+pub type PhysicalDeviceSynchronization2FeaturesKHR = PhysicalDeviceSynchronization2Features;
+pub type PhysicalDeviceShaderIntegerDotProductFeaturesKHR =
+    PhysicalDeviceShaderIntegerDotProductFeatures;
+pub type PhysicalDeviceShaderIntegerDotProductPropertiesKHR =
+    PhysicalDeviceShaderIntegerDotProductProperties;
+pub type FormatProperties3KHR = FormatProperties3;
+pub type PipelineRenderingCreateInfoKHR = PipelineRenderingCreateInfo;
+pub type RenderingInfoKHR = RenderingInfo;
+pub type RenderingAttachmentInfoKHR = RenderingAttachmentInfo;
+pub type PhysicalDeviceDynamicRenderingFeaturesKHR = PhysicalDeviceDynamicRenderingFeatures;
+pub type CommandBufferInheritanceRenderingInfoKHR = CommandBufferInheritanceRenderingInfo;
 pub type AttachmentSampleCountInfoNV = AttachmentSampleCountInfoAMD;

--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -647,10 +647,10 @@ impl IndirectStateFlagsNV {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPrivateDataSlotCreateFlagBitsEXT.html>"]
-pub struct PrivateDataSlotCreateFlagsEXT(pub(crate) Flags);
-vk_bitflags_wrapped!(PrivateDataSlotCreateFlagsEXT, Flags);
-impl PrivateDataSlotCreateFlagsEXT {}
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPrivateDataSlotCreateFlagBits.html>"]
+pub struct PrivateDataSlotCreateFlags(pub(crate) Flags);
+vk_bitflags_wrapped!(PrivateDataSlotCreateFlags, Flags);
+impl PrivateDataSlotCreateFlags {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDescriptorSetLayoutCreateFlagBits.html>"]
@@ -909,13 +909,16 @@ impl DeviceDiagnosticsConfigFlagsNV {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineCreationFeedbackFlagBitsEXT.html>"]
-pub struct PipelineCreationFeedbackFlagsEXT(pub(crate) Flags);
-vk_bitflags_wrapped!(PipelineCreationFeedbackFlagsEXT, Flags);
-impl PipelineCreationFeedbackFlagsEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineCreationFeedbackFlagBits.html>"]
+pub struct PipelineCreationFeedbackFlags(pub(crate) Flags);
+vk_bitflags_wrapped!(PipelineCreationFeedbackFlags, Flags);
+impl PipelineCreationFeedbackFlags {
     pub const VALID: Self = Self(0b1);
+    pub const VALID_EXT: Self = Self::VALID;
     pub const APPLICATION_PIPELINE_CACHE_HIT: Self = Self(0b10);
+    pub const APPLICATION_PIPELINE_CACHE_HIT_EXT: Self = Self::APPLICATION_PIPELINE_CACHE_HIT;
     pub const BASE_PIPELINE_ACCELERATION: Self = Self(0b100);
+    pub const BASE_PIPELINE_ACCELERATION_EXT: Self = Self::BASE_PIPELINE_ACCELERATION;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -952,86 +955,139 @@ vk_bitflags_wrapped!(PipelineCompilerControlFlagsAMD, Flags);
 impl PipelineCompilerControlFlagsAMD {}
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkToolPurposeFlagBitsEXT.html>"]
-pub struct ToolPurposeFlagsEXT(pub(crate) Flags);
-vk_bitflags_wrapped!(ToolPurposeFlagsEXT, Flags);
-impl ToolPurposeFlagsEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkToolPurposeFlagBits.html>"]
+pub struct ToolPurposeFlags(pub(crate) Flags);
+vk_bitflags_wrapped!(ToolPurposeFlags, Flags);
+impl ToolPurposeFlags {
     pub const VALIDATION: Self = Self(0b1);
+    pub const VALIDATION_EXT: Self = Self::VALIDATION;
     pub const PROFILING: Self = Self(0b10);
+    pub const PROFILING_EXT: Self = Self::PROFILING;
     pub const TRACING: Self = Self(0b100);
+    pub const TRACING_EXT: Self = Self::TRACING;
     pub const ADDITIONAL_FEATURES: Self = Self(0b1000);
+    pub const ADDITIONAL_FEATURES_EXT: Self = Self::ADDITIONAL_FEATURES;
     pub const MODIFYING_FEATURES: Self = Self(0b1_0000);
+    pub const MODIFYING_FEATURES_EXT: Self = Self::MODIFYING_FEATURES;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkAccessFlagBits2KHR.html>"]
-pub struct AccessFlags2KHR(pub(crate) Flags64);
-vk_bitflags_wrapped!(AccessFlags2KHR, Flags64);
-impl AccessFlags2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkAccessFlagBits2.html>"]
+pub struct AccessFlags2(pub(crate) Flags64);
+vk_bitflags_wrapped!(AccessFlags2, Flags64);
+impl AccessFlags2 {
     pub const NONE: Self = Self(0);
+    pub const NONE_KHR: Self = Self::NONE;
     pub const INDIRECT_COMMAND_READ: Self = Self(0b1);
+    pub const INDIRECT_COMMAND_READ_KHR: Self = Self::INDIRECT_COMMAND_READ;
     pub const INDEX_READ: Self = Self(0b10);
+    pub const INDEX_READ_KHR: Self = Self::INDEX_READ;
     pub const VERTEX_ATTRIBUTE_READ: Self = Self(0b100);
+    pub const VERTEX_ATTRIBUTE_READ_KHR: Self = Self::VERTEX_ATTRIBUTE_READ;
     pub const UNIFORM_READ: Self = Self(0b1000);
+    pub const UNIFORM_READ_KHR: Self = Self::UNIFORM_READ;
     pub const INPUT_ATTACHMENT_READ: Self = Self(0b1_0000);
+    pub const INPUT_ATTACHMENT_READ_KHR: Self = Self::INPUT_ATTACHMENT_READ;
     pub const SHADER_READ: Self = Self(0b10_0000);
+    pub const SHADER_READ_KHR: Self = Self::SHADER_READ;
     pub const SHADER_WRITE: Self = Self(0b100_0000);
+    pub const SHADER_WRITE_KHR: Self = Self::SHADER_WRITE;
     pub const COLOR_ATTACHMENT_READ: Self = Self(0b1000_0000);
+    pub const COLOR_ATTACHMENT_READ_KHR: Self = Self::COLOR_ATTACHMENT_READ;
     pub const COLOR_ATTACHMENT_WRITE: Self = Self(0b1_0000_0000);
+    pub const COLOR_ATTACHMENT_WRITE_KHR: Self = Self::COLOR_ATTACHMENT_WRITE;
     pub const DEPTH_STENCIL_ATTACHMENT_READ: Self = Self(0b10_0000_0000);
+    pub const DEPTH_STENCIL_ATTACHMENT_READ_KHR: Self = Self::DEPTH_STENCIL_ATTACHMENT_READ;
     pub const DEPTH_STENCIL_ATTACHMENT_WRITE: Self = Self(0b100_0000_0000);
+    pub const DEPTH_STENCIL_ATTACHMENT_WRITE_KHR: Self = Self::DEPTH_STENCIL_ATTACHMENT_WRITE;
     pub const TRANSFER_READ: Self = Self(0b1000_0000_0000);
+    pub const TRANSFER_READ_KHR: Self = Self::TRANSFER_READ;
     pub const TRANSFER_WRITE: Self = Self(0b1_0000_0000_0000);
+    pub const TRANSFER_WRITE_KHR: Self = Self::TRANSFER_WRITE;
     pub const HOST_READ: Self = Self(0b10_0000_0000_0000);
+    pub const HOST_READ_KHR: Self = Self::HOST_READ;
     pub const HOST_WRITE: Self = Self(0b100_0000_0000_0000);
+    pub const HOST_WRITE_KHR: Self = Self::HOST_WRITE;
     pub const MEMORY_READ: Self = Self(0b1000_0000_0000_0000);
+    pub const MEMORY_READ_KHR: Self = Self::MEMORY_READ;
     pub const MEMORY_WRITE: Self = Self(0b1_0000_0000_0000_0000);
+    pub const MEMORY_WRITE_KHR: Self = Self::MEMORY_WRITE;
     pub const SHADER_SAMPLED_READ: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const SHADER_SAMPLED_READ_KHR: Self = Self::SHADER_SAMPLED_READ;
     pub const SHADER_STORAGE_READ: Self = Self(0b10_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const SHADER_STORAGE_READ_KHR: Self = Self::SHADER_STORAGE_READ;
     pub const SHADER_STORAGE_WRITE: Self = Self(0b100_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const SHADER_STORAGE_WRITE_KHR: Self = Self::SHADER_STORAGE_WRITE;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineStageFlagBits2KHR.html>"]
-pub struct PipelineStageFlags2KHR(pub(crate) Flags64);
-vk_bitflags_wrapped!(PipelineStageFlags2KHR, Flags64);
-impl PipelineStageFlags2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineStageFlagBits2.html>"]
+pub struct PipelineStageFlags2(pub(crate) Flags64);
+vk_bitflags_wrapped!(PipelineStageFlags2, Flags64);
+impl PipelineStageFlags2 {
     pub const NONE: Self = Self(0);
+    pub const NONE_KHR: Self = Self::NONE;
     pub const TOP_OF_PIPE: Self = Self(0b1);
+    pub const TOP_OF_PIPE_KHR: Self = Self::TOP_OF_PIPE;
     pub const DRAW_INDIRECT: Self = Self(0b10);
+    pub const DRAW_INDIRECT_KHR: Self = Self::DRAW_INDIRECT;
     pub const VERTEX_INPUT: Self = Self(0b100);
+    pub const VERTEX_INPUT_KHR: Self = Self::VERTEX_INPUT;
     pub const VERTEX_SHADER: Self = Self(0b1000);
+    pub const VERTEX_SHADER_KHR: Self = Self::VERTEX_SHADER;
     pub const TESSELLATION_CONTROL_SHADER: Self = Self(0b1_0000);
+    pub const TESSELLATION_CONTROL_SHADER_KHR: Self = Self::TESSELLATION_CONTROL_SHADER;
     pub const TESSELLATION_EVALUATION_SHADER: Self = Self(0b10_0000);
+    pub const TESSELLATION_EVALUATION_SHADER_KHR: Self = Self::TESSELLATION_EVALUATION_SHADER;
     pub const GEOMETRY_SHADER: Self = Self(0b100_0000);
+    pub const GEOMETRY_SHADER_KHR: Self = Self::GEOMETRY_SHADER;
     pub const FRAGMENT_SHADER: Self = Self(0b1000_0000);
+    pub const FRAGMENT_SHADER_KHR: Self = Self::FRAGMENT_SHADER;
     pub const EARLY_FRAGMENT_TESTS: Self = Self(0b1_0000_0000);
+    pub const EARLY_FRAGMENT_TESTS_KHR: Self = Self::EARLY_FRAGMENT_TESTS;
     pub const LATE_FRAGMENT_TESTS: Self = Self(0b10_0000_0000);
+    pub const LATE_FRAGMENT_TESTS_KHR: Self = Self::LATE_FRAGMENT_TESTS;
     pub const COLOR_ATTACHMENT_OUTPUT: Self = Self(0b100_0000_0000);
+    pub const COLOR_ATTACHMENT_OUTPUT_KHR: Self = Self::COLOR_ATTACHMENT_OUTPUT;
     pub const COMPUTE_SHADER: Self = Self(0b1000_0000_0000);
+    pub const COMPUTE_SHADER_KHR: Self = Self::COMPUTE_SHADER;
     pub const ALL_TRANSFER: Self = Self(0b1_0000_0000_0000);
-    pub const TRANSFER: Self = Self::ALL_TRANSFER;
+    pub const ALL_TRANSFER_KHR: Self = Self::ALL_TRANSFER;
+    pub const TRANSFER: Self = Self::ALL_TRANSFER_KHR;
+    pub const TRANSFER_KHR: Self = Self::TRANSFER;
     pub const BOTTOM_OF_PIPE: Self = Self(0b10_0000_0000_0000);
+    pub const BOTTOM_OF_PIPE_KHR: Self = Self::BOTTOM_OF_PIPE;
     pub const HOST: Self = Self(0b100_0000_0000_0000);
+    pub const HOST_KHR: Self = Self::HOST;
     pub const ALL_GRAPHICS: Self = Self(0b1000_0000_0000_0000);
+    pub const ALL_GRAPHICS_KHR: Self = Self::ALL_GRAPHICS;
     pub const ALL_COMMANDS: Self = Self(0b1_0000_0000_0000_0000);
+    pub const ALL_COMMANDS_KHR: Self = Self::ALL_COMMANDS;
     pub const COPY: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const COPY_KHR: Self = Self::COPY;
     pub const RESOLVE: Self = Self(0b10_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const RESOLVE_KHR: Self = Self::RESOLVE;
     pub const BLIT: Self = Self(0b100_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const BLIT_KHR: Self = Self::BLIT;
     pub const CLEAR: Self = Self(0b1000_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const CLEAR_KHR: Self = Self::CLEAR;
     pub const INDEX_INPUT: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const INDEX_INPUT_KHR: Self = Self::INDEX_INPUT;
     pub const VERTEX_ATTRIBUTE_INPUT: Self =
         Self(0b10_0000_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const VERTEX_ATTRIBUTE_INPUT_KHR: Self = Self::VERTEX_ATTRIBUTE_INPUT;
     pub const PRE_RASTERIZATION_SHADERS: Self =
         Self(0b100_0000_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const PRE_RASTERIZATION_SHADERS_KHR: Self = Self::PRE_RASTERIZATION_SHADERS;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSubmitFlagBitsKHR.html>"]
-pub struct SubmitFlagsKHR(pub(crate) Flags);
-vk_bitflags_wrapped!(SubmitFlagsKHR, Flags);
-impl SubmitFlagsKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSubmitFlagBits.html>"]
+pub struct SubmitFlags(pub(crate) Flags);
+vk_bitflags_wrapped!(SubmitFlags, Flags);
+impl SubmitFlags {
     pub const PROTECTED: Self = Self(0b1);
+    pub const PROTECTED_KHR: Self = Self::PROTECTED;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1249,42 +1305,87 @@ impl ImageConstraintsInfoFlagsFUCHSIA {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkFormatFeatureFlagBits2KHR.html>"]
-pub struct FormatFeatureFlags2KHR(pub(crate) Flags64);
-vk_bitflags_wrapped!(FormatFeatureFlags2KHR, Flags64);
-impl FormatFeatureFlags2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkFormatFeatureFlagBits2.html>"]
+pub struct FormatFeatureFlags2(pub(crate) Flags64);
+vk_bitflags_wrapped!(FormatFeatureFlags2, Flags64);
+impl FormatFeatureFlags2 {
     pub const SAMPLED_IMAGE: Self = Self(0b1);
+    pub const SAMPLED_IMAGE_KHR: Self = Self::SAMPLED_IMAGE;
     pub const STORAGE_IMAGE: Self = Self(0b10);
+    pub const STORAGE_IMAGE_KHR: Self = Self::STORAGE_IMAGE;
     pub const STORAGE_IMAGE_ATOMIC: Self = Self(0b100);
+    pub const STORAGE_IMAGE_ATOMIC_KHR: Self = Self::STORAGE_IMAGE_ATOMIC;
     pub const UNIFORM_TEXEL_BUFFER: Self = Self(0b1000);
+    pub const UNIFORM_TEXEL_BUFFER_KHR: Self = Self::UNIFORM_TEXEL_BUFFER;
     pub const STORAGE_TEXEL_BUFFER: Self = Self(0b1_0000);
+    pub const STORAGE_TEXEL_BUFFER_KHR: Self = Self::STORAGE_TEXEL_BUFFER;
     pub const STORAGE_TEXEL_BUFFER_ATOMIC: Self = Self(0b10_0000);
+    pub const STORAGE_TEXEL_BUFFER_ATOMIC_KHR: Self = Self::STORAGE_TEXEL_BUFFER_ATOMIC;
     pub const VERTEX_BUFFER: Self = Self(0b100_0000);
+    pub const VERTEX_BUFFER_KHR: Self = Self::VERTEX_BUFFER;
     pub const COLOR_ATTACHMENT: Self = Self(0b1000_0000);
+    pub const COLOR_ATTACHMENT_KHR: Self = Self::COLOR_ATTACHMENT;
     pub const COLOR_ATTACHMENT_BLEND: Self = Self(0b1_0000_0000);
+    pub const COLOR_ATTACHMENT_BLEND_KHR: Self = Self::COLOR_ATTACHMENT_BLEND;
     pub const DEPTH_STENCIL_ATTACHMENT: Self = Self(0b10_0000_0000);
+    pub const DEPTH_STENCIL_ATTACHMENT_KHR: Self = Self::DEPTH_STENCIL_ATTACHMENT;
     pub const BLIT_SRC: Self = Self(0b100_0000_0000);
+    pub const BLIT_SRC_KHR: Self = Self::BLIT_SRC;
     pub const BLIT_DST: Self = Self(0b1000_0000_0000);
+    pub const BLIT_DST_KHR: Self = Self::BLIT_DST;
     pub const SAMPLED_IMAGE_FILTER_LINEAR: Self = Self(0b1_0000_0000_0000);
-    pub const SAMPLED_IMAGE_FILTER_CUBIC_EXT: Self = Self(0b10_0000_0000_0000);
+    pub const SAMPLED_IMAGE_FILTER_LINEAR_KHR: Self = Self::SAMPLED_IMAGE_FILTER_LINEAR;
+    pub const SAMPLED_IMAGE_FILTER_CUBIC: Self = Self(0b10_0000_0000_0000);
+    pub const SAMPLED_IMAGE_FILTER_CUBIC_EXT: Self = Self::SAMPLED_IMAGE_FILTER_CUBIC;
     pub const TRANSFER_SRC: Self = Self(0b100_0000_0000_0000);
+    pub const TRANSFER_SRC_KHR: Self = Self::TRANSFER_SRC;
     pub const TRANSFER_DST: Self = Self(0b1000_0000_0000_0000);
+    pub const TRANSFER_DST_KHR: Self = Self::TRANSFER_DST;
     pub const SAMPLED_IMAGE_FILTER_MINMAX: Self = Self(0b1_0000_0000_0000_0000);
+    pub const SAMPLED_IMAGE_FILTER_MINMAX_KHR: Self = Self::SAMPLED_IMAGE_FILTER_MINMAX;
     pub const MIDPOINT_CHROMA_SAMPLES: Self = Self(0b10_0000_0000_0000_0000);
+    pub const MIDPOINT_CHROMA_SAMPLES_KHR: Self = Self::MIDPOINT_CHROMA_SAMPLES;
     pub const SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER: Self = Self(0b100_0000_0000_0000_0000);
+    pub const SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_KHR: Self =
+        Self::SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER;
     pub const SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER: Self =
         Self(0b1000_0000_0000_0000_0000);
+    pub const SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_KHR: Self =
+        Self::SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER;
     pub const SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT: Self =
         Self(0b1_0000_0000_0000_0000_0000);
+    pub const SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_KHR: Self =
+        Self::SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT;
     pub const SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE: Self =
         Self(0b10_0000_0000_0000_0000_0000);
+    pub const SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_KHR: Self =
+        Self::SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE;
     pub const DISJOINT: Self = Self(0b100_0000_0000_0000_0000_0000);
+    pub const DISJOINT_KHR: Self = Self::DISJOINT;
     pub const COSITED_CHROMA_SAMPLES: Self = Self(0b1000_0000_0000_0000_0000_0000);
+    pub const COSITED_CHROMA_SAMPLES_KHR: Self = Self::COSITED_CHROMA_SAMPLES;
     pub const STORAGE_READ_WITHOUT_FORMAT: Self = Self(0b1000_0000_0000_0000_0000_0000_0000_0000);
+    pub const STORAGE_READ_WITHOUT_FORMAT_KHR: Self = Self::STORAGE_READ_WITHOUT_FORMAT;
     pub const STORAGE_WRITE_WITHOUT_FORMAT: Self =
         Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const STORAGE_WRITE_WITHOUT_FORMAT_KHR: Self = Self::STORAGE_WRITE_WITHOUT_FORMAT;
     pub const SAMPLED_IMAGE_DEPTH_COMPARISON: Self =
         Self(0b10_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const SAMPLED_IMAGE_DEPTH_COMPARISON_KHR: Self = Self::SAMPLED_IMAGE_DEPTH_COMPARISON;
+}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkRenderingFlagBits.html>"]
+pub struct RenderingFlags(pub(crate) Flags);
+vk_bitflags_wrapped!(RenderingFlags, Flags);
+impl RenderingFlags {
+    pub const CONTENTS_SECONDARY_COMMAND_BUFFERS: Self = Self(0b1);
+    pub const CONTENTS_SECONDARY_COMMAND_BUFFERS_KHR: Self =
+        Self::CONTENTS_SECONDARY_COMMAND_BUFFERS;
+    pub const SUSPENDING: Self = Self(0b10);
+    pub const SUSPENDING_KHR: Self = Self::SUSPENDING;
+    pub const RESUMING: Self = Self(0b100);
+    pub const RESUMING_KHR: Self = Self::RESUMING;
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1293,7 +1394,7 @@ pub struct VideoEncodeH265InputModeFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(VideoEncodeH265InputModeFlagsEXT, Flags);
 impl VideoEncodeH265InputModeFlagsEXT {
     pub const FRAME: Self = Self(0b1);
-    pub const SLICE: Self = Self(0b10);
+    pub const SLICE_SEGMENT: Self = Self(0b10);
     pub const NON_VCL: Self = Self(0b100);
 }
 #[repr(transparent)]
@@ -1303,7 +1404,7 @@ pub struct VideoEncodeH265OutputModeFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(VideoEncodeH265OutputModeFlagsEXT, Flags);
 impl VideoEncodeH265OutputModeFlagsEXT {
     pub const FRAME: Self = Self(0b1);
-    pub const SLICE: Self = Self(0b10);
+    pub const SLICE_SEGMENT: Self = Self(0b10);
     pub const NON_VCL: Self = Self(0b100);
 }
 #[repr(transparent)]
@@ -1316,16 +1417,6 @@ impl VideoEncodeH265CtbSizeFlagsEXT {
     pub const TYPE_16: Self = Self(0b10);
     pub const TYPE_32: Self = Self(0b100);
     pub const TYPE_64: Self = Self(0b1000);
-}
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkRenderingFlagBitsKHR.html>"]
-pub struct RenderingFlagsKHR(pub(crate) Flags);
-vk_bitflags_wrapped!(RenderingFlagsKHR, Flags);
-impl RenderingFlagsKHR {
-    pub const CONTENTS_SECONDARY_COMMAND_BUFFERS: Self = Self(0b1);
-    pub const SUSPENDING: Self = Self(0b10);
-    pub const RESUMING: Self = Self(0b100);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -1211,6 +1211,15 @@ impl VideoEncodeFlagsKHR {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeCapabilityFlagBitsKHR.html>"]
+pub struct VideoEncodeCapabilityFlagsKHR(pub(crate) Flags);
+vk_bitflags_wrapped!(VideoEncodeCapabilityFlagsKHR, Flags);
+impl VideoEncodeCapabilityFlagsKHR {
+    pub const DEFAULT: Self = Self(0);
+    pub const PRECEDING_EXTERNALLY_ENCODED_BYTES: Self = Self(0b1);
+}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeRateControlFlagBitsKHR.html>"]
 pub struct VideoEncodeRateControlFlagsKHR(pub(crate) Flags);
 vk_bitflags_wrapped!(VideoEncodeRateControlFlagsKHR, Flags);
@@ -1234,17 +1243,29 @@ impl VideoEncodeRateControlModeFlagsKHR {
 pub struct VideoEncodeH264CapabilityFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(VideoEncodeH264CapabilityFlagsEXT, Flags);
 impl VideoEncodeH264CapabilityFlagsEXT {
-    pub const CABAC: Self = Self(0b1);
-    pub const CAVLC: Self = Self(0b10);
-    pub const WEIGHTED_BI_PRED_IMPLICIT: Self = Self(0b100);
-    pub const TRANSFORM_8X8: Self = Self(0b1000);
-    pub const CHROMA_QP_OFFSET: Self = Self(0b1_0000);
-    pub const SECOND_CHROMA_QP_OFFSET: Self = Self(0b10_0000);
-    pub const DEBLOCKING_FILTER_DISABLED: Self = Self(0b100_0000);
-    pub const DEBLOCKING_FILTER_ENABLED: Self = Self(0b1000_0000);
-    pub const DEBLOCKING_FILTER_PARTIAL: Self = Self(0b1_0000_0000);
-    pub const MULTIPLE_SLICE_PER_FRAME: Self = Self(0b10_0000_0000);
-    pub const EVENLY_DISTRIBUTED_SLICE_SIZE: Self = Self(0b100_0000_0000);
+    pub const DIRECT_8X8_INFERENCE: Self = Self(0b1);
+    pub const SEPARATE_COLOUR_PLANE: Self = Self(0b10);
+    pub const QPPRIME_Y_ZERO_TRANSFORM_BYPASS: Self = Self(0b100);
+    pub const SCALING_LISTS: Self = Self(0b1000);
+    pub const HRD_COMPLIANCE: Self = Self(0b1_0000);
+    pub const CHROMA_QP_OFFSET: Self = Self(0b10_0000);
+    pub const SECOND_CHROMA_QP_OFFSET: Self = Self(0b100_0000);
+    pub const PIC_INIT_QP_MINUS26: Self = Self(0b1000_0000);
+    pub const WEIGHTED_PRED: Self = Self(0b1_0000_0000);
+    pub const WEIGHTED_BIPRED_EXPLICIT: Self = Self(0b10_0000_0000);
+    pub const WEIGHTED_BIPRED_IMPLICIT: Self = Self(0b100_0000_0000);
+    pub const WEIGHTED_PRED_NO_TABLE: Self = Self(0b1000_0000_0000);
+    pub const TRANSFORM_8X8: Self = Self(0b1_0000_0000_0000);
+    pub const CABAC: Self = Self(0b10_0000_0000_0000);
+    pub const CAVLC: Self = Self(0b100_0000_0000_0000);
+    pub const DEBLOCKING_FILTER_DISABLED: Self = Self(0b1000_0000_0000_0000);
+    pub const DEBLOCKING_FILTER_ENABLED: Self = Self(0b1_0000_0000_0000_0000);
+    pub const DEBLOCKING_FILTER_PARTIAL: Self = Self(0b10_0000_0000_0000_0000);
+    pub const DISABLE_DIRECT_SPATIAL_MV_PRED: Self = Self(0b100_0000_0000_0000_0000);
+    pub const MULTIPLE_SLICE_PER_FRAME: Self = Self(0b1000_0000_0000_0000_0000);
+    pub const SLICE_MB_COUNT: Self = Self(0b1_0000_0000_0000_0000_0000);
+    pub const ROW_UNALIGNED_SLICE: Self = Self(0b10_0000_0000_0000_0000_0000);
+    pub const DIFFERENT_SLICE_TYPE: Self = Self(0b100_0000_0000_0000_0000_0000);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1389,6 +1410,37 @@ impl RenderingFlags {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265CapabilityFlagBitsEXT.html>"]
+pub struct VideoEncodeH265CapabilityFlagsEXT(pub(crate) Flags);
+vk_bitflags_wrapped!(VideoEncodeH265CapabilityFlagsEXT, Flags);
+impl VideoEncodeH265CapabilityFlagsEXT {
+    pub const SEPARATE_COLOUR_PLANE: Self = Self(0b1);
+    pub const SCALING_LISTS: Self = Self(0b10);
+    pub const SAMPLE_ADAPTIVE_OFFSET_ENABLED: Self = Self(0b100);
+    pub const PCM_ENABLE: Self = Self(0b1000);
+    pub const SPS_TEMPORAL_MVP_ENABLED: Self = Self(0b1_0000);
+    pub const HRD_COMPLIANCE: Self = Self(0b10_0000);
+    pub const INIT_QP_MINUS26: Self = Self(0b100_0000);
+    pub const LOG2_PARALLEL_MERGE_LEVEL_MINUS2: Self = Self(0b1000_0000);
+    pub const SIGN_DATA_HIDING_ENABLED: Self = Self(0b1_0000_0000);
+    pub const TRANSFORM_SKIP_ENABLED: Self = Self(0b10_0000_0000);
+    pub const PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT: Self = Self(0b100_0000_0000);
+    pub const WEIGHTED_PRED: Self = Self(0b1000_0000_0000);
+    pub const WEIGHTED_BIPRED: Self = Self(0b1_0000_0000_0000);
+    pub const WEIGHTED_PRED_NO_TABLE: Self = Self(0b10_0000_0000_0000);
+    pub const TRANSQUANT_BYPASS_ENABLED: Self = Self(0b100_0000_0000_0000);
+    pub const ENTROPY_CODING_SYNC_ENABLED: Self = Self(0b1000_0000_0000_0000);
+    pub const DEBLOCKING_FILTER_OVERRIDE_ENABLED: Self = Self(0b1_0000_0000_0000_0000);
+    pub const MULTIPLE_TILE_PER_FRAME: Self = Self(0b10_0000_0000_0000_0000);
+    pub const MULTIPLE_SLICE_PER_TILE: Self = Self(0b100_0000_0000_0000_0000);
+    pub const MULTIPLE_TILE_PER_SLICE: Self = Self(0b1000_0000_0000_0000_0000);
+    pub const SLICE_SEGMENT_CTB_COUNT: Self = Self(0b1_0000_0000_0000_0000_0000);
+    pub const ROW_UNALIGNED_SLICE_SEGMENT: Self = Self(0b10_0000_0000_0000_0000_0000);
+    pub const DEPENDENT_SLICE_SEGMENT: Self = Self(0b100_0000_0000_0000_0000_0000);
+    pub const DIFFERENT_SLICE_TYPE: Self = Self(0b1000_0000_0000_0000_0000_0000);
+}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265InputModeFlagBitsEXT.html>"]
 pub struct VideoEncodeH265InputModeFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(VideoEncodeH265InputModeFlagsEXT, Flags);
@@ -1409,17 +1461,6 @@ impl VideoEncodeH265OutputModeFlagsEXT {
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265CtbSizeFlagBitsEXT.html>"]
-pub struct VideoEncodeH265CtbSizeFlagsEXT(pub(crate) Flags);
-vk_bitflags_wrapped!(VideoEncodeH265CtbSizeFlagsEXT, Flags);
-impl VideoEncodeH265CtbSizeFlagsEXT {
-    pub const TYPE_8: Self = Self(0b1);
-    pub const TYPE_16: Self = Self(0b10);
-    pub const TYPE_32: Self = Self(0b100);
-    pub const TYPE_64: Self = Self(0b1000);
-}
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265RateControlStructureFlagBitsEXT.html>"]
 pub struct VideoEncodeH265RateControlStructureFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(VideoEncodeH265RateControlStructureFlagsEXT, Flags);
@@ -1427,4 +1468,25 @@ impl VideoEncodeH265RateControlStructureFlagsEXT {
     pub const UNKNOWN: Self = Self(0);
     pub const FLAT: Self = Self(0b1);
     pub const DYADIC: Self = Self(0b10);
+}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265CtbSizeFlagBitsEXT.html>"]
+pub struct VideoEncodeH265CtbSizeFlagsEXT(pub(crate) Flags);
+vk_bitflags_wrapped!(VideoEncodeH265CtbSizeFlagsEXT, Flags);
+impl VideoEncodeH265CtbSizeFlagsEXT {
+    pub const TYPE_16: Self = Self(0b1);
+    pub const TYPE_32: Self = Self(0b10);
+    pub const TYPE_64: Self = Self(0b100);
+}
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265TransformBlockSizeFlagBitsEXT.html>"]
+pub struct VideoEncodeH265TransformBlockSizeFlagsEXT(pub(crate) Flags);
+vk_bitflags_wrapped!(VideoEncodeH265TransformBlockSizeFlagsEXT, Flags);
+impl VideoEncodeH265TransformBlockSizeFlagsEXT {
+    pub const TYPE_4: Self = Self(0b1);
+    pub const TYPE_8: Self = Self(0b10);
+    pub const TYPE_16: Self = Self(0b100);
+    pub const TYPE_32: Self = Self(0b1000);
 }

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -189,119 +189,122 @@ impl fmt::Debug for AccessFlags {
                 AccessFlags::COMMAND_PREPROCESS_WRITE_NV.0,
                 "COMMAND_PREPROCESS_WRITE_NV",
             ),
-            (AccessFlags::NONE_KHR.0, "NONE_KHR"),
+            (AccessFlags::NONE.0, "NONE"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for AccessFlags2KHR {
+impl fmt::Debug for AccessFlags2 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags64, &str)] = &[
-            (AccessFlags2KHR::NONE.0, "NONE"),
+            (AccessFlags2::NONE.0, "NONE"),
             (
-                AccessFlags2KHR::INDIRECT_COMMAND_READ.0,
+                AccessFlags2::INDIRECT_COMMAND_READ.0,
                 "INDIRECT_COMMAND_READ",
             ),
-            (AccessFlags2KHR::INDEX_READ.0, "INDEX_READ"),
+            (AccessFlags2::INDEX_READ.0, "INDEX_READ"),
             (
-                AccessFlags2KHR::VERTEX_ATTRIBUTE_READ.0,
+                AccessFlags2::VERTEX_ATTRIBUTE_READ.0,
                 "VERTEX_ATTRIBUTE_READ",
             ),
-            (AccessFlags2KHR::UNIFORM_READ.0, "UNIFORM_READ"),
+            (AccessFlags2::UNIFORM_READ.0, "UNIFORM_READ"),
             (
-                AccessFlags2KHR::INPUT_ATTACHMENT_READ.0,
+                AccessFlags2::INPUT_ATTACHMENT_READ.0,
                 "INPUT_ATTACHMENT_READ",
             ),
-            (AccessFlags2KHR::SHADER_READ.0, "SHADER_READ"),
-            (AccessFlags2KHR::SHADER_WRITE.0, "SHADER_WRITE"),
+            (AccessFlags2::SHADER_READ.0, "SHADER_READ"),
+            (AccessFlags2::SHADER_WRITE.0, "SHADER_WRITE"),
             (
-                AccessFlags2KHR::COLOR_ATTACHMENT_READ.0,
+                AccessFlags2::COLOR_ATTACHMENT_READ.0,
                 "COLOR_ATTACHMENT_READ",
             ),
             (
-                AccessFlags2KHR::COLOR_ATTACHMENT_WRITE.0,
+                AccessFlags2::COLOR_ATTACHMENT_WRITE.0,
                 "COLOR_ATTACHMENT_WRITE",
             ),
             (
-                AccessFlags2KHR::DEPTH_STENCIL_ATTACHMENT_READ.0,
+                AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ.0,
                 "DEPTH_STENCIL_ATTACHMENT_READ",
             ),
             (
-                AccessFlags2KHR::DEPTH_STENCIL_ATTACHMENT_WRITE.0,
+                AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE.0,
                 "DEPTH_STENCIL_ATTACHMENT_WRITE",
             ),
-            (AccessFlags2KHR::TRANSFER_READ.0, "TRANSFER_READ"),
-            (AccessFlags2KHR::TRANSFER_WRITE.0, "TRANSFER_WRITE"),
-            (AccessFlags2KHR::HOST_READ.0, "HOST_READ"),
-            (AccessFlags2KHR::HOST_WRITE.0, "HOST_WRITE"),
-            (AccessFlags2KHR::MEMORY_READ.0, "MEMORY_READ"),
-            (AccessFlags2KHR::MEMORY_WRITE.0, "MEMORY_WRITE"),
+            (AccessFlags2::TRANSFER_READ.0, "TRANSFER_READ"),
+            (AccessFlags2::TRANSFER_WRITE.0, "TRANSFER_WRITE"),
+            (AccessFlags2::HOST_READ.0, "HOST_READ"),
+            (AccessFlags2::HOST_WRITE.0, "HOST_WRITE"),
+            (AccessFlags2::MEMORY_READ.0, "MEMORY_READ"),
+            (AccessFlags2::MEMORY_WRITE.0, "MEMORY_WRITE"),
+            (AccessFlags2::SHADER_SAMPLED_READ.0, "SHADER_SAMPLED_READ"),
+            (AccessFlags2::SHADER_STORAGE_READ.0, "SHADER_STORAGE_READ"),
+            (AccessFlags2::SHADER_STORAGE_WRITE.0, "SHADER_STORAGE_WRITE"),
             (
-                AccessFlags2KHR::SHADER_SAMPLED_READ.0,
-                "SHADER_SAMPLED_READ",
+                AccessFlags2::VIDEO_DECODE_READ_KHR.0,
+                "VIDEO_DECODE_READ_KHR",
             ),
             (
-                AccessFlags2KHR::SHADER_STORAGE_READ.0,
-                "SHADER_STORAGE_READ",
+                AccessFlags2::VIDEO_DECODE_WRITE_KHR.0,
+                "VIDEO_DECODE_WRITE_KHR",
             ),
             (
-                AccessFlags2KHR::SHADER_STORAGE_WRITE.0,
-                "SHADER_STORAGE_WRITE",
+                AccessFlags2::VIDEO_ENCODE_READ_KHR.0,
+                "VIDEO_ENCODE_READ_KHR",
             ),
-            (AccessFlags2KHR::VIDEO_DECODE_READ.0, "VIDEO_DECODE_READ"),
-            (AccessFlags2KHR::VIDEO_DECODE_WRITE.0, "VIDEO_DECODE_WRITE"),
-            (AccessFlags2KHR::VIDEO_ENCODE_READ.0, "VIDEO_ENCODE_READ"),
-            (AccessFlags2KHR::VIDEO_ENCODE_WRITE.0, "VIDEO_ENCODE_WRITE"),
             (
-                AccessFlags2KHR::TRANSFORM_FEEDBACK_WRITE_EXT.0,
+                AccessFlags2::VIDEO_ENCODE_WRITE_KHR.0,
+                "VIDEO_ENCODE_WRITE_KHR",
+            ),
+            (
+                AccessFlags2::TRANSFORM_FEEDBACK_WRITE_EXT.0,
                 "TRANSFORM_FEEDBACK_WRITE_EXT",
             ),
             (
-                AccessFlags2KHR::TRANSFORM_FEEDBACK_COUNTER_READ_EXT.0,
+                AccessFlags2::TRANSFORM_FEEDBACK_COUNTER_READ_EXT.0,
                 "TRANSFORM_FEEDBACK_COUNTER_READ_EXT",
             ),
             (
-                AccessFlags2KHR::TRANSFORM_FEEDBACK_COUNTER_WRITE_EXT.0,
+                AccessFlags2::TRANSFORM_FEEDBACK_COUNTER_WRITE_EXT.0,
                 "TRANSFORM_FEEDBACK_COUNTER_WRITE_EXT",
             ),
             (
-                AccessFlags2KHR::CONDITIONAL_RENDERING_READ_EXT.0,
+                AccessFlags2::CONDITIONAL_RENDERING_READ_EXT.0,
                 "CONDITIONAL_RENDERING_READ_EXT",
             ),
             (
-                AccessFlags2KHR::COMMAND_PREPROCESS_READ_NV.0,
+                AccessFlags2::COMMAND_PREPROCESS_READ_NV.0,
                 "COMMAND_PREPROCESS_READ_NV",
             ),
             (
-                AccessFlags2KHR::COMMAND_PREPROCESS_WRITE_NV.0,
+                AccessFlags2::COMMAND_PREPROCESS_WRITE_NV.0,
                 "COMMAND_PREPROCESS_WRITE_NV",
             ),
             (
-                AccessFlags2KHR::FRAGMENT_SHADING_RATE_ATTACHMENT_READ.0,
-                "FRAGMENT_SHADING_RATE_ATTACHMENT_READ",
+                AccessFlags2::FRAGMENT_SHADING_RATE_ATTACHMENT_READ_KHR.0,
+                "FRAGMENT_SHADING_RATE_ATTACHMENT_READ_KHR",
             ),
             (
-                AccessFlags2KHR::ACCELERATION_STRUCTURE_READ.0,
-                "ACCELERATION_STRUCTURE_READ",
+                AccessFlags2::ACCELERATION_STRUCTURE_READ_KHR.0,
+                "ACCELERATION_STRUCTURE_READ_KHR",
             ),
             (
-                AccessFlags2KHR::ACCELERATION_STRUCTURE_WRITE.0,
-                "ACCELERATION_STRUCTURE_WRITE",
+                AccessFlags2::ACCELERATION_STRUCTURE_WRITE_KHR.0,
+                "ACCELERATION_STRUCTURE_WRITE_KHR",
             ),
             (
-                AccessFlags2KHR::FRAGMENT_DENSITY_MAP_READ_EXT.0,
+                AccessFlags2::FRAGMENT_DENSITY_MAP_READ_EXT.0,
                 "FRAGMENT_DENSITY_MAP_READ_EXT",
             ),
             (
-                AccessFlags2KHR::COLOR_ATTACHMENT_READ_NONCOHERENT_EXT.0,
+                AccessFlags2::COLOR_ATTACHMENT_READ_NONCOHERENT_EXT.0,
                 "COLOR_ATTACHMENT_READ_NONCOHERENT_EXT",
             ),
-            (AccessFlags2KHR::RESERVED_41_AMD.0, "RESERVED_41_AMD"),
+            (AccessFlags2::RESERVED_41_AMD.0, "RESERVED_41_AMD"),
             (
-                AccessFlags2KHR::INVOCATION_MASK_READ_HUAWEI.0,
+                AccessFlags2::INVOCATION_MASK_READ_HUAWEI.0,
                 "INVOCATION_MASK_READ_HUAWEI",
             ),
-            (AccessFlags2KHR::RESERVED_387.0, "RESERVED_387"),
+            (AccessFlags2::RESERVED_387_KHR.0, "RESERVED_387_KHR"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -345,7 +348,7 @@ impl fmt::Debug for AttachmentStoreOp {
         let name = match *self {
             Self::STORE => Some("STORE"),
             Self::DONT_CARE => Some("DONT_CARE"),
-            Self::NONE_KHR => Some("NONE_KHR"),
+            Self::NONE => Some("NONE"),
             _ => None,
         };
         if let Some(x) = name {
@@ -1109,10 +1112,10 @@ impl fmt::Debug for DescriptorType {
             Self::UNIFORM_BUFFER_DYNAMIC => Some("UNIFORM_BUFFER_DYNAMIC"),
             Self::STORAGE_BUFFER_DYNAMIC => Some("STORAGE_BUFFER_DYNAMIC"),
             Self::INPUT_ATTACHMENT => Some("INPUT_ATTACHMENT"),
-            Self::INLINE_UNIFORM_BLOCK_EXT => Some("INLINE_UNIFORM_BLOCK_EXT"),
             Self::ACCELERATION_STRUCTURE_KHR => Some("ACCELERATION_STRUCTURE_KHR"),
             Self::ACCELERATION_STRUCTURE_NV => Some("ACCELERATION_STRUCTURE_NV"),
             Self::MUTABLE_VALVE => Some("MUTABLE_VALVE"),
+            Self::INLINE_UNIFORM_BLOCK => Some("INLINE_UNIFORM_BLOCK"),
             _ => None,
         };
         if let Some(x) = name {
@@ -1324,6 +1327,7 @@ impl fmt::Debug for DriverId {
             Self::MESA_V3DV => Some("MESA_V3DV"),
             Self::MESA_PANVK => Some("MESA_PANVK"),
             Self::SAMSUNG_PROPRIETARY => Some("SAMSUNG_PROPRIETARY"),
+            Self::MESA_VENUS => Some("MESA_VENUS"),
             _ => None,
         };
         if let Some(x) = name {
@@ -1356,25 +1360,25 @@ impl fmt::Debug for DynamicState {
             Self::EXCLUSIVE_SCISSOR_NV => Some("EXCLUSIVE_SCISSOR_NV"),
             Self::FRAGMENT_SHADING_RATE_KHR => Some("FRAGMENT_SHADING_RATE_KHR"),
             Self::LINE_STIPPLE_EXT => Some("LINE_STIPPLE_EXT"),
-            Self::CULL_MODE_EXT => Some("CULL_MODE_EXT"),
-            Self::FRONT_FACE_EXT => Some("FRONT_FACE_EXT"),
-            Self::PRIMITIVE_TOPOLOGY_EXT => Some("PRIMITIVE_TOPOLOGY_EXT"),
-            Self::VIEWPORT_WITH_COUNT_EXT => Some("VIEWPORT_WITH_COUNT_EXT"),
-            Self::SCISSOR_WITH_COUNT_EXT => Some("SCISSOR_WITH_COUNT_EXT"),
-            Self::VERTEX_INPUT_BINDING_STRIDE_EXT => Some("VERTEX_INPUT_BINDING_STRIDE_EXT"),
-            Self::DEPTH_TEST_ENABLE_EXT => Some("DEPTH_TEST_ENABLE_EXT"),
-            Self::DEPTH_WRITE_ENABLE_EXT => Some("DEPTH_WRITE_ENABLE_EXT"),
-            Self::DEPTH_COMPARE_OP_EXT => Some("DEPTH_COMPARE_OP_EXT"),
-            Self::DEPTH_BOUNDS_TEST_ENABLE_EXT => Some("DEPTH_BOUNDS_TEST_ENABLE_EXT"),
-            Self::STENCIL_TEST_ENABLE_EXT => Some("STENCIL_TEST_ENABLE_EXT"),
-            Self::STENCIL_OP_EXT => Some("STENCIL_OP_EXT"),
             Self::VERTEX_INPUT_EXT => Some("VERTEX_INPUT_EXT"),
             Self::PATCH_CONTROL_POINTS_EXT => Some("PATCH_CONTROL_POINTS_EXT"),
-            Self::RASTERIZER_DISCARD_ENABLE_EXT => Some("RASTERIZER_DISCARD_ENABLE_EXT"),
-            Self::DEPTH_BIAS_ENABLE_EXT => Some("DEPTH_BIAS_ENABLE_EXT"),
             Self::LOGIC_OP_EXT => Some("LOGIC_OP_EXT"),
-            Self::PRIMITIVE_RESTART_ENABLE_EXT => Some("PRIMITIVE_RESTART_ENABLE_EXT"),
             Self::COLOR_WRITE_ENABLE_EXT => Some("COLOR_WRITE_ENABLE_EXT"),
+            Self::CULL_MODE => Some("CULL_MODE"),
+            Self::FRONT_FACE => Some("FRONT_FACE"),
+            Self::PRIMITIVE_TOPOLOGY => Some("PRIMITIVE_TOPOLOGY"),
+            Self::VIEWPORT_WITH_COUNT => Some("VIEWPORT_WITH_COUNT"),
+            Self::SCISSOR_WITH_COUNT => Some("SCISSOR_WITH_COUNT"),
+            Self::VERTEX_INPUT_BINDING_STRIDE => Some("VERTEX_INPUT_BINDING_STRIDE"),
+            Self::DEPTH_TEST_ENABLE => Some("DEPTH_TEST_ENABLE"),
+            Self::DEPTH_WRITE_ENABLE => Some("DEPTH_WRITE_ENABLE"),
+            Self::DEPTH_COMPARE_OP => Some("DEPTH_COMPARE_OP"),
+            Self::DEPTH_BOUNDS_TEST_ENABLE => Some("DEPTH_BOUNDS_TEST_ENABLE"),
+            Self::STENCIL_TEST_ENABLE => Some("STENCIL_TEST_ENABLE"),
+            Self::STENCIL_OP => Some("STENCIL_OP"),
+            Self::RASTERIZER_DISCARD_ENABLE => Some("RASTERIZER_DISCARD_ENABLE"),
+            Self::DEPTH_BIAS_ENABLE => Some("DEPTH_BIAS_ENABLE"),
+            Self::PRIMITIVE_RESTART_ENABLE => Some("PRIMITIVE_RESTART_ENABLE"),
             _ => None,
         };
         if let Some(x) = name {
@@ -1386,7 +1390,7 @@ impl fmt::Debug for DynamicState {
 }
 impl fmt::Debug for EventCreateFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN: &[(Flags, &str)] = &[(EventCreateFlags::DEVICE_ONLY_KHR.0, "DEVICE_ONLY_KHR")];
+        const KNOWN: &[(Flags, &str)] = &[(EventCreateFlags::DEVICE_ONLY.0, "DEVICE_ONLY")];
         debug_flags(f, KNOWN, self.0)
     }
 }
@@ -1789,20 +1793,6 @@ impl fmt::Debug for Format {
             Self::PVRTC1_4BPP_SRGB_BLOCK_IMG => Some("PVRTC1_4BPP_SRGB_BLOCK_IMG"),
             Self::PVRTC2_2BPP_SRGB_BLOCK_IMG => Some("PVRTC2_2BPP_SRGB_BLOCK_IMG"),
             Self::PVRTC2_4BPP_SRGB_BLOCK_IMG => Some("PVRTC2_4BPP_SRGB_BLOCK_IMG"),
-            Self::ASTC_4X4_SFLOAT_BLOCK_EXT => Some("ASTC_4X4_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_5X4_SFLOAT_BLOCK_EXT => Some("ASTC_5X4_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_5X5_SFLOAT_BLOCK_EXT => Some("ASTC_5X5_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_6X5_SFLOAT_BLOCK_EXT => Some("ASTC_6X5_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_6X6_SFLOAT_BLOCK_EXT => Some("ASTC_6X6_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_8X5_SFLOAT_BLOCK_EXT => Some("ASTC_8X5_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_8X6_SFLOAT_BLOCK_EXT => Some("ASTC_8X6_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_8X8_SFLOAT_BLOCK_EXT => Some("ASTC_8X8_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_10X5_SFLOAT_BLOCK_EXT => Some("ASTC_10X5_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_10X6_SFLOAT_BLOCK_EXT => Some("ASTC_10X6_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_10X8_SFLOAT_BLOCK_EXT => Some("ASTC_10X8_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_10X10_SFLOAT_BLOCK_EXT => Some("ASTC_10X10_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_12X10_SFLOAT_BLOCK_EXT => Some("ASTC_12X10_SFLOAT_BLOCK_EXT"),
-            Self::ASTC_12X12_SFLOAT_BLOCK_EXT => Some("ASTC_12X12_SFLOAT_BLOCK_EXT"),
             Self::ASTC_3X3X3_UNORM_BLOCK_EXT => Some("ASTC_3X3X3_UNORM_BLOCK_EXT"),
             Self::ASTC_3X3X3_SRGB_BLOCK_EXT => Some("ASTC_3X3X3_SRGB_BLOCK_EXT"),
             Self::ASTC_3X3X3_SFLOAT_BLOCK_EXT => Some("ASTC_3X3X3_SFLOAT_BLOCK_EXT"),
@@ -1833,16 +1823,6 @@ impl fmt::Debug for Format {
             Self::ASTC_6X6X6_UNORM_BLOCK_EXT => Some("ASTC_6X6X6_UNORM_BLOCK_EXT"),
             Self::ASTC_6X6X6_SRGB_BLOCK_EXT => Some("ASTC_6X6X6_SRGB_BLOCK_EXT"),
             Self::ASTC_6X6X6_SFLOAT_BLOCK_EXT => Some("ASTC_6X6X6_SFLOAT_BLOCK_EXT"),
-            Self::G8_B8R8_2PLANE_444_UNORM_EXT => Some("G8_B8R8_2PLANE_444_UNORM_EXT"),
-            Self::G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT => {
-                Some("G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT")
-            }
-            Self::G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT => {
-                Some("G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT")
-            }
-            Self::G16_B16R16_2PLANE_444_UNORM_EXT => Some("G16_B16R16_2PLANE_444_UNORM_EXT"),
-            Self::A4R4G4B4_UNORM_PACK16_EXT => Some("A4R4G4B4_UNORM_PACK16_EXT"),
-            Self::A4B4G4R4_UNORM_PACK16_EXT => Some("A4B4G4R4_UNORM_PACK16_EXT"),
             Self::G8B8G8R8_422_UNORM => Some("G8B8G8R8_422_UNORM"),
             Self::B8G8R8G8_422_UNORM => Some("B8G8R8G8_422_UNORM"),
             Self::G8_B8_R8_3PLANE_420_UNORM => Some("G8_B8_R8_3PLANE_420_UNORM"),
@@ -1905,6 +1885,30 @@ impl fmt::Debug for Format {
             Self::G16_B16_R16_3PLANE_422_UNORM => Some("G16_B16_R16_3PLANE_422_UNORM"),
             Self::G16_B16R16_2PLANE_422_UNORM => Some("G16_B16R16_2PLANE_422_UNORM"),
             Self::G16_B16_R16_3PLANE_444_UNORM => Some("G16_B16_R16_3PLANE_444_UNORM"),
+            Self::G8_B8R8_2PLANE_444_UNORM => Some("G8_B8R8_2PLANE_444_UNORM"),
+            Self::G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16 => {
+                Some("G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16")
+            }
+            Self::G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16 => {
+                Some("G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16")
+            }
+            Self::G16_B16R16_2PLANE_444_UNORM => Some("G16_B16R16_2PLANE_444_UNORM"),
+            Self::A4R4G4B4_UNORM_PACK16 => Some("A4R4G4B4_UNORM_PACK16"),
+            Self::A4B4G4R4_UNORM_PACK16 => Some("A4B4G4R4_UNORM_PACK16"),
+            Self::ASTC_4X4_SFLOAT_BLOCK => Some("ASTC_4X4_SFLOAT_BLOCK"),
+            Self::ASTC_5X4_SFLOAT_BLOCK => Some("ASTC_5X4_SFLOAT_BLOCK"),
+            Self::ASTC_5X5_SFLOAT_BLOCK => Some("ASTC_5X5_SFLOAT_BLOCK"),
+            Self::ASTC_6X5_SFLOAT_BLOCK => Some("ASTC_6X5_SFLOAT_BLOCK"),
+            Self::ASTC_6X6_SFLOAT_BLOCK => Some("ASTC_6X6_SFLOAT_BLOCK"),
+            Self::ASTC_8X5_SFLOAT_BLOCK => Some("ASTC_8X5_SFLOAT_BLOCK"),
+            Self::ASTC_8X6_SFLOAT_BLOCK => Some("ASTC_8X6_SFLOAT_BLOCK"),
+            Self::ASTC_8X8_SFLOAT_BLOCK => Some("ASTC_8X8_SFLOAT_BLOCK"),
+            Self::ASTC_10X5_SFLOAT_BLOCK => Some("ASTC_10X5_SFLOAT_BLOCK"),
+            Self::ASTC_10X6_SFLOAT_BLOCK => Some("ASTC_10X6_SFLOAT_BLOCK"),
+            Self::ASTC_10X8_SFLOAT_BLOCK => Some("ASTC_10X8_SFLOAT_BLOCK"),
+            Self::ASTC_10X10_SFLOAT_BLOCK => Some("ASTC_10X10_SFLOAT_BLOCK"),
+            Self::ASTC_12X10_SFLOAT_BLOCK => Some("ASTC_12X10_SFLOAT_BLOCK"),
+            Self::ASTC_12X12_SFLOAT_BLOCK => Some("ASTC_12X12_SFLOAT_BLOCK"),
             _ => None,
         };
         if let Some(x) = name {
@@ -1920,9 +1924,9 @@ impl fmt::Debug for FormatFeatureFlags {
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for FormatFeatureFlags2KHR {
+impl fmt::Debug for FormatFeatureFlags2 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN : & [(Flags64 , & str)] = & [(FormatFeatureFlags2KHR :: SAMPLED_IMAGE . 0 , "SAMPLED_IMAGE") , (FormatFeatureFlags2KHR :: STORAGE_IMAGE . 0 , "STORAGE_IMAGE") , (FormatFeatureFlags2KHR :: STORAGE_IMAGE_ATOMIC . 0 , "STORAGE_IMAGE_ATOMIC") , (FormatFeatureFlags2KHR :: UNIFORM_TEXEL_BUFFER . 0 , "UNIFORM_TEXEL_BUFFER") , (FormatFeatureFlags2KHR :: STORAGE_TEXEL_BUFFER . 0 , "STORAGE_TEXEL_BUFFER") , (FormatFeatureFlags2KHR :: STORAGE_TEXEL_BUFFER_ATOMIC . 0 , "STORAGE_TEXEL_BUFFER_ATOMIC") , (FormatFeatureFlags2KHR :: VERTEX_BUFFER . 0 , "VERTEX_BUFFER") , (FormatFeatureFlags2KHR :: COLOR_ATTACHMENT . 0 , "COLOR_ATTACHMENT") , (FormatFeatureFlags2KHR :: COLOR_ATTACHMENT_BLEND . 0 , "COLOR_ATTACHMENT_BLEND") , (FormatFeatureFlags2KHR :: DEPTH_STENCIL_ATTACHMENT . 0 , "DEPTH_STENCIL_ATTACHMENT") , (FormatFeatureFlags2KHR :: BLIT_SRC . 0 , "BLIT_SRC") , (FormatFeatureFlags2KHR :: BLIT_DST . 0 , "BLIT_DST") , (FormatFeatureFlags2KHR :: SAMPLED_IMAGE_FILTER_LINEAR . 0 , "SAMPLED_IMAGE_FILTER_LINEAR") , (FormatFeatureFlags2KHR :: SAMPLED_IMAGE_FILTER_CUBIC_EXT . 0 , "SAMPLED_IMAGE_FILTER_CUBIC_EXT") , (FormatFeatureFlags2KHR :: TRANSFER_SRC . 0 , "TRANSFER_SRC") , (FormatFeatureFlags2KHR :: TRANSFER_DST . 0 , "TRANSFER_DST") , (FormatFeatureFlags2KHR :: SAMPLED_IMAGE_FILTER_MINMAX . 0 , "SAMPLED_IMAGE_FILTER_MINMAX") , (FormatFeatureFlags2KHR :: MIDPOINT_CHROMA_SAMPLES . 0 , "MIDPOINT_CHROMA_SAMPLES") , (FormatFeatureFlags2KHR :: SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER") , (FormatFeatureFlags2KHR :: SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER") , (FormatFeatureFlags2KHR :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT") , (FormatFeatureFlags2KHR :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE") , (FormatFeatureFlags2KHR :: DISJOINT . 0 , "DISJOINT") , (FormatFeatureFlags2KHR :: COSITED_CHROMA_SAMPLES . 0 , "COSITED_CHROMA_SAMPLES") , (FormatFeatureFlags2KHR :: STORAGE_READ_WITHOUT_FORMAT . 0 , "STORAGE_READ_WITHOUT_FORMAT") , (FormatFeatureFlags2KHR :: STORAGE_WRITE_WITHOUT_FORMAT . 0 , "STORAGE_WRITE_WITHOUT_FORMAT") , (FormatFeatureFlags2KHR :: SAMPLED_IMAGE_DEPTH_COMPARISON . 0 , "SAMPLED_IMAGE_DEPTH_COMPARISON") , (FormatFeatureFlags2KHR :: VIDEO_DECODE_OUTPUT . 0 , "VIDEO_DECODE_OUTPUT") , (FormatFeatureFlags2KHR :: VIDEO_DECODE_DPB . 0 , "VIDEO_DECODE_DPB") , (FormatFeatureFlags2KHR :: ACCELERATION_STRUCTURE_VERTEX_BUFFER . 0 , "ACCELERATION_STRUCTURE_VERTEX_BUFFER") , (FormatFeatureFlags2KHR :: FRAGMENT_DENSITY_MAP_EXT . 0 , "FRAGMENT_DENSITY_MAP_EXT") , (FormatFeatureFlags2KHR :: FRAGMENT_SHADING_RATE_ATTACHMENT . 0 , "FRAGMENT_SHADING_RATE_ATTACHMENT") , (FormatFeatureFlags2KHR :: VIDEO_ENCODE_INPUT . 0 , "VIDEO_ENCODE_INPUT") , (FormatFeatureFlags2KHR :: VIDEO_ENCODE_DPB . 0 , "VIDEO_ENCODE_DPB") , (FormatFeatureFlags2KHR :: LINEAR_COLOR_ATTACHMENT_NV . 0 , "LINEAR_COLOR_ATTACHMENT_NV") , (FormatFeatureFlags2KHR :: RESERVED_34_QCOM . 0 , "RESERVED_34_QCOM") , (FormatFeatureFlags2KHR :: RESERVED_35_QCOM . 0 , "RESERVED_35_QCOM") , (FormatFeatureFlags2KHR :: RESERVED_36_QCOM . 0 , "RESERVED_36_QCOM") , (FormatFeatureFlags2KHR :: RESERVED_37_QCOM . 0 , "RESERVED_37_QCOM")] ;
+        const KNOWN : & [(Flags64 , & str)] = & [(FormatFeatureFlags2 :: SAMPLED_IMAGE . 0 , "SAMPLED_IMAGE") , (FormatFeatureFlags2 :: STORAGE_IMAGE . 0 , "STORAGE_IMAGE") , (FormatFeatureFlags2 :: STORAGE_IMAGE_ATOMIC . 0 , "STORAGE_IMAGE_ATOMIC") , (FormatFeatureFlags2 :: UNIFORM_TEXEL_BUFFER . 0 , "UNIFORM_TEXEL_BUFFER") , (FormatFeatureFlags2 :: STORAGE_TEXEL_BUFFER . 0 , "STORAGE_TEXEL_BUFFER") , (FormatFeatureFlags2 :: STORAGE_TEXEL_BUFFER_ATOMIC . 0 , "STORAGE_TEXEL_BUFFER_ATOMIC") , (FormatFeatureFlags2 :: VERTEX_BUFFER . 0 , "VERTEX_BUFFER") , (FormatFeatureFlags2 :: COLOR_ATTACHMENT . 0 , "COLOR_ATTACHMENT") , (FormatFeatureFlags2 :: COLOR_ATTACHMENT_BLEND . 0 , "COLOR_ATTACHMENT_BLEND") , (FormatFeatureFlags2 :: DEPTH_STENCIL_ATTACHMENT . 0 , "DEPTH_STENCIL_ATTACHMENT") , (FormatFeatureFlags2 :: BLIT_SRC . 0 , "BLIT_SRC") , (FormatFeatureFlags2 :: BLIT_DST . 0 , "BLIT_DST") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_FILTER_LINEAR . 0 , "SAMPLED_IMAGE_FILTER_LINEAR") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_FILTER_CUBIC . 0 , "SAMPLED_IMAGE_FILTER_CUBIC") , (FormatFeatureFlags2 :: TRANSFER_SRC . 0 , "TRANSFER_SRC") , (FormatFeatureFlags2 :: TRANSFER_DST . 0 , "TRANSFER_DST") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_FILTER_MINMAX . 0 , "SAMPLED_IMAGE_FILTER_MINMAX") , (FormatFeatureFlags2 :: MIDPOINT_CHROMA_SAMPLES . 0 , "MIDPOINT_CHROMA_SAMPLES") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE . 0 , "SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE") , (FormatFeatureFlags2 :: DISJOINT . 0 , "DISJOINT") , (FormatFeatureFlags2 :: COSITED_CHROMA_SAMPLES . 0 , "COSITED_CHROMA_SAMPLES") , (FormatFeatureFlags2 :: STORAGE_READ_WITHOUT_FORMAT . 0 , "STORAGE_READ_WITHOUT_FORMAT") , (FormatFeatureFlags2 :: STORAGE_WRITE_WITHOUT_FORMAT . 0 , "STORAGE_WRITE_WITHOUT_FORMAT") , (FormatFeatureFlags2 :: SAMPLED_IMAGE_DEPTH_COMPARISON . 0 , "SAMPLED_IMAGE_DEPTH_COMPARISON") , (FormatFeatureFlags2 :: VIDEO_DECODE_OUTPUT_KHR . 0 , "VIDEO_DECODE_OUTPUT_KHR") , (FormatFeatureFlags2 :: VIDEO_DECODE_DPB_KHR . 0 , "VIDEO_DECODE_DPB_KHR") , (FormatFeatureFlags2 :: ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR . 0 , "ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR") , (FormatFeatureFlags2 :: FRAGMENT_DENSITY_MAP_EXT . 0 , "FRAGMENT_DENSITY_MAP_EXT") , (FormatFeatureFlags2 :: FRAGMENT_SHADING_RATE_ATTACHMENT_KHR . 0 , "FRAGMENT_SHADING_RATE_ATTACHMENT_KHR") , (FormatFeatureFlags2 :: VIDEO_ENCODE_INPUT_KHR . 0 , "VIDEO_ENCODE_INPUT_KHR") , (FormatFeatureFlags2 :: VIDEO_ENCODE_DPB_KHR . 0 , "VIDEO_ENCODE_DPB_KHR") , (FormatFeatureFlags2 :: LINEAR_COLOR_ATTACHMENT_NV . 0 , "LINEAR_COLOR_ATTACHMENT_NV") , (FormatFeatureFlags2 :: RESERVED_34_QCOM . 0 , "RESERVED_34_QCOM") , (FormatFeatureFlags2 :: RESERVED_35_QCOM . 0 , "RESERVED_35_QCOM") , (FormatFeatureFlags2 :: RESERVED_36_QCOM . 0 , "RESERVED_36_QCOM") , (FormatFeatureFlags2 :: RESERVED_37_QCOM . 0 , "RESERVED_37_QCOM")] ;
         debug_flags(f, KNOWN, self.0)
     }
 }
@@ -2087,10 +2091,10 @@ impl fmt::Debug for ImageAspectFlags {
             (ImageAspectFlags::MEMORY_PLANE_1_EXT.0, "MEMORY_PLANE_1_EXT"),
             (ImageAspectFlags::MEMORY_PLANE_2_EXT.0, "MEMORY_PLANE_2_EXT"),
             (ImageAspectFlags::MEMORY_PLANE_3_EXT.0, "MEMORY_PLANE_3_EXT"),
-            (ImageAspectFlags::NONE_KHR.0, "NONE_KHR"),
             (ImageAspectFlags::PLANE_0.0, "PLANE_0"),
             (ImageAspectFlags::PLANE_1.0, "PLANE_1"),
             (ImageAspectFlags::PLANE_2.0, "PLANE_2"),
+            (ImageAspectFlags::NONE.0, "NONE"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -2192,8 +2196,6 @@ impl fmt::Debug for ImageLayout {
             Self::VIDEO_ENCODE_DST_KHR => Some("VIDEO_ENCODE_DST_KHR"),
             Self::VIDEO_ENCODE_SRC_KHR => Some("VIDEO_ENCODE_SRC_KHR"),
             Self::VIDEO_ENCODE_DPB_KHR => Some("VIDEO_ENCODE_DPB_KHR"),
-            Self::READ_ONLY_OPTIMAL_KHR => Some("READ_ONLY_OPTIMAL_KHR"),
-            Self::ATTACHMENT_OPTIMAL_KHR => Some("ATTACHMENT_OPTIMAL_KHR"),
             Self::DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL => {
                 Some("DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL")
             }
@@ -2204,6 +2206,8 @@ impl fmt::Debug for ImageLayout {
             Self::DEPTH_READ_ONLY_OPTIMAL => Some("DEPTH_READ_ONLY_OPTIMAL"),
             Self::STENCIL_ATTACHMENT_OPTIMAL => Some("STENCIL_ATTACHMENT_OPTIMAL"),
             Self::STENCIL_READ_ONLY_OPTIMAL => Some("STENCIL_READ_ONLY_OPTIMAL"),
+            Self::READ_ONLY_OPTIMAL => Some("READ_ONLY_OPTIMAL"),
+            Self::ATTACHMENT_OPTIMAL => Some("ATTACHMENT_OPTIMAL"),
             _ => None,
         };
         if let Some(x) = name {
@@ -2318,6 +2322,7 @@ impl fmt::Debug for ImageViewCreateFlags {
                 ImageViewCreateFlags::FRAGMENT_DENSITY_MAP_DYNAMIC_EXT.0,
                 "FRAGMENT_DENSITY_MAP_DYNAMIC_EXT",
             ),
+            (ImageViewCreateFlags::RESERVED_2_AMD.0, "RESERVED_2_AMD"),
             (
                 ImageViewCreateFlags::FRAGMENT_DENSITY_MAP_DEFERRED_EXT.0,
                 "FRAGMENT_DENSITY_MAP_DEFERRED_EXT",
@@ -2727,11 +2732,11 @@ impl fmt::Debug for PipelineCacheCreateFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (PipelineCacheCreateFlags::RESERVED_1_EXT.0, "RESERVED_1_EXT"),
-            (
-                PipelineCacheCreateFlags::EXTERNALLY_SYNCHRONIZED_EXT.0,
-                "EXTERNALLY_SYNCHRONIZED_EXT",
-            ),
             (PipelineCacheCreateFlags::RESERVED_2_KHR.0, "RESERVED_2_KHR"),
+            (
+                PipelineCacheCreateFlags::EXTERNALLY_SYNCHRONIZED.0,
+                "EXTERNALLY_SYNCHRONIZED",
+            ),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -2844,14 +2849,6 @@ impl fmt::Debug for PipelineCreateFlags {
                 "INDIRECT_BINDABLE_NV",
             ),
             (PipelineCreateFlags::LIBRARY_KHR.0, "LIBRARY_KHR"),
-            (
-                PipelineCreateFlags::FAIL_ON_PIPELINE_COMPILE_REQUIRED_EXT.0,
-                "FAIL_ON_PIPELINE_COMPILE_REQUIRED_EXT",
-            ),
-            (
-                PipelineCreateFlags::EARLY_RETURN_ON_FAILURE_EXT.0,
-                "EARLY_RETURN_ON_FAILURE_EXT",
-            ),
             (PipelineCreateFlags::RESERVED_23_AMD.0, "RESERVED_23_AMD"),
             (PipelineCreateFlags::RESERVED_10_AMD.0, "RESERVED_10_AMD"),
             (
@@ -2863,20 +2860,28 @@ impl fmt::Debug for PipelineCreateFlags {
                 "VIEW_INDEX_FROM_DEVICE_INDEX",
             ),
             (PipelineCreateFlags::DISPATCH_BASE.0, "DISPATCH_BASE"),
+            (
+                PipelineCreateFlags::FAIL_ON_PIPELINE_COMPILE_REQUIRED.0,
+                "FAIL_ON_PIPELINE_COMPILE_REQUIRED",
+            ),
+            (
+                PipelineCreateFlags::EARLY_RETURN_ON_FAILURE.0,
+                "EARLY_RETURN_ON_FAILURE",
+            ),
         ];
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for PipelineCreationFeedbackFlagsEXT {
+impl fmt::Debug for PipelineCreationFeedbackFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
-            (PipelineCreationFeedbackFlagsEXT::VALID.0, "VALID"),
+            (PipelineCreationFeedbackFlags::VALID.0, "VALID"),
             (
-                PipelineCreationFeedbackFlagsEXT::APPLICATION_PIPELINE_CACHE_HIT.0,
+                PipelineCreationFeedbackFlags::APPLICATION_PIPELINE_CACHE_HIT.0,
                 "APPLICATION_PIPELINE_CACHE_HIT",
             ),
             (
-                PipelineCreationFeedbackFlagsEXT::BASE_PIPELINE_ACCELERATION.0,
+                PipelineCreationFeedbackFlags::BASE_PIPELINE_ACCELERATION.0,
                 "BASE_PIPELINE_ACCELERATION",
             ),
         ];
@@ -2976,16 +2981,16 @@ impl fmt::Debug for PipelineShaderStageCreateFlags {
                 "RESERVED_2_NV",
             ),
             (
-                PipelineShaderStageCreateFlags::ALLOW_VARYING_SUBGROUP_SIZE_EXT.0,
-                "ALLOW_VARYING_SUBGROUP_SIZE_EXT",
-            ),
-            (
-                PipelineShaderStageCreateFlags::REQUIRE_FULL_SUBGROUPS_EXT.0,
-                "REQUIRE_FULL_SUBGROUPS_EXT",
-            ),
-            (
                 PipelineShaderStageCreateFlags::RESERVED_3_KHR.0,
                 "RESERVED_3_KHR",
+            ),
+            (
+                PipelineShaderStageCreateFlags::ALLOW_VARYING_SUBGROUP_SIZE.0,
+                "ALLOW_VARYING_SUBGROUP_SIZE",
+            ),
+            (
+                PipelineShaderStageCreateFlags::REQUIRE_FULL_SUBGROUPS.0,
+                "REQUIRE_FULL_SUBGROUPS",
             ),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -3056,101 +3061,101 @@ impl fmt::Debug for PipelineStageFlags {
                 PipelineStageFlags::COMMAND_PREPROCESS_NV.0,
                 "COMMAND_PREPROCESS_NV",
             ),
-            (PipelineStageFlags::NONE_KHR.0, "NONE_KHR"),
+            (PipelineStageFlags::NONE.0, "NONE"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for PipelineStageFlags2KHR {
+impl fmt::Debug for PipelineStageFlags2 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags64, &str)] = &[
-            (PipelineStageFlags2KHR::NONE.0, "NONE"),
-            (PipelineStageFlags2KHR::TOP_OF_PIPE.0, "TOP_OF_PIPE"),
-            (PipelineStageFlags2KHR::DRAW_INDIRECT.0, "DRAW_INDIRECT"),
-            (PipelineStageFlags2KHR::VERTEX_INPUT.0, "VERTEX_INPUT"),
-            (PipelineStageFlags2KHR::VERTEX_SHADER.0, "VERTEX_SHADER"),
+            (PipelineStageFlags2::NONE.0, "NONE"),
+            (PipelineStageFlags2::TOP_OF_PIPE.0, "TOP_OF_PIPE"),
+            (PipelineStageFlags2::DRAW_INDIRECT.0, "DRAW_INDIRECT"),
+            (PipelineStageFlags2::VERTEX_INPUT.0, "VERTEX_INPUT"),
+            (PipelineStageFlags2::VERTEX_SHADER.0, "VERTEX_SHADER"),
             (
-                PipelineStageFlags2KHR::TESSELLATION_CONTROL_SHADER.0,
+                PipelineStageFlags2::TESSELLATION_CONTROL_SHADER.0,
                 "TESSELLATION_CONTROL_SHADER",
             ),
             (
-                PipelineStageFlags2KHR::TESSELLATION_EVALUATION_SHADER.0,
+                PipelineStageFlags2::TESSELLATION_EVALUATION_SHADER.0,
                 "TESSELLATION_EVALUATION_SHADER",
             ),
-            (PipelineStageFlags2KHR::GEOMETRY_SHADER.0, "GEOMETRY_SHADER"),
-            (PipelineStageFlags2KHR::FRAGMENT_SHADER.0, "FRAGMENT_SHADER"),
+            (PipelineStageFlags2::GEOMETRY_SHADER.0, "GEOMETRY_SHADER"),
+            (PipelineStageFlags2::FRAGMENT_SHADER.0, "FRAGMENT_SHADER"),
             (
-                PipelineStageFlags2KHR::EARLY_FRAGMENT_TESTS.0,
+                PipelineStageFlags2::EARLY_FRAGMENT_TESTS.0,
                 "EARLY_FRAGMENT_TESTS",
             ),
             (
-                PipelineStageFlags2KHR::LATE_FRAGMENT_TESTS.0,
+                PipelineStageFlags2::LATE_FRAGMENT_TESTS.0,
                 "LATE_FRAGMENT_TESTS",
             ),
             (
-                PipelineStageFlags2KHR::COLOR_ATTACHMENT_OUTPUT.0,
+                PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT.0,
                 "COLOR_ATTACHMENT_OUTPUT",
             ),
-            (PipelineStageFlags2KHR::COMPUTE_SHADER.0, "COMPUTE_SHADER"),
-            (PipelineStageFlags2KHR::ALL_TRANSFER.0, "ALL_TRANSFER"),
-            (PipelineStageFlags2KHR::BOTTOM_OF_PIPE.0, "BOTTOM_OF_PIPE"),
-            (PipelineStageFlags2KHR::HOST.0, "HOST"),
-            (PipelineStageFlags2KHR::ALL_GRAPHICS.0, "ALL_GRAPHICS"),
-            (PipelineStageFlags2KHR::ALL_COMMANDS.0, "ALL_COMMANDS"),
-            (PipelineStageFlags2KHR::COPY.0, "COPY"),
-            (PipelineStageFlags2KHR::RESOLVE.0, "RESOLVE"),
-            (PipelineStageFlags2KHR::BLIT.0, "BLIT"),
-            (PipelineStageFlags2KHR::CLEAR.0, "CLEAR"),
-            (PipelineStageFlags2KHR::INDEX_INPUT.0, "INDEX_INPUT"),
+            (PipelineStageFlags2::COMPUTE_SHADER.0, "COMPUTE_SHADER"),
+            (PipelineStageFlags2::ALL_TRANSFER.0, "ALL_TRANSFER"),
+            (PipelineStageFlags2::BOTTOM_OF_PIPE.0, "BOTTOM_OF_PIPE"),
+            (PipelineStageFlags2::HOST.0, "HOST"),
+            (PipelineStageFlags2::ALL_GRAPHICS.0, "ALL_GRAPHICS"),
+            (PipelineStageFlags2::ALL_COMMANDS.0, "ALL_COMMANDS"),
+            (PipelineStageFlags2::COPY.0, "COPY"),
+            (PipelineStageFlags2::RESOLVE.0, "RESOLVE"),
+            (PipelineStageFlags2::BLIT.0, "BLIT"),
+            (PipelineStageFlags2::CLEAR.0, "CLEAR"),
+            (PipelineStageFlags2::INDEX_INPUT.0, "INDEX_INPUT"),
             (
-                PipelineStageFlags2KHR::VERTEX_ATTRIBUTE_INPUT.0,
+                PipelineStageFlags2::VERTEX_ATTRIBUTE_INPUT.0,
                 "VERTEX_ATTRIBUTE_INPUT",
             ),
             (
-                PipelineStageFlags2KHR::PRE_RASTERIZATION_SHADERS.0,
+                PipelineStageFlags2::PRE_RASTERIZATION_SHADERS.0,
                 "PRE_RASTERIZATION_SHADERS",
             ),
-            (PipelineStageFlags2KHR::VIDEO_DECODE.0, "VIDEO_DECODE"),
-            (PipelineStageFlags2KHR::VIDEO_ENCODE.0, "VIDEO_ENCODE"),
+            (PipelineStageFlags2::VIDEO_DECODE_KHR.0, "VIDEO_DECODE_KHR"),
+            (PipelineStageFlags2::VIDEO_ENCODE_KHR.0, "VIDEO_ENCODE_KHR"),
             (
-                PipelineStageFlags2KHR::TRANSFORM_FEEDBACK_EXT.0,
+                PipelineStageFlags2::TRANSFORM_FEEDBACK_EXT.0,
                 "TRANSFORM_FEEDBACK_EXT",
             ),
             (
-                PipelineStageFlags2KHR::CONDITIONAL_RENDERING_EXT.0,
+                PipelineStageFlags2::CONDITIONAL_RENDERING_EXT.0,
                 "CONDITIONAL_RENDERING_EXT",
             ),
             (
-                PipelineStageFlags2KHR::COMMAND_PREPROCESS_NV.0,
+                PipelineStageFlags2::COMMAND_PREPROCESS_NV.0,
                 "COMMAND_PREPROCESS_NV",
             ),
             (
-                PipelineStageFlags2KHR::FRAGMENT_SHADING_RATE_ATTACHMENT.0,
-                "FRAGMENT_SHADING_RATE_ATTACHMENT",
+                PipelineStageFlags2::FRAGMENT_SHADING_RATE_ATTACHMENT_KHR.0,
+                "FRAGMENT_SHADING_RATE_ATTACHMENT_KHR",
             ),
             (
-                PipelineStageFlags2KHR::ACCELERATION_STRUCTURE_BUILD.0,
-                "ACCELERATION_STRUCTURE_BUILD",
+                PipelineStageFlags2::ACCELERATION_STRUCTURE_BUILD_KHR.0,
+                "ACCELERATION_STRUCTURE_BUILD_KHR",
             ),
             (
-                PipelineStageFlags2KHR::RAY_TRACING_SHADER.0,
-                "RAY_TRACING_SHADER",
+                PipelineStageFlags2::RAY_TRACING_SHADER_KHR.0,
+                "RAY_TRACING_SHADER_KHR",
             ),
             (
-                PipelineStageFlags2KHR::FRAGMENT_DENSITY_PROCESS_EXT.0,
+                PipelineStageFlags2::FRAGMENT_DENSITY_PROCESS_EXT.0,
                 "FRAGMENT_DENSITY_PROCESS_EXT",
             ),
-            (PipelineStageFlags2KHR::TASK_SHADER_NV.0, "TASK_SHADER_NV"),
-            (PipelineStageFlags2KHR::MESH_SHADER_NV.0, "MESH_SHADER_NV"),
+            (PipelineStageFlags2::TASK_SHADER_NV.0, "TASK_SHADER_NV"),
+            (PipelineStageFlags2::MESH_SHADER_NV.0, "MESH_SHADER_NV"),
             (
-                PipelineStageFlags2KHR::SUBPASS_SHADING_HUAWEI.0,
+                PipelineStageFlags2::SUBPASS_SHADING_HUAWEI.0,
                 "SUBPASS_SHADING_HUAWEI",
             ),
             (
-                PipelineStageFlags2KHR::INVOCATION_MASK_HUAWEI.0,
+                PipelineStageFlags2::INVOCATION_MASK_HUAWEI.0,
                 "INVOCATION_MASK_HUAWEI",
             ),
-            (PipelineStageFlags2KHR::RESERVED_387.0, "RESERVED_387"),
+            (PipelineStageFlags2::RESERVED_387_KHR.0, "RESERVED_387_KHR"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -3250,7 +3255,7 @@ impl fmt::Debug for PrimitiveTopology {
         }
     }
 }
-impl fmt::Debug for PrivateDataSlotCreateFlagsEXT {
+impl fmt::Debug for PrivateDataSlotCreateFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[];
         debug_flags(f, KNOWN, self.0)
@@ -3419,7 +3424,7 @@ impl fmt::Debug for QueueFlags {
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for QueueGlobalPriorityEXT {
+impl fmt::Debug for QueueGlobalPriorityKHR {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
             Self::LOW => Some("LOW"),
@@ -3473,15 +3478,15 @@ impl fmt::Debug for RenderPassCreateFlags {
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for RenderingFlagsKHR {
+impl fmt::Debug for RenderingFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (
-                RenderingFlagsKHR::CONTENTS_SECONDARY_COMMAND_BUFFERS.0,
+                RenderingFlags::CONTENTS_SECONDARY_COMMAND_BUFFERS.0,
                 "CONTENTS_SECONDARY_COMMAND_BUFFERS",
             ),
-            (RenderingFlagsKHR::SUSPENDING.0, "SUSPENDING"),
-            (RenderingFlagsKHR::RESUMING.0, "RESUMING"),
+            (RenderingFlags::SUSPENDING.0, "SUSPENDING"),
+            (RenderingFlags::RESUMING.0, "RESUMING"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -4049,7 +4054,9 @@ impl fmt::Debug for StructureType {
             Self::VIDEO_ENCODE_H265_DPB_SLOT_INFO_EXT => {
                 Some("VIDEO_ENCODE_H265_DPB_SLOT_INFO_EXT")
             }
-            Self::VIDEO_ENCODE_H265_NALU_SLICE_EXT => Some("VIDEO_ENCODE_H265_NALU_SLICE_EXT"),
+            Self::VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_EXT => {
+                Some("VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_EXT")
+            }
             Self::VIDEO_ENCODE_H265_EMIT_PICTURE_PARAMETERS_EXT => {
                 Some("VIDEO_ENCODE_H265_EMIT_PICTURE_PARAMETERS_EXT")
             }
@@ -4082,15 +4089,6 @@ impl fmt::Debug for StructureType {
             Self::TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD => {
                 Some("TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD")
             }
-            Self::RENDERING_INFO_KHR => Some("RENDERING_INFO_KHR"),
-            Self::RENDERING_ATTACHMENT_INFO_KHR => Some("RENDERING_ATTACHMENT_INFO_KHR"),
-            Self::PIPELINE_RENDERING_CREATE_INFO_KHR => Some("PIPELINE_RENDERING_CREATE_INFO_KHR"),
-            Self::PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR")
-            }
-            Self::COMMAND_BUFFER_INHERITANCE_RENDERING_INFO_KHR => {
-                Some("COMMAND_BUFFER_INHERITANCE_RENDERING_INFO_KHR")
-            }
             Self::RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR => {
                 Some("RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR")
             }
@@ -4118,9 +4116,6 @@ impl fmt::Debug for StructureType {
             }
             Self::VALIDATION_FLAGS_EXT => Some("VALIDATION_FLAGS_EXT"),
             Self::VI_SURFACE_CREATE_INFO_NN => Some("VI_SURFACE_CREATE_INFO_NN"),
-            Self::PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT")
-            }
             Self::IMAGE_VIEW_ASTC_DECODE_MODE_EXT => Some("IMAGE_VIEW_ASTC_DECODE_MODE_EXT"),
             Self::PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT")
@@ -4258,18 +4253,6 @@ impl fmt::Debug for StructureType {
             Self::EXTERNAL_FORMAT_ANDROID => Some("EXTERNAL_FORMAT_ANDROID"),
             Self::ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID => {
                 Some("ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID")
-            }
-            Self::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT")
-            }
-            Self::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT => {
-                Some("PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT")
-            }
-            Self::WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT => {
-                Some("WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT")
-            }
-            Self::DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT => {
-                Some("DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT")
             }
             Self::SAMPLE_LOCATIONS_INFO_EXT => Some("SAMPLE_LOCATIONS_INFO_EXT"),
             Self::RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT => {
@@ -4443,9 +4426,6 @@ impl fmt::Debug for StructureType {
             Self::FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT => {
                 Some("FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT")
             }
-            Self::DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT => {
-                Some("DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT")
-            }
             Self::IMPORT_MEMORY_HOST_POINTER_INFO_EXT => {
                 Some("IMPORT_MEMORY_HOST_POINTER_INFO_EXT")
             }
@@ -4478,6 +4458,15 @@ impl fmt::Debug for StructureType {
             Self::VIDEO_DECODE_H265_DPB_SLOT_INFO_EXT => {
                 Some("VIDEO_DECODE_H265_DPB_SLOT_INFO_EXT")
             }
+            Self::DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR => {
+                Some("DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR")
+            }
+            Self::PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR => {
+                Some("PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR")
+            }
+            Self::QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR => {
+                Some("QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR")
+            }
             Self::DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD => {
                 Some("DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD")
             }
@@ -4491,9 +4480,6 @@ impl fmt::Debug for StructureType {
                 Some("PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT")
             }
             Self::PRESENT_FRAME_TOKEN_GGP => Some("PRESENT_FRAME_TOKEN_GGP"),
-            Self::PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT => {
-                Some("PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT")
-            }
             Self::PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV => {
                 Some("PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV")
             }
@@ -4548,9 +4534,6 @@ impl fmt::Debug for StructureType {
             Self::IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA => {
                 Some("IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA")
             }
-            Self::PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES_KHR")
-            }
             Self::METAL_SURFACE_CREATE_INFO_EXT => Some("METAL_SURFACE_CREATE_INFO_EXT"),
             Self::PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT")
@@ -4560,15 +4543,6 @@ impl fmt::Debug for StructureType {
             }
             Self::RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT => {
                 Some("RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT")
-            }
-            Self::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT => {
-                Some("PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT")
-            }
-            Self::PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT => {
-                Some("PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT")
-            }
-            Self::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT")
             }
             Self::FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR => {
                 Some("FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR")
@@ -4610,9 +4584,6 @@ impl fmt::Debug for StructureType {
             }
             Self::BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT => {
                 Some("BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT")
-            }
-            Self::PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT => {
-                Some("PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT")
             }
             Self::VALIDATION_FEATURES_EXT => Some("VALIDATION_FEATURES_EXT"),
             Self::PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR => {
@@ -4690,9 +4661,6 @@ impl fmt::Debug for StructureType {
             Self::PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT")
             }
-            Self::PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT")
-            }
             Self::PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV => {
                 Some("PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV")
             }
@@ -4719,17 +4687,8 @@ impl fmt::Debug for StructureType {
             Self::COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV => {
                 Some("COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV")
             }
-            Self::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR")
-            }
-            Self::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES_KHR => {
-                Some("PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES_KHR")
-            }
             Self::PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT")
-            }
-            Self::PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT => {
-                Some("PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT")
             }
             Self::COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM => {
                 Some("COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM")
@@ -4766,16 +4725,6 @@ impl fmt::Debug for StructureType {
             Self::PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR => {
                 Some("PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR")
             }
-            Self::PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT")
-            }
-            Self::DEVICE_PRIVATE_DATA_CREATE_INFO_EXT => {
-                Some("DEVICE_PRIVATE_DATA_CREATE_INFO_EXT")
-            }
-            Self::PRIVATE_DATA_SLOT_CREATE_INFO_EXT => Some("PRIVATE_DATA_SLOT_CREATE_INFO_EXT"),
-            Self::PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT")
-            }
             Self::VIDEO_ENCODE_INFO_KHR => Some("VIDEO_ENCODE_INFO_KHR"),
             Self::VIDEO_ENCODE_RATE_CONTROL_INFO_KHR => Some("VIDEO_ENCODE_RATE_CONTROL_INFO_KHR"),
             Self::VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR => {
@@ -4788,25 +4737,12 @@ impl fmt::Debug for StructureType {
                 Some("DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV")
             }
             Self::RESERVED_QCOM => Some("RESERVED_QCOM"),
-            Self::MEMORY_BARRIER_2_KHR => Some("MEMORY_BARRIER_2_KHR"),
-            Self::BUFFER_MEMORY_BARRIER_2_KHR => Some("BUFFER_MEMORY_BARRIER_2_KHR"),
-            Self::IMAGE_MEMORY_BARRIER_2_KHR => Some("IMAGE_MEMORY_BARRIER_2_KHR"),
-            Self::DEPENDENCY_INFO_KHR => Some("DEPENDENCY_INFO_KHR"),
-            Self::SUBMIT_INFO_2_KHR => Some("SUBMIT_INFO_2_KHR"),
-            Self::SEMAPHORE_SUBMIT_INFO_KHR => Some("SEMAPHORE_SUBMIT_INFO_KHR"),
-            Self::COMMAND_BUFFER_SUBMIT_INFO_KHR => Some("COMMAND_BUFFER_SUBMIT_INFO_KHR"),
-            Self::PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR")
-            }
             Self::QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV => {
                 Some("QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV")
             }
             Self::CHECKPOINT_DATA_2_NV => Some("CHECKPOINT_DATA_2_NV"),
             Self::PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR => {
                 Some("PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR")
-            }
-            Self::PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES_KHR")
             }
             Self::PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV => {
                 Some("PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV")
@@ -4836,23 +4772,9 @@ impl fmt::Debug for StructureType {
                 Some("PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT")
             }
             Self::COPY_COMMAND_TRANSFORM_INFO_QCOM => Some("COPY_COMMAND_TRANSFORM_INFO_QCOM"),
-            Self::PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT")
-            }
             Self::PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR => {
                 Some("PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR")
             }
-            Self::COPY_BUFFER_INFO_2_KHR => Some("COPY_BUFFER_INFO_2_KHR"),
-            Self::COPY_IMAGE_INFO_2_KHR => Some("COPY_IMAGE_INFO_2_KHR"),
-            Self::COPY_BUFFER_TO_IMAGE_INFO_2_KHR => Some("COPY_BUFFER_TO_IMAGE_INFO_2_KHR"),
-            Self::COPY_IMAGE_TO_BUFFER_INFO_2_KHR => Some("COPY_IMAGE_TO_BUFFER_INFO_2_KHR"),
-            Self::BLIT_IMAGE_INFO_2_KHR => Some("BLIT_IMAGE_INFO_2_KHR"),
-            Self::RESOLVE_IMAGE_INFO_2_KHR => Some("RESOLVE_IMAGE_INFO_2_KHR"),
-            Self::BUFFER_COPY_2_KHR => Some("BUFFER_COPY_2_KHR"),
-            Self::IMAGE_COPY_2_KHR => Some("IMAGE_COPY_2_KHR"),
-            Self::IMAGE_BLIT_2_KHR => Some("IMAGE_BLIT_2_KHR"),
-            Self::BUFFER_IMAGE_COPY_2_KHR => Some("BUFFER_IMAGE_COPY_2_KHR"),
-            Self::IMAGE_RESOLVE_2_KHR => Some("IMAGE_RESOLVE_2_KHR"),
             Self::PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT")
             }
@@ -4888,7 +4810,6 @@ impl fmt::Debug for StructureType {
             Self::PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT")
             }
-            Self::FORMAT_PROPERTIES_3_KHR => Some("FORMAT_PROPERTIES_3_KHR"),
             Self::IMPORT_MEMORY_ZIRCON_HANDLE_INFO_FUCHSIA => {
                 Some("IMPORT_MEMORY_ZIRCON_HANDLE_INFO_FUCHSIA")
             }
@@ -4954,12 +4875,6 @@ impl fmt::Debug for StructureType {
             Self::PIPELINE_COLOR_WRITE_CREATE_INFO_EXT => {
                 Some("PIPELINE_COLOR_WRITE_CREATE_INFO_EXT")
             }
-            Self::PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_EXT => {
-                Some("PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_EXT")
-            }
-            Self::QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_EXT => {
-                Some("QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_EXT")
-            }
             Self::PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT")
             }
@@ -4978,18 +4893,6 @@ impl fmt::Debug for StructureType {
             }
             Self::PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT")
-            }
-            Self::PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES_KHR => {
-                Some("PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES_KHR")
-            }
-            Self::PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES_KHR => {
-                Some("PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES_KHR")
-            }
-            Self::DEVICE_BUFFER_MEMORY_REQUIREMENTS_KHR => {
-                Some("DEVICE_BUFFER_MEMORY_REQUIREMENTS_KHR")
-            }
-            Self::DEVICE_IMAGE_MEMORY_REQUIREMENTS_KHR => {
-                Some("DEVICE_IMAGE_MEMORY_REQUIREMENTS_KHR")
             }
             Self::PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_QCOM => {
                 Some("PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_QCOM")
@@ -5238,6 +5141,108 @@ impl fmt::Debug for StructureType {
             Self::DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO => {
                 Some("DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO")
             }
+            Self::PHYSICAL_DEVICE_VULKAN_1_3_FEATURES => {
+                Some("PHYSICAL_DEVICE_VULKAN_1_3_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES")
+            }
+            Self::PIPELINE_CREATION_FEEDBACK_CREATE_INFO => {
+                Some("PIPELINE_CREATION_FEEDBACK_CREATE_INFO")
+            }
+            Self::PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES => {
+                Some("PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_TOOL_PROPERTIES => Some("PHYSICAL_DEVICE_TOOL_PROPERTIES"),
+            Self::PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES => {
+                Some("PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES => {
+                Some("PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES")
+            }
+            Self::DEVICE_PRIVATE_DATA_CREATE_INFO => Some("DEVICE_PRIVATE_DATA_CREATE_INFO"),
+            Self::PRIVATE_DATA_SLOT_CREATE_INFO => Some("PRIVATE_DATA_SLOT_CREATE_INFO"),
+            Self::PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES => {
+                Some("PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES")
+            }
+            Self::MEMORY_BARRIER_2 => Some("MEMORY_BARRIER_2"),
+            Self::BUFFER_MEMORY_BARRIER_2 => Some("BUFFER_MEMORY_BARRIER_2"),
+            Self::IMAGE_MEMORY_BARRIER_2 => Some("IMAGE_MEMORY_BARRIER_2"),
+            Self::DEPENDENCY_INFO => Some("DEPENDENCY_INFO"),
+            Self::SUBMIT_INFO_2 => Some("SUBMIT_INFO_2"),
+            Self::SEMAPHORE_SUBMIT_INFO => Some("SEMAPHORE_SUBMIT_INFO"),
+            Self::COMMAND_BUFFER_SUBMIT_INFO => Some("COMMAND_BUFFER_SUBMIT_INFO"),
+            Self::PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES => {
+                Some("PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES => {
+                Some("PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES => {
+                Some("PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES")
+            }
+            Self::COPY_BUFFER_INFO_2 => Some("COPY_BUFFER_INFO_2"),
+            Self::COPY_IMAGE_INFO_2 => Some("COPY_IMAGE_INFO_2"),
+            Self::COPY_BUFFER_TO_IMAGE_INFO_2 => Some("COPY_BUFFER_TO_IMAGE_INFO_2"),
+            Self::COPY_IMAGE_TO_BUFFER_INFO_2 => Some("COPY_IMAGE_TO_BUFFER_INFO_2"),
+            Self::BLIT_IMAGE_INFO_2 => Some("BLIT_IMAGE_INFO_2"),
+            Self::RESOLVE_IMAGE_INFO_2 => Some("RESOLVE_IMAGE_INFO_2"),
+            Self::BUFFER_COPY_2 => Some("BUFFER_COPY_2"),
+            Self::IMAGE_COPY_2 => Some("IMAGE_COPY_2"),
+            Self::IMAGE_BLIT_2 => Some("IMAGE_BLIT_2"),
+            Self::BUFFER_IMAGE_COPY_2 => Some("BUFFER_IMAGE_COPY_2"),
+            Self::IMAGE_RESOLVE_2 => Some("IMAGE_RESOLVE_2"),
+            Self::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES")
+            }
+            Self::PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO => {
+                Some("PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO")
+            }
+            Self::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES => {
+                Some("PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES => {
+                Some("PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES")
+            }
+            Self::WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK => {
+                Some("WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK")
+            }
+            Self::DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO => {
+                Some("DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO")
+            }
+            Self::PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES => {
+                Some("PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES")
+            }
+            Self::RENDERING_INFO => Some("RENDERING_INFO"),
+            Self::RENDERING_ATTACHMENT_INFO => Some("RENDERING_ATTACHMENT_INFO"),
+            Self::PIPELINE_RENDERING_CREATE_INFO => Some("PIPELINE_RENDERING_CREATE_INFO"),
+            Self::PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES => {
+                Some("PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES")
+            }
+            Self::COMMAND_BUFFER_INHERITANCE_RENDERING_INFO => {
+                Some("COMMAND_BUFFER_INHERITANCE_RENDERING_INFO")
+            }
+            Self::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES => {
+                Some("PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES")
+            }
+            Self::PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES")
+            }
+            Self::FORMAT_PROPERTIES_3 => Some("FORMAT_PROPERTIES_3"),
+            Self::PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES => {
+                Some("PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES")
+            }
+            Self::PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES => {
+                Some("PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES")
+            }
+            Self::DEVICE_BUFFER_MEMORY_REQUIREMENTS => Some("DEVICE_BUFFER_MEMORY_REQUIREMENTS"),
+            Self::DEVICE_IMAGE_MEMORY_REQUIREMENTS => Some("DEVICE_IMAGE_MEMORY_REQUIREMENTS"),
             _ => None,
         };
         if let Some(x) = name {
@@ -5263,9 +5268,9 @@ impl fmt::Debug for SubgroupFeatureFlags {
         debug_flags(f, KNOWN, self.0)
     }
 }
-impl fmt::Debug for SubmitFlagsKHR {
+impl fmt::Debug for SubmitFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN: &[(Flags, &str)] = &[(SubmitFlagsKHR::PROTECTED.0, "PROTECTED")];
+        const KNOWN: &[(Flags, &str)] = &[(SubmitFlags::PROTECTED.0, "PROTECTED")];
         debug_flags(f, KNOWN, self.0)
     }
 }
@@ -5418,22 +5423,22 @@ impl fmt::Debug for TimeDomainEXT {
         }
     }
 }
-impl fmt::Debug for ToolPurposeFlagsEXT {
+impl fmt::Debug for ToolPurposeFlags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
-            (ToolPurposeFlagsEXT::VALIDATION.0, "VALIDATION"),
-            (ToolPurposeFlagsEXT::PROFILING.0, "PROFILING"),
-            (ToolPurposeFlagsEXT::TRACING.0, "TRACING"),
+            (ToolPurposeFlags::VALIDATION.0, "VALIDATION"),
+            (ToolPurposeFlags::PROFILING.0, "PROFILING"),
+            (ToolPurposeFlags::TRACING.0, "TRACING"),
             (
-                ToolPurposeFlagsEXT::ADDITIONAL_FEATURES.0,
+                ToolPurposeFlags::ADDITIONAL_FEATURES.0,
                 "ADDITIONAL_FEATURES",
             ),
+            (ToolPurposeFlags::MODIFYING_FEATURES.0, "MODIFYING_FEATURES"),
             (
-                ToolPurposeFlagsEXT::MODIFYING_FEATURES.0,
-                "MODIFYING_FEATURES",
+                ToolPurposeFlags::DEBUG_REPORTING_EXT.0,
+                "DEBUG_REPORTING_EXT",
             ),
-            (ToolPurposeFlagsEXT::DEBUG_REPORTING.0, "DEBUG_REPORTING"),
-            (ToolPurposeFlagsEXT::DEBUG_MARKERS.0, "DEBUG_MARKERS"),
+            (ToolPurposeFlags::DEBUG_MARKERS_EXT.0, "DEBUG_MARKERS_EXT"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -5799,7 +5804,10 @@ impl fmt::Debug for VideoEncodeH265InputModeFlagsEXT {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoEncodeH265InputModeFlagsEXT::FRAME.0, "FRAME"),
-            (VideoEncodeH265InputModeFlagsEXT::SLICE.0, "SLICE"),
+            (
+                VideoEncodeH265InputModeFlagsEXT::SLICE_SEGMENT.0,
+                "SLICE_SEGMENT",
+            ),
             (VideoEncodeH265InputModeFlagsEXT::NON_VCL.0, "NON_VCL"),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -5809,7 +5817,10 @@ impl fmt::Debug for VideoEncodeH265OutputModeFlagsEXT {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
             (VideoEncodeH265OutputModeFlagsEXT::FRAME.0, "FRAME"),
-            (VideoEncodeH265OutputModeFlagsEXT::SLICE.0, "SLICE"),
+            (
+                VideoEncodeH265OutputModeFlagsEXT::SLICE_SEGMENT.0,
+                "SLICE_SEGMENT",
+            ),
             (VideoEncodeH265OutputModeFlagsEXT::NON_VCL.0, "NON_VCL"),
         ];
         debug_flags(f, KNOWN, self.0)

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -4038,6 +4038,9 @@ impl fmt::Debug for StructureType {
             Self::VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_EXT => {
                 Some("VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_EXT")
             }
+            Self::VIDEO_ENCODE_H264_REFERENCE_LISTS_EXT => {
+                Some("VIDEO_ENCODE_H264_REFERENCE_LISTS_EXT")
+            }
             Self::VIDEO_ENCODE_H265_CAPABILITIES_EXT => Some("VIDEO_ENCODE_H265_CAPABILITIES_EXT"),
             Self::VIDEO_ENCODE_H265_SESSION_CREATE_INFO_EXT => {
                 Some("VIDEO_ENCODE_H265_SESSION_CREATE_INFO_EXT")
@@ -4730,6 +4733,7 @@ impl fmt::Debug for StructureType {
             Self::VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR => {
                 Some("VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR")
             }
+            Self::VIDEO_ENCODE_CAPABILITIES_KHR => Some("VIDEO_ENCODE_CAPABILITIES_KHR"),
             Self::PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV => {
                 Some("PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV")
             }
@@ -5678,6 +5682,18 @@ impl fmt::Debug for VideoDecodeH265CreateFlagsEXT {
         debug_flags(f, KNOWN, self.0)
     }
 }
+impl fmt::Debug for VideoEncodeCapabilityFlagsKHR {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const KNOWN: &[(Flags, &str)] = &[
+            (VideoEncodeCapabilityFlagsKHR::DEFAULT.0, "DEFAULT"),
+            (
+                VideoEncodeCapabilityFlagsKHR::PRECEDING_EXTERNALLY_ENCODED_BYTES.0,
+                "PRECEDING_EXTERNALLY_ENCODED_BYTES",
+            ),
+        ];
+        debug_flags(f, KNOWN, self.0)
+    }
+}
 impl fmt::Debug for VideoEncodeFlagsKHR {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
@@ -5690,15 +5706,25 @@ impl fmt::Debug for VideoEncodeFlagsKHR {
 impl fmt::Debug for VideoEncodeH264CapabilityFlagsEXT {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
-            (VideoEncodeH264CapabilityFlagsEXT::CABAC.0, "CABAC"),
-            (VideoEncodeH264CapabilityFlagsEXT::CAVLC.0, "CAVLC"),
             (
-                VideoEncodeH264CapabilityFlagsEXT::WEIGHTED_BI_PRED_IMPLICIT.0,
-                "WEIGHTED_BI_PRED_IMPLICIT",
+                VideoEncodeH264CapabilityFlagsEXT::DIRECT_8X8_INFERENCE.0,
+                "DIRECT_8X8_INFERENCE",
             ),
             (
-                VideoEncodeH264CapabilityFlagsEXT::TRANSFORM_8X8.0,
-                "TRANSFORM_8X8",
+                VideoEncodeH264CapabilityFlagsEXT::SEPARATE_COLOUR_PLANE.0,
+                "SEPARATE_COLOUR_PLANE",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::QPPRIME_Y_ZERO_TRANSFORM_BYPASS.0,
+                "QPPRIME_Y_ZERO_TRANSFORM_BYPASS",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::SCALING_LISTS.0,
+                "SCALING_LISTS",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::HRD_COMPLIANCE.0,
+                "HRD_COMPLIANCE",
             ),
             (
                 VideoEncodeH264CapabilityFlagsEXT::CHROMA_QP_OFFSET.0,
@@ -5708,6 +5734,32 @@ impl fmt::Debug for VideoEncodeH264CapabilityFlagsEXT {
                 VideoEncodeH264CapabilityFlagsEXT::SECOND_CHROMA_QP_OFFSET.0,
                 "SECOND_CHROMA_QP_OFFSET",
             ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::PIC_INIT_QP_MINUS26.0,
+                "PIC_INIT_QP_MINUS26",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::WEIGHTED_PRED.0,
+                "WEIGHTED_PRED",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::WEIGHTED_BIPRED_EXPLICIT.0,
+                "WEIGHTED_BIPRED_EXPLICIT",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::WEIGHTED_BIPRED_IMPLICIT.0,
+                "WEIGHTED_BIPRED_IMPLICIT",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::WEIGHTED_PRED_NO_TABLE.0,
+                "WEIGHTED_PRED_NO_TABLE",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::TRANSFORM_8X8.0,
+                "TRANSFORM_8X8",
+            ),
+            (VideoEncodeH264CapabilityFlagsEXT::CABAC.0, "CABAC"),
+            (VideoEncodeH264CapabilityFlagsEXT::CAVLC.0, "CAVLC"),
             (
                 VideoEncodeH264CapabilityFlagsEXT::DEBLOCKING_FILTER_DISABLED.0,
                 "DEBLOCKING_FILTER_DISABLED",
@@ -5721,12 +5773,24 @@ impl fmt::Debug for VideoEncodeH264CapabilityFlagsEXT {
                 "DEBLOCKING_FILTER_PARTIAL",
             ),
             (
+                VideoEncodeH264CapabilityFlagsEXT::DISABLE_DIRECT_SPATIAL_MV_PRED.0,
+                "DISABLE_DIRECT_SPATIAL_MV_PRED",
+            ),
+            (
                 VideoEncodeH264CapabilityFlagsEXT::MULTIPLE_SLICE_PER_FRAME.0,
                 "MULTIPLE_SLICE_PER_FRAME",
             ),
             (
-                VideoEncodeH264CapabilityFlagsEXT::EVENLY_DISTRIBUTED_SLICE_SIZE.0,
-                "EVENLY_DISTRIBUTED_SLICE_SIZE",
+                VideoEncodeH264CapabilityFlagsEXT::SLICE_MB_COUNT.0,
+                "SLICE_MB_COUNT",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::ROW_UNALIGNED_SLICE.0,
+                "ROW_UNALIGNED_SLICE",
+            ),
+            (
+                VideoEncodeH264CapabilityFlagsEXT::DIFFERENT_SLICE_TYPE.0,
+                "DIFFERENT_SLICE_TYPE",
             ),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -5779,7 +5843,104 @@ impl fmt::Debug for VideoEncodeH264RateControlStructureFlagsEXT {
 }
 impl fmt::Debug for VideoEncodeH265CapabilityFlagsEXT {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const KNOWN: &[(Flags, &str)] = &[];
+        const KNOWN: &[(Flags, &str)] = &[
+            (
+                VideoEncodeH265CapabilityFlagsEXT::SEPARATE_COLOUR_PLANE.0,
+                "SEPARATE_COLOUR_PLANE",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::SCALING_LISTS.0,
+                "SCALING_LISTS",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::SAMPLE_ADAPTIVE_OFFSET_ENABLED.0,
+                "SAMPLE_ADAPTIVE_OFFSET_ENABLED",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::PCM_ENABLE.0,
+                "PCM_ENABLE",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::SPS_TEMPORAL_MVP_ENABLED.0,
+                "SPS_TEMPORAL_MVP_ENABLED",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::HRD_COMPLIANCE.0,
+                "HRD_COMPLIANCE",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::INIT_QP_MINUS26.0,
+                "INIT_QP_MINUS26",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::LOG2_PARALLEL_MERGE_LEVEL_MINUS2.0,
+                "LOG2_PARALLEL_MERGE_LEVEL_MINUS2",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::SIGN_DATA_HIDING_ENABLED.0,
+                "SIGN_DATA_HIDING_ENABLED",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::TRANSFORM_SKIP_ENABLED.0,
+                "TRANSFORM_SKIP_ENABLED",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT.0,
+                "PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::WEIGHTED_PRED.0,
+                "WEIGHTED_PRED",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::WEIGHTED_BIPRED.0,
+                "WEIGHTED_BIPRED",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::WEIGHTED_PRED_NO_TABLE.0,
+                "WEIGHTED_PRED_NO_TABLE",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::TRANSQUANT_BYPASS_ENABLED.0,
+                "TRANSQUANT_BYPASS_ENABLED",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::ENTROPY_CODING_SYNC_ENABLED.0,
+                "ENTROPY_CODING_SYNC_ENABLED",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::DEBLOCKING_FILTER_OVERRIDE_ENABLED.0,
+                "DEBLOCKING_FILTER_OVERRIDE_ENABLED",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::MULTIPLE_TILE_PER_FRAME.0,
+                "MULTIPLE_TILE_PER_FRAME",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::MULTIPLE_SLICE_PER_TILE.0,
+                "MULTIPLE_SLICE_PER_TILE",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::MULTIPLE_TILE_PER_SLICE.0,
+                "MULTIPLE_TILE_PER_SLICE",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::SLICE_SEGMENT_CTB_COUNT.0,
+                "SLICE_SEGMENT_CTB_COUNT",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::ROW_UNALIGNED_SLICE_SEGMENT.0,
+                "ROW_UNALIGNED_SLICE_SEGMENT",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::DEPENDENT_SLICE_SEGMENT.0,
+                "DEPENDENT_SLICE_SEGMENT",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::DIFFERENT_SLICE_TYPE.0,
+                "DIFFERENT_SLICE_TYPE",
+            ),
+        ];
         debug_flags(f, KNOWN, self.0)
     }
 }
@@ -5792,7 +5953,6 @@ impl fmt::Debug for VideoEncodeH265CreateFlagsEXT {
 impl fmt::Debug for VideoEncodeH265CtbSizeFlagsEXT {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         const KNOWN: &[(Flags, &str)] = &[
-            (VideoEncodeH265CtbSizeFlagsEXT::TYPE_8.0, "TYPE_8"),
             (VideoEncodeH265CtbSizeFlagsEXT::TYPE_16.0, "TYPE_16"),
             (VideoEncodeH265CtbSizeFlagsEXT::TYPE_32.0, "TYPE_32"),
             (VideoEncodeH265CtbSizeFlagsEXT::TYPE_64.0, "TYPE_64"),
@@ -5837,6 +5997,29 @@ impl fmt::Debug for VideoEncodeH265RateControlStructureFlagsEXT {
             (
                 VideoEncodeH265RateControlStructureFlagsEXT::DYADIC.0,
                 "DYADIC",
+            ),
+        ];
+        debug_flags(f, KNOWN, self.0)
+    }
+}
+impl fmt::Debug for VideoEncodeH265TransformBlockSizeFlagsEXT {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        const KNOWN: &[(Flags, &str)] = &[
+            (
+                VideoEncodeH265TransformBlockSizeFlagsEXT::TYPE_4.0,
+                "TYPE_4",
+            ),
+            (
+                VideoEncodeH265TransformBlockSizeFlagsEXT::TYPE_8.0,
+                "TYPE_8",
+            ),
+            (
+                VideoEncodeH265TransformBlockSizeFlagsEXT::TYPE_16.0,
+                "TYPE_16",
+            ),
+            (
+                VideoEncodeH265TransformBlockSizeFlagsEXT::TYPE_32.0,
+                "TYPE_32",
             ),
         ];
         debug_flags(f, KNOWN, self.0)

--- a/ash/src/vk/constants.rs
+++ b/ash/src/vk/constants.rs
@@ -22,5 +22,5 @@ pub const MAX_DEVICE_GROUP_SIZE: usize = 32;
 pub const MAX_DRIVER_NAME_SIZE: usize = 256;
 pub const MAX_DRIVER_INFO_SIZE: usize = 256;
 pub const SHADER_UNUSED_KHR: u32 = !0;
-pub const MAX_GLOBAL_PRIORITY_SIZE_EXT: usize = 16;
+pub const MAX_GLOBAL_PRIORITY_SIZE_KHR: usize = 16;
 pub const SHADER_UNUSED_NV: u32 = SHADER_UNUSED_KHR;

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -56,7 +56,7 @@ pub const API_VERSION_1_1: u32 = make_api_version(0, 1, 1, 0);
 pub const API_VERSION_1_2: u32 = make_api_version(0, 1, 2, 0);
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_API_VERSION_1_3.html>"]
 pub const API_VERSION_1_3: u32 = make_api_version(0, 1, 3, 0);
-pub const HEADER_VERSION: u32 = 205u32;
+pub const HEADER_VERSION: u32 = 206u32;
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_HEADER_VERSION_COMPLETE.html>"]
 pub const HEADER_VERSION_COMPLETE: u32 = make_api_version(0, 1, 3, HEADER_VERSION);
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSampleMask.html>"]
@@ -316,11 +316,6 @@ vk_bitflags_wrapped!(VideoDecodeH264CreateFlagsEXT, Flags);
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoDecodeH265CreateFlagsEXT.html>"]
 pub struct VideoDecodeH265CreateFlagsEXT(pub(crate) Flags);
 vk_bitflags_wrapped!(VideoDecodeH265CreateFlagsEXT, Flags);
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265CapabilityFlagsEXT.html>"]
-pub struct VideoEncodeH265CapabilityFlagsEXT(pub(crate) Flags);
-vk_bitflags_wrapped!(VideoEncodeH265CapabilityFlagsEXT, Flags);
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265CreateFlagsEXT.html>"]
@@ -51138,6 +51133,107 @@ impl<'a> VideoEncodeRateControlLayerInfoKHRBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeCapabilitiesKHR.html>"]
+pub struct VideoEncodeCapabilitiesKHR {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub flags: VideoEncodeCapabilityFlagsKHR,
+    pub rate_control_modes: VideoEncodeRateControlModeFlagsKHR,
+    pub rate_control_layer_count: u8,
+    pub quality_level_count: u8,
+    pub input_image_data_fill_alignment: Extent2D,
+}
+impl ::std::default::Default for VideoEncodeCapabilitiesKHR {
+    fn default() -> Self {
+        Self {
+            s_type: StructureType::VIDEO_ENCODE_CAPABILITIES_KHR,
+            p_next: ::std::ptr::null(),
+            flags: VideoEncodeCapabilityFlagsKHR::default(),
+            rate_control_modes: VideoEncodeRateControlModeFlagsKHR::default(),
+            rate_control_layer_count: u8::default(),
+            quality_level_count: u8::default(),
+            input_image_data_fill_alignment: Extent2D::default(),
+        }
+    }
+}
+impl VideoEncodeCapabilitiesKHR {
+    pub fn builder<'a>() -> VideoEncodeCapabilitiesKHRBuilder<'a> {
+        VideoEncodeCapabilitiesKHRBuilder {
+            inner: Self::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct VideoEncodeCapabilitiesKHRBuilder<'a> {
+    inner: VideoEncodeCapabilitiesKHR,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsVideoCapabilitiesKHR for VideoEncodeCapabilitiesKHRBuilder<'_> {}
+unsafe impl ExtendsVideoCapabilitiesKHR for VideoEncodeCapabilitiesKHR {}
+pub unsafe trait ExtendsVideoEncodeCapabilitiesKHR {}
+impl<'a> ::std::ops::Deref for VideoEncodeCapabilitiesKHRBuilder<'a> {
+    type Target = VideoEncodeCapabilitiesKHR;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for VideoEncodeCapabilitiesKHRBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> VideoEncodeCapabilitiesKHRBuilder<'a> {
+    pub fn flags(mut self, flags: VideoEncodeCapabilityFlagsKHR) -> Self {
+        self.inner.flags = flags;
+        self
+    }
+    pub fn rate_control_modes(
+        mut self,
+        rate_control_modes: VideoEncodeRateControlModeFlagsKHR,
+    ) -> Self {
+        self.inner.rate_control_modes = rate_control_modes;
+        self
+    }
+    pub fn rate_control_layer_count(mut self, rate_control_layer_count: u8) -> Self {
+        self.inner.rate_control_layer_count = rate_control_layer_count;
+        self
+    }
+    pub fn quality_level_count(mut self, quality_level_count: u8) -> Self {
+        self.inner.quality_level_count = quality_level_count;
+        self
+    }
+    pub fn input_image_data_fill_alignment(
+        mut self,
+        input_image_data_fill_alignment: Extent2D,
+    ) -> Self {
+        self.inner.input_image_data_fill_alignment = input_image_data_fill_alignment;
+        self
+    }
+    #[doc = r" Prepends the given extension struct between the root and the first pointer. This"]
+    #[doc = r" method only exists on structs that can be passed to a function directly. Only"]
+    #[doc = r" valid extension structs can be pushed into the chain."]
+    #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
+    #[doc = r" chain will look like `A -> D -> B -> C`."]
+    pub fn push_next<T: ExtendsVideoEncodeCapabilitiesKHR>(mut self, next: &'a mut T) -> Self {
+        unsafe {
+            let next_ptr = <*const T>::cast(next);
+            let last_next = ptr_chain_iter(next).last().unwrap();
+            (*last_next).p_next = self.inner.p_next as _;
+            self.inner.p_next = next_ptr;
+        }
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> VideoEncodeCapabilitiesKHR {
+        self.inner
+    }
+}
+#[repr(C)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Copy, Clone)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH264CapabilitiesEXT.html>"]
 pub struct VideoEncodeH264CapabilitiesEXT {
     pub s_type: StructureType,
@@ -51145,13 +51241,14 @@ pub struct VideoEncodeH264CapabilitiesEXT {
     pub flags: VideoEncodeH264CapabilityFlagsEXT,
     pub input_mode_flags: VideoEncodeH264InputModeFlagsEXT,
     pub output_mode_flags: VideoEncodeH264OutputModeFlagsEXT,
-    pub min_picture_size_in_mbs: Extent2D,
-    pub max_picture_size_in_mbs: Extent2D,
-    pub input_image_data_alignment: Extent2D,
-    pub max_num_l0_reference_for_p: u8,
-    pub max_num_l0_reference_for_b: u8,
-    pub max_num_l1_reference: u8,
-    pub quality_level_count: u8,
+    pub max_p_picture_l0_reference_count: u8,
+    pub max_b_picture_l0_reference_count: u8,
+    pub max_l1_reference_count: u8,
+    pub motion_vectors_over_pic_boundaries_flag: Bool32,
+    pub max_bytes_per_pic_denom: u32,
+    pub max_bits_per_mb_denom: u32,
+    pub log2_max_mv_length_horizontal: u32,
+    pub log2_max_mv_length_vertical: u32,
     pub std_extension_version: ExtensionProperties,
 }
 impl ::std::default::Default for VideoEncodeH264CapabilitiesEXT {
@@ -51162,13 +51259,14 @@ impl ::std::default::Default for VideoEncodeH264CapabilitiesEXT {
             flags: VideoEncodeH264CapabilityFlagsEXT::default(),
             input_mode_flags: VideoEncodeH264InputModeFlagsEXT::default(),
             output_mode_flags: VideoEncodeH264OutputModeFlagsEXT::default(),
-            min_picture_size_in_mbs: Extent2D::default(),
-            max_picture_size_in_mbs: Extent2D::default(),
-            input_image_data_alignment: Extent2D::default(),
-            max_num_l0_reference_for_p: u8::default(),
-            max_num_l0_reference_for_b: u8::default(),
-            max_num_l1_reference: u8::default(),
-            quality_level_count: u8::default(),
+            max_p_picture_l0_reference_count: u8::default(),
+            max_b_picture_l0_reference_count: u8::default(),
+            max_l1_reference_count: u8::default(),
+            motion_vectors_over_pic_boundaries_flag: Bool32::default(),
+            max_bytes_per_pic_denom: u32::default(),
+            max_bits_per_mb_denom: u32::default(),
+            log2_max_mv_length_horizontal: u32::default(),
+            log2_max_mv_length_vertical: u32::default(),
             std_extension_version: ExtensionProperties::default(),
         }
     }
@@ -51186,8 +51284,8 @@ pub struct VideoEncodeH264CapabilitiesEXTBuilder<'a> {
     inner: VideoEncodeH264CapabilitiesEXT,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsVideoCapabilitiesKHR for VideoEncodeH264CapabilitiesEXTBuilder<'_> {}
-unsafe impl ExtendsVideoCapabilitiesKHR for VideoEncodeH264CapabilitiesEXT {}
+unsafe impl ExtendsVideoEncodeCapabilitiesKHR for VideoEncodeH264CapabilitiesEXTBuilder<'_> {}
+unsafe impl ExtendsVideoEncodeCapabilitiesKHR for VideoEncodeH264CapabilitiesEXT {}
 impl<'a> ::std::ops::Deref for VideoEncodeH264CapabilitiesEXTBuilder<'a> {
     type Target = VideoEncodeH264CapabilitiesEXT;
     fn deref(&self) -> &Self::Target {
@@ -51215,32 +51313,46 @@ impl<'a> VideoEncodeH264CapabilitiesEXTBuilder<'a> {
         self.inner.output_mode_flags = output_mode_flags;
         self
     }
-    pub fn min_picture_size_in_mbs(mut self, min_picture_size_in_mbs: Extent2D) -> Self {
-        self.inner.min_picture_size_in_mbs = min_picture_size_in_mbs;
+    pub fn max_p_picture_l0_reference_count(
+        mut self,
+        max_p_picture_l0_reference_count: u8,
+    ) -> Self {
+        self.inner.max_p_picture_l0_reference_count = max_p_picture_l0_reference_count;
         self
     }
-    pub fn max_picture_size_in_mbs(mut self, max_picture_size_in_mbs: Extent2D) -> Self {
-        self.inner.max_picture_size_in_mbs = max_picture_size_in_mbs;
+    pub fn max_b_picture_l0_reference_count(
+        mut self,
+        max_b_picture_l0_reference_count: u8,
+    ) -> Self {
+        self.inner.max_b_picture_l0_reference_count = max_b_picture_l0_reference_count;
         self
     }
-    pub fn input_image_data_alignment(mut self, input_image_data_alignment: Extent2D) -> Self {
-        self.inner.input_image_data_alignment = input_image_data_alignment;
+    pub fn max_l1_reference_count(mut self, max_l1_reference_count: u8) -> Self {
+        self.inner.max_l1_reference_count = max_l1_reference_count;
         self
     }
-    pub fn max_num_l0_reference_for_p(mut self, max_num_l0_reference_for_p: u8) -> Self {
-        self.inner.max_num_l0_reference_for_p = max_num_l0_reference_for_p;
+    pub fn motion_vectors_over_pic_boundaries_flag(
+        mut self,
+        motion_vectors_over_pic_boundaries_flag: bool,
+    ) -> Self {
+        self.inner.motion_vectors_over_pic_boundaries_flag =
+            motion_vectors_over_pic_boundaries_flag.into();
         self
     }
-    pub fn max_num_l0_reference_for_b(mut self, max_num_l0_reference_for_b: u8) -> Self {
-        self.inner.max_num_l0_reference_for_b = max_num_l0_reference_for_b;
+    pub fn max_bytes_per_pic_denom(mut self, max_bytes_per_pic_denom: u32) -> Self {
+        self.inner.max_bytes_per_pic_denom = max_bytes_per_pic_denom;
         self
     }
-    pub fn max_num_l1_reference(mut self, max_num_l1_reference: u8) -> Self {
-        self.inner.max_num_l1_reference = max_num_l1_reference;
+    pub fn max_bits_per_mb_denom(mut self, max_bits_per_mb_denom: u32) -> Self {
+        self.inner.max_bits_per_mb_denom = max_bits_per_mb_denom;
         self
     }
-    pub fn quality_level_count(mut self, quality_level_count: u8) -> Self {
-        self.inner.quality_level_count = quality_level_count;
+    pub fn log2_max_mv_length_horizontal(mut self, log2_max_mv_length_horizontal: u32) -> Self {
+        self.inner.log2_max_mv_length_horizontal = log2_max_mv_length_horizontal;
+        self
+    }
+    pub fn log2_max_mv_length_vertical(mut self, log2_max_mv_length_vertical: u32) -> Self {
+        self.inner.log2_max_mv_length_vertical = log2_max_mv_length_vertical;
         self
     }
     pub fn std_extension_version(mut self, std_extension_version: ExtensionProperties) -> Self {
@@ -51481,7 +51593,7 @@ pub struct VideoEncodeH264DpbSlotInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub slot_index: i8,
-    pub p_std_picture_info: *const StdVideoEncodeH264PictureInfo,
+    pub p_std_reference_info: *const StdVideoEncodeH264ReferenceInfo,
 }
 impl ::std::default::Default for VideoEncodeH264DpbSlotInfoEXT {
     fn default() -> Self {
@@ -51489,7 +51601,7 @@ impl ::std::default::Default for VideoEncodeH264DpbSlotInfoEXT {
             s_type: StructureType::VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT,
             p_next: ::std::ptr::null(),
             slot_index: i8::default(),
-            p_std_picture_info: ::std::ptr::null(),
+            p_std_reference_info: ::std::ptr::null(),
         }
     }
 }
@@ -51522,8 +51634,11 @@ impl<'a> VideoEncodeH264DpbSlotInfoEXTBuilder<'a> {
         self.inner.slot_index = slot_index;
         self
     }
-    pub fn std_picture_info(mut self, std_picture_info: &'a StdVideoEncodeH264PictureInfo) -> Self {
-        self.inner.p_std_picture_info = std_picture_info;
+    pub fn std_reference_info(
+        mut self,
+        std_reference_info: &'a StdVideoEncodeH264ReferenceInfo,
+    ) -> Self {
+        self.inner.p_std_reference_info = std_reference_info;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
@@ -51540,23 +51655,17 @@ impl<'a> VideoEncodeH264DpbSlotInfoEXTBuilder<'a> {
 pub struct VideoEncodeH264VclFrameInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub ref_default_final_list0_entry_count: u8,
-    pub p_ref_default_final_list0_entries: *const VideoEncodeH264DpbSlotInfoEXT,
-    pub ref_default_final_list1_entry_count: u8,
-    pub p_ref_default_final_list1_entries: *const VideoEncodeH264DpbSlotInfoEXT,
+    pub p_reference_final_lists: *const VideoEncodeH264ReferenceListsEXT,
     pub nalu_slice_entry_count: u32,
     pub p_nalu_slice_entries: *const VideoEncodeH264NaluSliceEXT,
-    pub p_current_picture_info: *const VideoEncodeH264DpbSlotInfoEXT,
+    pub p_current_picture_info: *const StdVideoEncodeH264PictureInfo,
 }
 impl ::std::default::Default for VideoEncodeH264VclFrameInfoEXT {
     fn default() -> Self {
         Self {
             s_type: StructureType::VIDEO_ENCODE_H264_VCL_FRAME_INFO_EXT,
             p_next: ::std::ptr::null(),
-            ref_default_final_list0_entry_count: u8::default(),
-            p_ref_default_final_list0_entries: ::std::ptr::null(),
-            ref_default_final_list1_entry_count: u8::default(),
-            p_ref_default_final_list1_entries: ::std::ptr::null(),
+            p_reference_final_lists: ::std::ptr::null(),
             nalu_slice_entry_count: u32::default(),
             p_nalu_slice_entries: ::std::ptr::null(),
             p_current_picture_info: ::std::ptr::null(),
@@ -51590,20 +51699,11 @@ impl<'a> ::std::ops::DerefMut for VideoEncodeH264VclFrameInfoEXTBuilder<'a> {
     }
 }
 impl<'a> VideoEncodeH264VclFrameInfoEXTBuilder<'a> {
-    pub fn ref_default_final_list0_entries(
+    pub fn reference_final_lists(
         mut self,
-        ref_default_final_list0_entries: &'a [VideoEncodeH264DpbSlotInfoEXT],
+        reference_final_lists: &'a VideoEncodeH264ReferenceListsEXT,
     ) -> Self {
-        self.inner.ref_default_final_list0_entry_count = ref_default_final_list0_entries.len() as _;
-        self.inner.p_ref_default_final_list0_entries = ref_default_final_list0_entries.as_ptr();
-        self
-    }
-    pub fn ref_default_final_list1_entries(
-        mut self,
-        ref_default_final_list1_entries: &'a [VideoEncodeH264DpbSlotInfoEXT],
-    ) -> Self {
-        self.inner.ref_default_final_list1_entry_count = ref_default_final_list1_entries.len() as _;
-        self.inner.p_ref_default_final_list1_entries = ref_default_final_list1_entries.as_ptr();
+        self.inner.p_reference_final_lists = reference_final_lists;
         self
     }
     pub fn nalu_slice_entries(
@@ -51616,7 +51716,7 @@ impl<'a> VideoEncodeH264VclFrameInfoEXTBuilder<'a> {
     }
     pub fn current_picture_info(
         mut self,
-        current_picture_info: &'a VideoEncodeH264DpbSlotInfoEXT,
+        current_picture_info: &'a StdVideoEncodeH264PictureInfo,
     ) -> Self {
         self.inner.p_current_picture_info = current_picture_info;
         self
@@ -51625,6 +51725,87 @@ impl<'a> VideoEncodeH264VclFrameInfoEXTBuilder<'a> {
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
     pub fn build(self) -> VideoEncodeH264VclFrameInfoEXT {
+        self.inner
+    }
+}
+#[repr(C)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH264ReferenceListsEXT.html>"]
+pub struct VideoEncodeH264ReferenceListsEXT {
+    pub s_type: StructureType,
+    pub p_next: *const c_void,
+    pub reference_list0_entry_count: u8,
+    pub p_reference_list0_entries: *const VideoEncodeH264DpbSlotInfoEXT,
+    pub reference_list1_entry_count: u8,
+    pub p_reference_list1_entries: *const VideoEncodeH264DpbSlotInfoEXT,
+    pub p_mem_mgmt_ctrl_operations: *const StdVideoEncodeH264RefMemMgmtCtrlOperations,
+}
+impl ::std::default::Default for VideoEncodeH264ReferenceListsEXT {
+    fn default() -> Self {
+        Self {
+            s_type: StructureType::VIDEO_ENCODE_H264_REFERENCE_LISTS_EXT,
+            p_next: ::std::ptr::null(),
+            reference_list0_entry_count: u8::default(),
+            p_reference_list0_entries: ::std::ptr::null(),
+            reference_list1_entry_count: u8::default(),
+            p_reference_list1_entries: ::std::ptr::null(),
+            p_mem_mgmt_ctrl_operations: ::std::ptr::null(),
+        }
+    }
+}
+impl VideoEncodeH264ReferenceListsEXT {
+    pub fn builder<'a>() -> VideoEncodeH264ReferenceListsEXTBuilder<'a> {
+        VideoEncodeH264ReferenceListsEXTBuilder {
+            inner: Self::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct VideoEncodeH264ReferenceListsEXTBuilder<'a> {
+    inner: VideoEncodeH264ReferenceListsEXT,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+impl<'a> ::std::ops::Deref for VideoEncodeH264ReferenceListsEXTBuilder<'a> {
+    type Target = VideoEncodeH264ReferenceListsEXT;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for VideoEncodeH264ReferenceListsEXTBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> VideoEncodeH264ReferenceListsEXTBuilder<'a> {
+    pub fn reference_list0_entries(
+        mut self,
+        reference_list0_entries: &'a [VideoEncodeH264DpbSlotInfoEXT],
+    ) -> Self {
+        self.inner.reference_list0_entry_count = reference_list0_entries.len() as _;
+        self.inner.p_reference_list0_entries = reference_list0_entries.as_ptr();
+        self
+    }
+    pub fn reference_list1_entries(
+        mut self,
+        reference_list1_entries: &'a [VideoEncodeH264DpbSlotInfoEXT],
+    ) -> Self {
+        self.inner.reference_list1_entry_count = reference_list1_entries.len() as _;
+        self.inner.p_reference_list1_entries = reference_list1_entries.as_ptr();
+        self
+    }
+    pub fn mem_mgmt_ctrl_operations(
+        mut self,
+        mem_mgmt_ctrl_operations: &'a StdVideoEncodeH264RefMemMgmtCtrlOperations,
+    ) -> Self {
+        self.inner.p_mem_mgmt_ctrl_operations = mem_mgmt_ctrl_operations;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> VideoEncodeH264ReferenceListsEXT {
         self.inner
     }
 }
@@ -51772,24 +51953,18 @@ impl<'a> VideoEncodeH264ProfileEXTBuilder<'a> {
 pub struct VideoEncodeH264NaluSliceEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub p_slice_header_std: *const StdVideoEncodeH264SliceHeader,
     pub mb_count: u32,
-    pub ref_final_list0_entry_count: u8,
-    pub p_ref_final_list0_entries: *const VideoEncodeH264DpbSlotInfoEXT,
-    pub ref_final_list1_entry_count: u8,
-    pub p_ref_final_list1_entries: *const VideoEncodeH264DpbSlotInfoEXT,
+    pub p_reference_final_lists: *const VideoEncodeH264ReferenceListsEXT,
+    pub p_slice_header_std: *const StdVideoEncodeH264SliceHeader,
 }
 impl ::std::default::Default for VideoEncodeH264NaluSliceEXT {
     fn default() -> Self {
         Self {
             s_type: StructureType::VIDEO_ENCODE_H264_NALU_SLICE_EXT,
             p_next: ::std::ptr::null(),
-            p_slice_header_std: ::std::ptr::null(),
             mb_count: u32::default(),
-            ref_final_list0_entry_count: u8::default(),
-            p_ref_final_list0_entries: ::std::ptr::null(),
-            ref_final_list1_entry_count: u8::default(),
-            p_ref_final_list1_entries: ::std::ptr::null(),
+            p_reference_final_lists: ::std::ptr::null(),
+            p_slice_header_std: ::std::ptr::null(),
         }
     }
 }
@@ -51818,28 +51993,19 @@ impl<'a> ::std::ops::DerefMut for VideoEncodeH264NaluSliceEXTBuilder<'a> {
     }
 }
 impl<'a> VideoEncodeH264NaluSliceEXTBuilder<'a> {
-    pub fn slice_header_std(mut self, slice_header_std: &'a StdVideoEncodeH264SliceHeader) -> Self {
-        self.inner.p_slice_header_std = slice_header_std;
-        self
-    }
     pub fn mb_count(mut self, mb_count: u32) -> Self {
         self.inner.mb_count = mb_count;
         self
     }
-    pub fn ref_final_list0_entries(
+    pub fn reference_final_lists(
         mut self,
-        ref_final_list0_entries: &'a [VideoEncodeH264DpbSlotInfoEXT],
+        reference_final_lists: &'a VideoEncodeH264ReferenceListsEXT,
     ) -> Self {
-        self.inner.ref_final_list0_entry_count = ref_final_list0_entries.len() as _;
-        self.inner.p_ref_final_list0_entries = ref_final_list0_entries.as_ptr();
+        self.inner.p_reference_final_lists = reference_final_lists;
         self
     }
-    pub fn ref_final_list1_entries(
-        mut self,
-        ref_final_list1_entries: &'a [VideoEncodeH264DpbSlotInfoEXT],
-    ) -> Self {
-        self.inner.ref_final_list1_entry_count = ref_final_list1_entries.len() as _;
-        self.inner.p_ref_final_list1_entries = ref_final_list1_entries.as_ptr();
+    pub fn slice_header_std(mut self, slice_header_std: &'a StdVideoEncodeH264SliceHeader) -> Self {
+        self.inner.p_slice_header_std = slice_header_std;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
@@ -52156,12 +52322,22 @@ pub struct VideoEncodeH265CapabilitiesEXT {
     pub input_mode_flags: VideoEncodeH265InputModeFlagsEXT,
     pub output_mode_flags: VideoEncodeH265OutputModeFlagsEXT,
     pub ctb_sizes: VideoEncodeH265CtbSizeFlagsEXT,
-    pub input_image_data_alignment: Extent2D,
-    pub max_num_l0_reference_for_p: u8,
-    pub max_num_l0_reference_for_b: u8,
-    pub max_num_l1_reference: u8,
-    pub max_num_sub_layers: u8,
-    pub quality_level_count: u8,
+    pub transform_block_sizes: VideoEncodeH265TransformBlockSizeFlagsEXT,
+    pub max_p_picture_l0_reference_count: u8,
+    pub max_b_picture_l0_reference_count: u8,
+    pub max_l1_reference_count: u8,
+    pub max_sub_layers_count: u8,
+    pub min_log2_min_luma_coding_block_size_minus3: u8,
+    pub max_log2_min_luma_coding_block_size_minus3: u8,
+    pub min_log2_min_luma_transform_block_size_minus2: u8,
+    pub max_log2_min_luma_transform_block_size_minus2: u8,
+    pub min_max_transform_hierarchy_depth_inter: u8,
+    pub max_max_transform_hierarchy_depth_inter: u8,
+    pub min_max_transform_hierarchy_depth_intra: u8,
+    pub max_max_transform_hierarchy_depth_intra: u8,
+    pub max_diff_cu_qp_delta_depth: u8,
+    pub min_max_num_merge_cand: u8,
+    pub max_max_num_merge_cand: u8,
     pub std_extension_version: ExtensionProperties,
 }
 impl ::std::default::Default for VideoEncodeH265CapabilitiesEXT {
@@ -52173,12 +52349,22 @@ impl ::std::default::Default for VideoEncodeH265CapabilitiesEXT {
             input_mode_flags: VideoEncodeH265InputModeFlagsEXT::default(),
             output_mode_flags: VideoEncodeH265OutputModeFlagsEXT::default(),
             ctb_sizes: VideoEncodeH265CtbSizeFlagsEXT::default(),
-            input_image_data_alignment: Extent2D::default(),
-            max_num_l0_reference_for_p: u8::default(),
-            max_num_l0_reference_for_b: u8::default(),
-            max_num_l1_reference: u8::default(),
-            max_num_sub_layers: u8::default(),
-            quality_level_count: u8::default(),
+            transform_block_sizes: VideoEncodeH265TransformBlockSizeFlagsEXT::default(),
+            max_p_picture_l0_reference_count: u8::default(),
+            max_b_picture_l0_reference_count: u8::default(),
+            max_l1_reference_count: u8::default(),
+            max_sub_layers_count: u8::default(),
+            min_log2_min_luma_coding_block_size_minus3: u8::default(),
+            max_log2_min_luma_coding_block_size_minus3: u8::default(),
+            min_log2_min_luma_transform_block_size_minus2: u8::default(),
+            max_log2_min_luma_transform_block_size_minus2: u8::default(),
+            min_max_transform_hierarchy_depth_inter: u8::default(),
+            max_max_transform_hierarchy_depth_inter: u8::default(),
+            min_max_transform_hierarchy_depth_intra: u8::default(),
+            max_max_transform_hierarchy_depth_intra: u8::default(),
+            max_diff_cu_qp_delta_depth: u8::default(),
+            min_max_num_merge_cand: u8::default(),
+            max_max_num_merge_cand: u8::default(),
             std_extension_version: ExtensionProperties::default(),
         }
     }
@@ -52196,8 +52382,8 @@ pub struct VideoEncodeH265CapabilitiesEXTBuilder<'a> {
     inner: VideoEncodeH265CapabilitiesEXT,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsVideoCapabilitiesKHR for VideoEncodeH265CapabilitiesEXTBuilder<'_> {}
-unsafe impl ExtendsVideoCapabilitiesKHR for VideoEncodeH265CapabilitiesEXT {}
+unsafe impl ExtendsVideoEncodeCapabilitiesKHR for VideoEncodeH265CapabilitiesEXTBuilder<'_> {}
+unsafe impl ExtendsVideoEncodeCapabilitiesKHR for VideoEncodeH265CapabilitiesEXT {}
 impl<'a> ::std::ops::Deref for VideoEncodeH265CapabilitiesEXTBuilder<'a> {
     type Target = VideoEncodeH265CapabilitiesEXT;
     fn deref(&self) -> &Self::Target {
@@ -52229,28 +52415,109 @@ impl<'a> VideoEncodeH265CapabilitiesEXTBuilder<'a> {
         self.inner.ctb_sizes = ctb_sizes;
         self
     }
-    pub fn input_image_data_alignment(mut self, input_image_data_alignment: Extent2D) -> Self {
-        self.inner.input_image_data_alignment = input_image_data_alignment;
+    pub fn transform_block_sizes(
+        mut self,
+        transform_block_sizes: VideoEncodeH265TransformBlockSizeFlagsEXT,
+    ) -> Self {
+        self.inner.transform_block_sizes = transform_block_sizes;
         self
     }
-    pub fn max_num_l0_reference_for_p(mut self, max_num_l0_reference_for_p: u8) -> Self {
-        self.inner.max_num_l0_reference_for_p = max_num_l0_reference_for_p;
+    pub fn max_p_picture_l0_reference_count(
+        mut self,
+        max_p_picture_l0_reference_count: u8,
+    ) -> Self {
+        self.inner.max_p_picture_l0_reference_count = max_p_picture_l0_reference_count;
         self
     }
-    pub fn max_num_l0_reference_for_b(mut self, max_num_l0_reference_for_b: u8) -> Self {
-        self.inner.max_num_l0_reference_for_b = max_num_l0_reference_for_b;
+    pub fn max_b_picture_l0_reference_count(
+        mut self,
+        max_b_picture_l0_reference_count: u8,
+    ) -> Self {
+        self.inner.max_b_picture_l0_reference_count = max_b_picture_l0_reference_count;
         self
     }
-    pub fn max_num_l1_reference(mut self, max_num_l1_reference: u8) -> Self {
-        self.inner.max_num_l1_reference = max_num_l1_reference;
+    pub fn max_l1_reference_count(mut self, max_l1_reference_count: u8) -> Self {
+        self.inner.max_l1_reference_count = max_l1_reference_count;
         self
     }
-    pub fn max_num_sub_layers(mut self, max_num_sub_layers: u8) -> Self {
-        self.inner.max_num_sub_layers = max_num_sub_layers;
+    pub fn max_sub_layers_count(mut self, max_sub_layers_count: u8) -> Self {
+        self.inner.max_sub_layers_count = max_sub_layers_count;
         self
     }
-    pub fn quality_level_count(mut self, quality_level_count: u8) -> Self {
-        self.inner.quality_level_count = quality_level_count;
+    pub fn min_log2_min_luma_coding_block_size_minus3(
+        mut self,
+        min_log2_min_luma_coding_block_size_minus3: u8,
+    ) -> Self {
+        self.inner.min_log2_min_luma_coding_block_size_minus3 =
+            min_log2_min_luma_coding_block_size_minus3;
+        self
+    }
+    pub fn max_log2_min_luma_coding_block_size_minus3(
+        mut self,
+        max_log2_min_luma_coding_block_size_minus3: u8,
+    ) -> Self {
+        self.inner.max_log2_min_luma_coding_block_size_minus3 =
+            max_log2_min_luma_coding_block_size_minus3;
+        self
+    }
+    pub fn min_log2_min_luma_transform_block_size_minus2(
+        mut self,
+        min_log2_min_luma_transform_block_size_minus2: u8,
+    ) -> Self {
+        self.inner.min_log2_min_luma_transform_block_size_minus2 =
+            min_log2_min_luma_transform_block_size_minus2;
+        self
+    }
+    pub fn max_log2_min_luma_transform_block_size_minus2(
+        mut self,
+        max_log2_min_luma_transform_block_size_minus2: u8,
+    ) -> Self {
+        self.inner.max_log2_min_luma_transform_block_size_minus2 =
+            max_log2_min_luma_transform_block_size_minus2;
+        self
+    }
+    pub fn min_max_transform_hierarchy_depth_inter(
+        mut self,
+        min_max_transform_hierarchy_depth_inter: u8,
+    ) -> Self {
+        self.inner.min_max_transform_hierarchy_depth_inter =
+            min_max_transform_hierarchy_depth_inter;
+        self
+    }
+    pub fn max_max_transform_hierarchy_depth_inter(
+        mut self,
+        max_max_transform_hierarchy_depth_inter: u8,
+    ) -> Self {
+        self.inner.max_max_transform_hierarchy_depth_inter =
+            max_max_transform_hierarchy_depth_inter;
+        self
+    }
+    pub fn min_max_transform_hierarchy_depth_intra(
+        mut self,
+        min_max_transform_hierarchy_depth_intra: u8,
+    ) -> Self {
+        self.inner.min_max_transform_hierarchy_depth_intra =
+            min_max_transform_hierarchy_depth_intra;
+        self
+    }
+    pub fn max_max_transform_hierarchy_depth_intra(
+        mut self,
+        max_max_transform_hierarchy_depth_intra: u8,
+    ) -> Self {
+        self.inner.max_max_transform_hierarchy_depth_intra =
+            max_max_transform_hierarchy_depth_intra;
+        self
+    }
+    pub fn max_diff_cu_qp_delta_depth(mut self, max_diff_cu_qp_delta_depth: u8) -> Self {
+        self.inner.max_diff_cu_qp_delta_depth = max_diff_cu_qp_delta_depth;
+        self
+    }
+    pub fn min_max_num_merge_cand(mut self, min_max_num_merge_cand: u8) -> Self {
+        self.inner.min_max_num_merge_cand = min_max_num_merge_cand;
+        self
+    }
+    pub fn max_max_num_merge_cand(mut self, max_max_num_merge_cand: u8) -> Self {
+        self.inner.max_max_num_merge_cand = max_max_num_merge_cand;
         self
     }
     pub fn std_extension_version(mut self, std_extension_version: ExtensionProperties) -> Self {

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -54,9 +54,11 @@ pub const API_VERSION_1_0: u32 = make_api_version(0, 1, 0, 0);
 pub const API_VERSION_1_1: u32 = make_api_version(0, 1, 1, 0);
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_API_VERSION_1_2.html>"]
 pub const API_VERSION_1_2: u32 = make_api_version(0, 1, 2, 0);
-pub const HEADER_VERSION: u32 = 203u32;
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_API_VERSION_1_3.html>"]
+pub const API_VERSION_1_3: u32 = make_api_version(0, 1, 3, 0);
+pub const HEADER_VERSION: u32 = 205u32;
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_HEADER_VERSION_COMPLETE.html>"]
-pub const HEADER_VERSION_COMPLETE: u32 = make_api_version(0, 1, 2, HEADER_VERSION);
+pub const HEADER_VERSION_COMPLETE: u32 = make_api_version(0, 1, 3, HEADER_VERSION);
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSampleMask.html>"]
 pub type SampleMask = u32;
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBool32.html>"]
@@ -419,7 +421,7 @@ handle_nondispatchable ! (AccelerationStructureNV , ACCELERATION_STRUCTURE_NV , 
 handle_nondispatchable ! (PerformanceConfigurationINTEL , PERFORMANCE_CONFIGURATION_INTEL , doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPerformanceConfigurationINTEL.html>") ;
 handle_nondispatchable ! (BufferCollectionFUCHSIA , BUFFER_COLLECTION_FUCHSIA , doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBufferCollectionFUCHSIA.html>") ;
 handle_nondispatchable ! (DeferredOperationKHR , DEFERRED_OPERATION_KHR , doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDeferredOperationKHR.html>") ;
-handle_nondispatchable ! (PrivateDataSlotEXT , PRIVATE_DATA_SLOT_EXT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPrivateDataSlotEXT.html>") ;
+handle_nondispatchable ! (PrivateDataSlot , PRIVATE_DATA_SLOT , doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPrivateDataSlot.html>") ;
 handle_nondispatchable ! (CuModuleNVX , CU_MODULE_NVX , doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCuModuleNVX.html>") ;
 handle_nondispatchable ! (CuFunctionNVX , CU_FUNCTION_NVX , doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCuFunctionNVX.html>") ;
 handle_nondispatchable!(
@@ -12271,8 +12273,8 @@ pub struct Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a> {
 }
 unsafe impl ExtendsSubmitInfo for Win32KeyedMutexAcquireReleaseInfoNVBuilder<'_> {}
 unsafe impl ExtendsSubmitInfo for Win32KeyedMutexAcquireReleaseInfoNV {}
-unsafe impl ExtendsSubmitInfo2KHR for Win32KeyedMutexAcquireReleaseInfoNVBuilder<'_> {}
-unsafe impl ExtendsSubmitInfo2KHR for Win32KeyedMutexAcquireReleaseInfoNV {}
+unsafe impl ExtendsSubmitInfo2 for Win32KeyedMutexAcquireReleaseInfoNVBuilder<'_> {}
+unsafe impl ExtendsSubmitInfo2 for Win32KeyedMutexAcquireReleaseInfoNV {}
 impl<'a> ::std::ops::Deref for Win32KeyedMutexAcquireReleaseInfoNVBuilder<'a> {
     type Target = Win32KeyedMutexAcquireReleaseInfoNV;
     fn deref(&self) -> &Self::Target {
@@ -12381,48 +12383,48 @@ impl<'a> PhysicalDeviceDeviceGeneratedCommandsFeaturesNVBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDevicePrivateDataCreateInfoEXT.html>"]
-pub struct DevicePrivateDataCreateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDevicePrivateDataCreateInfo.html>"]
+pub struct DevicePrivateDataCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub private_data_slot_request_count: u32,
 }
-impl ::std::default::Default for DevicePrivateDataCreateInfoEXT {
+impl ::std::default::Default for DevicePrivateDataCreateInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::DEVICE_PRIVATE_DATA_CREATE_INFO_EXT,
+            s_type: StructureType::DEVICE_PRIVATE_DATA_CREATE_INFO,
             p_next: ::std::ptr::null(),
             private_data_slot_request_count: u32::default(),
         }
     }
 }
-impl DevicePrivateDataCreateInfoEXT {
-    pub fn builder<'a>() -> DevicePrivateDataCreateInfoEXTBuilder<'a> {
-        DevicePrivateDataCreateInfoEXTBuilder {
+impl DevicePrivateDataCreateInfo {
+    pub fn builder<'a>() -> DevicePrivateDataCreateInfoBuilder<'a> {
+        DevicePrivateDataCreateInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct DevicePrivateDataCreateInfoEXTBuilder<'a> {
-    inner: DevicePrivateDataCreateInfoEXT,
+pub struct DevicePrivateDataCreateInfoBuilder<'a> {
+    inner: DevicePrivateDataCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceCreateInfo for DevicePrivateDataCreateInfoEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for DevicePrivateDataCreateInfoEXT {}
-impl<'a> ::std::ops::Deref for DevicePrivateDataCreateInfoEXTBuilder<'a> {
-    type Target = DevicePrivateDataCreateInfoEXT;
+unsafe impl ExtendsDeviceCreateInfo for DevicePrivateDataCreateInfoBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for DevicePrivateDataCreateInfo {}
+impl<'a> ::std::ops::Deref for DevicePrivateDataCreateInfoBuilder<'a> {
+    type Target = DevicePrivateDataCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for DevicePrivateDataCreateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for DevicePrivateDataCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> DevicePrivateDataCreateInfoEXTBuilder<'a> {
+impl<'a> DevicePrivateDataCreateInfoBuilder<'a> {
     pub fn private_data_slot_request_count(mut self, private_data_slot_request_count: u32) -> Self {
         self.inner.private_data_slot_request_count = private_data_slot_request_count;
         self
@@ -12430,111 +12432,111 @@ impl<'a> DevicePrivateDataCreateInfoEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> DevicePrivateDataCreateInfoEXT {
+    pub fn build(self) -> DevicePrivateDataCreateInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPrivateDataSlotCreateInfoEXT.html>"]
-pub struct PrivateDataSlotCreateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPrivateDataSlotCreateInfo.html>"]
+pub struct PrivateDataSlotCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub flags: PrivateDataSlotCreateFlagsEXT,
+    pub flags: PrivateDataSlotCreateFlags,
 }
-impl ::std::default::Default for PrivateDataSlotCreateInfoEXT {
+impl ::std::default::Default for PrivateDataSlotCreateInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PRIVATE_DATA_SLOT_CREATE_INFO_EXT,
+            s_type: StructureType::PRIVATE_DATA_SLOT_CREATE_INFO,
             p_next: ::std::ptr::null(),
-            flags: PrivateDataSlotCreateFlagsEXT::default(),
+            flags: PrivateDataSlotCreateFlags::default(),
         }
     }
 }
-impl PrivateDataSlotCreateInfoEXT {
-    pub fn builder<'a>() -> PrivateDataSlotCreateInfoEXTBuilder<'a> {
-        PrivateDataSlotCreateInfoEXTBuilder {
+impl PrivateDataSlotCreateInfo {
+    pub fn builder<'a>() -> PrivateDataSlotCreateInfoBuilder<'a> {
+        PrivateDataSlotCreateInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PrivateDataSlotCreateInfoEXTBuilder<'a> {
-    inner: PrivateDataSlotCreateInfoEXT,
+pub struct PrivateDataSlotCreateInfoBuilder<'a> {
+    inner: PrivateDataSlotCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for PrivateDataSlotCreateInfoEXTBuilder<'a> {
-    type Target = PrivateDataSlotCreateInfoEXT;
+impl<'a> ::std::ops::Deref for PrivateDataSlotCreateInfoBuilder<'a> {
+    type Target = PrivateDataSlotCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PrivateDataSlotCreateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PrivateDataSlotCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PrivateDataSlotCreateInfoEXTBuilder<'a> {
-    pub fn flags(mut self, flags: PrivateDataSlotCreateFlagsEXT) -> Self {
+impl<'a> PrivateDataSlotCreateInfoBuilder<'a> {
+    pub fn flags(mut self, flags: PrivateDataSlotCreateFlags) -> Self {
         self.inner.flags = flags;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PrivateDataSlotCreateInfoEXT {
+    pub fn build(self) -> PrivateDataSlotCreateInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDevicePrivateDataFeaturesEXT.html>"]
-pub struct PhysicalDevicePrivateDataFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDevicePrivateDataFeatures.html>"]
+pub struct PhysicalDevicePrivateDataFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub private_data: Bool32,
 }
-impl ::std::default::Default for PhysicalDevicePrivateDataFeaturesEXT {
+impl ::std::default::Default for PhysicalDevicePrivateDataFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES,
             p_next: ::std::ptr::null_mut(),
             private_data: Bool32::default(),
         }
     }
 }
-impl PhysicalDevicePrivateDataFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDevicePrivateDataFeaturesEXTBuilder<'a> {
-        PhysicalDevicePrivateDataFeaturesEXTBuilder {
+impl PhysicalDevicePrivateDataFeatures {
+    pub fn builder<'a>() -> PhysicalDevicePrivateDataFeaturesBuilder<'a> {
+        PhysicalDevicePrivateDataFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDevicePrivateDataFeaturesEXTBuilder<'a> {
-    inner: PhysicalDevicePrivateDataFeaturesEXT,
+pub struct PhysicalDevicePrivateDataFeaturesBuilder<'a> {
+    inner: PhysicalDevicePrivateDataFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDevicePrivateDataFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDevicePrivateDataFeaturesEXT {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDevicePrivateDataFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDevicePrivateDataFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDevicePrivateDataFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDevicePrivateDataFeaturesEXT;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDevicePrivateDataFeaturesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDevicePrivateDataFeatures {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDevicePrivateDataFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDevicePrivateDataFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDevicePrivateDataFeaturesBuilder<'a> {
+    type Target = PhysicalDevicePrivateDataFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDevicePrivateDataFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDevicePrivateDataFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDevicePrivateDataFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDevicePrivateDataFeaturesBuilder<'a> {
     pub fn private_data(mut self, private_data: bool) -> Self {
         self.inner.private_data = private_data.into();
         self
@@ -12542,7 +12544,7 @@ impl<'a> PhysicalDevicePrivateDataFeaturesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDevicePrivateDataFeaturesEXT {
+    pub fn build(self) -> PhysicalDevicePrivateDataFeatures {
         self.inner
     }
 }
@@ -15812,8 +15814,8 @@ pub struct Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a> {
 }
 unsafe impl ExtendsSubmitInfo for Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'_> {}
 unsafe impl ExtendsSubmitInfo for Win32KeyedMutexAcquireReleaseInfoKHR {}
-unsafe impl ExtendsSubmitInfo2KHR for Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'_> {}
-unsafe impl ExtendsSubmitInfo2KHR for Win32KeyedMutexAcquireReleaseInfoKHR {}
+unsafe impl ExtendsSubmitInfo2 for Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'_> {}
+unsafe impl ExtendsSubmitInfo2 for Win32KeyedMutexAcquireReleaseInfoKHR {}
 impl<'a> ::std::ops::Deref for Win32KeyedMutexAcquireReleaseInfoKHRBuilder<'a> {
     type Target = Win32KeyedMutexAcquireReleaseInfoKHR;
     fn deref(&self) -> &Self::Target {
@@ -18129,8 +18131,8 @@ pub struct DeviceGroupRenderPassBeginInfoBuilder<'a> {
 }
 unsafe impl ExtendsRenderPassBeginInfo for DeviceGroupRenderPassBeginInfoBuilder<'_> {}
 unsafe impl ExtendsRenderPassBeginInfo for DeviceGroupRenderPassBeginInfo {}
-unsafe impl ExtendsRenderingInfoKHR for DeviceGroupRenderPassBeginInfoBuilder<'_> {}
-unsafe impl ExtendsRenderingInfoKHR for DeviceGroupRenderPassBeginInfo {}
+unsafe impl ExtendsRenderingInfo for DeviceGroupRenderPassBeginInfoBuilder<'_> {}
+unsafe impl ExtendsRenderingInfo for DeviceGroupRenderPassBeginInfo {}
 impl<'a> ::std::ops::Deref for DeviceGroupRenderPassBeginInfoBuilder<'a> {
     type Target = DeviceGroupRenderPassBeginInfo;
     fn deref(&self) -> &Self::Target {
@@ -21150,46 +21152,46 @@ impl<'a> BufferMemoryRequirementsInfo2Builder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDeviceBufferMemoryRequirementsKHR.html>"]
-pub struct DeviceBufferMemoryRequirementsKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDeviceBufferMemoryRequirements.html>"]
+pub struct DeviceBufferMemoryRequirements {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub p_create_info: *const BufferCreateInfo,
 }
-impl ::std::default::Default for DeviceBufferMemoryRequirementsKHR {
+impl ::std::default::Default for DeviceBufferMemoryRequirements {
     fn default() -> Self {
         Self {
-            s_type: StructureType::DEVICE_BUFFER_MEMORY_REQUIREMENTS_KHR,
+            s_type: StructureType::DEVICE_BUFFER_MEMORY_REQUIREMENTS,
             p_next: ::std::ptr::null(),
             p_create_info: ::std::ptr::null(),
         }
     }
 }
-impl DeviceBufferMemoryRequirementsKHR {
-    pub fn builder<'a>() -> DeviceBufferMemoryRequirementsKHRBuilder<'a> {
-        DeviceBufferMemoryRequirementsKHRBuilder {
+impl DeviceBufferMemoryRequirements {
+    pub fn builder<'a>() -> DeviceBufferMemoryRequirementsBuilder<'a> {
+        DeviceBufferMemoryRequirementsBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct DeviceBufferMemoryRequirementsKHRBuilder<'a> {
-    inner: DeviceBufferMemoryRequirementsKHR,
+pub struct DeviceBufferMemoryRequirementsBuilder<'a> {
+    inner: DeviceBufferMemoryRequirements,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for DeviceBufferMemoryRequirementsKHRBuilder<'a> {
-    type Target = DeviceBufferMemoryRequirementsKHR;
+impl<'a> ::std::ops::Deref for DeviceBufferMemoryRequirementsBuilder<'a> {
+    type Target = DeviceBufferMemoryRequirements;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for DeviceBufferMemoryRequirementsKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for DeviceBufferMemoryRequirementsBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> DeviceBufferMemoryRequirementsKHRBuilder<'a> {
+impl<'a> DeviceBufferMemoryRequirementsBuilder<'a> {
     pub fn create_info(mut self, create_info: &'a BufferCreateInfo) -> Self {
         self.inner.p_create_info = create_info;
         self
@@ -21197,7 +21199,7 @@ impl<'a> DeviceBufferMemoryRequirementsKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> DeviceBufferMemoryRequirementsKHR {
+    pub fn build(self) -> DeviceBufferMemoryRequirements {
         self.inner
     }
 }
@@ -21327,48 +21329,48 @@ impl<'a> ImageSparseMemoryRequirementsInfo2Builder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDeviceImageMemoryRequirementsKHR.html>"]
-pub struct DeviceImageMemoryRequirementsKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDeviceImageMemoryRequirements.html>"]
+pub struct DeviceImageMemoryRequirements {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub p_create_info: *const ImageCreateInfo,
     pub plane_aspect: ImageAspectFlags,
 }
-impl ::std::default::Default for DeviceImageMemoryRequirementsKHR {
+impl ::std::default::Default for DeviceImageMemoryRequirements {
     fn default() -> Self {
         Self {
-            s_type: StructureType::DEVICE_IMAGE_MEMORY_REQUIREMENTS_KHR,
+            s_type: StructureType::DEVICE_IMAGE_MEMORY_REQUIREMENTS,
             p_next: ::std::ptr::null(),
             p_create_info: ::std::ptr::null(),
             plane_aspect: ImageAspectFlags::default(),
         }
     }
 }
-impl DeviceImageMemoryRequirementsKHR {
-    pub fn builder<'a>() -> DeviceImageMemoryRequirementsKHRBuilder<'a> {
-        DeviceImageMemoryRequirementsKHRBuilder {
+impl DeviceImageMemoryRequirements {
+    pub fn builder<'a>() -> DeviceImageMemoryRequirementsBuilder<'a> {
+        DeviceImageMemoryRequirementsBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct DeviceImageMemoryRequirementsKHRBuilder<'a> {
-    inner: DeviceImageMemoryRequirementsKHR,
+pub struct DeviceImageMemoryRequirementsBuilder<'a> {
+    inner: DeviceImageMemoryRequirements,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for DeviceImageMemoryRequirementsKHRBuilder<'a> {
-    type Target = DeviceImageMemoryRequirementsKHR;
+impl<'a> ::std::ops::Deref for DeviceImageMemoryRequirementsBuilder<'a> {
+    type Target = DeviceImageMemoryRequirements;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for DeviceImageMemoryRequirementsKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for DeviceImageMemoryRequirementsBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> DeviceImageMemoryRequirementsKHRBuilder<'a> {
+impl<'a> DeviceImageMemoryRequirementsBuilder<'a> {
     pub fn create_info(mut self, create_info: &'a ImageCreateInfo) -> Self {
         self.inner.p_create_info = create_info;
         self
@@ -21380,7 +21382,7 @@ impl<'a> DeviceImageMemoryRequirementsKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> DeviceImageMemoryRequirementsKHR {
+    pub fn build(self) -> DeviceImageMemoryRequirements {
         self.inner
     }
 }
@@ -22815,8 +22817,8 @@ pub struct SampleLocationsInfoEXTBuilder<'a> {
 }
 unsafe impl ExtendsImageMemoryBarrier for SampleLocationsInfoEXTBuilder<'_> {}
 unsafe impl ExtendsImageMemoryBarrier for SampleLocationsInfoEXT {}
-unsafe impl ExtendsImageMemoryBarrier2KHR for SampleLocationsInfoEXTBuilder<'_> {}
-unsafe impl ExtendsImageMemoryBarrier2KHR for SampleLocationsInfoEXT {}
+unsafe impl ExtendsImageMemoryBarrier2 for SampleLocationsInfoEXTBuilder<'_> {}
+unsafe impl ExtendsImageMemoryBarrier2 for SampleLocationsInfoEXT {}
 impl<'a> ::std::ops::Deref for SampleLocationsInfoEXTBuilder<'a> {
     type Target = SampleLocationsInfoEXT;
     fn deref(&self) -> &Self::Target {
@@ -23602,55 +23604,52 @@ impl<'a> PipelineColorBlendAdvancedStateCreateInfoEXTBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceInlineUniformBlockFeaturesEXT.html>"]
-pub struct PhysicalDeviceInlineUniformBlockFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceInlineUniformBlockFeatures.html>"]
+pub struct PhysicalDeviceInlineUniformBlockFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub inline_uniform_block: Bool32,
     pub descriptor_binding_inline_uniform_block_update_after_bind: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceInlineUniformBlockFeaturesEXT {
+impl ::std::default::Default for PhysicalDeviceInlineUniformBlockFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES,
             p_next: ::std::ptr::null_mut(),
             inline_uniform_block: Bool32::default(),
             descriptor_binding_inline_uniform_block_update_after_bind: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceInlineUniformBlockFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
-        PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder {
+impl PhysicalDeviceInlineUniformBlockFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceInlineUniformBlockFeaturesBuilder<'a> {
+        PhysicalDeviceInlineUniformBlockFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
-    inner: PhysicalDeviceInlineUniformBlockFeaturesEXT,
+pub struct PhysicalDeviceInlineUniformBlockFeaturesBuilder<'a> {
+    inner: PhysicalDeviceInlineUniformBlockFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'_>
-{
-}
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceInlineUniformBlockFeaturesEXT {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceInlineUniformBlockFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDeviceInlineUniformBlockFeaturesEXT;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceInlineUniformBlockFeaturesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceInlineUniformBlockFeatures {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceInlineUniformBlockFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceInlineUniformBlockFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceInlineUniformBlockFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceInlineUniformBlockFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceInlineUniformBlockFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceInlineUniformBlockFeaturesBuilder<'a> {
     pub fn inline_uniform_block(mut self, inline_uniform_block: bool) -> Self {
         self.inner.inline_uniform_block = inline_uniform_block.into();
         self
@@ -23667,15 +23666,15 @@ impl<'a> PhysicalDeviceInlineUniformBlockFeaturesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceInlineUniformBlockFeaturesEXT {
+    pub fn build(self) -> PhysicalDeviceInlineUniformBlockFeatures {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceInlineUniformBlockPropertiesEXT.html>"]
-pub struct PhysicalDeviceInlineUniformBlockPropertiesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceInlineUniformBlockProperties.html>"]
+pub struct PhysicalDeviceInlineUniformBlockProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub max_inline_uniform_block_size: u32,
@@ -23684,10 +23683,10 @@ pub struct PhysicalDeviceInlineUniformBlockPropertiesEXT {
     pub max_descriptor_set_inline_uniform_blocks: u32,
     pub max_descriptor_set_update_after_bind_inline_uniform_blocks: u32,
 }
-impl ::std::default::Default for PhysicalDeviceInlineUniformBlockPropertiesEXT {
+impl ::std::default::Default for PhysicalDeviceInlineUniformBlockProperties {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
             max_inline_uniform_block_size: u32::default(),
             max_per_stage_descriptor_inline_uniform_blocks: u32::default(),
@@ -23697,36 +23696,36 @@ impl ::std::default::Default for PhysicalDeviceInlineUniformBlockPropertiesEXT {
         }
     }
 }
-impl PhysicalDeviceInlineUniformBlockPropertiesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
-        PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder {
+impl PhysicalDeviceInlineUniformBlockProperties {
+    pub fn builder<'a>() -> PhysicalDeviceInlineUniformBlockPropertiesBuilder<'a> {
+        PhysicalDeviceInlineUniformBlockPropertiesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
-    inner: PhysicalDeviceInlineUniformBlockPropertiesEXT,
+pub struct PhysicalDeviceInlineUniformBlockPropertiesBuilder<'a> {
+    inner: PhysicalDeviceInlineUniformBlockProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'_>
+    for PhysicalDeviceInlineUniformBlockPropertiesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceInlineUniformBlockPropertiesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
-    type Target = PhysicalDeviceInlineUniformBlockPropertiesEXT;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceInlineUniformBlockProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceInlineUniformBlockPropertiesBuilder<'a> {
+    type Target = PhysicalDeviceInlineUniformBlockProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceInlineUniformBlockPropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceInlineUniformBlockPropertiesBuilder<'a> {
     pub fn max_inline_uniform_block_size(mut self, max_inline_uniform_block_size: u32) -> Self {
         self.inner.max_inline_uniform_block_size = max_inline_uniform_block_size;
         self
@@ -23768,57 +23767,57 @@ impl<'a> PhysicalDeviceInlineUniformBlockPropertiesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceInlineUniformBlockPropertiesEXT {
+    pub fn build(self) -> PhysicalDeviceInlineUniformBlockProperties {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkWriteDescriptorSetInlineUniformBlockEXT.html>"]
-pub struct WriteDescriptorSetInlineUniformBlockEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkWriteDescriptorSetInlineUniformBlock.html>"]
+pub struct WriteDescriptorSetInlineUniformBlock {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub data_size: u32,
     pub p_data: *const c_void,
 }
-impl ::std::default::Default for WriteDescriptorSetInlineUniformBlockEXT {
+impl ::std::default::Default for WriteDescriptorSetInlineUniformBlock {
     fn default() -> Self {
         Self {
-            s_type: StructureType::WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT,
+            s_type: StructureType::WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK,
             p_next: ::std::ptr::null(),
             data_size: u32::default(),
             p_data: ::std::ptr::null(),
         }
     }
 }
-impl WriteDescriptorSetInlineUniformBlockEXT {
-    pub fn builder<'a>() -> WriteDescriptorSetInlineUniformBlockEXTBuilder<'a> {
-        WriteDescriptorSetInlineUniformBlockEXTBuilder {
+impl WriteDescriptorSetInlineUniformBlock {
+    pub fn builder<'a>() -> WriteDescriptorSetInlineUniformBlockBuilder<'a> {
+        WriteDescriptorSetInlineUniformBlockBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct WriteDescriptorSetInlineUniformBlockEXTBuilder<'a> {
-    inner: WriteDescriptorSetInlineUniformBlockEXT,
+pub struct WriteDescriptorSetInlineUniformBlockBuilder<'a> {
+    inner: WriteDescriptorSetInlineUniformBlock,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsWriteDescriptorSet for WriteDescriptorSetInlineUniformBlockEXTBuilder<'_> {}
-unsafe impl ExtendsWriteDescriptorSet for WriteDescriptorSetInlineUniformBlockEXT {}
-impl<'a> ::std::ops::Deref for WriteDescriptorSetInlineUniformBlockEXTBuilder<'a> {
-    type Target = WriteDescriptorSetInlineUniformBlockEXT;
+unsafe impl ExtendsWriteDescriptorSet for WriteDescriptorSetInlineUniformBlockBuilder<'_> {}
+unsafe impl ExtendsWriteDescriptorSet for WriteDescriptorSetInlineUniformBlock {}
+impl<'a> ::std::ops::Deref for WriteDescriptorSetInlineUniformBlockBuilder<'a> {
+    type Target = WriteDescriptorSetInlineUniformBlock;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for WriteDescriptorSetInlineUniformBlockEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for WriteDescriptorSetInlineUniformBlockBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> WriteDescriptorSetInlineUniformBlockEXTBuilder<'a> {
+impl<'a> WriteDescriptorSetInlineUniformBlockBuilder<'a> {
     pub fn data(mut self, data: &'a [u8]) -> Self {
         self.inner.data_size = data.len() as _;
         self.inner.p_data = data.as_ptr() as *const c_void;
@@ -23827,58 +23826,58 @@ impl<'a> WriteDescriptorSetInlineUniformBlockEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> WriteDescriptorSetInlineUniformBlockEXT {
+    pub fn build(self) -> WriteDescriptorSetInlineUniformBlock {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDescriptorPoolInlineUniformBlockCreateInfoEXT.html>"]
-pub struct DescriptorPoolInlineUniformBlockCreateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDescriptorPoolInlineUniformBlockCreateInfo.html>"]
+pub struct DescriptorPoolInlineUniformBlockCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub max_inline_uniform_block_bindings: u32,
 }
-impl ::std::default::Default for DescriptorPoolInlineUniformBlockCreateInfoEXT {
+impl ::std::default::Default for DescriptorPoolInlineUniformBlockCreateInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT,
+            s_type: StructureType::DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO,
             p_next: ::std::ptr::null(),
             max_inline_uniform_block_bindings: u32::default(),
         }
     }
 }
-impl DescriptorPoolInlineUniformBlockCreateInfoEXT {
-    pub fn builder<'a>() -> DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'a> {
-        DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder {
+impl DescriptorPoolInlineUniformBlockCreateInfo {
+    pub fn builder<'a>() -> DescriptorPoolInlineUniformBlockCreateInfoBuilder<'a> {
+        DescriptorPoolInlineUniformBlockCreateInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'a> {
-    inner: DescriptorPoolInlineUniformBlockCreateInfoEXT,
+pub struct DescriptorPoolInlineUniformBlockCreateInfoBuilder<'a> {
+    inner: DescriptorPoolInlineUniformBlockCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsDescriptorPoolCreateInfo
-    for DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'_>
+    for DescriptorPoolInlineUniformBlockCreateInfoBuilder<'_>
 {
 }
-unsafe impl ExtendsDescriptorPoolCreateInfo for DescriptorPoolInlineUniformBlockCreateInfoEXT {}
-impl<'a> ::std::ops::Deref for DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'a> {
-    type Target = DescriptorPoolInlineUniformBlockCreateInfoEXT;
+unsafe impl ExtendsDescriptorPoolCreateInfo for DescriptorPoolInlineUniformBlockCreateInfo {}
+impl<'a> ::std::ops::Deref for DescriptorPoolInlineUniformBlockCreateInfoBuilder<'a> {
+    type Target = DescriptorPoolInlineUniformBlockCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for DescriptorPoolInlineUniformBlockCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'a> {
+impl<'a> DescriptorPoolInlineUniformBlockCreateInfoBuilder<'a> {
     pub fn max_inline_uniform_block_bindings(
         mut self,
         max_inline_uniform_block_bindings: u32,
@@ -23889,7 +23888,7 @@ impl<'a> DescriptorPoolInlineUniformBlockCreateInfoEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> DescriptorPoolInlineUniformBlockCreateInfoEXT {
+    pub fn build(self) -> DescriptorPoolInlineUniformBlockCreateInfo {
         self.inner
     }
 }
@@ -24229,50 +24228,50 @@ impl<'a> PhysicalDeviceMaintenance3PropertiesBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceMaintenance4FeaturesKHR.html>"]
-pub struct PhysicalDeviceMaintenance4FeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceMaintenance4Features.html>"]
+pub struct PhysicalDeviceMaintenance4Features {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub maintenance4: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceMaintenance4FeaturesKHR {
+impl ::std::default::Default for PhysicalDeviceMaintenance4Features {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES_KHR,
+            s_type: StructureType::PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES,
             p_next: ::std::ptr::null_mut(),
             maintenance4: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceMaintenance4FeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceMaintenance4FeaturesKHRBuilder<'a> {
-        PhysicalDeviceMaintenance4FeaturesKHRBuilder {
+impl PhysicalDeviceMaintenance4Features {
+    pub fn builder<'a>() -> PhysicalDeviceMaintenance4FeaturesBuilder<'a> {
+        PhysicalDeviceMaintenance4FeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceMaintenance4FeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceMaintenance4FeaturesKHR,
+pub struct PhysicalDeviceMaintenance4FeaturesBuilder<'a> {
+    inner: PhysicalDeviceMaintenance4Features,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceMaintenance4FeaturesKHRBuilder<'_> {}
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceMaintenance4FeaturesKHR {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceMaintenance4FeaturesKHRBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceMaintenance4FeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceMaintenance4FeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceMaintenance4FeaturesKHR;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceMaintenance4FeaturesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceMaintenance4Features {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceMaintenance4FeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceMaintenance4Features {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceMaintenance4FeaturesBuilder<'a> {
+    type Target = PhysicalDeviceMaintenance4Features;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceMaintenance4FeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceMaintenance4FeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceMaintenance4FeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceMaintenance4FeaturesBuilder<'a> {
     pub fn maintenance4(mut self, maintenance4: bool) -> Self {
         self.inner.maintenance4 = maintenance4.into();
         self
@@ -24280,58 +24279,55 @@ impl<'a> PhysicalDeviceMaintenance4FeaturesKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceMaintenance4FeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceMaintenance4Features {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceMaintenance4PropertiesKHR.html>"]
-pub struct PhysicalDeviceMaintenance4PropertiesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceMaintenance4Properties.html>"]
+pub struct PhysicalDeviceMaintenance4Properties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub max_buffer_size: DeviceSize,
 }
-impl ::std::default::Default for PhysicalDeviceMaintenance4PropertiesKHR {
+impl ::std::default::Default for PhysicalDeviceMaintenance4Properties {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES_KHR,
+            s_type: StructureType::PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
             max_buffer_size: DeviceSize::default(),
         }
     }
 }
-impl PhysicalDeviceMaintenance4PropertiesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceMaintenance4PropertiesKHRBuilder<'a> {
-        PhysicalDeviceMaintenance4PropertiesKHRBuilder {
+impl PhysicalDeviceMaintenance4Properties {
+    pub fn builder<'a>() -> PhysicalDeviceMaintenance4PropertiesBuilder<'a> {
+        PhysicalDeviceMaintenance4PropertiesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceMaintenance4PropertiesKHRBuilder<'a> {
-    inner: PhysicalDeviceMaintenance4PropertiesKHR,
+pub struct PhysicalDeviceMaintenance4PropertiesBuilder<'a> {
+    inner: PhysicalDeviceMaintenance4Properties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceMaintenance4PropertiesKHRBuilder<'_>
-{
-}
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceMaintenance4PropertiesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceMaintenance4PropertiesKHRBuilder<'a> {
-    type Target = PhysicalDeviceMaintenance4PropertiesKHR;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceMaintenance4PropertiesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceMaintenance4Properties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceMaintenance4PropertiesBuilder<'a> {
+    type Target = PhysicalDeviceMaintenance4Properties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceMaintenance4PropertiesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceMaintenance4PropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceMaintenance4PropertiesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceMaintenance4PropertiesBuilder<'a> {
     pub fn max_buffer_size(mut self, max_buffer_size: DeviceSize) -> Self {
         self.inner.max_buffer_size = max_buffer_size;
         self
@@ -24339,7 +24335,7 @@ impl<'a> PhysicalDeviceMaintenance4PropertiesKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceMaintenance4PropertiesKHR {
+    pub fn build(self) -> PhysicalDeviceMaintenance4Properties {
         self.inner
     }
 }
@@ -25178,109 +25174,109 @@ impl<'a> ShaderStatisticsInfoAMDBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDeviceQueueGlobalPriorityCreateInfoEXT.html>"]
-pub struct DeviceQueueGlobalPriorityCreateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDeviceQueueGlobalPriorityCreateInfoKHR.html>"]
+pub struct DeviceQueueGlobalPriorityCreateInfoKHR {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub global_priority: QueueGlobalPriorityEXT,
+    pub global_priority: QueueGlobalPriorityKHR,
 }
-impl ::std::default::Default for DeviceQueueGlobalPriorityCreateInfoEXT {
+impl ::std::default::Default for DeviceQueueGlobalPriorityCreateInfoKHR {
     fn default() -> Self {
         Self {
-            s_type: StructureType::DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT,
+            s_type: StructureType::DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR,
             p_next: ::std::ptr::null(),
-            global_priority: QueueGlobalPriorityEXT::default(),
+            global_priority: QueueGlobalPriorityKHR::default(),
         }
     }
 }
-impl DeviceQueueGlobalPriorityCreateInfoEXT {
-    pub fn builder<'a>() -> DeviceQueueGlobalPriorityCreateInfoEXTBuilder<'a> {
-        DeviceQueueGlobalPriorityCreateInfoEXTBuilder {
+impl DeviceQueueGlobalPriorityCreateInfoKHR {
+    pub fn builder<'a>() -> DeviceQueueGlobalPriorityCreateInfoKHRBuilder<'a> {
+        DeviceQueueGlobalPriorityCreateInfoKHRBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct DeviceQueueGlobalPriorityCreateInfoEXTBuilder<'a> {
-    inner: DeviceQueueGlobalPriorityCreateInfoEXT,
+pub struct DeviceQueueGlobalPriorityCreateInfoKHRBuilder<'a> {
+    inner: DeviceQueueGlobalPriorityCreateInfoKHR,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsDeviceQueueCreateInfo for DeviceQueueGlobalPriorityCreateInfoEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceQueueCreateInfo for DeviceQueueGlobalPriorityCreateInfoEXT {}
-impl<'a> ::std::ops::Deref for DeviceQueueGlobalPriorityCreateInfoEXTBuilder<'a> {
-    type Target = DeviceQueueGlobalPriorityCreateInfoEXT;
+unsafe impl ExtendsDeviceQueueCreateInfo for DeviceQueueGlobalPriorityCreateInfoKHRBuilder<'_> {}
+unsafe impl ExtendsDeviceQueueCreateInfo for DeviceQueueGlobalPriorityCreateInfoKHR {}
+impl<'a> ::std::ops::Deref for DeviceQueueGlobalPriorityCreateInfoKHRBuilder<'a> {
+    type Target = DeviceQueueGlobalPriorityCreateInfoKHR;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for DeviceQueueGlobalPriorityCreateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for DeviceQueueGlobalPriorityCreateInfoKHRBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> DeviceQueueGlobalPriorityCreateInfoEXTBuilder<'a> {
-    pub fn global_priority(mut self, global_priority: QueueGlobalPriorityEXT) -> Self {
+impl<'a> DeviceQueueGlobalPriorityCreateInfoKHRBuilder<'a> {
+    pub fn global_priority(mut self, global_priority: QueueGlobalPriorityKHR) -> Self {
         self.inner.global_priority = global_priority;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> DeviceQueueGlobalPriorityCreateInfoEXT {
+    pub fn build(self) -> DeviceQueueGlobalPriorityCreateInfoKHR {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceGlobalPriorityQueryFeaturesEXT.html>"]
-pub struct PhysicalDeviceGlobalPriorityQueryFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR.html>"]
+pub struct PhysicalDeviceGlobalPriorityQueryFeaturesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub global_priority_query: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceGlobalPriorityQueryFeaturesEXT {
+impl ::std::default::Default for PhysicalDeviceGlobalPriorityQueryFeaturesKHR {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR,
             p_next: ::std::ptr::null_mut(),
             global_priority_query: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceGlobalPriorityQueryFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceGlobalPriorityQueryFeaturesEXTBuilder<'a> {
-        PhysicalDeviceGlobalPriorityQueryFeaturesEXTBuilder {
+impl PhysicalDeviceGlobalPriorityQueryFeaturesKHR {
+    pub fn builder<'a>() -> PhysicalDeviceGlobalPriorityQueryFeaturesKHRBuilder<'a> {
+        PhysicalDeviceGlobalPriorityQueryFeaturesKHRBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceGlobalPriorityQueryFeaturesEXTBuilder<'a> {
-    inner: PhysicalDeviceGlobalPriorityQueryFeaturesEXT,
+pub struct PhysicalDeviceGlobalPriorityQueryFeaturesKHRBuilder<'a> {
+    inner: PhysicalDeviceGlobalPriorityQueryFeaturesKHR,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceGlobalPriorityQueryFeaturesEXTBuilder<'_>
+    for PhysicalDeviceGlobalPriorityQueryFeaturesKHRBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceGlobalPriorityQueryFeaturesEXT {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceGlobalPriorityQueryFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceGlobalPriorityQueryFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceGlobalPriorityQueryFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDeviceGlobalPriorityQueryFeaturesEXT;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceGlobalPriorityQueryFeaturesKHR {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceGlobalPriorityQueryFeaturesKHRBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceGlobalPriorityQueryFeaturesKHR {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceGlobalPriorityQueryFeaturesKHRBuilder<'a> {
+    type Target = PhysicalDeviceGlobalPriorityQueryFeaturesKHR;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceGlobalPriorityQueryFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceGlobalPriorityQueryFeaturesKHRBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceGlobalPriorityQueryFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceGlobalPriorityQueryFeaturesKHRBuilder<'a> {
     pub fn global_priority_query(mut self, global_priority_query: bool) -> Self {
         self.inner.global_priority_query = global_priority_query.into();
         self
@@ -25288,64 +25284,64 @@ impl<'a> PhysicalDeviceGlobalPriorityQueryFeaturesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceGlobalPriorityQueryFeaturesEXT {
+    pub fn build(self) -> PhysicalDeviceGlobalPriorityQueryFeaturesKHR {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkQueueFamilyGlobalPriorityPropertiesEXT.html>"]
-pub struct QueueFamilyGlobalPriorityPropertiesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkQueueFamilyGlobalPriorityPropertiesKHR.html>"]
+pub struct QueueFamilyGlobalPriorityPropertiesKHR {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub priority_count: u32,
-    pub priorities: [QueueGlobalPriorityEXT; MAX_GLOBAL_PRIORITY_SIZE_EXT],
+    pub priorities: [QueueGlobalPriorityKHR; MAX_GLOBAL_PRIORITY_SIZE_KHR],
 }
-impl ::std::default::Default for QueueFamilyGlobalPriorityPropertiesEXT {
+impl ::std::default::Default for QueueFamilyGlobalPriorityPropertiesKHR {
     fn default() -> Self {
         Self {
-            s_type: StructureType::QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_EXT,
+            s_type: StructureType::QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR,
             p_next: ::std::ptr::null_mut(),
             priority_count: u32::default(),
             priorities: unsafe { ::std::mem::zeroed() },
         }
     }
 }
-impl QueueFamilyGlobalPriorityPropertiesEXT {
-    pub fn builder<'a>() -> QueueFamilyGlobalPriorityPropertiesEXTBuilder<'a> {
-        QueueFamilyGlobalPriorityPropertiesEXTBuilder {
+impl QueueFamilyGlobalPriorityPropertiesKHR {
+    pub fn builder<'a>() -> QueueFamilyGlobalPriorityPropertiesKHRBuilder<'a> {
+        QueueFamilyGlobalPriorityPropertiesKHRBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct QueueFamilyGlobalPriorityPropertiesEXTBuilder<'a> {
-    inner: QueueFamilyGlobalPriorityPropertiesEXT,
+pub struct QueueFamilyGlobalPriorityPropertiesKHRBuilder<'a> {
+    inner: QueueFamilyGlobalPriorityPropertiesKHR,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsQueueFamilyProperties2 for QueueFamilyGlobalPriorityPropertiesEXTBuilder<'_> {}
-unsafe impl ExtendsQueueFamilyProperties2 for QueueFamilyGlobalPriorityPropertiesEXT {}
-impl<'a> ::std::ops::Deref for QueueFamilyGlobalPriorityPropertiesEXTBuilder<'a> {
-    type Target = QueueFamilyGlobalPriorityPropertiesEXT;
+unsafe impl ExtendsQueueFamilyProperties2 for QueueFamilyGlobalPriorityPropertiesKHRBuilder<'_> {}
+unsafe impl ExtendsQueueFamilyProperties2 for QueueFamilyGlobalPriorityPropertiesKHR {}
+impl<'a> ::std::ops::Deref for QueueFamilyGlobalPriorityPropertiesKHRBuilder<'a> {
+    type Target = QueueFamilyGlobalPriorityPropertiesKHR;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for QueueFamilyGlobalPriorityPropertiesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for QueueFamilyGlobalPriorityPropertiesKHRBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> QueueFamilyGlobalPriorityPropertiesEXTBuilder<'a> {
+impl<'a> QueueFamilyGlobalPriorityPropertiesKHRBuilder<'a> {
     pub fn priority_count(mut self, priority_count: u32) -> Self {
         self.inner.priority_count = priority_count;
         self
     }
     pub fn priorities(
         mut self,
-        priorities: [QueueGlobalPriorityEXT; MAX_GLOBAL_PRIORITY_SIZE_EXT],
+        priorities: [QueueGlobalPriorityKHR; MAX_GLOBAL_PRIORITY_SIZE_KHR],
     ) -> Self {
         self.inner.priorities = priorities;
         self
@@ -25353,7 +25349,7 @@ impl<'a> QueueFamilyGlobalPriorityPropertiesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> QueueFamilyGlobalPriorityPropertiesEXT {
+    pub fn build(self) -> QueueFamilyGlobalPriorityPropertiesKHR {
         self.inner
     }
 }
@@ -35934,56 +35930,53 @@ impl<'a> RenderPassAttachmentBeginInfoBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT.html>"]
-pub struct PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceTextureCompressionASTCHDRFeatures.html>"]
+pub struct PhysicalDeviceTextureCompressionASTCHDRFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub texture_compression_astc_hdr: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {
+impl ::std::default::Default for PhysicalDeviceTextureCompressionASTCHDRFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES,
             p_next: ::std::ptr::null_mut(),
             texture_compression_astc_hdr: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'a> {
-        PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder {
+impl PhysicalDeviceTextureCompressionASTCHDRFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceTextureCompressionASTCHDRFeaturesBuilder<'a> {
+        PhysicalDeviceTextureCompressionASTCHDRFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'a> {
-    inner: PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT,
+pub struct PhysicalDeviceTextureCompressionASTCHDRFeaturesBuilder<'a> {
+    inner: PhysicalDeviceTextureCompressionASTCHDRFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'_>
+    for PhysicalDeviceTextureCompressionASTCHDRFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {}
-unsafe impl ExtendsDeviceCreateInfo
-    for PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'_>
-{
-}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceTextureCompressionASTCHDRFeatures {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceTextureCompressionASTCHDRFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceTextureCompressionASTCHDRFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceTextureCompressionASTCHDRFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceTextureCompressionASTCHDRFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceTextureCompressionASTCHDRFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceTextureCompressionASTCHDRFeaturesBuilder<'a> {
     pub fn texture_compression_astc_hdr(mut self, texture_compression_astc_hdr: bool) -> Self {
         self.inner.texture_compression_astc_hdr = texture_compression_astc_hdr.into();
         self
@@ -35991,7 +35984,7 @@ impl<'a> PhysicalDeviceTextureCompressionASTCHDRFeaturesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT {
+    pub fn build(self) -> PhysicalDeviceTextureCompressionASTCHDRFeatures {
         self.inner
     }
 }
@@ -36470,37 +36463,37 @@ impl<'a> PresentFrameTokenGGPBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone, Default)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineCreationFeedbackEXT.html>"]
-pub struct PipelineCreationFeedbackEXT {
-    pub flags: PipelineCreationFeedbackFlagsEXT,
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineCreationFeedback.html>"]
+pub struct PipelineCreationFeedback {
+    pub flags: PipelineCreationFeedbackFlags,
     pub duration: u64,
 }
-impl PipelineCreationFeedbackEXT {
-    pub fn builder<'a>() -> PipelineCreationFeedbackEXTBuilder<'a> {
-        PipelineCreationFeedbackEXTBuilder {
+impl PipelineCreationFeedback {
+    pub fn builder<'a>() -> PipelineCreationFeedbackBuilder<'a> {
+        PipelineCreationFeedbackBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PipelineCreationFeedbackEXTBuilder<'a> {
-    inner: PipelineCreationFeedbackEXT,
+pub struct PipelineCreationFeedbackBuilder<'a> {
+    inner: PipelineCreationFeedback,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for PipelineCreationFeedbackEXTBuilder<'a> {
-    type Target = PipelineCreationFeedbackEXT;
+impl<'a> ::std::ops::Deref for PipelineCreationFeedbackBuilder<'a> {
+    type Target = PipelineCreationFeedback;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PipelineCreationFeedbackEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PipelineCreationFeedbackBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PipelineCreationFeedbackEXTBuilder<'a> {
-    pub fn flags(mut self, flags: PipelineCreationFeedbackFlagsEXT) -> Self {
+impl<'a> PipelineCreationFeedbackBuilder<'a> {
+    pub fn flags(mut self, flags: PipelineCreationFeedbackFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -36511,25 +36504,25 @@ impl<'a> PipelineCreationFeedbackEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PipelineCreationFeedbackEXT {
+    pub fn build(self) -> PipelineCreationFeedback {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineCreationFeedbackCreateInfoEXT.html>"]
-pub struct PipelineCreationFeedbackCreateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineCreationFeedbackCreateInfo.html>"]
+pub struct PipelineCreationFeedbackCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub p_pipeline_creation_feedback: *mut PipelineCreationFeedbackEXT,
+    pub p_pipeline_creation_feedback: *mut PipelineCreationFeedback,
     pub pipeline_stage_creation_feedback_count: u32,
-    pub p_pipeline_stage_creation_feedbacks: *mut PipelineCreationFeedbackEXT,
+    pub p_pipeline_stage_creation_feedbacks: *mut PipelineCreationFeedback,
 }
-impl ::std::default::Default for PipelineCreationFeedbackCreateInfoEXT {
+impl ::std::default::Default for PipelineCreationFeedbackCreateInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT,
+            s_type: StructureType::PIPELINE_CREATION_FEEDBACK_CREATE_INFO,
             p_next: ::std::ptr::null(),
             p_pipeline_creation_feedback: ::std::ptr::null_mut(),
             pipeline_stage_creation_feedback_count: u32::default(),
@@ -36537,55 +36530,55 @@ impl ::std::default::Default for PipelineCreationFeedbackCreateInfoEXT {
         }
     }
 }
-impl PipelineCreationFeedbackCreateInfoEXT {
-    pub fn builder<'a>() -> PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
-        PipelineCreationFeedbackCreateInfoEXTBuilder {
+impl PipelineCreationFeedbackCreateInfo {
+    pub fn builder<'a>() -> PipelineCreationFeedbackCreateInfoBuilder<'a> {
+        PipelineCreationFeedbackCreateInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
-    inner: PipelineCreationFeedbackCreateInfoEXT,
+pub struct PipelineCreationFeedbackCreateInfoBuilder<'a> {
+    inner: PipelineCreationFeedbackCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineCreationFeedbackCreateInfoEXTBuilder<'_> {}
-unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineCreationFeedbackCreateInfoEXT {}
-unsafe impl ExtendsComputePipelineCreateInfo for PipelineCreationFeedbackCreateInfoEXTBuilder<'_> {}
-unsafe impl ExtendsComputePipelineCreateInfo for PipelineCreationFeedbackCreateInfoEXT {}
+unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineCreationFeedbackCreateInfoBuilder<'_> {}
+unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineCreationFeedbackCreateInfo {}
+unsafe impl ExtendsComputePipelineCreateInfo for PipelineCreationFeedbackCreateInfoBuilder<'_> {}
+unsafe impl ExtendsComputePipelineCreateInfo for PipelineCreationFeedbackCreateInfo {}
 unsafe impl ExtendsRayTracingPipelineCreateInfoNV
-    for PipelineCreationFeedbackCreateInfoEXTBuilder<'_>
+    for PipelineCreationFeedbackCreateInfoBuilder<'_>
 {
 }
-unsafe impl ExtendsRayTracingPipelineCreateInfoNV for PipelineCreationFeedbackCreateInfoEXT {}
+unsafe impl ExtendsRayTracingPipelineCreateInfoNV for PipelineCreationFeedbackCreateInfo {}
 unsafe impl ExtendsRayTracingPipelineCreateInfoKHR
-    for PipelineCreationFeedbackCreateInfoEXTBuilder<'_>
+    for PipelineCreationFeedbackCreateInfoBuilder<'_>
 {
 }
-unsafe impl ExtendsRayTracingPipelineCreateInfoKHR for PipelineCreationFeedbackCreateInfoEXT {}
-impl<'a> ::std::ops::Deref for PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
-    type Target = PipelineCreationFeedbackCreateInfoEXT;
+unsafe impl ExtendsRayTracingPipelineCreateInfoKHR for PipelineCreationFeedbackCreateInfo {}
+impl<'a> ::std::ops::Deref for PipelineCreationFeedbackCreateInfoBuilder<'a> {
+    type Target = PipelineCreationFeedbackCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PipelineCreationFeedbackCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
+impl<'a> PipelineCreationFeedbackCreateInfoBuilder<'a> {
     pub fn pipeline_creation_feedback(
         mut self,
-        pipeline_creation_feedback: &'a mut PipelineCreationFeedbackEXT,
+        pipeline_creation_feedback: &'a mut PipelineCreationFeedback,
     ) -> Self {
         self.inner.p_pipeline_creation_feedback = pipeline_creation_feedback;
         self
     }
     pub fn pipeline_stage_creation_feedbacks(
         mut self,
-        pipeline_stage_creation_feedbacks: &'a mut [PipelineCreationFeedbackEXT],
+        pipeline_stage_creation_feedbacks: &'a mut [PipelineCreationFeedback],
     ) -> Self {
         self.inner.pipeline_stage_creation_feedback_count =
             pipeline_stage_creation_feedbacks.len() as _;
@@ -36596,7 +36589,7 @@ impl<'a> PipelineCreationFeedbackCreateInfoEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PipelineCreationFeedbackCreateInfoEXT {
+    pub fn build(self) -> PipelineCreationFeedbackCreateInfo {
         self.inner
     }
 }
@@ -37253,8 +37246,8 @@ pub struct PerformanceQuerySubmitInfoKHRBuilder<'a> {
 }
 unsafe impl ExtendsSubmitInfo for PerformanceQuerySubmitInfoKHRBuilder<'_> {}
 unsafe impl ExtendsSubmitInfo for PerformanceQuerySubmitInfoKHR {}
-unsafe impl ExtendsSubmitInfo2KHR for PerformanceQuerySubmitInfoKHRBuilder<'_> {}
-unsafe impl ExtendsSubmitInfo2KHR for PerformanceQuerySubmitInfoKHR {}
+unsafe impl ExtendsSubmitInfo2 for PerformanceQuerySubmitInfoKHRBuilder<'_> {}
+unsafe impl ExtendsSubmitInfo2 for PerformanceQuerySubmitInfoKHR {}
 impl<'a> ::std::ops::Deref for PerformanceQuerySubmitInfoKHRBuilder<'a> {
     type Target = PerformanceQuerySubmitInfoKHR;
     fn deref(&self) -> &Self::Target {
@@ -39074,61 +39067,59 @@ impl<'a> PipelineExecutableInternalRepresentationKHRBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT.html>"]
-pub struct PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures.html>"]
+pub struct PhysicalDeviceShaderDemoteToHelperInvocationFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub shader_demote_to_helper_invocation: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT {
+impl ::std::default::Default for PhysicalDeviceShaderDemoteToHelperInvocationFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES,
             p_next: ::std::ptr::null_mut(),
             shader_demote_to_helper_invocation: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'a> {
-        PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder {
+impl PhysicalDeviceShaderDemoteToHelperInvocationFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceShaderDemoteToHelperInvocationFeaturesBuilder<'a> {
+        PhysicalDeviceShaderDemoteToHelperInvocationFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'a> {
-    inner: PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT,
+pub struct PhysicalDeviceShaderDemoteToHelperInvocationFeaturesBuilder<'a> {
+    inner: PhysicalDeviceShaderDemoteToHelperInvocationFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'_>
+    for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesBuilder<'_>
 {
 }
 unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
+    for PhysicalDeviceShaderDemoteToHelperInvocationFeatures
 {
 }
 unsafe impl ExtendsDeviceCreateInfo
-    for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'_>
+    for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderDemoteToHelperInvocationFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceShaderDemoteToHelperInvocationFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut
-    for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'a>
-{
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderDemoteToHelperInvocationFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceShaderDemoteToHelperInvocationFeaturesBuilder<'a> {
     pub fn shader_demote_to_helper_invocation(
         mut self,
         shader_demote_to_helper_invocation: bool,
@@ -39139,7 +39130,7 @@ impl<'a> PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT {
+    pub fn build(self) -> PhysicalDeviceShaderDemoteToHelperInvocationFeatures {
         self.inner
     }
 }
@@ -39207,8 +39198,8 @@ impl<'a> PhysicalDeviceTexelBufferAlignmentFeaturesEXTBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT.html>"]
-pub struct PhysicalDeviceTexelBufferAlignmentPropertiesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceTexelBufferAlignmentProperties.html>"]
+pub struct PhysicalDeviceTexelBufferAlignmentProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub storage_texel_buffer_offset_alignment_bytes: DeviceSize,
@@ -39216,10 +39207,10 @@ pub struct PhysicalDeviceTexelBufferAlignmentPropertiesEXT {
     pub uniform_texel_buffer_offset_alignment_bytes: DeviceSize,
     pub uniform_texel_buffer_offset_single_texel_alignment: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceTexelBufferAlignmentPropertiesEXT {
+impl ::std::default::Default for PhysicalDeviceTexelBufferAlignmentProperties {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
             storage_texel_buffer_offset_alignment_bytes: DeviceSize::default(),
             storage_texel_buffer_offset_single_texel_alignment: Bool32::default(),
@@ -39228,36 +39219,36 @@ impl ::std::default::Default for PhysicalDeviceTexelBufferAlignmentPropertiesEXT
         }
     }
 }
-impl PhysicalDeviceTexelBufferAlignmentPropertiesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
-        PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder {
+impl PhysicalDeviceTexelBufferAlignmentProperties {
+    pub fn builder<'a>() -> PhysicalDeviceTexelBufferAlignmentPropertiesBuilder<'a> {
+        PhysicalDeviceTexelBufferAlignmentPropertiesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
-    inner: PhysicalDeviceTexelBufferAlignmentPropertiesEXT,
+pub struct PhysicalDeviceTexelBufferAlignmentPropertiesBuilder<'a> {
+    inner: PhysicalDeviceTexelBufferAlignmentProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'_>
+    for PhysicalDeviceTexelBufferAlignmentPropertiesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceTexelBufferAlignmentPropertiesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
-    type Target = PhysicalDeviceTexelBufferAlignmentPropertiesEXT;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceTexelBufferAlignmentProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceTexelBufferAlignmentPropertiesBuilder<'a> {
+    type Target = PhysicalDeviceTexelBufferAlignmentProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceTexelBufferAlignmentPropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceTexelBufferAlignmentPropertiesBuilder<'a> {
     pub fn storage_texel_buffer_offset_alignment_bytes(
         mut self,
         storage_texel_buffer_offset_alignment_bytes: DeviceSize,
@@ -39295,62 +39286,62 @@ impl<'a> PhysicalDeviceTexelBufferAlignmentPropertiesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceTexelBufferAlignmentPropertiesEXT {
+    pub fn build(self) -> PhysicalDeviceTexelBufferAlignmentProperties {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlFeaturesEXT.html>"]
-pub struct PhysicalDeviceSubgroupSizeControlFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlFeatures.html>"]
+pub struct PhysicalDeviceSubgroupSizeControlFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub subgroup_size_control: Bool32,
     pub compute_full_subgroups: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceSubgroupSizeControlFeaturesEXT {
+impl ::std::default::Default for PhysicalDeviceSubgroupSizeControlFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES,
             p_next: ::std::ptr::null_mut(),
             subgroup_size_control: Bool32::default(),
             compute_full_subgroups: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceSubgroupSizeControlFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
-        PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder {
+impl PhysicalDeviceSubgroupSizeControlFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceSubgroupSizeControlFeaturesBuilder<'a> {
+        PhysicalDeviceSubgroupSizeControlFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
-    inner: PhysicalDeviceSubgroupSizeControlFeaturesEXT,
+pub struct PhysicalDeviceSubgroupSizeControlFeaturesBuilder<'a> {
+    inner: PhysicalDeviceSubgroupSizeControlFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'_>
+    for PhysicalDeviceSubgroupSizeControlFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceSubgroupSizeControlFeaturesEXT {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSubgroupSizeControlFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDeviceSubgroupSizeControlFeaturesEXT;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceSubgroupSizeControlFeatures {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSubgroupSizeControlFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSubgroupSizeControlFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceSubgroupSizeControlFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceSubgroupSizeControlFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceSubgroupSizeControlFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceSubgroupSizeControlFeaturesBuilder<'a> {
     pub fn subgroup_size_control(mut self, subgroup_size_control: bool) -> Self {
         self.inner.subgroup_size_control = subgroup_size_control.into();
         self
@@ -39362,15 +39353,15 @@ impl<'a> PhysicalDeviceSubgroupSizeControlFeaturesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceSubgroupSizeControlFeaturesEXT {
+    pub fn build(self) -> PhysicalDeviceSubgroupSizeControlFeatures {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlPropertiesEXT.html>"]
-pub struct PhysicalDeviceSubgroupSizeControlPropertiesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceSubgroupSizeControlProperties.html>"]
+pub struct PhysicalDeviceSubgroupSizeControlProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub min_subgroup_size: u32,
@@ -39378,10 +39369,10 @@ pub struct PhysicalDeviceSubgroupSizeControlPropertiesEXT {
     pub max_compute_workgroup_subgroups: u32,
     pub required_subgroup_size_stages: ShaderStageFlags,
 }
-impl ::std::default::Default for PhysicalDeviceSubgroupSizeControlPropertiesEXT {
+impl ::std::default::Default for PhysicalDeviceSubgroupSizeControlProperties {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
             min_subgroup_size: u32::default(),
             max_subgroup_size: u32::default(),
@@ -39390,36 +39381,36 @@ impl ::std::default::Default for PhysicalDeviceSubgroupSizeControlPropertiesEXT 
         }
     }
 }
-impl PhysicalDeviceSubgroupSizeControlPropertiesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
-        PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder {
+impl PhysicalDeviceSubgroupSizeControlProperties {
+    pub fn builder<'a>() -> PhysicalDeviceSubgroupSizeControlPropertiesBuilder<'a> {
+        PhysicalDeviceSubgroupSizeControlPropertiesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
-    inner: PhysicalDeviceSubgroupSizeControlPropertiesEXT,
+pub struct PhysicalDeviceSubgroupSizeControlPropertiesBuilder<'a> {
+    inner: PhysicalDeviceSubgroupSizeControlProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'_>
+    for PhysicalDeviceSubgroupSizeControlPropertiesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceSubgroupSizeControlPropertiesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
-    type Target = PhysicalDeviceSubgroupSizeControlPropertiesEXT;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceSubgroupSizeControlProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceSubgroupSizeControlPropertiesBuilder<'a> {
+    type Target = PhysicalDeviceSubgroupSizeControlProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceSubgroupSizeControlPropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceSubgroupSizeControlPropertiesBuilder<'a> {
     pub fn min_subgroup_size(mut self, min_subgroup_size: u32) -> Self {
         self.inner.min_subgroup_size = min_subgroup_size;
         self
@@ -39442,61 +39433,61 @@ impl<'a> PhysicalDeviceSubgroupSizeControlPropertiesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceSubgroupSizeControlPropertiesEXT {
+    pub fn build(self) -> PhysicalDeviceSubgroupSizeControlProperties {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT.html>"]
-pub struct PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineShaderStageRequiredSubgroupSizeCreateInfo.html>"]
+pub struct PipelineShaderStageRequiredSubgroupSizeCreateInfo {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub required_subgroup_size: u32,
 }
-impl ::std::default::Default for PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT {
+impl ::std::default::Default for PipelineShaderStageRequiredSubgroupSizeCreateInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT,
+            s_type: StructureType::PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO,
             p_next: ::std::ptr::null_mut(),
             required_subgroup_size: u32::default(),
         }
     }
 }
-impl PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT {
-    pub fn builder<'a>() -> PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
-        PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder {
+impl PipelineShaderStageRequiredSubgroupSizeCreateInfo {
+    pub fn builder<'a>() -> PipelineShaderStageRequiredSubgroupSizeCreateInfoBuilder<'a> {
+        PipelineShaderStageRequiredSubgroupSizeCreateInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
-    inner: PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT,
+pub struct PipelineShaderStageRequiredSubgroupSizeCreateInfoBuilder<'a> {
+    inner: PipelineShaderStageRequiredSubgroupSizeCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPipelineShaderStageCreateInfo
-    for PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'_>
+    for PipelineShaderStageRequiredSubgroupSizeCreateInfoBuilder<'_>
 {
 }
 unsafe impl ExtendsPipelineShaderStageCreateInfo
-    for PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT
+    for PipelineShaderStageRequiredSubgroupSizeCreateInfo
 {
 }
-impl<'a> ::std::ops::Deref for PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
-    type Target = PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT;
+impl<'a> ::std::ops::Deref for PipelineShaderStageRequiredSubgroupSizeCreateInfoBuilder<'a> {
+    type Target = PipelineShaderStageRequiredSubgroupSizeCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PipelineShaderStageRequiredSubgroupSizeCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
+impl<'a> PipelineShaderStageRequiredSubgroupSizeCreateInfoBuilder<'a> {
     pub fn required_subgroup_size(mut self, required_subgroup_size: u32) -> Self {
         self.inner.required_subgroup_size = required_subgroup_size;
         self
@@ -39504,7 +39495,7 @@ impl<'a> PipelineShaderStageRequiredSubgroupSizeCreateInfoEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PipelineShaderStageRequiredSubgroupSizeCreateInfoEXT {
+    pub fn build(self) -> PipelineShaderStageRequiredSubgroupSizeCreateInfo {
         self.inner
     }
 }
@@ -39979,59 +39970,56 @@ impl<'a> PipelineRasterizationLineStateCreateInfoEXTBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT.html>"]
-pub struct PhysicalDevicePipelineCreationCacheControlFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDevicePipelineCreationCacheControlFeatures.html>"]
+pub struct PhysicalDevicePipelineCreationCacheControlFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub pipeline_creation_cache_control: Bool32,
 }
-impl ::std::default::Default for PhysicalDevicePipelineCreationCacheControlFeaturesEXT {
+impl ::std::default::Default for PhysicalDevicePipelineCreationCacheControlFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES,
             p_next: ::std::ptr::null_mut(),
             pipeline_creation_cache_control: Bool32::default(),
         }
     }
 }
-impl PhysicalDevicePipelineCreationCacheControlFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'a> {
-        PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder {
+impl PhysicalDevicePipelineCreationCacheControlFeatures {
+    pub fn builder<'a>() -> PhysicalDevicePipelineCreationCacheControlFeaturesBuilder<'a> {
+        PhysicalDevicePipelineCreationCacheControlFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'a> {
-    inner: PhysicalDevicePipelineCreationCacheControlFeaturesEXT,
+pub struct PhysicalDevicePipelineCreationCacheControlFeaturesBuilder<'a> {
+    inner: PhysicalDevicePipelineCreationCacheControlFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'_>
+    for PhysicalDevicePipelineCreationCacheControlFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDevicePipelineCreationCacheControlFeaturesEXT
-{
-}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDevicePipelineCreationCacheControlFeatures {}
 unsafe impl ExtendsDeviceCreateInfo
-    for PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'_>
+    for PhysicalDevicePipelineCreationCacheControlFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDevicePipelineCreationCacheControlFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDevicePipelineCreationCacheControlFeaturesEXT;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDevicePipelineCreationCacheControlFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDevicePipelineCreationCacheControlFeaturesBuilder<'a> {
+    type Target = PhysicalDevicePipelineCreationCacheControlFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDevicePipelineCreationCacheControlFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDevicePipelineCreationCacheControlFeaturesBuilder<'a> {
     pub fn pipeline_creation_cache_control(
         mut self,
         pipeline_creation_cache_control: bool,
@@ -40042,7 +40030,7 @@ impl<'a> PhysicalDevicePipelineCreationCacheControlFeaturesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDevicePipelineCreationCacheControlFeaturesEXT {
+    pub fn build(self) -> PhysicalDevicePipelineCreationCacheControlFeatures {
         self.inner
     }
 }
@@ -41509,6 +41497,615 @@ impl<'a> PhysicalDeviceVulkan12PropertiesBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceVulkan13Features.html>"]
+pub struct PhysicalDeviceVulkan13Features {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub robust_image_access: Bool32,
+    pub inline_uniform_block: Bool32,
+    pub descriptor_binding_inline_uniform_block_update_after_bind: Bool32,
+    pub pipeline_creation_cache_control: Bool32,
+    pub private_data: Bool32,
+    pub shader_demote_to_helper_invocation: Bool32,
+    pub shader_terminate_invocation: Bool32,
+    pub subgroup_size_control: Bool32,
+    pub compute_full_subgroups: Bool32,
+    pub synchronization2: Bool32,
+    pub texture_compression_astc_hdr: Bool32,
+    pub shader_zero_initialize_workgroup_memory: Bool32,
+    pub dynamic_rendering: Bool32,
+    pub shader_integer_dot_product: Bool32,
+    pub maintenance4: Bool32,
+}
+impl ::std::default::Default for PhysicalDeviceVulkan13Features {
+    fn default() -> Self {
+        Self {
+            s_type: StructureType::PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
+            p_next: ::std::ptr::null_mut(),
+            robust_image_access: Bool32::default(),
+            inline_uniform_block: Bool32::default(),
+            descriptor_binding_inline_uniform_block_update_after_bind: Bool32::default(),
+            pipeline_creation_cache_control: Bool32::default(),
+            private_data: Bool32::default(),
+            shader_demote_to_helper_invocation: Bool32::default(),
+            shader_terminate_invocation: Bool32::default(),
+            subgroup_size_control: Bool32::default(),
+            compute_full_subgroups: Bool32::default(),
+            synchronization2: Bool32::default(),
+            texture_compression_astc_hdr: Bool32::default(),
+            shader_zero_initialize_workgroup_memory: Bool32::default(),
+            dynamic_rendering: Bool32::default(),
+            shader_integer_dot_product: Bool32::default(),
+            maintenance4: Bool32::default(),
+        }
+    }
+}
+impl PhysicalDeviceVulkan13Features {
+    pub fn builder<'a>() -> PhysicalDeviceVulkan13FeaturesBuilder<'a> {
+        PhysicalDeviceVulkan13FeaturesBuilder {
+            inner: Self::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceVulkan13FeaturesBuilder<'a> {
+    inner: PhysicalDeviceVulkan13Features,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceVulkan13FeaturesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceVulkan13Features {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkan13FeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceVulkan13Features {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceVulkan13FeaturesBuilder<'a> {
+    type Target = PhysicalDeviceVulkan13Features;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan13FeaturesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceVulkan13FeaturesBuilder<'a> {
+    pub fn robust_image_access(mut self, robust_image_access: bool) -> Self {
+        self.inner.robust_image_access = robust_image_access.into();
+        self
+    }
+    pub fn inline_uniform_block(mut self, inline_uniform_block: bool) -> Self {
+        self.inner.inline_uniform_block = inline_uniform_block.into();
+        self
+    }
+    pub fn descriptor_binding_inline_uniform_block_update_after_bind(
+        mut self,
+        descriptor_binding_inline_uniform_block_update_after_bind: bool,
+    ) -> Self {
+        self.inner
+            .descriptor_binding_inline_uniform_block_update_after_bind =
+            descriptor_binding_inline_uniform_block_update_after_bind.into();
+        self
+    }
+    pub fn pipeline_creation_cache_control(
+        mut self,
+        pipeline_creation_cache_control: bool,
+    ) -> Self {
+        self.inner.pipeline_creation_cache_control = pipeline_creation_cache_control.into();
+        self
+    }
+    pub fn private_data(mut self, private_data: bool) -> Self {
+        self.inner.private_data = private_data.into();
+        self
+    }
+    pub fn shader_demote_to_helper_invocation(
+        mut self,
+        shader_demote_to_helper_invocation: bool,
+    ) -> Self {
+        self.inner.shader_demote_to_helper_invocation = shader_demote_to_helper_invocation.into();
+        self
+    }
+    pub fn shader_terminate_invocation(mut self, shader_terminate_invocation: bool) -> Self {
+        self.inner.shader_terminate_invocation = shader_terminate_invocation.into();
+        self
+    }
+    pub fn subgroup_size_control(mut self, subgroup_size_control: bool) -> Self {
+        self.inner.subgroup_size_control = subgroup_size_control.into();
+        self
+    }
+    pub fn compute_full_subgroups(mut self, compute_full_subgroups: bool) -> Self {
+        self.inner.compute_full_subgroups = compute_full_subgroups.into();
+        self
+    }
+    pub fn synchronization2(mut self, synchronization2: bool) -> Self {
+        self.inner.synchronization2 = synchronization2.into();
+        self
+    }
+    pub fn texture_compression_astc_hdr(mut self, texture_compression_astc_hdr: bool) -> Self {
+        self.inner.texture_compression_astc_hdr = texture_compression_astc_hdr.into();
+        self
+    }
+    pub fn shader_zero_initialize_workgroup_memory(
+        mut self,
+        shader_zero_initialize_workgroup_memory: bool,
+    ) -> Self {
+        self.inner.shader_zero_initialize_workgroup_memory =
+            shader_zero_initialize_workgroup_memory.into();
+        self
+    }
+    pub fn dynamic_rendering(mut self, dynamic_rendering: bool) -> Self {
+        self.inner.dynamic_rendering = dynamic_rendering.into();
+        self
+    }
+    pub fn shader_integer_dot_product(mut self, shader_integer_dot_product: bool) -> Self {
+        self.inner.shader_integer_dot_product = shader_integer_dot_product.into();
+        self
+    }
+    pub fn maintenance4(mut self, maintenance4: bool) -> Self {
+        self.inner.maintenance4 = maintenance4.into();
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceVulkan13Features {
+        self.inner
+    }
+}
+#[repr(C)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceVulkan13Properties.html>"]
+pub struct PhysicalDeviceVulkan13Properties {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub min_subgroup_size: u32,
+    pub max_subgroup_size: u32,
+    pub max_compute_workgroup_subgroups: u32,
+    pub required_subgroup_size_stages: ShaderStageFlags,
+    pub max_inline_uniform_block_size: u32,
+    pub max_per_stage_descriptor_inline_uniform_blocks: u32,
+    pub max_per_stage_descriptor_update_after_bind_inline_uniform_blocks: u32,
+    pub max_descriptor_set_inline_uniform_blocks: u32,
+    pub max_descriptor_set_update_after_bind_inline_uniform_blocks: u32,
+    pub max_inline_uniform_total_size: u32,
+    pub integer_dot_product8_bit_unsigned_accelerated: Bool32,
+    pub integer_dot_product8_bit_signed_accelerated: Bool32,
+    pub integer_dot_product8_bit_mixed_signedness_accelerated: Bool32,
+    pub integer_dot_product4x8_bit_packed_unsigned_accelerated: Bool32,
+    pub integer_dot_product4x8_bit_packed_signed_accelerated: Bool32,
+    pub integer_dot_product4x8_bit_packed_mixed_signedness_accelerated: Bool32,
+    pub integer_dot_product16_bit_unsigned_accelerated: Bool32,
+    pub integer_dot_product16_bit_signed_accelerated: Bool32,
+    pub integer_dot_product16_bit_mixed_signedness_accelerated: Bool32,
+    pub integer_dot_product32_bit_unsigned_accelerated: Bool32,
+    pub integer_dot_product32_bit_signed_accelerated: Bool32,
+    pub integer_dot_product32_bit_mixed_signedness_accelerated: Bool32,
+    pub integer_dot_product64_bit_unsigned_accelerated: Bool32,
+    pub integer_dot_product64_bit_signed_accelerated: Bool32,
+    pub integer_dot_product64_bit_mixed_signedness_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating8_bit_signed_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated:
+        Bool32,
+    pub integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating16_bit_signed_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating32_bit_signed_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating64_bit_signed_accelerated: Bool32,
+    pub integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated: Bool32,
+    pub storage_texel_buffer_offset_alignment_bytes: DeviceSize,
+    pub storage_texel_buffer_offset_single_texel_alignment: Bool32,
+    pub uniform_texel_buffer_offset_alignment_bytes: DeviceSize,
+    pub uniform_texel_buffer_offset_single_texel_alignment: Bool32,
+    pub max_buffer_size: DeviceSize,
+}
+impl ::std::default::Default for PhysicalDeviceVulkan13Properties {
+    fn default() -> Self {
+        Self { s_type : StructureType :: PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES , p_next : :: std :: ptr :: null_mut () , min_subgroup_size : u32 :: default () , max_subgroup_size : u32 :: default () , max_compute_workgroup_subgroups : u32 :: default () , required_subgroup_size_stages : ShaderStageFlags :: default () , max_inline_uniform_block_size : u32 :: default () , max_per_stage_descriptor_inline_uniform_blocks : u32 :: default () , max_per_stage_descriptor_update_after_bind_inline_uniform_blocks : u32 :: default () , max_descriptor_set_inline_uniform_blocks : u32 :: default () , max_descriptor_set_update_after_bind_inline_uniform_blocks : u32 :: default () , max_inline_uniform_total_size : u32 :: default () , integer_dot_product8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product64_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated : Bool32 :: default () , storage_texel_buffer_offset_alignment_bytes : DeviceSize :: default () , storage_texel_buffer_offset_single_texel_alignment : Bool32 :: default () , uniform_texel_buffer_offset_alignment_bytes : DeviceSize :: default () , uniform_texel_buffer_offset_single_texel_alignment : Bool32 :: default () , max_buffer_size : DeviceSize :: default () }
+    }
+}
+impl PhysicalDeviceVulkan13Properties {
+    pub fn builder<'a>() -> PhysicalDeviceVulkan13PropertiesBuilder<'a> {
+        PhysicalDeviceVulkan13PropertiesBuilder {
+            inner: Self::default(),
+            marker: ::std::marker::PhantomData,
+        }
+    }
+}
+#[repr(transparent)]
+pub struct PhysicalDeviceVulkan13PropertiesBuilder<'a> {
+    inner: PhysicalDeviceVulkan13Properties,
+    marker: ::std::marker::PhantomData<&'a ()>,
+}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceVulkan13PropertiesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceVulkan13Properties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceVulkan13PropertiesBuilder<'a> {
+    type Target = PhysicalDeviceVulkan13Properties;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceVulkan13PropertiesBuilder<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+impl<'a> PhysicalDeviceVulkan13PropertiesBuilder<'a> {
+    pub fn min_subgroup_size(mut self, min_subgroup_size: u32) -> Self {
+        self.inner.min_subgroup_size = min_subgroup_size;
+        self
+    }
+    pub fn max_subgroup_size(mut self, max_subgroup_size: u32) -> Self {
+        self.inner.max_subgroup_size = max_subgroup_size;
+        self
+    }
+    pub fn max_compute_workgroup_subgroups(mut self, max_compute_workgroup_subgroups: u32) -> Self {
+        self.inner.max_compute_workgroup_subgroups = max_compute_workgroup_subgroups;
+        self
+    }
+    pub fn required_subgroup_size_stages(
+        mut self,
+        required_subgroup_size_stages: ShaderStageFlags,
+    ) -> Self {
+        self.inner.required_subgroup_size_stages = required_subgroup_size_stages;
+        self
+    }
+    pub fn max_inline_uniform_block_size(mut self, max_inline_uniform_block_size: u32) -> Self {
+        self.inner.max_inline_uniform_block_size = max_inline_uniform_block_size;
+        self
+    }
+    pub fn max_per_stage_descriptor_inline_uniform_blocks(
+        mut self,
+        max_per_stage_descriptor_inline_uniform_blocks: u32,
+    ) -> Self {
+        self.inner.max_per_stage_descriptor_inline_uniform_blocks =
+            max_per_stage_descriptor_inline_uniform_blocks;
+        self
+    }
+    pub fn max_per_stage_descriptor_update_after_bind_inline_uniform_blocks(
+        mut self,
+        max_per_stage_descriptor_update_after_bind_inline_uniform_blocks: u32,
+    ) -> Self {
+        self.inner
+            .max_per_stage_descriptor_update_after_bind_inline_uniform_blocks =
+            max_per_stage_descriptor_update_after_bind_inline_uniform_blocks;
+        self
+    }
+    pub fn max_descriptor_set_inline_uniform_blocks(
+        mut self,
+        max_descriptor_set_inline_uniform_blocks: u32,
+    ) -> Self {
+        self.inner.max_descriptor_set_inline_uniform_blocks =
+            max_descriptor_set_inline_uniform_blocks;
+        self
+    }
+    pub fn max_descriptor_set_update_after_bind_inline_uniform_blocks(
+        mut self,
+        max_descriptor_set_update_after_bind_inline_uniform_blocks: u32,
+    ) -> Self {
+        self.inner
+            .max_descriptor_set_update_after_bind_inline_uniform_blocks =
+            max_descriptor_set_update_after_bind_inline_uniform_blocks;
+        self
+    }
+    pub fn max_inline_uniform_total_size(mut self, max_inline_uniform_total_size: u32) -> Self {
+        self.inner.max_inline_uniform_total_size = max_inline_uniform_total_size;
+        self
+    }
+    pub fn integer_dot_product8_bit_unsigned_accelerated(
+        mut self,
+        integer_dot_product8_bit_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner.integer_dot_product8_bit_unsigned_accelerated =
+            integer_dot_product8_bit_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product8_bit_signed_accelerated(
+        mut self,
+        integer_dot_product8_bit_signed_accelerated: bool,
+    ) -> Self {
+        self.inner.integer_dot_product8_bit_signed_accelerated =
+            integer_dot_product8_bit_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product8_bit_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product8_bit_mixed_signedness_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product8_bit_mixed_signedness_accelerated =
+            integer_dot_product8_bit_mixed_signedness_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product4x8_bit_packed_unsigned_accelerated(
+        mut self,
+        integer_dot_product4x8_bit_packed_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product4x8_bit_packed_unsigned_accelerated =
+            integer_dot_product4x8_bit_packed_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product4x8_bit_packed_signed_accelerated(
+        mut self,
+        integer_dot_product4x8_bit_packed_signed_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product4x8_bit_packed_signed_accelerated =
+            integer_dot_product4x8_bit_packed_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product4x8_bit_packed_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product4x8_bit_packed_mixed_signedness_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product4x8_bit_packed_mixed_signedness_accelerated =
+            integer_dot_product4x8_bit_packed_mixed_signedness_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product16_bit_unsigned_accelerated(
+        mut self,
+        integer_dot_product16_bit_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner.integer_dot_product16_bit_unsigned_accelerated =
+            integer_dot_product16_bit_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product16_bit_signed_accelerated(
+        mut self,
+        integer_dot_product16_bit_signed_accelerated: bool,
+    ) -> Self {
+        self.inner.integer_dot_product16_bit_signed_accelerated =
+            integer_dot_product16_bit_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product16_bit_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product16_bit_mixed_signedness_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product16_bit_mixed_signedness_accelerated =
+            integer_dot_product16_bit_mixed_signedness_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product32_bit_unsigned_accelerated(
+        mut self,
+        integer_dot_product32_bit_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner.integer_dot_product32_bit_unsigned_accelerated =
+            integer_dot_product32_bit_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product32_bit_signed_accelerated(
+        mut self,
+        integer_dot_product32_bit_signed_accelerated: bool,
+    ) -> Self {
+        self.inner.integer_dot_product32_bit_signed_accelerated =
+            integer_dot_product32_bit_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product32_bit_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product32_bit_mixed_signedness_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product32_bit_mixed_signedness_accelerated =
+            integer_dot_product32_bit_mixed_signedness_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product64_bit_unsigned_accelerated(
+        mut self,
+        integer_dot_product64_bit_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner.integer_dot_product64_bit_unsigned_accelerated =
+            integer_dot_product64_bit_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product64_bit_signed_accelerated(
+        mut self,
+        integer_dot_product64_bit_signed_accelerated: bool,
+    ) -> Self {
+        self.inner.integer_dot_product64_bit_signed_accelerated =
+            integer_dot_product64_bit_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product64_bit_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product64_bit_mixed_signedness_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product64_bit_mixed_signedness_accelerated =
+            integer_dot_product64_bit_mixed_signedness_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated =
+            integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating8_bit_signed_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating8_bit_signed_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating8_bit_signed_accelerated =
+            integer_dot_product_accumulating_saturating8_bit_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated =
+            integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated =
+            integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated =
+            integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated : bool,
+    ) -> Self {
+        self . inner . integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated = integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated . into () ;
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated =
+            integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating16_bit_signed_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating16_bit_signed_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating16_bit_signed_accelerated =
+            integer_dot_product_accumulating_saturating16_bit_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated =
+            integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated =
+            integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating32_bit_signed_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating32_bit_signed_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating32_bit_signed_accelerated =
+            integer_dot_product_accumulating_saturating32_bit_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated =
+            integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated =
+            integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating64_bit_signed_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating64_bit_signed_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating64_bit_signed_accelerated =
+            integer_dot_product_accumulating_saturating64_bit_signed_accelerated.into();
+        self
+    }
+    pub fn integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated(
+        mut self,
+        integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated: bool,
+    ) -> Self {
+        self.inner
+            .integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated =
+            integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated.into();
+        self
+    }
+    pub fn storage_texel_buffer_offset_alignment_bytes(
+        mut self,
+        storage_texel_buffer_offset_alignment_bytes: DeviceSize,
+    ) -> Self {
+        self.inner.storage_texel_buffer_offset_alignment_bytes =
+            storage_texel_buffer_offset_alignment_bytes;
+        self
+    }
+    pub fn storage_texel_buffer_offset_single_texel_alignment(
+        mut self,
+        storage_texel_buffer_offset_single_texel_alignment: bool,
+    ) -> Self {
+        self.inner
+            .storage_texel_buffer_offset_single_texel_alignment =
+            storage_texel_buffer_offset_single_texel_alignment.into();
+        self
+    }
+    pub fn uniform_texel_buffer_offset_alignment_bytes(
+        mut self,
+        uniform_texel_buffer_offset_alignment_bytes: DeviceSize,
+    ) -> Self {
+        self.inner.uniform_texel_buffer_offset_alignment_bytes =
+            uniform_texel_buffer_offset_alignment_bytes;
+        self
+    }
+    pub fn uniform_texel_buffer_offset_single_texel_alignment(
+        mut self,
+        uniform_texel_buffer_offset_single_texel_alignment: bool,
+    ) -> Self {
+        self.inner
+            .uniform_texel_buffer_offset_single_texel_alignment =
+            uniform_texel_buffer_offset_single_texel_alignment.into();
+        self
+    }
+    pub fn max_buffer_size(mut self, max_buffer_size: DeviceSize) -> Self {
+        self.inner.max_buffer_size = max_buffer_size;
+        self
+    }
+    #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
+    #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
+    #[doc = r" so references to builders can be passed directly to Vulkan functions."]
+    pub fn build(self) -> PhysicalDeviceVulkan13Properties {
+        self.inner
+    }
+}
+#[repr(C)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Copy, Clone)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineCompilerControlCreateInfoAMD.html>"]
 pub struct PipelineCompilerControlCreateInfoAMD {
     pub s_type: StructureType,
@@ -41627,20 +42224,20 @@ impl<'a> PhysicalDeviceCoherentMemoryFeaturesAMDBuilder<'a> {
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceToolPropertiesEXT.html>"]
-pub struct PhysicalDeviceToolPropertiesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceToolProperties.html>"]
+pub struct PhysicalDeviceToolProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub name: [c_char; MAX_EXTENSION_NAME_SIZE],
     pub version: [c_char; MAX_EXTENSION_NAME_SIZE],
-    pub purposes: ToolPurposeFlagsEXT,
+    pub purposes: ToolPurposeFlags,
     pub description: [c_char; MAX_DESCRIPTION_SIZE],
     pub layer: [c_char; MAX_EXTENSION_NAME_SIZE],
 }
 #[cfg(feature = "debug")]
-impl fmt::Debug for PhysicalDeviceToolPropertiesEXT {
+impl fmt::Debug for PhysicalDeviceToolProperties {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("PhysicalDeviceToolPropertiesEXT")
+        fmt.debug_struct("PhysicalDeviceToolProperties")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
             .field("name", &unsafe {
@@ -41659,44 +42256,44 @@ impl fmt::Debug for PhysicalDeviceToolPropertiesEXT {
             .finish()
     }
 }
-impl ::std::default::Default for PhysicalDeviceToolPropertiesEXT {
+impl ::std::default::Default for PhysicalDeviceToolProperties {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_TOOL_PROPERTIES,
             p_next: ::std::ptr::null_mut(),
             name: unsafe { ::std::mem::zeroed() },
             version: unsafe { ::std::mem::zeroed() },
-            purposes: ToolPurposeFlagsEXT::default(),
+            purposes: ToolPurposeFlags::default(),
             description: unsafe { ::std::mem::zeroed() },
             layer: unsafe { ::std::mem::zeroed() },
         }
     }
 }
-impl PhysicalDeviceToolPropertiesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
-        PhysicalDeviceToolPropertiesEXTBuilder {
+impl PhysicalDeviceToolProperties {
+    pub fn builder<'a>() -> PhysicalDeviceToolPropertiesBuilder<'a> {
+        PhysicalDeviceToolPropertiesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceToolPropertiesEXTBuilder<'a> {
-    inner: PhysicalDeviceToolPropertiesEXT,
+pub struct PhysicalDeviceToolPropertiesBuilder<'a> {
+    inner: PhysicalDeviceToolProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for PhysicalDeviceToolPropertiesEXTBuilder<'a> {
-    type Target = PhysicalDeviceToolPropertiesEXT;
+impl<'a> ::std::ops::Deref for PhysicalDeviceToolPropertiesBuilder<'a> {
+    type Target = PhysicalDeviceToolProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceToolPropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceToolPropertiesBuilder<'a> {
     pub fn name(mut self, name: [c_char; MAX_EXTENSION_NAME_SIZE]) -> Self {
         self.inner.name = name;
         self
@@ -41705,7 +42302,7 @@ impl<'a> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
         self.inner.version = version;
         self
     }
-    pub fn purposes(mut self, purposes: ToolPurposeFlagsEXT) -> Self {
+    pub fn purposes(mut self, purposes: ToolPurposeFlags) -> Self {
         self.inner.purposes = purposes;
         self
     }
@@ -41720,7 +42317,7 @@ impl<'a> PhysicalDeviceToolPropertiesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceToolPropertiesEXT {
+    pub fn build(self) -> PhysicalDeviceToolProperties {
         self.inner
     }
 }
@@ -43501,10 +44098,10 @@ pub struct CopyCommandTransformInfoQCOMBuilder<'a> {
     inner: CopyCommandTransformInfoQCOM,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsBufferImageCopy2KHR for CopyCommandTransformInfoQCOMBuilder<'_> {}
-unsafe impl ExtendsBufferImageCopy2KHR for CopyCommandTransformInfoQCOM {}
-unsafe impl ExtendsImageBlit2KHR for CopyCommandTransformInfoQCOMBuilder<'_> {}
-unsafe impl ExtendsImageBlit2KHR for CopyCommandTransformInfoQCOM {}
+unsafe impl ExtendsBufferImageCopy2 for CopyCommandTransformInfoQCOMBuilder<'_> {}
+unsafe impl ExtendsBufferImageCopy2 for CopyCommandTransformInfoQCOM {}
+unsafe impl ExtendsImageBlit2 for CopyCommandTransformInfoQCOMBuilder<'_> {}
+unsafe impl ExtendsImageBlit2 for CopyCommandTransformInfoQCOM {}
 impl<'a> ::std::ops::Deref for CopyCommandTransformInfoQCOMBuilder<'a> {
     type Target = CopyCommandTransformInfoQCOM;
     fn deref(&self) -> &Self::Target {
@@ -43716,61 +44313,56 @@ impl<'a> DeviceDiagnosticsConfigCreateInfoNVBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR.html>"]
-pub struct PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures.html>"]
+pub struct PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub shader_zero_initialize_workgroup_memory: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR {
+impl ::std::default::Default for PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES_KHR,
+            s_type: StructureType::PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES,
             p_next: ::std::ptr::null_mut(),
             shader_zero_initialize_workgroup_memory: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'a> {
-        PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder {
+impl PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesBuilder<'a> {
+        PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR,
+pub struct PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesBuilder<'a> {
+    inner: PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'_>
+    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR
-{
-}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures {}
 unsafe impl ExtendsDeviceCreateInfo
-    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'_>
+    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR;
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut
-    for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'a>
-{
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesBuilder<'a> {
     pub fn shader_zero_initialize_workgroup_memory(
         mut self,
         shader_zero_initialize_workgroup_memory: bool,
@@ -43782,7 +44374,7 @@ impl<'a> PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures {
         self.inner
     }
 }
@@ -44005,50 +44597,50 @@ impl<'a> PhysicalDeviceRobustness2PropertiesEXTBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceImageRobustnessFeaturesEXT.html>"]
-pub struct PhysicalDeviceImageRobustnessFeaturesEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceImageRobustnessFeatures.html>"]
+pub struct PhysicalDeviceImageRobustnessFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub robust_image_access: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceImageRobustnessFeaturesEXT {
+impl ::std::default::Default for PhysicalDeviceImageRobustnessFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT,
+            s_type: StructureType::PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES,
             p_next: ::std::ptr::null_mut(),
             robust_image_access: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceImageRobustnessFeaturesEXT {
-    pub fn builder<'a>() -> PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'a> {
-        PhysicalDeviceImageRobustnessFeaturesEXTBuilder {
+impl PhysicalDeviceImageRobustnessFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceImageRobustnessFeaturesBuilder<'a> {
+        PhysicalDeviceImageRobustnessFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'a> {
-    inner: PhysicalDeviceImageRobustnessFeaturesEXT,
+pub struct PhysicalDeviceImageRobustnessFeaturesBuilder<'a> {
+    inner: PhysicalDeviceImageRobustnessFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceImageRobustnessFeaturesEXT {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceImageRobustnessFeaturesEXT {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'a> {
-    type Target = PhysicalDeviceImageRobustnessFeaturesEXT;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceImageRobustnessFeaturesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceImageRobustnessFeatures {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceImageRobustnessFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceImageRobustnessFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceImageRobustnessFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceImageRobustnessFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceImageRobustnessFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'a> {
+impl<'a> PhysicalDeviceImageRobustnessFeaturesBuilder<'a> {
     pub fn robust_image_access(mut self, robust_image_access: bool) -> Self {
         self.inner.robust_image_access = robust_image_access.into();
         self
@@ -44056,7 +44648,7 @@ impl<'a> PhysicalDeviceImageRobustnessFeaturesEXTBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceImageRobustnessFeaturesEXT {
+    pub fn build(self) -> PhysicalDeviceImageRobustnessFeatures {
         self.inner
     }
 }
@@ -44513,18 +45105,18 @@ impl<'a> PhysicalDeviceSubpassShadingFeaturesHUAWEIBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBufferCopy2KHR.html>"]
-pub struct BufferCopy2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBufferCopy2.html>"]
+pub struct BufferCopy2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_offset: DeviceSize,
     pub dst_offset: DeviceSize,
     pub size: DeviceSize,
 }
-impl ::std::default::Default for BufferCopy2KHR {
+impl ::std::default::Default for BufferCopy2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::BUFFER_COPY_2_KHR,
+            s_type: StructureType::BUFFER_COPY_2,
             p_next: ::std::ptr::null(),
             src_offset: DeviceSize::default(),
             dst_offset: DeviceSize::default(),
@@ -44532,31 +45124,31 @@ impl ::std::default::Default for BufferCopy2KHR {
         }
     }
 }
-impl BufferCopy2KHR {
-    pub fn builder<'a>() -> BufferCopy2KHRBuilder<'a> {
-        BufferCopy2KHRBuilder {
+impl BufferCopy2 {
+    pub fn builder<'a>() -> BufferCopy2Builder<'a> {
+        BufferCopy2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct BufferCopy2KHRBuilder<'a> {
-    inner: BufferCopy2KHR,
+pub struct BufferCopy2Builder<'a> {
+    inner: BufferCopy2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for BufferCopy2KHRBuilder<'a> {
-    type Target = BufferCopy2KHR;
+impl<'a> ::std::ops::Deref for BufferCopy2Builder<'a> {
+    type Target = BufferCopy2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for BufferCopy2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for BufferCopy2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> BufferCopy2KHRBuilder<'a> {
+impl<'a> BufferCopy2Builder<'a> {
     pub fn src_offset(mut self, src_offset: DeviceSize) -> Self {
         self.inner.src_offset = src_offset;
         self
@@ -44572,15 +45164,15 @@ impl<'a> BufferCopy2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> BufferCopy2KHR {
+    pub fn build(self) -> BufferCopy2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageCopy2KHR.html>"]
-pub struct ImageCopy2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageCopy2.html>"]
+pub struct ImageCopy2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_subresource: ImageSubresourceLayers,
@@ -44589,10 +45181,10 @@ pub struct ImageCopy2KHR {
     pub dst_offset: Offset3D,
     pub extent: Extent3D,
 }
-impl ::std::default::Default for ImageCopy2KHR {
+impl ::std::default::Default for ImageCopy2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::IMAGE_COPY_2_KHR,
+            s_type: StructureType::IMAGE_COPY_2,
             p_next: ::std::ptr::null(),
             src_subresource: ImageSubresourceLayers::default(),
             src_offset: Offset3D::default(),
@@ -44602,31 +45194,31 @@ impl ::std::default::Default for ImageCopy2KHR {
         }
     }
 }
-impl ImageCopy2KHR {
-    pub fn builder<'a>() -> ImageCopy2KHRBuilder<'a> {
-        ImageCopy2KHRBuilder {
+impl ImageCopy2 {
+    pub fn builder<'a>() -> ImageCopy2Builder<'a> {
+        ImageCopy2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct ImageCopy2KHRBuilder<'a> {
-    inner: ImageCopy2KHR,
+pub struct ImageCopy2Builder<'a> {
+    inner: ImageCopy2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for ImageCopy2KHRBuilder<'a> {
-    type Target = ImageCopy2KHR;
+impl<'a> ::std::ops::Deref for ImageCopy2Builder<'a> {
+    type Target = ImageCopy2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for ImageCopy2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for ImageCopy2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> ImageCopy2KHRBuilder<'a> {
+impl<'a> ImageCopy2Builder<'a> {
     pub fn src_subresource(mut self, src_subresource: ImageSubresourceLayers) -> Self {
         self.inner.src_subresource = src_subresource;
         self
@@ -44650,15 +45242,15 @@ impl<'a> ImageCopy2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> ImageCopy2KHR {
+    pub fn build(self) -> ImageCopy2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageBlit2KHR.html>"]
-pub struct ImageBlit2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageBlit2.html>"]
+pub struct ImageBlit2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_subresource: ImageSubresourceLayers,
@@ -44666,10 +45258,10 @@ pub struct ImageBlit2KHR {
     pub dst_subresource: ImageSubresourceLayers,
     pub dst_offsets: [Offset3D; 2],
 }
-impl ::std::default::Default for ImageBlit2KHR {
+impl ::std::default::Default for ImageBlit2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::IMAGE_BLIT_2_KHR,
+            s_type: StructureType::IMAGE_BLIT_2,
             p_next: ::std::ptr::null(),
             src_subresource: ImageSubresourceLayers::default(),
             src_offsets: unsafe { ::std::mem::zeroed() },
@@ -44678,32 +45270,32 @@ impl ::std::default::Default for ImageBlit2KHR {
         }
     }
 }
-impl ImageBlit2KHR {
-    pub fn builder<'a>() -> ImageBlit2KHRBuilder<'a> {
-        ImageBlit2KHRBuilder {
+impl ImageBlit2 {
+    pub fn builder<'a>() -> ImageBlit2Builder<'a> {
+        ImageBlit2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct ImageBlit2KHRBuilder<'a> {
-    inner: ImageBlit2KHR,
+pub struct ImageBlit2Builder<'a> {
+    inner: ImageBlit2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsImageBlit2KHR {}
-impl<'a> ::std::ops::Deref for ImageBlit2KHRBuilder<'a> {
-    type Target = ImageBlit2KHR;
+pub unsafe trait ExtendsImageBlit2 {}
+impl<'a> ::std::ops::Deref for ImageBlit2Builder<'a> {
+    type Target = ImageBlit2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for ImageBlit2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for ImageBlit2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> ImageBlit2KHRBuilder<'a> {
+impl<'a> ImageBlit2Builder<'a> {
     pub fn src_subresource(mut self, src_subresource: ImageSubresourceLayers) -> Self {
         self.inner.src_subresource = src_subresource;
         self
@@ -44725,7 +45317,7 @@ impl<'a> ImageBlit2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageBlit2KHR>(mut self, next: &'a mut T) -> Self {
+    pub fn push_next<T: ExtendsImageBlit2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = <*const T>::cast(next);
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -44737,15 +45329,15 @@ impl<'a> ImageBlit2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> ImageBlit2KHR {
+    pub fn build(self) -> ImageBlit2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBufferImageCopy2KHR.html>"]
-pub struct BufferImageCopy2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBufferImageCopy2.html>"]
+pub struct BufferImageCopy2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub buffer_offset: DeviceSize,
@@ -44755,10 +45347,10 @@ pub struct BufferImageCopy2KHR {
     pub image_offset: Offset3D,
     pub image_extent: Extent3D,
 }
-impl ::std::default::Default for BufferImageCopy2KHR {
+impl ::std::default::Default for BufferImageCopy2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::BUFFER_IMAGE_COPY_2_KHR,
+            s_type: StructureType::BUFFER_IMAGE_COPY_2,
             p_next: ::std::ptr::null(),
             buffer_offset: DeviceSize::default(),
             buffer_row_length: u32::default(),
@@ -44769,32 +45361,32 @@ impl ::std::default::Default for BufferImageCopy2KHR {
         }
     }
 }
-impl BufferImageCopy2KHR {
-    pub fn builder<'a>() -> BufferImageCopy2KHRBuilder<'a> {
-        BufferImageCopy2KHRBuilder {
+impl BufferImageCopy2 {
+    pub fn builder<'a>() -> BufferImageCopy2Builder<'a> {
+        BufferImageCopy2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct BufferImageCopy2KHRBuilder<'a> {
-    inner: BufferImageCopy2KHR,
+pub struct BufferImageCopy2Builder<'a> {
+    inner: BufferImageCopy2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsBufferImageCopy2KHR {}
-impl<'a> ::std::ops::Deref for BufferImageCopy2KHRBuilder<'a> {
-    type Target = BufferImageCopy2KHR;
+pub unsafe trait ExtendsBufferImageCopy2 {}
+impl<'a> ::std::ops::Deref for BufferImageCopy2Builder<'a> {
+    type Target = BufferImageCopy2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for BufferImageCopy2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for BufferImageCopy2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> BufferImageCopy2KHRBuilder<'a> {
+impl<'a> BufferImageCopy2Builder<'a> {
     pub fn buffer_offset(mut self, buffer_offset: DeviceSize) -> Self {
         self.inner.buffer_offset = buffer_offset;
         self
@@ -44824,7 +45416,7 @@ impl<'a> BufferImageCopy2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsBufferImageCopy2KHR>(mut self, next: &'a mut T) -> Self {
+    pub fn push_next<T: ExtendsBufferImageCopy2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = <*const T>::cast(next);
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -44836,15 +45428,15 @@ impl<'a> BufferImageCopy2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> BufferImageCopy2KHR {
+    pub fn build(self) -> BufferImageCopy2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageResolve2KHR.html>"]
-pub struct ImageResolve2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageResolve2.html>"]
+pub struct ImageResolve2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_subresource: ImageSubresourceLayers,
@@ -44853,10 +45445,10 @@ pub struct ImageResolve2KHR {
     pub dst_offset: Offset3D,
     pub extent: Extent3D,
 }
-impl ::std::default::Default for ImageResolve2KHR {
+impl ::std::default::Default for ImageResolve2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::IMAGE_RESOLVE_2_KHR,
+            s_type: StructureType::IMAGE_RESOLVE_2,
             p_next: ::std::ptr::null(),
             src_subresource: ImageSubresourceLayers::default(),
             src_offset: Offset3D::default(),
@@ -44866,31 +45458,31 @@ impl ::std::default::Default for ImageResolve2KHR {
         }
     }
 }
-impl ImageResolve2KHR {
-    pub fn builder<'a>() -> ImageResolve2KHRBuilder<'a> {
-        ImageResolve2KHRBuilder {
+impl ImageResolve2 {
+    pub fn builder<'a>() -> ImageResolve2Builder<'a> {
+        ImageResolve2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct ImageResolve2KHRBuilder<'a> {
-    inner: ImageResolve2KHR,
+pub struct ImageResolve2Builder<'a> {
+    inner: ImageResolve2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for ImageResolve2KHRBuilder<'a> {
-    type Target = ImageResolve2KHR;
+impl<'a> ::std::ops::Deref for ImageResolve2Builder<'a> {
+    type Target = ImageResolve2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for ImageResolve2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for ImageResolve2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> ImageResolve2KHRBuilder<'a> {
+impl<'a> ImageResolve2Builder<'a> {
     pub fn src_subresource(mut self, src_subresource: ImageSubresourceLayers) -> Self {
         self.inner.src_subresource = src_subresource;
         self
@@ -44914,26 +45506,26 @@ impl<'a> ImageResolve2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> ImageResolve2KHR {
+    pub fn build(self) -> ImageResolve2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCopyBufferInfo2KHR.html>"]
-pub struct CopyBufferInfo2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCopyBufferInfo2.html>"]
+pub struct CopyBufferInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_buffer: Buffer,
     pub dst_buffer: Buffer,
     pub region_count: u32,
-    pub p_regions: *const BufferCopy2KHR,
+    pub p_regions: *const BufferCopy2,
 }
-impl ::std::default::Default for CopyBufferInfo2KHR {
+impl ::std::default::Default for CopyBufferInfo2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::COPY_BUFFER_INFO_2_KHR,
+            s_type: StructureType::COPY_BUFFER_INFO_2,
             p_next: ::std::ptr::null(),
             src_buffer: Buffer::default(),
             dst_buffer: Buffer::default(),
@@ -44942,31 +45534,31 @@ impl ::std::default::Default for CopyBufferInfo2KHR {
         }
     }
 }
-impl CopyBufferInfo2KHR {
-    pub fn builder<'a>() -> CopyBufferInfo2KHRBuilder<'a> {
-        CopyBufferInfo2KHRBuilder {
+impl CopyBufferInfo2 {
+    pub fn builder<'a>() -> CopyBufferInfo2Builder<'a> {
+        CopyBufferInfo2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct CopyBufferInfo2KHRBuilder<'a> {
-    inner: CopyBufferInfo2KHR,
+pub struct CopyBufferInfo2Builder<'a> {
+    inner: CopyBufferInfo2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for CopyBufferInfo2KHRBuilder<'a> {
-    type Target = CopyBufferInfo2KHR;
+impl<'a> ::std::ops::Deref for CopyBufferInfo2Builder<'a> {
+    type Target = CopyBufferInfo2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for CopyBufferInfo2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for CopyBufferInfo2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> CopyBufferInfo2KHRBuilder<'a> {
+impl<'a> CopyBufferInfo2Builder<'a> {
     pub fn src_buffer(mut self, src_buffer: Buffer) -> Self {
         self.inner.src_buffer = src_buffer;
         self
@@ -44975,7 +45567,7 @@ impl<'a> CopyBufferInfo2KHRBuilder<'a> {
         self.inner.dst_buffer = dst_buffer;
         self
     }
-    pub fn regions(mut self, regions: &'a [BufferCopy2KHR]) -> Self {
+    pub fn regions(mut self, regions: &'a [BufferCopy2]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -44983,15 +45575,15 @@ impl<'a> CopyBufferInfo2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> CopyBufferInfo2KHR {
+    pub fn build(self) -> CopyBufferInfo2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCopyImageInfo2KHR.html>"]
-pub struct CopyImageInfo2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCopyImageInfo2.html>"]
+pub struct CopyImageInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_image: Image,
@@ -44999,12 +45591,12 @@ pub struct CopyImageInfo2KHR {
     pub dst_image: Image,
     pub dst_image_layout: ImageLayout,
     pub region_count: u32,
-    pub p_regions: *const ImageCopy2KHR,
+    pub p_regions: *const ImageCopy2,
 }
-impl ::std::default::Default for CopyImageInfo2KHR {
+impl ::std::default::Default for CopyImageInfo2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::COPY_IMAGE_INFO_2_KHR,
+            s_type: StructureType::COPY_IMAGE_INFO_2,
             p_next: ::std::ptr::null(),
             src_image: Image::default(),
             src_image_layout: ImageLayout::default(),
@@ -45015,31 +45607,31 @@ impl ::std::default::Default for CopyImageInfo2KHR {
         }
     }
 }
-impl CopyImageInfo2KHR {
-    pub fn builder<'a>() -> CopyImageInfo2KHRBuilder<'a> {
-        CopyImageInfo2KHRBuilder {
+impl CopyImageInfo2 {
+    pub fn builder<'a>() -> CopyImageInfo2Builder<'a> {
+        CopyImageInfo2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct CopyImageInfo2KHRBuilder<'a> {
-    inner: CopyImageInfo2KHR,
+pub struct CopyImageInfo2Builder<'a> {
+    inner: CopyImageInfo2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for CopyImageInfo2KHRBuilder<'a> {
-    type Target = CopyImageInfo2KHR;
+impl<'a> ::std::ops::Deref for CopyImageInfo2Builder<'a> {
+    type Target = CopyImageInfo2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for CopyImageInfo2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for CopyImageInfo2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> CopyImageInfo2KHRBuilder<'a> {
+impl<'a> CopyImageInfo2Builder<'a> {
     pub fn src_image(mut self, src_image: Image) -> Self {
         self.inner.src_image = src_image;
         self
@@ -45056,7 +45648,7 @@ impl<'a> CopyImageInfo2KHRBuilder<'a> {
         self.inner.dst_image_layout = dst_image_layout;
         self
     }
-    pub fn regions(mut self, regions: &'a [ImageCopy2KHR]) -> Self {
+    pub fn regions(mut self, regions: &'a [ImageCopy2]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -45064,15 +45656,15 @@ impl<'a> CopyImageInfo2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> CopyImageInfo2KHR {
+    pub fn build(self) -> CopyImageInfo2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBlitImageInfo2KHR.html>"]
-pub struct BlitImageInfo2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBlitImageInfo2.html>"]
+pub struct BlitImageInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_image: Image,
@@ -45080,13 +45672,13 @@ pub struct BlitImageInfo2KHR {
     pub dst_image: Image,
     pub dst_image_layout: ImageLayout,
     pub region_count: u32,
-    pub p_regions: *const ImageBlit2KHR,
+    pub p_regions: *const ImageBlit2,
     pub filter: Filter,
 }
-impl ::std::default::Default for BlitImageInfo2KHR {
+impl ::std::default::Default for BlitImageInfo2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::BLIT_IMAGE_INFO_2_KHR,
+            s_type: StructureType::BLIT_IMAGE_INFO_2,
             p_next: ::std::ptr::null(),
             src_image: Image::default(),
             src_image_layout: ImageLayout::default(),
@@ -45098,31 +45690,31 @@ impl ::std::default::Default for BlitImageInfo2KHR {
         }
     }
 }
-impl BlitImageInfo2KHR {
-    pub fn builder<'a>() -> BlitImageInfo2KHRBuilder<'a> {
-        BlitImageInfo2KHRBuilder {
+impl BlitImageInfo2 {
+    pub fn builder<'a>() -> BlitImageInfo2Builder<'a> {
+        BlitImageInfo2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct BlitImageInfo2KHRBuilder<'a> {
-    inner: BlitImageInfo2KHR,
+pub struct BlitImageInfo2Builder<'a> {
+    inner: BlitImageInfo2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for BlitImageInfo2KHRBuilder<'a> {
-    type Target = BlitImageInfo2KHR;
+impl<'a> ::std::ops::Deref for BlitImageInfo2Builder<'a> {
+    type Target = BlitImageInfo2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for BlitImageInfo2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for BlitImageInfo2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> BlitImageInfo2KHRBuilder<'a> {
+impl<'a> BlitImageInfo2Builder<'a> {
     pub fn src_image(mut self, src_image: Image) -> Self {
         self.inner.src_image = src_image;
         self
@@ -45139,7 +45731,7 @@ impl<'a> BlitImageInfo2KHRBuilder<'a> {
         self.inner.dst_image_layout = dst_image_layout;
         self
     }
-    pub fn regions(mut self, regions: &'a [ImageBlit2KHR]) -> Self {
+    pub fn regions(mut self, regions: &'a [ImageBlit2]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -45151,27 +45743,27 @@ impl<'a> BlitImageInfo2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> BlitImageInfo2KHR {
+    pub fn build(self) -> BlitImageInfo2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCopyBufferToImageInfo2KHR.html>"]
-pub struct CopyBufferToImageInfo2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCopyBufferToImageInfo2.html>"]
+pub struct CopyBufferToImageInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_buffer: Buffer,
     pub dst_image: Image,
     pub dst_image_layout: ImageLayout,
     pub region_count: u32,
-    pub p_regions: *const BufferImageCopy2KHR,
+    pub p_regions: *const BufferImageCopy2,
 }
-impl ::std::default::Default for CopyBufferToImageInfo2KHR {
+impl ::std::default::Default for CopyBufferToImageInfo2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::COPY_BUFFER_TO_IMAGE_INFO_2_KHR,
+            s_type: StructureType::COPY_BUFFER_TO_IMAGE_INFO_2,
             p_next: ::std::ptr::null(),
             src_buffer: Buffer::default(),
             dst_image: Image::default(),
@@ -45181,31 +45773,31 @@ impl ::std::default::Default for CopyBufferToImageInfo2KHR {
         }
     }
 }
-impl CopyBufferToImageInfo2KHR {
-    pub fn builder<'a>() -> CopyBufferToImageInfo2KHRBuilder<'a> {
-        CopyBufferToImageInfo2KHRBuilder {
+impl CopyBufferToImageInfo2 {
+    pub fn builder<'a>() -> CopyBufferToImageInfo2Builder<'a> {
+        CopyBufferToImageInfo2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct CopyBufferToImageInfo2KHRBuilder<'a> {
-    inner: CopyBufferToImageInfo2KHR,
+pub struct CopyBufferToImageInfo2Builder<'a> {
+    inner: CopyBufferToImageInfo2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for CopyBufferToImageInfo2KHRBuilder<'a> {
-    type Target = CopyBufferToImageInfo2KHR;
+impl<'a> ::std::ops::Deref for CopyBufferToImageInfo2Builder<'a> {
+    type Target = CopyBufferToImageInfo2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for CopyBufferToImageInfo2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for CopyBufferToImageInfo2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> CopyBufferToImageInfo2KHRBuilder<'a> {
+impl<'a> CopyBufferToImageInfo2Builder<'a> {
     pub fn src_buffer(mut self, src_buffer: Buffer) -> Self {
         self.inner.src_buffer = src_buffer;
         self
@@ -45218,7 +45810,7 @@ impl<'a> CopyBufferToImageInfo2KHRBuilder<'a> {
         self.inner.dst_image_layout = dst_image_layout;
         self
     }
-    pub fn regions(mut self, regions: &'a [BufferImageCopy2KHR]) -> Self {
+    pub fn regions(mut self, regions: &'a [BufferImageCopy2]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -45226,27 +45818,27 @@ impl<'a> CopyBufferToImageInfo2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> CopyBufferToImageInfo2KHR {
+    pub fn build(self) -> CopyBufferToImageInfo2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCopyImageToBufferInfo2KHR.html>"]
-pub struct CopyImageToBufferInfo2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCopyImageToBufferInfo2.html>"]
+pub struct CopyImageToBufferInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_image: Image,
     pub src_image_layout: ImageLayout,
     pub dst_buffer: Buffer,
     pub region_count: u32,
-    pub p_regions: *const BufferImageCopy2KHR,
+    pub p_regions: *const BufferImageCopy2,
 }
-impl ::std::default::Default for CopyImageToBufferInfo2KHR {
+impl ::std::default::Default for CopyImageToBufferInfo2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::COPY_IMAGE_TO_BUFFER_INFO_2_KHR,
+            s_type: StructureType::COPY_IMAGE_TO_BUFFER_INFO_2,
             p_next: ::std::ptr::null(),
             src_image: Image::default(),
             src_image_layout: ImageLayout::default(),
@@ -45256,31 +45848,31 @@ impl ::std::default::Default for CopyImageToBufferInfo2KHR {
         }
     }
 }
-impl CopyImageToBufferInfo2KHR {
-    pub fn builder<'a>() -> CopyImageToBufferInfo2KHRBuilder<'a> {
-        CopyImageToBufferInfo2KHRBuilder {
+impl CopyImageToBufferInfo2 {
+    pub fn builder<'a>() -> CopyImageToBufferInfo2Builder<'a> {
+        CopyImageToBufferInfo2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct CopyImageToBufferInfo2KHRBuilder<'a> {
-    inner: CopyImageToBufferInfo2KHR,
+pub struct CopyImageToBufferInfo2Builder<'a> {
+    inner: CopyImageToBufferInfo2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for CopyImageToBufferInfo2KHRBuilder<'a> {
-    type Target = CopyImageToBufferInfo2KHR;
+impl<'a> ::std::ops::Deref for CopyImageToBufferInfo2Builder<'a> {
+    type Target = CopyImageToBufferInfo2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for CopyImageToBufferInfo2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for CopyImageToBufferInfo2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> CopyImageToBufferInfo2KHRBuilder<'a> {
+impl<'a> CopyImageToBufferInfo2Builder<'a> {
     pub fn src_image(mut self, src_image: Image) -> Self {
         self.inner.src_image = src_image;
         self
@@ -45293,7 +45885,7 @@ impl<'a> CopyImageToBufferInfo2KHRBuilder<'a> {
         self.inner.dst_buffer = dst_buffer;
         self
     }
-    pub fn regions(mut self, regions: &'a [BufferImageCopy2KHR]) -> Self {
+    pub fn regions(mut self, regions: &'a [BufferImageCopy2]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -45301,15 +45893,15 @@ impl<'a> CopyImageToBufferInfo2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> CopyImageToBufferInfo2KHR {
+    pub fn build(self) -> CopyImageToBufferInfo2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkResolveImageInfo2KHR.html>"]
-pub struct ResolveImageInfo2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkResolveImageInfo2.html>"]
+pub struct ResolveImageInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub src_image: Image,
@@ -45317,12 +45909,12 @@ pub struct ResolveImageInfo2KHR {
     pub dst_image: Image,
     pub dst_image_layout: ImageLayout,
     pub region_count: u32,
-    pub p_regions: *const ImageResolve2KHR,
+    pub p_regions: *const ImageResolve2,
 }
-impl ::std::default::Default for ResolveImageInfo2KHR {
+impl ::std::default::Default for ResolveImageInfo2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::RESOLVE_IMAGE_INFO_2_KHR,
+            s_type: StructureType::RESOLVE_IMAGE_INFO_2,
             p_next: ::std::ptr::null(),
             src_image: Image::default(),
             src_image_layout: ImageLayout::default(),
@@ -45333,31 +45925,31 @@ impl ::std::default::Default for ResolveImageInfo2KHR {
         }
     }
 }
-impl ResolveImageInfo2KHR {
-    pub fn builder<'a>() -> ResolveImageInfo2KHRBuilder<'a> {
-        ResolveImageInfo2KHRBuilder {
+impl ResolveImageInfo2 {
+    pub fn builder<'a>() -> ResolveImageInfo2Builder<'a> {
+        ResolveImageInfo2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct ResolveImageInfo2KHRBuilder<'a> {
-    inner: ResolveImageInfo2KHR,
+pub struct ResolveImageInfo2Builder<'a> {
+    inner: ResolveImageInfo2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for ResolveImageInfo2KHRBuilder<'a> {
-    type Target = ResolveImageInfo2KHR;
+impl<'a> ::std::ops::Deref for ResolveImageInfo2Builder<'a> {
+    type Target = ResolveImageInfo2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for ResolveImageInfo2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for ResolveImageInfo2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> ResolveImageInfo2KHRBuilder<'a> {
+impl<'a> ResolveImageInfo2Builder<'a> {
     pub fn src_image(mut self, src_image: Image) -> Self {
         self.inner.src_image = src_image;
         self
@@ -45374,7 +45966,7 @@ impl<'a> ResolveImageInfo2KHRBuilder<'a> {
         self.inner.dst_image_layout = dst_image_layout;
         self
     }
-    pub fn regions(mut self, regions: &'a [ImageResolve2KHR]) -> Self {
+    pub fn regions(mut self, regions: &'a [ImageResolve2]) -> Self {
         self.inner.region_count = regions.len() as _;
         self.inner.p_regions = regions.as_ptr();
         self
@@ -45382,7 +45974,7 @@ impl<'a> ResolveImageInfo2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> ResolveImageInfo2KHR {
+    pub fn build(self) -> ResolveImageInfo2 {
         self.inner
     }
 }
@@ -45948,56 +46540,53 @@ impl<'a> PhysicalDeviceFragmentShadingRateKHRBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR.html>"]
-pub struct PhysicalDeviceShaderTerminateInvocationFeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderTerminateInvocationFeatures.html>"]
+pub struct PhysicalDeviceShaderTerminateInvocationFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub shader_terminate_invocation: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceShaderTerminateInvocationFeaturesKHR {
+impl ::std::default::Default for PhysicalDeviceShaderTerminateInvocationFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES_KHR,
+            s_type: StructureType::PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES,
             p_next: ::std::ptr::null_mut(),
             shader_terminate_invocation: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceShaderTerminateInvocationFeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'a> {
-        PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder {
+impl PhysicalDeviceShaderTerminateInvocationFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceShaderTerminateInvocationFeaturesBuilder<'a> {
+        PhysicalDeviceShaderTerminateInvocationFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceShaderTerminateInvocationFeaturesKHR,
+pub struct PhysicalDeviceShaderTerminateInvocationFeaturesBuilder<'a> {
+    inner: PhysicalDeviceShaderTerminateInvocationFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'_>
+    for PhysicalDeviceShaderTerminateInvocationFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceShaderTerminateInvocationFeaturesKHR {}
-unsafe impl ExtendsDeviceCreateInfo
-    for PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'_>
-{
-}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderTerminateInvocationFeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceShaderTerminateInvocationFeaturesKHR;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceShaderTerminateInvocationFeatures {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderTerminateInvocationFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderTerminateInvocationFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceShaderTerminateInvocationFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceShaderTerminateInvocationFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderTerminateInvocationFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceShaderTerminateInvocationFeaturesBuilder<'a> {
     pub fn shader_terminate_invocation(mut self, shader_terminate_invocation: bool) -> Self {
         self.inner.shader_terminate_invocation = shader_terminate_invocation.into();
         self
@@ -46005,7 +46594,7 @@ impl<'a> PhysicalDeviceShaderTerminateInvocationFeaturesKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceShaderTerminateInvocationFeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceShaderTerminateInvocationFeatures {
         self.inner
     }
 }
@@ -46997,88 +47586,88 @@ impl<'a> PipelineColorWriteCreateInfoEXTBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkMemoryBarrier2KHR.html>"]
-pub struct MemoryBarrier2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkMemoryBarrier2.html>"]
+pub struct MemoryBarrier2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub src_stage_mask: PipelineStageFlags2KHR,
-    pub src_access_mask: AccessFlags2KHR,
-    pub dst_stage_mask: PipelineStageFlags2KHR,
-    pub dst_access_mask: AccessFlags2KHR,
+    pub src_stage_mask: PipelineStageFlags2,
+    pub src_access_mask: AccessFlags2,
+    pub dst_stage_mask: PipelineStageFlags2,
+    pub dst_access_mask: AccessFlags2,
 }
-impl ::std::default::Default for MemoryBarrier2KHR {
+impl ::std::default::Default for MemoryBarrier2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::MEMORY_BARRIER_2_KHR,
+            s_type: StructureType::MEMORY_BARRIER_2,
             p_next: ::std::ptr::null(),
-            src_stage_mask: PipelineStageFlags2KHR::default(),
-            src_access_mask: AccessFlags2KHR::default(),
-            dst_stage_mask: PipelineStageFlags2KHR::default(),
-            dst_access_mask: AccessFlags2KHR::default(),
+            src_stage_mask: PipelineStageFlags2::default(),
+            src_access_mask: AccessFlags2::default(),
+            dst_stage_mask: PipelineStageFlags2::default(),
+            dst_access_mask: AccessFlags2::default(),
         }
     }
 }
-impl MemoryBarrier2KHR {
-    pub fn builder<'a>() -> MemoryBarrier2KHRBuilder<'a> {
-        MemoryBarrier2KHRBuilder {
+impl MemoryBarrier2 {
+    pub fn builder<'a>() -> MemoryBarrier2Builder<'a> {
+        MemoryBarrier2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct MemoryBarrier2KHRBuilder<'a> {
-    inner: MemoryBarrier2KHR,
+pub struct MemoryBarrier2Builder<'a> {
+    inner: MemoryBarrier2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsSubpassDependency2 for MemoryBarrier2KHRBuilder<'_> {}
-unsafe impl ExtendsSubpassDependency2 for MemoryBarrier2KHR {}
-impl<'a> ::std::ops::Deref for MemoryBarrier2KHRBuilder<'a> {
-    type Target = MemoryBarrier2KHR;
+unsafe impl ExtendsSubpassDependency2 for MemoryBarrier2Builder<'_> {}
+unsafe impl ExtendsSubpassDependency2 for MemoryBarrier2 {}
+impl<'a> ::std::ops::Deref for MemoryBarrier2Builder<'a> {
+    type Target = MemoryBarrier2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for MemoryBarrier2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for MemoryBarrier2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> MemoryBarrier2KHRBuilder<'a> {
-    pub fn src_stage_mask(mut self, src_stage_mask: PipelineStageFlags2KHR) -> Self {
+impl<'a> MemoryBarrier2Builder<'a> {
+    pub fn src_stage_mask(mut self, src_stage_mask: PipelineStageFlags2) -> Self {
         self.inner.src_stage_mask = src_stage_mask;
         self
     }
-    pub fn src_access_mask(mut self, src_access_mask: AccessFlags2KHR) -> Self {
+    pub fn src_access_mask(mut self, src_access_mask: AccessFlags2) -> Self {
         self.inner.src_access_mask = src_access_mask;
         self
     }
-    pub fn dst_stage_mask(mut self, dst_stage_mask: PipelineStageFlags2KHR) -> Self {
+    pub fn dst_stage_mask(mut self, dst_stage_mask: PipelineStageFlags2) -> Self {
         self.inner.dst_stage_mask = dst_stage_mask;
         self
     }
-    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags2KHR) -> Self {
+    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags2) -> Self {
         self.inner.dst_access_mask = dst_access_mask;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> MemoryBarrier2KHR {
+    pub fn build(self) -> MemoryBarrier2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageMemoryBarrier2KHR.html>"]
-pub struct ImageMemoryBarrier2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkImageMemoryBarrier2.html>"]
+pub struct ImageMemoryBarrier2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub src_stage_mask: PipelineStageFlags2KHR,
-    pub src_access_mask: AccessFlags2KHR,
-    pub dst_stage_mask: PipelineStageFlags2KHR,
-    pub dst_access_mask: AccessFlags2KHR,
+    pub src_stage_mask: PipelineStageFlags2,
+    pub src_access_mask: AccessFlags2,
+    pub dst_stage_mask: PipelineStageFlags2,
+    pub dst_access_mask: AccessFlags2,
     pub old_layout: ImageLayout,
     pub new_layout: ImageLayout,
     pub src_queue_family_index: u32,
@@ -47086,15 +47675,15 @@ pub struct ImageMemoryBarrier2KHR {
     pub image: Image,
     pub subresource_range: ImageSubresourceRange,
 }
-impl ::std::default::Default for ImageMemoryBarrier2KHR {
+impl ::std::default::Default for ImageMemoryBarrier2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::IMAGE_MEMORY_BARRIER_2_KHR,
+            s_type: StructureType::IMAGE_MEMORY_BARRIER_2,
             p_next: ::std::ptr::null(),
-            src_stage_mask: PipelineStageFlags2KHR::default(),
-            src_access_mask: AccessFlags2KHR::default(),
-            dst_stage_mask: PipelineStageFlags2KHR::default(),
-            dst_access_mask: AccessFlags2KHR::default(),
+            src_stage_mask: PipelineStageFlags2::default(),
+            src_access_mask: AccessFlags2::default(),
+            dst_stage_mask: PipelineStageFlags2::default(),
+            dst_access_mask: AccessFlags2::default(),
             old_layout: ImageLayout::default(),
             new_layout: ImageLayout::default(),
             src_queue_family_index: u32::default(),
@@ -47104,45 +47693,45 @@ impl ::std::default::Default for ImageMemoryBarrier2KHR {
         }
     }
 }
-impl ImageMemoryBarrier2KHR {
-    pub fn builder<'a>() -> ImageMemoryBarrier2KHRBuilder<'a> {
-        ImageMemoryBarrier2KHRBuilder {
+impl ImageMemoryBarrier2 {
+    pub fn builder<'a>() -> ImageMemoryBarrier2Builder<'a> {
+        ImageMemoryBarrier2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct ImageMemoryBarrier2KHRBuilder<'a> {
-    inner: ImageMemoryBarrier2KHR,
+pub struct ImageMemoryBarrier2Builder<'a> {
+    inner: ImageMemoryBarrier2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsImageMemoryBarrier2KHR {}
-impl<'a> ::std::ops::Deref for ImageMemoryBarrier2KHRBuilder<'a> {
-    type Target = ImageMemoryBarrier2KHR;
+pub unsafe trait ExtendsImageMemoryBarrier2 {}
+impl<'a> ::std::ops::Deref for ImageMemoryBarrier2Builder<'a> {
+    type Target = ImageMemoryBarrier2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for ImageMemoryBarrier2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for ImageMemoryBarrier2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> ImageMemoryBarrier2KHRBuilder<'a> {
-    pub fn src_stage_mask(mut self, src_stage_mask: PipelineStageFlags2KHR) -> Self {
+impl<'a> ImageMemoryBarrier2Builder<'a> {
+    pub fn src_stage_mask(mut self, src_stage_mask: PipelineStageFlags2) -> Self {
         self.inner.src_stage_mask = src_stage_mask;
         self
     }
-    pub fn src_access_mask(mut self, src_access_mask: AccessFlags2KHR) -> Self {
+    pub fn src_access_mask(mut self, src_access_mask: AccessFlags2) -> Self {
         self.inner.src_access_mask = src_access_mask;
         self
     }
-    pub fn dst_stage_mask(mut self, dst_stage_mask: PipelineStageFlags2KHR) -> Self {
+    pub fn dst_stage_mask(mut self, dst_stage_mask: PipelineStageFlags2) -> Self {
         self.inner.dst_stage_mask = dst_stage_mask;
         self
     }
-    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags2KHR) -> Self {
+    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags2) -> Self {
         self.inner.dst_access_mask = dst_access_mask;
         self
     }
@@ -47175,7 +47764,7 @@ impl<'a> ImageMemoryBarrier2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsImageMemoryBarrier2KHR>(mut self, next: &'a mut T) -> Self {
+    pub fn push_next<T: ExtendsImageMemoryBarrier2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = <*const T>::cast(next);
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47187,36 +47776,36 @@ impl<'a> ImageMemoryBarrier2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> ImageMemoryBarrier2KHR {
+    pub fn build(self) -> ImageMemoryBarrier2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBufferMemoryBarrier2KHR.html>"]
-pub struct BufferMemoryBarrier2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkBufferMemoryBarrier2.html>"]
+pub struct BufferMemoryBarrier2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub src_stage_mask: PipelineStageFlags2KHR,
-    pub src_access_mask: AccessFlags2KHR,
-    pub dst_stage_mask: PipelineStageFlags2KHR,
-    pub dst_access_mask: AccessFlags2KHR,
+    pub src_stage_mask: PipelineStageFlags2,
+    pub src_access_mask: AccessFlags2,
+    pub dst_stage_mask: PipelineStageFlags2,
+    pub dst_access_mask: AccessFlags2,
     pub src_queue_family_index: u32,
     pub dst_queue_family_index: u32,
     pub buffer: Buffer,
     pub offset: DeviceSize,
     pub size: DeviceSize,
 }
-impl ::std::default::Default for BufferMemoryBarrier2KHR {
+impl ::std::default::Default for BufferMemoryBarrier2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::BUFFER_MEMORY_BARRIER_2_KHR,
+            s_type: StructureType::BUFFER_MEMORY_BARRIER_2,
             p_next: ::std::ptr::null(),
-            src_stage_mask: PipelineStageFlags2KHR::default(),
-            src_access_mask: AccessFlags2KHR::default(),
-            dst_stage_mask: PipelineStageFlags2KHR::default(),
-            dst_access_mask: AccessFlags2KHR::default(),
+            src_stage_mask: PipelineStageFlags2::default(),
+            src_access_mask: AccessFlags2::default(),
+            dst_stage_mask: PipelineStageFlags2::default(),
+            dst_access_mask: AccessFlags2::default(),
             src_queue_family_index: u32::default(),
             dst_queue_family_index: u32::default(),
             buffer: Buffer::default(),
@@ -47225,44 +47814,44 @@ impl ::std::default::Default for BufferMemoryBarrier2KHR {
         }
     }
 }
-impl BufferMemoryBarrier2KHR {
-    pub fn builder<'a>() -> BufferMemoryBarrier2KHRBuilder<'a> {
-        BufferMemoryBarrier2KHRBuilder {
+impl BufferMemoryBarrier2 {
+    pub fn builder<'a>() -> BufferMemoryBarrier2Builder<'a> {
+        BufferMemoryBarrier2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct BufferMemoryBarrier2KHRBuilder<'a> {
-    inner: BufferMemoryBarrier2KHR,
+pub struct BufferMemoryBarrier2Builder<'a> {
+    inner: BufferMemoryBarrier2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for BufferMemoryBarrier2KHRBuilder<'a> {
-    type Target = BufferMemoryBarrier2KHR;
+impl<'a> ::std::ops::Deref for BufferMemoryBarrier2Builder<'a> {
+    type Target = BufferMemoryBarrier2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for BufferMemoryBarrier2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for BufferMemoryBarrier2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> BufferMemoryBarrier2KHRBuilder<'a> {
-    pub fn src_stage_mask(mut self, src_stage_mask: PipelineStageFlags2KHR) -> Self {
+impl<'a> BufferMemoryBarrier2Builder<'a> {
+    pub fn src_stage_mask(mut self, src_stage_mask: PipelineStageFlags2) -> Self {
         self.inner.src_stage_mask = src_stage_mask;
         self
     }
-    pub fn src_access_mask(mut self, src_access_mask: AccessFlags2KHR) -> Self {
+    pub fn src_access_mask(mut self, src_access_mask: AccessFlags2) -> Self {
         self.inner.src_access_mask = src_access_mask;
         self
     }
-    pub fn dst_stage_mask(mut self, dst_stage_mask: PipelineStageFlags2KHR) -> Self {
+    pub fn dst_stage_mask(mut self, dst_stage_mask: PipelineStageFlags2) -> Self {
         self.inner.dst_stage_mask = dst_stage_mask;
         self
     }
-    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags2KHR) -> Self {
+    pub fn dst_access_mask(mut self, dst_access_mask: AccessFlags2) -> Self {
         self.inner.dst_access_mask = dst_access_mask;
         self
     }
@@ -47289,29 +47878,29 @@ impl<'a> BufferMemoryBarrier2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> BufferMemoryBarrier2KHR {
+    pub fn build(self) -> BufferMemoryBarrier2 {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDependencyInfoKHR.html>"]
-pub struct DependencyInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkDependencyInfo.html>"]
+pub struct DependencyInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub dependency_flags: DependencyFlags,
     pub memory_barrier_count: u32,
-    pub p_memory_barriers: *const MemoryBarrier2KHR,
+    pub p_memory_barriers: *const MemoryBarrier2,
     pub buffer_memory_barrier_count: u32,
-    pub p_buffer_memory_barriers: *const BufferMemoryBarrier2KHR,
+    pub p_buffer_memory_barriers: *const BufferMemoryBarrier2,
     pub image_memory_barrier_count: u32,
-    pub p_image_memory_barriers: *const ImageMemoryBarrier2KHR,
+    pub p_image_memory_barriers: *const ImageMemoryBarrier2,
 }
-impl ::std::default::Default for DependencyInfoKHR {
+impl ::std::default::Default for DependencyInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::DEPENDENCY_INFO_KHR,
+            s_type: StructureType::DEPENDENCY_INFO,
             p_next: ::std::ptr::null(),
             dependency_flags: DependencyFlags::default(),
             memory_barrier_count: u32::default(),
@@ -47323,43 +47912,43 @@ impl ::std::default::Default for DependencyInfoKHR {
         }
     }
 }
-impl DependencyInfoKHR {
-    pub fn builder<'a>() -> DependencyInfoKHRBuilder<'a> {
-        DependencyInfoKHRBuilder {
+impl DependencyInfo {
+    pub fn builder<'a>() -> DependencyInfoBuilder<'a> {
+        DependencyInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct DependencyInfoKHRBuilder<'a> {
-    inner: DependencyInfoKHR,
+pub struct DependencyInfoBuilder<'a> {
+    inner: DependencyInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for DependencyInfoKHRBuilder<'a> {
-    type Target = DependencyInfoKHR;
+impl<'a> ::std::ops::Deref for DependencyInfoBuilder<'a> {
+    type Target = DependencyInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for DependencyInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for DependencyInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> DependencyInfoKHRBuilder<'a> {
+impl<'a> DependencyInfoBuilder<'a> {
     pub fn dependency_flags(mut self, dependency_flags: DependencyFlags) -> Self {
         self.inner.dependency_flags = dependency_flags;
         self
     }
-    pub fn memory_barriers(mut self, memory_barriers: &'a [MemoryBarrier2KHR]) -> Self {
+    pub fn memory_barriers(mut self, memory_barriers: &'a [MemoryBarrier2]) -> Self {
         self.inner.memory_barrier_count = memory_barriers.len() as _;
         self.inner.p_memory_barriers = memory_barriers.as_ptr();
         self
     }
     pub fn buffer_memory_barriers(
         mut self,
-        buffer_memory_barriers: &'a [BufferMemoryBarrier2KHR],
+        buffer_memory_barriers: &'a [BufferMemoryBarrier2],
     ) -> Self {
         self.inner.buffer_memory_barrier_count = buffer_memory_barriers.len() as _;
         self.inner.p_buffer_memory_barriers = buffer_memory_barriers.as_ptr();
@@ -47367,7 +47956,7 @@ impl<'a> DependencyInfoKHRBuilder<'a> {
     }
     pub fn image_memory_barriers(
         mut self,
-        image_memory_barriers: &'a [ImageMemoryBarrier2KHR],
+        image_memory_barriers: &'a [ImageMemoryBarrier2],
     ) -> Self {
         self.inner.image_memory_barrier_count = image_memory_barriers.len() as _;
         self.inner.p_image_memory_barriers = image_memory_barriers.as_ptr();
@@ -47376,59 +47965,59 @@ impl<'a> DependencyInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> DependencyInfoKHR {
+    pub fn build(self) -> DependencyInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSemaphoreSubmitInfoKHR.html>"]
-pub struct SemaphoreSubmitInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSemaphoreSubmitInfo.html>"]
+pub struct SemaphoreSubmitInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub semaphore: Semaphore,
     pub value: u64,
-    pub stage_mask: PipelineStageFlags2KHR,
+    pub stage_mask: PipelineStageFlags2,
     pub device_index: u32,
 }
-impl ::std::default::Default for SemaphoreSubmitInfoKHR {
+impl ::std::default::Default for SemaphoreSubmitInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::SEMAPHORE_SUBMIT_INFO_KHR,
+            s_type: StructureType::SEMAPHORE_SUBMIT_INFO,
             p_next: ::std::ptr::null(),
             semaphore: Semaphore::default(),
             value: u64::default(),
-            stage_mask: PipelineStageFlags2KHR::default(),
+            stage_mask: PipelineStageFlags2::default(),
             device_index: u32::default(),
         }
     }
 }
-impl SemaphoreSubmitInfoKHR {
-    pub fn builder<'a>() -> SemaphoreSubmitInfoKHRBuilder<'a> {
-        SemaphoreSubmitInfoKHRBuilder {
+impl SemaphoreSubmitInfo {
+    pub fn builder<'a>() -> SemaphoreSubmitInfoBuilder<'a> {
+        SemaphoreSubmitInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct SemaphoreSubmitInfoKHRBuilder<'a> {
-    inner: SemaphoreSubmitInfoKHR,
+pub struct SemaphoreSubmitInfoBuilder<'a> {
+    inner: SemaphoreSubmitInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for SemaphoreSubmitInfoKHRBuilder<'a> {
-    type Target = SemaphoreSubmitInfoKHR;
+impl<'a> ::std::ops::Deref for SemaphoreSubmitInfoBuilder<'a> {
+    type Target = SemaphoreSubmitInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for SemaphoreSubmitInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for SemaphoreSubmitInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> SemaphoreSubmitInfoKHRBuilder<'a> {
+impl<'a> SemaphoreSubmitInfoBuilder<'a> {
     pub fn semaphore(mut self, semaphore: Semaphore) -> Self {
         self.inner.semaphore = semaphore;
         self
@@ -47437,7 +48026,7 @@ impl<'a> SemaphoreSubmitInfoKHRBuilder<'a> {
         self.inner.value = value;
         self
     }
-    pub fn stage_mask(mut self, stage_mask: PipelineStageFlags2KHR) -> Self {
+    pub fn stage_mask(mut self, stage_mask: PipelineStageFlags2) -> Self {
         self.inner.stage_mask = stage_mask;
         self
     }
@@ -47448,55 +48037,55 @@ impl<'a> SemaphoreSubmitInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> SemaphoreSubmitInfoKHR {
+    pub fn build(self) -> SemaphoreSubmitInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCommandBufferSubmitInfoKHR.html>"]
-pub struct CommandBufferSubmitInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCommandBufferSubmitInfo.html>"]
+pub struct CommandBufferSubmitInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub command_buffer: CommandBuffer,
     pub device_mask: u32,
 }
-impl ::std::default::Default for CommandBufferSubmitInfoKHR {
+impl ::std::default::Default for CommandBufferSubmitInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::COMMAND_BUFFER_SUBMIT_INFO_KHR,
+            s_type: StructureType::COMMAND_BUFFER_SUBMIT_INFO,
             p_next: ::std::ptr::null(),
             command_buffer: CommandBuffer::default(),
             device_mask: u32::default(),
         }
     }
 }
-impl CommandBufferSubmitInfoKHR {
-    pub fn builder<'a>() -> CommandBufferSubmitInfoKHRBuilder<'a> {
-        CommandBufferSubmitInfoKHRBuilder {
+impl CommandBufferSubmitInfo {
+    pub fn builder<'a>() -> CommandBufferSubmitInfoBuilder<'a> {
+        CommandBufferSubmitInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct CommandBufferSubmitInfoKHRBuilder<'a> {
-    inner: CommandBufferSubmitInfoKHR,
+pub struct CommandBufferSubmitInfoBuilder<'a> {
+    inner: CommandBufferSubmitInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for CommandBufferSubmitInfoKHRBuilder<'a> {
-    type Target = CommandBufferSubmitInfoKHR;
+impl<'a> ::std::ops::Deref for CommandBufferSubmitInfoBuilder<'a> {
+    type Target = CommandBufferSubmitInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for CommandBufferSubmitInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for CommandBufferSubmitInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> CommandBufferSubmitInfoKHRBuilder<'a> {
+impl<'a> CommandBufferSubmitInfoBuilder<'a> {
     pub fn command_buffer(mut self, command_buffer: CommandBuffer) -> Self {
         self.inner.command_buffer = command_buffer;
         self
@@ -47508,31 +48097,31 @@ impl<'a> CommandBufferSubmitInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> CommandBufferSubmitInfoKHR {
+    pub fn build(self) -> CommandBufferSubmitInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSubmitInfo2KHR.html>"]
-pub struct SubmitInfo2KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSubmitInfo2.html>"]
+pub struct SubmitInfo2 {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub flags: SubmitFlagsKHR,
+    pub flags: SubmitFlags,
     pub wait_semaphore_info_count: u32,
-    pub p_wait_semaphore_infos: *const SemaphoreSubmitInfoKHR,
+    pub p_wait_semaphore_infos: *const SemaphoreSubmitInfo,
     pub command_buffer_info_count: u32,
-    pub p_command_buffer_infos: *const CommandBufferSubmitInfoKHR,
+    pub p_command_buffer_infos: *const CommandBufferSubmitInfo,
     pub signal_semaphore_info_count: u32,
-    pub p_signal_semaphore_infos: *const SemaphoreSubmitInfoKHR,
+    pub p_signal_semaphore_infos: *const SemaphoreSubmitInfo,
 }
-impl ::std::default::Default for SubmitInfo2KHR {
+impl ::std::default::Default for SubmitInfo2 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::SUBMIT_INFO_2_KHR,
+            s_type: StructureType::SUBMIT_INFO_2,
             p_next: ::std::ptr::null(),
-            flags: SubmitFlagsKHR::default(),
+            flags: SubmitFlags::default(),
             wait_semaphore_info_count: u32::default(),
             p_wait_semaphore_infos: ::std::ptr::null(),
             command_buffer_info_count: u32::default(),
@@ -47542,47 +48131,44 @@ impl ::std::default::Default for SubmitInfo2KHR {
         }
     }
 }
-impl SubmitInfo2KHR {
-    pub fn builder<'a>() -> SubmitInfo2KHRBuilder<'a> {
-        SubmitInfo2KHRBuilder {
+impl SubmitInfo2 {
+    pub fn builder<'a>() -> SubmitInfo2Builder<'a> {
+        SubmitInfo2Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct SubmitInfo2KHRBuilder<'a> {
-    inner: SubmitInfo2KHR,
+pub struct SubmitInfo2Builder<'a> {
+    inner: SubmitInfo2,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsSubmitInfo2KHR {}
-impl<'a> ::std::ops::Deref for SubmitInfo2KHRBuilder<'a> {
-    type Target = SubmitInfo2KHR;
+pub unsafe trait ExtendsSubmitInfo2 {}
+impl<'a> ::std::ops::Deref for SubmitInfo2Builder<'a> {
+    type Target = SubmitInfo2;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for SubmitInfo2KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for SubmitInfo2Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> SubmitInfo2KHRBuilder<'a> {
-    pub fn flags(mut self, flags: SubmitFlagsKHR) -> Self {
+impl<'a> SubmitInfo2Builder<'a> {
+    pub fn flags(mut self, flags: SubmitFlags) -> Self {
         self.inner.flags = flags;
         self
     }
-    pub fn wait_semaphore_infos(
-        mut self,
-        wait_semaphore_infos: &'a [SemaphoreSubmitInfoKHR],
-    ) -> Self {
+    pub fn wait_semaphore_infos(mut self, wait_semaphore_infos: &'a [SemaphoreSubmitInfo]) -> Self {
         self.inner.wait_semaphore_info_count = wait_semaphore_infos.len() as _;
         self.inner.p_wait_semaphore_infos = wait_semaphore_infos.as_ptr();
         self
     }
     pub fn command_buffer_infos(
         mut self,
-        command_buffer_infos: &'a [CommandBufferSubmitInfoKHR],
+        command_buffer_infos: &'a [CommandBufferSubmitInfo],
     ) -> Self {
         self.inner.command_buffer_info_count = command_buffer_infos.len() as _;
         self.inner.p_command_buffer_infos = command_buffer_infos.as_ptr();
@@ -47590,7 +48176,7 @@ impl<'a> SubmitInfo2KHRBuilder<'a> {
     }
     pub fn signal_semaphore_infos(
         mut self,
-        signal_semaphore_infos: &'a [SemaphoreSubmitInfoKHR],
+        signal_semaphore_infos: &'a [SemaphoreSubmitInfo],
     ) -> Self {
         self.inner.signal_semaphore_info_count = signal_semaphore_infos.len() as _;
         self.inner.p_signal_semaphore_infos = signal_semaphore_infos.as_ptr();
@@ -47601,7 +48187,7 @@ impl<'a> SubmitInfo2KHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsSubmitInfo2KHR>(mut self, next: &'a mut T) -> Self {
+    pub fn push_next<T: ExtendsSubmitInfo2>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = <*const T>::cast(next);
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -47613,7 +48199,7 @@ impl<'a> SubmitInfo2KHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> SubmitInfo2KHR {
+    pub fn build(self) -> SubmitInfo2 {
         self.inner
     }
 }
@@ -47624,14 +48210,14 @@ impl<'a> SubmitInfo2KHRBuilder<'a> {
 pub struct QueueFamilyCheckpointProperties2NV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
-    pub checkpoint_execution_stage_mask: PipelineStageFlags2KHR,
+    pub checkpoint_execution_stage_mask: PipelineStageFlags2,
 }
 impl ::std::default::Default for QueueFamilyCheckpointProperties2NV {
     fn default() -> Self {
         Self {
             s_type: StructureType::QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV,
             p_next: ::std::ptr::null_mut(),
-            checkpoint_execution_stage_mask: PipelineStageFlags2KHR::default(),
+            checkpoint_execution_stage_mask: PipelineStageFlags2::default(),
         }
     }
 }
@@ -47664,7 +48250,7 @@ impl<'a> ::std::ops::DerefMut for QueueFamilyCheckpointProperties2NVBuilder<'a> 
 impl<'a> QueueFamilyCheckpointProperties2NVBuilder<'a> {
     pub fn checkpoint_execution_stage_mask(
         mut self,
-        checkpoint_execution_stage_mask: PipelineStageFlags2KHR,
+        checkpoint_execution_stage_mask: PipelineStageFlags2,
     ) -> Self {
         self.inner.checkpoint_execution_stage_mask = checkpoint_execution_stage_mask;
         self
@@ -47683,7 +48269,7 @@ impl<'a> QueueFamilyCheckpointProperties2NVBuilder<'a> {
 pub struct CheckpointData2NV {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
-    pub stage: PipelineStageFlags2KHR,
+    pub stage: PipelineStageFlags2,
     pub p_checkpoint_marker: *mut c_void,
 }
 impl ::std::default::Default for CheckpointData2NV {
@@ -47691,7 +48277,7 @@ impl ::std::default::Default for CheckpointData2NV {
         Self {
             s_type: StructureType::CHECKPOINT_DATA_2_NV,
             p_next: ::std::ptr::null_mut(),
-            stage: PipelineStageFlags2KHR::default(),
+            stage: PipelineStageFlags2::default(),
             p_checkpoint_marker: ::std::ptr::null_mut(),
         }
     }
@@ -47721,7 +48307,7 @@ impl<'a> ::std::ops::DerefMut for CheckpointData2NVBuilder<'a> {
     }
 }
 impl<'a> CheckpointData2NVBuilder<'a> {
-    pub fn stage(mut self, stage: PipelineStageFlags2KHR) -> Self {
+    pub fn stage(mut self, stage: PipelineStageFlags2) -> Self {
         self.inner.stage = stage;
         self
     }
@@ -47739,53 +48325,50 @@ impl<'a> CheckpointData2NVBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceSynchronization2FeaturesKHR.html>"]
-pub struct PhysicalDeviceSynchronization2FeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceSynchronization2Features.html>"]
+pub struct PhysicalDeviceSynchronization2Features {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub synchronization2: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceSynchronization2FeaturesKHR {
+impl ::std::default::Default for PhysicalDeviceSynchronization2Features {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR,
+            s_type: StructureType::PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES,
             p_next: ::std::ptr::null_mut(),
             synchronization2: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceSynchronization2FeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceSynchronization2FeaturesKHRBuilder<'a> {
-        PhysicalDeviceSynchronization2FeaturesKHRBuilder {
+impl PhysicalDeviceSynchronization2Features {
+    pub fn builder<'a>() -> PhysicalDeviceSynchronization2FeaturesBuilder<'a> {
+        PhysicalDeviceSynchronization2FeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceSynchronization2FeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceSynchronization2FeaturesKHR,
+pub struct PhysicalDeviceSynchronization2FeaturesBuilder<'a> {
+    inner: PhysicalDeviceSynchronization2Features,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceSynchronization2FeaturesKHRBuilder<'_>
-{
-}
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceSynchronization2FeaturesKHR {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSynchronization2FeaturesKHRBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSynchronization2FeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceSynchronization2FeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceSynchronization2FeaturesKHR;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceSynchronization2FeaturesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceSynchronization2Features {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSynchronization2FeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceSynchronization2Features {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceSynchronization2FeaturesBuilder<'a> {
+    type Target = PhysicalDeviceSynchronization2Features;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceSynchronization2FeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceSynchronization2FeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceSynchronization2FeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceSynchronization2FeaturesBuilder<'a> {
     pub fn synchronization2(mut self, synchronization2: bool) -> Self {
         self.inner.synchronization2 = synchronization2.into();
         self
@@ -47793,7 +48376,7 @@ impl<'a> PhysicalDeviceSynchronization2FeaturesKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceSynchronization2FeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceSynchronization2Features {
         self.inner
     }
 }
@@ -51917,8 +52500,8 @@ pub struct VideoEncodeH265VclFrameInfoEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub p_reference_final_lists: *const VideoEncodeH265ReferenceListsEXT,
-    pub nalu_slice_entry_count: u32,
-    pub p_nalu_slice_entries: *const VideoEncodeH265NaluSliceEXT,
+    pub nalu_slice_segment_entry_count: u32,
+    pub p_nalu_slice_segment_entries: *const VideoEncodeH265NaluSliceSegmentEXT,
     pub p_current_picture_info: *const StdVideoEncodeH265PictureInfo,
 }
 impl ::std::default::Default for VideoEncodeH265VclFrameInfoEXT {
@@ -51927,8 +52510,8 @@ impl ::std::default::Default for VideoEncodeH265VclFrameInfoEXT {
             s_type: StructureType::VIDEO_ENCODE_H265_VCL_FRAME_INFO_EXT,
             p_next: ::std::ptr::null(),
             p_reference_final_lists: ::std::ptr::null(),
-            nalu_slice_entry_count: u32::default(),
-            p_nalu_slice_entries: ::std::ptr::null(),
+            nalu_slice_segment_entry_count: u32::default(),
+            p_nalu_slice_segment_entries: ::std::ptr::null(),
             p_current_picture_info: ::std::ptr::null(),
         }
     }
@@ -51967,12 +52550,12 @@ impl<'a> VideoEncodeH265VclFrameInfoEXTBuilder<'a> {
         self.inner.p_reference_final_lists = reference_final_lists;
         self
     }
-    pub fn nalu_slice_entries(
+    pub fn nalu_slice_segment_entries(
         mut self,
-        nalu_slice_entries: &'a [VideoEncodeH265NaluSliceEXT],
+        nalu_slice_segment_entries: &'a [VideoEncodeH265NaluSliceSegmentEXT],
     ) -> Self {
-        self.inner.nalu_slice_entry_count = nalu_slice_entries.len() as _;
-        self.inner.p_nalu_slice_entries = nalu_slice_entries.as_ptr();
+        self.inner.nalu_slice_segment_entry_count = nalu_slice_segment_entries.len() as _;
+        self.inner.p_nalu_slice_segment_entries = nalu_slice_segment_entries.as_ptr();
         self
     }
     pub fn current_picture_info(
@@ -52075,50 +52658,50 @@ impl<'a> VideoEncodeH265EmitPictureParametersEXTBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265NaluSliceEXT.html>"]
-pub struct VideoEncodeH265NaluSliceEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265NaluSliceSegmentEXT.html>"]
+pub struct VideoEncodeH265NaluSliceSegmentEXT {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub ctb_count: u32,
     pub p_reference_final_lists: *const VideoEncodeH265ReferenceListsEXT,
-    pub p_slice_header_std: *const StdVideoEncodeH265SliceHeader,
+    pub p_slice_segment_header_std: *const StdVideoEncodeH265SliceSegmentHeader,
 }
-impl ::std::default::Default for VideoEncodeH265NaluSliceEXT {
+impl ::std::default::Default for VideoEncodeH265NaluSliceSegmentEXT {
     fn default() -> Self {
         Self {
-            s_type: StructureType::VIDEO_ENCODE_H265_NALU_SLICE_EXT,
+            s_type: StructureType::VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_EXT,
             p_next: ::std::ptr::null(),
             ctb_count: u32::default(),
             p_reference_final_lists: ::std::ptr::null(),
-            p_slice_header_std: ::std::ptr::null(),
+            p_slice_segment_header_std: ::std::ptr::null(),
         }
     }
 }
-impl VideoEncodeH265NaluSliceEXT {
-    pub fn builder<'a>() -> VideoEncodeH265NaluSliceEXTBuilder<'a> {
-        VideoEncodeH265NaluSliceEXTBuilder {
+impl VideoEncodeH265NaluSliceSegmentEXT {
+    pub fn builder<'a>() -> VideoEncodeH265NaluSliceSegmentEXTBuilder<'a> {
+        VideoEncodeH265NaluSliceSegmentEXTBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct VideoEncodeH265NaluSliceEXTBuilder<'a> {
-    inner: VideoEncodeH265NaluSliceEXT,
+pub struct VideoEncodeH265NaluSliceSegmentEXTBuilder<'a> {
+    inner: VideoEncodeH265NaluSliceSegmentEXT,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for VideoEncodeH265NaluSliceEXTBuilder<'a> {
-    type Target = VideoEncodeH265NaluSliceEXT;
+impl<'a> ::std::ops::Deref for VideoEncodeH265NaluSliceSegmentEXTBuilder<'a> {
+    type Target = VideoEncodeH265NaluSliceSegmentEXT;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for VideoEncodeH265NaluSliceEXTBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for VideoEncodeH265NaluSliceSegmentEXTBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> VideoEncodeH265NaluSliceEXTBuilder<'a> {
+impl<'a> VideoEncodeH265NaluSliceSegmentEXTBuilder<'a> {
     pub fn ctb_count(mut self, ctb_count: u32) -> Self {
         self.inner.ctb_count = ctb_count;
         self
@@ -52130,14 +52713,17 @@ impl<'a> VideoEncodeH265NaluSliceEXTBuilder<'a> {
         self.inner.p_reference_final_lists = reference_final_lists;
         self
     }
-    pub fn slice_header_std(mut self, slice_header_std: &'a StdVideoEncodeH265SliceHeader) -> Self {
-        self.inner.p_slice_header_std = slice_header_std;
+    pub fn slice_segment_header_std(
+        mut self,
+        slice_segment_header_std: &'a StdVideoEncodeH265SliceSegmentHeader,
+    ) -> Self {
+        self.inner.p_slice_segment_header_std = slice_segment_header_std;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> VideoEncodeH265NaluSliceEXT {
+    pub fn build(self) -> VideoEncodeH265NaluSliceSegmentEXT {
         self.inner
     }
 }
@@ -53282,56 +53868,53 @@ impl<'a> CuLaunchInfoNVXBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR.html>"]
-pub struct PhysicalDeviceShaderIntegerDotProductFeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderIntegerDotProductFeatures.html>"]
+pub struct PhysicalDeviceShaderIntegerDotProductFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub shader_integer_dot_product: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceShaderIntegerDotProductFeaturesKHR {
+impl ::std::default::Default for PhysicalDeviceShaderIntegerDotProductFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR,
+            s_type: StructureType::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES,
             p_next: ::std::ptr::null_mut(),
             shader_integer_dot_product: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceShaderIntegerDotProductFeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceShaderIntegerDotProductFeaturesKHRBuilder<'a> {
-        PhysicalDeviceShaderIntegerDotProductFeaturesKHRBuilder {
+impl PhysicalDeviceShaderIntegerDotProductFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceShaderIntegerDotProductFeaturesBuilder<'a> {
+        PhysicalDeviceShaderIntegerDotProductFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceShaderIntegerDotProductFeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceShaderIntegerDotProductFeaturesKHR,
+pub struct PhysicalDeviceShaderIntegerDotProductFeaturesBuilder<'a> {
+    inner: PhysicalDeviceShaderIntegerDotProductFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceShaderIntegerDotProductFeaturesKHRBuilder<'_>
+    for PhysicalDeviceShaderIntegerDotProductFeaturesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceShaderIntegerDotProductFeaturesKHR {}
-unsafe impl ExtendsDeviceCreateInfo
-    for PhysicalDeviceShaderIntegerDotProductFeaturesKHRBuilder<'_>
-{
-}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderIntegerDotProductFeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceShaderIntegerDotProductFeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceShaderIntegerDotProductFeaturesKHR;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceShaderIntegerDotProductFeatures {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderIntegerDotProductFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceShaderIntegerDotProductFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceShaderIntegerDotProductFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceShaderIntegerDotProductFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderIntegerDotProductFeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderIntegerDotProductFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceShaderIntegerDotProductFeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceShaderIntegerDotProductFeaturesBuilder<'a> {
     pub fn shader_integer_dot_product(mut self, shader_integer_dot_product: bool) -> Self {
         self.inner.shader_integer_dot_product = shader_integer_dot_product.into();
         self
@@ -53339,15 +53922,15 @@ impl<'a> PhysicalDeviceShaderIntegerDotProductFeaturesKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceShaderIntegerDotProductFeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceShaderIntegerDotProductFeatures {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR.html>"]
-pub struct PhysicalDeviceShaderIntegerDotProductPropertiesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderIntegerDotProductProperties.html>"]
+pub struct PhysicalDeviceShaderIntegerDotProductProperties {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub integer_dot_product8_bit_unsigned_accelerated: Bool32,
@@ -53382,44 +53965,41 @@ pub struct PhysicalDeviceShaderIntegerDotProductPropertiesKHR {
     pub integer_dot_product_accumulating_saturating64_bit_signed_accelerated: Bool32,
     pub integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceShaderIntegerDotProductPropertiesKHR {
+impl ::std::default::Default for PhysicalDeviceShaderIntegerDotProductProperties {
     fn default() -> Self {
-        Self { s_type : StructureType :: PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES_KHR , p_next : :: std :: ptr :: null_mut () , integer_dot_product8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product64_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated : Bool32 :: default () }
+        Self { s_type : StructureType :: PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES , p_next : :: std :: ptr :: null_mut () , integer_dot_product8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product64_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating8_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating4x8_bit_packed_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating16_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating32_bit_mixed_signedness_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_unsigned_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_signed_accelerated : Bool32 :: default () , integer_dot_product_accumulating_saturating64_bit_mixed_signedness_accelerated : Bool32 :: default () }
     }
 }
-impl PhysicalDeviceShaderIntegerDotProductPropertiesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceShaderIntegerDotProductPropertiesKHRBuilder<'a> {
-        PhysicalDeviceShaderIntegerDotProductPropertiesKHRBuilder {
+impl PhysicalDeviceShaderIntegerDotProductProperties {
+    pub fn builder<'a>() -> PhysicalDeviceShaderIntegerDotProductPropertiesBuilder<'a> {
+        PhysicalDeviceShaderIntegerDotProductPropertiesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceShaderIntegerDotProductPropertiesKHRBuilder<'a> {
-    inner: PhysicalDeviceShaderIntegerDotProductPropertiesKHR,
+pub struct PhysicalDeviceShaderIntegerDotProductPropertiesBuilder<'a> {
+    inner: PhysicalDeviceShaderIntegerDotProductProperties,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceShaderIntegerDotProductPropertiesKHRBuilder<'_>
+    for PhysicalDeviceShaderIntegerDotProductPropertiesBuilder<'_>
 {
 }
-unsafe impl ExtendsPhysicalDeviceProperties2
-    for PhysicalDeviceShaderIntegerDotProductPropertiesKHR
-{
-}
-impl<'a> ::std::ops::Deref for PhysicalDeviceShaderIntegerDotProductPropertiesKHRBuilder<'a> {
-    type Target = PhysicalDeviceShaderIntegerDotProductPropertiesKHR;
+unsafe impl ExtendsPhysicalDeviceProperties2 for PhysicalDeviceShaderIntegerDotProductProperties {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceShaderIntegerDotProductPropertiesBuilder<'a> {
+    type Target = PhysicalDeviceShaderIntegerDotProductProperties;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderIntegerDotProductPropertiesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceShaderIntegerDotProductPropertiesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceShaderIntegerDotProductPropertiesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceShaderIntegerDotProductPropertiesBuilder<'a> {
     pub fn integer_dot_product8_bit_unsigned_accelerated(
         mut self,
         integer_dot_product8_bit_unsigned_accelerated: bool,
@@ -53683,7 +54263,7 @@ impl<'a> PhysicalDeviceShaderIntegerDotProductPropertiesKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceShaderIntegerDotProductPropertiesKHR {
+    pub fn build(self) -> PhysicalDeviceShaderIntegerDotProductProperties {
         self.inner
     }
 }
@@ -54821,12 +55401,9 @@ impl<'a> ImageFormatConstraintsInfoFUCHSIABuilder<'a> {
         self.inner.sysmem_pixel_format = sysmem_pixel_format;
         self
     }
-    pub fn color_space_count(mut self, color_space_count: u32) -> Self {
-        self.inner.color_space_count = color_space_count;
-        self
-    }
-    pub fn color_spaces(mut self, color_spaces: &'a SysmemColorSpaceFUCHSIA) -> Self {
-        self.inner.p_color_spaces = color_spaces;
+    pub fn color_spaces(mut self, color_spaces: &'a [SysmemColorSpaceFUCHSIA]) -> Self {
+        self.inner.color_space_count = color_spaces.len() as _;
+        self.inner.p_color_spaces = color_spaces.as_ptr();
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
@@ -55060,74 +55637,68 @@ impl<'a> PhysicalDeviceRGBA10X6FormatsFeaturesEXTBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkFormatProperties3KHR.html>"]
-pub struct FormatProperties3KHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkFormatProperties3.html>"]
+pub struct FormatProperties3 {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
-    pub linear_tiling_features: FormatFeatureFlags2KHR,
-    pub optimal_tiling_features: FormatFeatureFlags2KHR,
-    pub buffer_features: FormatFeatureFlags2KHR,
+    pub linear_tiling_features: FormatFeatureFlags2,
+    pub optimal_tiling_features: FormatFeatureFlags2,
+    pub buffer_features: FormatFeatureFlags2,
 }
-impl ::std::default::Default for FormatProperties3KHR {
+impl ::std::default::Default for FormatProperties3 {
     fn default() -> Self {
         Self {
-            s_type: StructureType::FORMAT_PROPERTIES_3_KHR,
+            s_type: StructureType::FORMAT_PROPERTIES_3,
             p_next: ::std::ptr::null_mut(),
-            linear_tiling_features: FormatFeatureFlags2KHR::default(),
-            optimal_tiling_features: FormatFeatureFlags2KHR::default(),
-            buffer_features: FormatFeatureFlags2KHR::default(),
+            linear_tiling_features: FormatFeatureFlags2::default(),
+            optimal_tiling_features: FormatFeatureFlags2::default(),
+            buffer_features: FormatFeatureFlags2::default(),
         }
     }
 }
-impl FormatProperties3KHR {
-    pub fn builder<'a>() -> FormatProperties3KHRBuilder<'a> {
-        FormatProperties3KHRBuilder {
+impl FormatProperties3 {
+    pub fn builder<'a>() -> FormatProperties3Builder<'a> {
+        FormatProperties3Builder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct FormatProperties3KHRBuilder<'a> {
-    inner: FormatProperties3KHR,
+pub struct FormatProperties3Builder<'a> {
+    inner: FormatProperties3,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsFormatProperties2 for FormatProperties3KHRBuilder<'_> {}
-unsafe impl ExtendsFormatProperties2 for FormatProperties3KHR {}
-impl<'a> ::std::ops::Deref for FormatProperties3KHRBuilder<'a> {
-    type Target = FormatProperties3KHR;
+unsafe impl ExtendsFormatProperties2 for FormatProperties3Builder<'_> {}
+unsafe impl ExtendsFormatProperties2 for FormatProperties3 {}
+impl<'a> ::std::ops::Deref for FormatProperties3Builder<'a> {
+    type Target = FormatProperties3;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for FormatProperties3KHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for FormatProperties3Builder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> FormatProperties3KHRBuilder<'a> {
-    pub fn linear_tiling_features(
-        mut self,
-        linear_tiling_features: FormatFeatureFlags2KHR,
-    ) -> Self {
+impl<'a> FormatProperties3Builder<'a> {
+    pub fn linear_tiling_features(mut self, linear_tiling_features: FormatFeatureFlags2) -> Self {
         self.inner.linear_tiling_features = linear_tiling_features;
         self
     }
-    pub fn optimal_tiling_features(
-        mut self,
-        optimal_tiling_features: FormatFeatureFlags2KHR,
-    ) -> Self {
+    pub fn optimal_tiling_features(mut self, optimal_tiling_features: FormatFeatureFlags2) -> Self {
         self.inner.optimal_tiling_features = optimal_tiling_features;
         self
     }
-    pub fn buffer_features(mut self, buffer_features: FormatFeatureFlags2KHR) -> Self {
+    pub fn buffer_features(mut self, buffer_features: FormatFeatureFlags2) -> Self {
         self.inner.buffer_features = buffer_features;
         self
     }
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> FormatProperties3KHR {
+    pub fn build(self) -> FormatProperties3 {
         self.inner
     }
 }
@@ -55200,7 +55771,7 @@ impl<'a> DrmFormatModifierPropertiesList2EXTBuilder<'a> {
 pub struct DrmFormatModifierProperties2EXT {
     pub drm_format_modifier: u64,
     pub drm_format_modifier_plane_count: u32,
-    pub drm_format_modifier_tiling_features: FormatFeatureFlags2KHR,
+    pub drm_format_modifier_tiling_features: FormatFeatureFlags2,
 }
 impl DrmFormatModifierProperties2EXT {
     pub fn builder<'a>() -> DrmFormatModifierProperties2EXTBuilder<'a> {
@@ -55237,7 +55808,7 @@ impl<'a> DrmFormatModifierProperties2EXTBuilder<'a> {
     }
     pub fn drm_format_modifier_tiling_features(
         mut self,
-        drm_format_modifier_tiling_features: FormatFeatureFlags2KHR,
+        drm_format_modifier_tiling_features: FormatFeatureFlags2,
     ) -> Self {
         self.inner.drm_format_modifier_tiling_features = drm_format_modifier_tiling_features;
         self
@@ -55258,7 +55829,7 @@ pub struct AndroidHardwareBufferFormatProperties2ANDROID {
     pub p_next: *mut c_void,
     pub format: Format,
     pub external_format: u64,
-    pub format_features: FormatFeatureFlags2KHR,
+    pub format_features: FormatFeatureFlags2,
     pub sampler_ycbcr_conversion_components: ComponentMapping,
     pub suggested_ycbcr_model: SamplerYcbcrModelConversion,
     pub suggested_ycbcr_range: SamplerYcbcrRange,
@@ -55272,7 +55843,7 @@ impl ::std::default::Default for AndroidHardwareBufferFormatProperties2ANDROID {
             p_next: ::std::ptr::null_mut(),
             format: Format::default(),
             external_format: u64::default(),
-            format_features: FormatFeatureFlags2KHR::default(),
+            format_features: FormatFeatureFlags2::default(),
             sampler_ycbcr_conversion_components: ComponentMapping::default(),
             suggested_ycbcr_model: SamplerYcbcrModelConversion::default(),
             suggested_ycbcr_range: SamplerYcbcrRange::default(),
@@ -55322,7 +55893,7 @@ impl<'a> AndroidHardwareBufferFormatProperties2ANDROIDBuilder<'a> {
         self.inner.external_format = external_format;
         self
     }
-    pub fn format_features(mut self, format_features: FormatFeatureFlags2KHR) -> Self {
+    pub fn format_features(mut self, format_features: FormatFeatureFlags2) -> Self {
         self.inner.format_features = format_features;
         self
     }
@@ -55362,8 +55933,8 @@ impl<'a> AndroidHardwareBufferFormatProperties2ANDROIDBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineRenderingCreateInfoKHR.html>"]
-pub struct PipelineRenderingCreateInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPipelineRenderingCreateInfo.html>"]
+pub struct PipelineRenderingCreateInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub view_mask: u32,
@@ -55372,10 +55943,10 @@ pub struct PipelineRenderingCreateInfoKHR {
     pub depth_attachment_format: Format,
     pub stencil_attachment_format: Format,
 }
-impl ::std::default::Default for PipelineRenderingCreateInfoKHR {
+impl ::std::default::Default for PipelineRenderingCreateInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PIPELINE_RENDERING_CREATE_INFO_KHR,
+            s_type: StructureType::PIPELINE_RENDERING_CREATE_INFO,
             p_next: ::std::ptr::null(),
             view_mask: u32::default(),
             color_attachment_count: u32::default(),
@@ -55385,33 +55956,33 @@ impl ::std::default::Default for PipelineRenderingCreateInfoKHR {
         }
     }
 }
-impl PipelineRenderingCreateInfoKHR {
-    pub fn builder<'a>() -> PipelineRenderingCreateInfoKHRBuilder<'a> {
-        PipelineRenderingCreateInfoKHRBuilder {
+impl PipelineRenderingCreateInfo {
+    pub fn builder<'a>() -> PipelineRenderingCreateInfoBuilder<'a> {
+        PipelineRenderingCreateInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PipelineRenderingCreateInfoKHRBuilder<'a> {
-    inner: PipelineRenderingCreateInfoKHR,
+pub struct PipelineRenderingCreateInfoBuilder<'a> {
+    inner: PipelineRenderingCreateInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineRenderingCreateInfoKHRBuilder<'_> {}
-unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineRenderingCreateInfoKHR {}
-impl<'a> ::std::ops::Deref for PipelineRenderingCreateInfoKHRBuilder<'a> {
-    type Target = PipelineRenderingCreateInfoKHR;
+unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineRenderingCreateInfoBuilder<'_> {}
+unsafe impl ExtendsGraphicsPipelineCreateInfo for PipelineRenderingCreateInfo {}
+impl<'a> ::std::ops::Deref for PipelineRenderingCreateInfoBuilder<'a> {
+    type Target = PipelineRenderingCreateInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PipelineRenderingCreateInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PipelineRenderingCreateInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PipelineRenderingCreateInfoKHRBuilder<'a> {
+impl<'a> PipelineRenderingCreateInfoBuilder<'a> {
     pub fn view_mask(mut self, view_mask: u32) -> Self {
         self.inner.view_mask = view_mask;
         self
@@ -55432,32 +56003,32 @@ impl<'a> PipelineRenderingCreateInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PipelineRenderingCreateInfoKHR {
+    pub fn build(self) -> PipelineRenderingCreateInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkRenderingInfoKHR.html>"]
-pub struct RenderingInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkRenderingInfo.html>"]
+pub struct RenderingInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub flags: RenderingFlagsKHR,
+    pub flags: RenderingFlags,
     pub render_area: Rect2D,
     pub layer_count: u32,
     pub view_mask: u32,
     pub color_attachment_count: u32,
-    pub p_color_attachments: *const RenderingAttachmentInfoKHR,
-    pub p_depth_attachment: *const RenderingAttachmentInfoKHR,
-    pub p_stencil_attachment: *const RenderingAttachmentInfoKHR,
+    pub p_color_attachments: *const RenderingAttachmentInfo,
+    pub p_depth_attachment: *const RenderingAttachmentInfo,
+    pub p_stencil_attachment: *const RenderingAttachmentInfo,
 }
-impl ::std::default::Default for RenderingInfoKHR {
+impl ::std::default::Default for RenderingInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::RENDERING_INFO_KHR,
+            s_type: StructureType::RENDERING_INFO,
             p_next: ::std::ptr::null(),
-            flags: RenderingFlagsKHR::default(),
+            flags: RenderingFlags::default(),
             render_area: Rect2D::default(),
             layer_count: u32::default(),
             view_mask: u32::default(),
@@ -55468,33 +56039,33 @@ impl ::std::default::Default for RenderingInfoKHR {
         }
     }
 }
-impl RenderingInfoKHR {
-    pub fn builder<'a>() -> RenderingInfoKHRBuilder<'a> {
-        RenderingInfoKHRBuilder {
+impl RenderingInfo {
+    pub fn builder<'a>() -> RenderingInfoBuilder<'a> {
+        RenderingInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct RenderingInfoKHRBuilder<'a> {
-    inner: RenderingInfoKHR,
+pub struct RenderingInfoBuilder<'a> {
+    inner: RenderingInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-pub unsafe trait ExtendsRenderingInfoKHR {}
-impl<'a> ::std::ops::Deref for RenderingInfoKHRBuilder<'a> {
-    type Target = RenderingInfoKHR;
+pub unsafe trait ExtendsRenderingInfo {}
+impl<'a> ::std::ops::Deref for RenderingInfoBuilder<'a> {
+    type Target = RenderingInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for RenderingInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for RenderingInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> RenderingInfoKHRBuilder<'a> {
-    pub fn flags(mut self, flags: RenderingFlagsKHR) -> Self {
+impl<'a> RenderingInfoBuilder<'a> {
+    pub fn flags(mut self, flags: RenderingFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -55510,22 +56081,16 @@ impl<'a> RenderingInfoKHRBuilder<'a> {
         self.inner.view_mask = view_mask;
         self
     }
-    pub fn color_attachments(
-        mut self,
-        color_attachments: &'a [RenderingAttachmentInfoKHR],
-    ) -> Self {
+    pub fn color_attachments(mut self, color_attachments: &'a [RenderingAttachmentInfo]) -> Self {
         self.inner.color_attachment_count = color_attachments.len() as _;
         self.inner.p_color_attachments = color_attachments.as_ptr();
         self
     }
-    pub fn depth_attachment(mut self, depth_attachment: &'a RenderingAttachmentInfoKHR) -> Self {
+    pub fn depth_attachment(mut self, depth_attachment: &'a RenderingAttachmentInfo) -> Self {
         self.inner.p_depth_attachment = depth_attachment;
         self
     }
-    pub fn stencil_attachment(
-        mut self,
-        stencil_attachment: &'a RenderingAttachmentInfoKHR,
-    ) -> Self {
+    pub fn stencil_attachment(mut self, stencil_attachment: &'a RenderingAttachmentInfo) -> Self {
         self.inner.p_stencil_attachment = stencil_attachment;
         self
     }
@@ -55534,7 +56099,7 @@ impl<'a> RenderingInfoKHRBuilder<'a> {
     #[doc = r" valid extension structs can be pushed into the chain."]
     #[doc = r" If the chain looks like `A -> B -> C`, and you call `builder.push_next(&mut D)`, then the"]
     #[doc = r" chain will look like `A -> D -> B -> C`."]
-    pub fn push_next<T: ExtendsRenderingInfoKHR>(mut self, next: &'a mut T) -> Self {
+    pub fn push_next<T: ExtendsRenderingInfo>(mut self, next: &'a mut T) -> Self {
         unsafe {
             let next_ptr = <*const T>::cast(next);
             let last_next = ptr_chain_iter(next).last().unwrap();
@@ -55546,14 +56111,14 @@ impl<'a> RenderingInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> RenderingInfoKHR {
+    pub fn build(self) -> RenderingInfo {
         self.inner
     }
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkRenderingAttachmentInfoKHR.html>"]
-pub struct RenderingAttachmentInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkRenderingAttachmentInfo.html>"]
+pub struct RenderingAttachmentInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub image_view: ImageView,
@@ -55566,9 +56131,9 @@ pub struct RenderingAttachmentInfoKHR {
     pub clear_value: ClearValue,
 }
 #[cfg(feature = "debug")]
-impl fmt::Debug for RenderingAttachmentInfoKHR {
+impl fmt::Debug for RenderingAttachmentInfo {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("RenderingAttachmentInfoKHR")
+        fmt.debug_struct("RenderingAttachmentInfo")
             .field("s_type", &self.s_type)
             .field("p_next", &self.p_next)
             .field("image_view", &self.image_view)
@@ -55582,10 +56147,10 @@ impl fmt::Debug for RenderingAttachmentInfoKHR {
             .finish()
     }
 }
-impl ::std::default::Default for RenderingAttachmentInfoKHR {
+impl ::std::default::Default for RenderingAttachmentInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::RENDERING_ATTACHMENT_INFO_KHR,
+            s_type: StructureType::RENDERING_ATTACHMENT_INFO,
             p_next: ::std::ptr::null(),
             image_view: ImageView::default(),
             image_layout: ImageLayout::default(),
@@ -55598,31 +56163,31 @@ impl ::std::default::Default for RenderingAttachmentInfoKHR {
         }
     }
 }
-impl RenderingAttachmentInfoKHR {
-    pub fn builder<'a>() -> RenderingAttachmentInfoKHRBuilder<'a> {
-        RenderingAttachmentInfoKHRBuilder {
+impl RenderingAttachmentInfo {
+    pub fn builder<'a>() -> RenderingAttachmentInfoBuilder<'a> {
+        RenderingAttachmentInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct RenderingAttachmentInfoKHRBuilder<'a> {
-    inner: RenderingAttachmentInfoKHR,
+pub struct RenderingAttachmentInfoBuilder<'a> {
+    inner: RenderingAttachmentInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-impl<'a> ::std::ops::Deref for RenderingAttachmentInfoKHRBuilder<'a> {
-    type Target = RenderingAttachmentInfoKHR;
+impl<'a> ::std::ops::Deref for RenderingAttachmentInfoBuilder<'a> {
+    type Target = RenderingAttachmentInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for RenderingAttachmentInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for RenderingAttachmentInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> RenderingAttachmentInfoKHRBuilder<'a> {
+impl<'a> RenderingAttachmentInfoBuilder<'a> {
     pub fn image_view(mut self, image_view: ImageView) -> Self {
         self.inner.image_view = image_view;
         self
@@ -55658,7 +56223,7 @@ impl<'a> RenderingAttachmentInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> RenderingAttachmentInfoKHR {
+    pub fn build(self) -> RenderingAttachmentInfo {
         self.inner
     }
 }
@@ -55697,8 +56262,8 @@ pub struct RenderingFragmentShadingRateAttachmentInfoKHRBuilder<'a> {
     inner: RenderingFragmentShadingRateAttachmentInfoKHR,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsRenderingInfoKHR for RenderingFragmentShadingRateAttachmentInfoKHRBuilder<'_> {}
-unsafe impl ExtendsRenderingInfoKHR for RenderingFragmentShadingRateAttachmentInfoKHR {}
+unsafe impl ExtendsRenderingInfo for RenderingFragmentShadingRateAttachmentInfoKHRBuilder<'_> {}
+unsafe impl ExtendsRenderingInfo for RenderingFragmentShadingRateAttachmentInfoKHR {}
 impl<'a> ::std::ops::Deref for RenderingFragmentShadingRateAttachmentInfoKHRBuilder<'a> {
     type Target = RenderingFragmentShadingRateAttachmentInfoKHR;
     fn deref(&self) -> &Self::Target {
@@ -55766,8 +56331,8 @@ pub struct RenderingFragmentDensityMapAttachmentInfoEXTBuilder<'a> {
     inner: RenderingFragmentDensityMapAttachmentInfoEXT,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsRenderingInfoKHR for RenderingFragmentDensityMapAttachmentInfoEXTBuilder<'_> {}
-unsafe impl ExtendsRenderingInfoKHR for RenderingFragmentDensityMapAttachmentInfoEXT {}
+unsafe impl ExtendsRenderingInfo for RenderingFragmentDensityMapAttachmentInfoEXTBuilder<'_> {}
+unsafe impl ExtendsRenderingInfo for RenderingFragmentDensityMapAttachmentInfoEXT {}
 impl<'a> ::std::ops::Deref for RenderingFragmentDensityMapAttachmentInfoEXTBuilder<'a> {
     type Target = RenderingFragmentDensityMapAttachmentInfoEXT;
     fn deref(&self) -> &Self::Target {
@@ -55798,53 +56363,50 @@ impl<'a> RenderingFragmentDensityMapAttachmentInfoEXTBuilder<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceDynamicRenderingFeaturesKHR.html>"]
-pub struct PhysicalDeviceDynamicRenderingFeaturesKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceDynamicRenderingFeatures.html>"]
+pub struct PhysicalDeviceDynamicRenderingFeatures {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
     pub dynamic_rendering: Bool32,
 }
-impl ::std::default::Default for PhysicalDeviceDynamicRenderingFeaturesKHR {
+impl ::std::default::Default for PhysicalDeviceDynamicRenderingFeatures {
     fn default() -> Self {
         Self {
-            s_type: StructureType::PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR,
+            s_type: StructureType::PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES,
             p_next: ::std::ptr::null_mut(),
             dynamic_rendering: Bool32::default(),
         }
     }
 }
-impl PhysicalDeviceDynamicRenderingFeaturesKHR {
-    pub fn builder<'a>() -> PhysicalDeviceDynamicRenderingFeaturesKHRBuilder<'a> {
-        PhysicalDeviceDynamicRenderingFeaturesKHRBuilder {
+impl PhysicalDeviceDynamicRenderingFeatures {
+    pub fn builder<'a>() -> PhysicalDeviceDynamicRenderingFeaturesBuilder<'a> {
+        PhysicalDeviceDynamicRenderingFeaturesBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct PhysicalDeviceDynamicRenderingFeaturesKHRBuilder<'a> {
-    inner: PhysicalDeviceDynamicRenderingFeaturesKHR,
+pub struct PhysicalDeviceDynamicRenderingFeaturesBuilder<'a> {
+    inner: PhysicalDeviceDynamicRenderingFeatures,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
-unsafe impl ExtendsPhysicalDeviceFeatures2
-    for PhysicalDeviceDynamicRenderingFeaturesKHRBuilder<'_>
-{
-}
-unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceDynamicRenderingFeaturesKHR {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceDynamicRenderingFeaturesKHRBuilder<'_> {}
-unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceDynamicRenderingFeaturesKHR {}
-impl<'a> ::std::ops::Deref for PhysicalDeviceDynamicRenderingFeaturesKHRBuilder<'a> {
-    type Target = PhysicalDeviceDynamicRenderingFeaturesKHR;
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceDynamicRenderingFeaturesBuilder<'_> {}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceDynamicRenderingFeatures {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceDynamicRenderingFeaturesBuilder<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceDynamicRenderingFeatures {}
+impl<'a> ::std::ops::Deref for PhysicalDeviceDynamicRenderingFeaturesBuilder<'a> {
+    type Target = PhysicalDeviceDynamicRenderingFeatures;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for PhysicalDeviceDynamicRenderingFeaturesKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for PhysicalDeviceDynamicRenderingFeaturesBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> PhysicalDeviceDynamicRenderingFeaturesKHRBuilder<'a> {
+impl<'a> PhysicalDeviceDynamicRenderingFeaturesBuilder<'a> {
     pub fn dynamic_rendering(mut self, dynamic_rendering: bool) -> Self {
         self.inner.dynamic_rendering = dynamic_rendering.into();
         self
@@ -55852,18 +56414,18 @@ impl<'a> PhysicalDeviceDynamicRenderingFeaturesKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> PhysicalDeviceDynamicRenderingFeaturesKHR {
+    pub fn build(self) -> PhysicalDeviceDynamicRenderingFeatures {
         self.inner
     }
 }
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCommandBufferInheritanceRenderingInfoKHR.html>"]
-pub struct CommandBufferInheritanceRenderingInfoKHR {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkCommandBufferInheritanceRenderingInfo.html>"]
+pub struct CommandBufferInheritanceRenderingInfo {
     pub s_type: StructureType,
     pub p_next: *const c_void,
-    pub flags: RenderingFlagsKHR,
+    pub flags: RenderingFlags,
     pub view_mask: u32,
     pub color_attachment_count: u32,
     pub p_color_attachment_formats: *const Format,
@@ -55871,12 +56433,12 @@ pub struct CommandBufferInheritanceRenderingInfoKHR {
     pub stencil_attachment_format: Format,
     pub rasterization_samples: SampleCountFlags,
 }
-impl ::std::default::Default for CommandBufferInheritanceRenderingInfoKHR {
+impl ::std::default::Default for CommandBufferInheritanceRenderingInfo {
     fn default() -> Self {
         Self {
-            s_type: StructureType::COMMAND_BUFFER_INHERITANCE_RENDERING_INFO_KHR,
+            s_type: StructureType::COMMAND_BUFFER_INHERITANCE_RENDERING_INFO,
             p_next: ::std::ptr::null(),
-            flags: RenderingFlagsKHR::default(),
+            flags: RenderingFlags::default(),
             view_mask: u32::default(),
             color_attachment_count: u32::default(),
             p_color_attachment_formats: ::std::ptr::null(),
@@ -55886,37 +56448,37 @@ impl ::std::default::Default for CommandBufferInheritanceRenderingInfoKHR {
         }
     }
 }
-impl CommandBufferInheritanceRenderingInfoKHR {
-    pub fn builder<'a>() -> CommandBufferInheritanceRenderingInfoKHRBuilder<'a> {
-        CommandBufferInheritanceRenderingInfoKHRBuilder {
+impl CommandBufferInheritanceRenderingInfo {
+    pub fn builder<'a>() -> CommandBufferInheritanceRenderingInfoBuilder<'a> {
+        CommandBufferInheritanceRenderingInfoBuilder {
             inner: Self::default(),
             marker: ::std::marker::PhantomData,
         }
     }
 }
 #[repr(transparent)]
-pub struct CommandBufferInheritanceRenderingInfoKHRBuilder<'a> {
-    inner: CommandBufferInheritanceRenderingInfoKHR,
+pub struct CommandBufferInheritanceRenderingInfoBuilder<'a> {
+    inner: CommandBufferInheritanceRenderingInfo,
     marker: ::std::marker::PhantomData<&'a ()>,
 }
 unsafe impl ExtendsCommandBufferInheritanceInfo
-    for CommandBufferInheritanceRenderingInfoKHRBuilder<'_>
+    for CommandBufferInheritanceRenderingInfoBuilder<'_>
 {
 }
-unsafe impl ExtendsCommandBufferInheritanceInfo for CommandBufferInheritanceRenderingInfoKHR {}
-impl<'a> ::std::ops::Deref for CommandBufferInheritanceRenderingInfoKHRBuilder<'a> {
-    type Target = CommandBufferInheritanceRenderingInfoKHR;
+unsafe impl ExtendsCommandBufferInheritanceInfo for CommandBufferInheritanceRenderingInfo {}
+impl<'a> ::std::ops::Deref for CommandBufferInheritanceRenderingInfoBuilder<'a> {
+    type Target = CommandBufferInheritanceRenderingInfo;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<'a> ::std::ops::DerefMut for CommandBufferInheritanceRenderingInfoKHRBuilder<'a> {
+impl<'a> ::std::ops::DerefMut for CommandBufferInheritanceRenderingInfoBuilder<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<'a> CommandBufferInheritanceRenderingInfoKHRBuilder<'a> {
-    pub fn flags(mut self, flags: RenderingFlagsKHR) -> Self {
+impl<'a> CommandBufferInheritanceRenderingInfoBuilder<'a> {
+    pub fn flags(mut self, flags: RenderingFlags) -> Self {
         self.inner.flags = flags;
         self
     }
@@ -55944,7 +56506,7 @@ impl<'a> CommandBufferInheritanceRenderingInfoKHRBuilder<'a> {
     #[doc = r" Calling build will **discard** all the lifetime information. Only call this if"]
     #[doc = r" necessary! Builders implement `Deref` targeting their corresponding Vulkan struct,"]
     #[doc = r" so references to builders can be passed directly to Vulkan functions."]
-    pub fn build(self) -> CommandBufferInheritanceRenderingInfoKHR {
+    pub fn build(self) -> CommandBufferInheritanceRenderingInfo {
         self.inner
     }
 }
@@ -56058,8 +56620,8 @@ unsafe impl ExtendsCommandBufferInheritanceInfo for MultiviewPerViewAttributesIn
 unsafe impl ExtendsCommandBufferInheritanceInfo for MultiviewPerViewAttributesInfoNVX {}
 unsafe impl ExtendsGraphicsPipelineCreateInfo for MultiviewPerViewAttributesInfoNVXBuilder<'_> {}
 unsafe impl ExtendsGraphicsPipelineCreateInfo for MultiviewPerViewAttributesInfoNVX {}
-unsafe impl ExtendsRenderingInfoKHR for MultiviewPerViewAttributesInfoNVXBuilder<'_> {}
-unsafe impl ExtendsRenderingInfoKHR for MultiviewPerViewAttributesInfoNVX {}
+unsafe impl ExtendsRenderingInfo for MultiviewPerViewAttributesInfoNVXBuilder<'_> {}
+unsafe impl ExtendsRenderingInfo for MultiviewPerViewAttributesInfoNVX {}
 impl<'a> ::std::ops::Deref for MultiviewPerViewAttributesInfoNVXBuilder<'a> {
     type Target = MultiviewPerViewAttributesInfoNVX;
     fn deref(&self) -> &Self::Target {
@@ -56210,7 +56772,7 @@ impl<'a> ImageViewMinLodCreateInfoEXTBuilder<'a> {
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM.html>"]
 pub struct PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM {
     pub s_type: StructureType,
-    pub p_next: *const c_void,
+    pub p_next: *mut c_void,
     pub rasterization_order_color_attachment_access: Bool32,
     pub rasterization_order_depth_attachment_access: Bool32,
     pub rasterization_order_stencil_attachment_access: Bool32,
@@ -56220,7 +56782,7 @@ impl ::std::default::Default for PhysicalDeviceRasterizationOrderAttachmentAcces
         Self {
             s_type:
                 StructureType::PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_ARM,
-            p_next: ::std::ptr::null(),
+            p_next: ::std::ptr::null_mut(),
             rasterization_order_color_attachment_access: Bool32::default(),
             rasterization_order_depth_attachment_access: Bool32::default(),
             rasterization_order_stencil_attachment_access: Bool32::default(),

--- a/ash/src/vk/enums.rs
+++ b/ash/src/vk/enums.rs
@@ -1545,9 +1545,9 @@ impl ShaderInfoTypeAMD {
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkQueueGlobalPriorityEXT.html>"]
-pub struct QueueGlobalPriorityEXT(pub(crate) i32);
-impl QueueGlobalPriorityEXT {
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkQueueGlobalPriorityKHR.html>"]
+pub struct QueueGlobalPriorityKHR(pub(crate) i32);
+impl QueueGlobalPriorityKHR {
     pub const fn from_raw(x: i32) -> Self {
         Self(x)
     }
@@ -1555,11 +1555,15 @@ impl QueueGlobalPriorityEXT {
         self.0
     }
 }
-impl QueueGlobalPriorityEXT {
+impl QueueGlobalPriorityKHR {
     pub const LOW: Self = Self(128);
     pub const MEDIUM: Self = Self(256);
     pub const HIGH: Self = Self(512);
     pub const REALTIME: Self = Self(1_024);
+    pub const LOW_EXT: Self = Self::LOW;
+    pub const MEDIUM_EXT: Self = Self::MEDIUM;
+    pub const HIGH_EXT: Self = Self::HIGH;
+    pub const REALTIME_EXT: Self = Self::REALTIME;
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -1659,6 +1663,8 @@ impl DriverId {
     pub const MESA_PANVK: Self = Self(20);
     #[doc = "Samsung Electronics Co., Ltd."]
     pub const SAMSUNG_PROPRIETARY: Self = Self(21);
+    #[doc = "Mesa open source project"]
+    pub const MESA_VENUS: Self = Self(22);
 }
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -2287,10 +2293,10 @@ impl fmt::Debug for ObjectType {
             Self::PERFORMANCE_CONFIGURATION_INTEL => Some("PERFORMANCE_CONFIGURATION_INTEL"),
             Self::DEFERRED_OPERATION_KHR => Some("DEFERRED_OPERATION_KHR"),
             Self::INDIRECT_COMMANDS_LAYOUT_NV => Some("INDIRECT_COMMANDS_LAYOUT_NV"),
-            Self::PRIVATE_DATA_SLOT_EXT => Some("PRIVATE_DATA_SLOT_EXT"),
             Self::BUFFER_COLLECTION_FUCHSIA => Some("BUFFER_COLLECTION_FUCHSIA"),
             Self::SAMPLER_YCBCR_CONVERSION => Some("SAMPLER_YCBCR_CONVERSION"),
             Self::DESCRIPTOR_UPDATE_TEMPLATE => Some("DESCRIPTOR_UPDATE_TEMPLATE"),
+            Self::PRIVATE_DATA_SLOT => Some("PRIVATE_DATA_SLOT"),
             _ => None,
         };
         if let Some(x) = name {
@@ -2332,7 +2338,7 @@ impl fmt::Debug for Result {
             Self::ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT => {
                 Some("ERROR_INVALID_DRM_FORMAT_MODIFIER_PLANE_LAYOUT_EXT")
             }
-            Self::ERROR_NOT_PERMITTED_EXT => Some("ERROR_NOT_PERMITTED_EXT"),
+            Self::ERROR_NOT_PERMITTED_KHR => Some("ERROR_NOT_PERMITTED_KHR"),
             Self::ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT => {
                 Some("ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT")
             }
@@ -2340,13 +2346,13 @@ impl fmt::Debug for Result {
             Self::THREAD_DONE_KHR => Some("THREAD_DONE_KHR"),
             Self::OPERATION_DEFERRED_KHR => Some("OPERATION_DEFERRED_KHR"),
             Self::OPERATION_NOT_DEFERRED_KHR => Some("OPERATION_NOT_DEFERRED_KHR"),
-            Self::PIPELINE_COMPILE_REQUIRED_EXT => Some("PIPELINE_COMPILE_REQUIRED_EXT"),
             Self::ERROR_OUT_OF_POOL_MEMORY => Some("ERROR_OUT_OF_POOL_MEMORY"),
             Self::ERROR_INVALID_EXTERNAL_HANDLE => Some("ERROR_INVALID_EXTERNAL_HANDLE"),
             Self::ERROR_FRAGMENTATION => Some("ERROR_FRAGMENTATION"),
             Self::ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS => {
                 Some("ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS")
             }
+            Self::PIPELINE_COMPILE_REQUIRED => Some("PIPELINE_COMPILE_REQUIRED"),
             _ => None,
         };
         if let Some(x) = name {

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -2908,9 +2908,9 @@ impl KhrVideoDecodeQueueFn {
     }
 }
 #[doc = "Generated from 'VK_KHR_video_decode_queue'"]
-impl AccessFlags2KHR {
-    pub const VIDEO_DECODE_READ: Self = Self(0b1000_0000_0000_0000_0000_0000_0000_0000_0000);
-    pub const VIDEO_DECODE_WRITE: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000_0000);
+impl AccessFlags2 {
+    pub const VIDEO_DECODE_READ_KHR: Self = Self(0b1000_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const VIDEO_DECODE_WRITE_KHR: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_decode_queue'"]
 impl BufferUsageFlags {
@@ -2923,9 +2923,9 @@ impl FormatFeatureFlags {
     pub const VIDEO_DECODE_DPB_KHR: Self = Self(0b100_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_decode_queue'"]
-impl FormatFeatureFlags2KHR {
-    pub const VIDEO_DECODE_OUTPUT: Self = Self(0b10_0000_0000_0000_0000_0000_0000);
-    pub const VIDEO_DECODE_DPB: Self = Self(0b100_0000_0000_0000_0000_0000_0000);
+impl FormatFeatureFlags2 {
+    pub const VIDEO_DECODE_OUTPUT_KHR: Self = Self(0b10_0000_0000_0000_0000_0000_0000);
+    pub const VIDEO_DECODE_DPB_KHR: Self = Self(0b100_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_decode_queue'"]
 impl ImageLayout {
@@ -2940,8 +2940,8 @@ impl ImageUsageFlags {
     pub const VIDEO_DECODE_DPB_KHR: Self = Self(0b1_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_decode_queue'"]
-impl PipelineStageFlags2KHR {
-    pub const VIDEO_DECODE: Self = Self(0b100_0000_0000_0000_0000_0000_0000);
+impl PipelineStageFlags2 {
+    pub const VIDEO_DECODE_KHR: Self = Self(0b100_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_decode_queue'"]
 impl QueueFlags {
@@ -3937,7 +3937,7 @@ impl ExtVideoEncodeH265Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_encode_h265\0") }
     }
-    pub const SPEC_VERSION: u32 = 3u32;
+    pub const SPEC_VERSION: u32 = 4u32;
 }
 #[derive(Clone)]
 pub struct ExtVideoEncodeH265Fn {}
@@ -3959,7 +3959,7 @@ impl StructureType {
     pub const VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_EXT: Self = Self(1_000_039_003);
     pub const VIDEO_ENCODE_H265_VCL_FRAME_INFO_EXT: Self = Self(1_000_039_004);
     pub const VIDEO_ENCODE_H265_DPB_SLOT_INFO_EXT: Self = Self(1_000_039_005);
-    pub const VIDEO_ENCODE_H265_NALU_SLICE_EXT: Self = Self(1_000_039_006);
+    pub const VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_EXT: Self = Self(1_000_039_006);
     pub const VIDEO_ENCODE_H265_EMIT_PICTURE_PARAMETERS_EXT: Self = Self(1_000_039_007);
     pub const VIDEO_ENCODE_H265_PROFILE_EXT: Self = Self(1_000_039_008);
     pub const VIDEO_ENCODE_H265_REFERENCE_LISTS_EXT: Self = Self(1_000_039_009);
@@ -4121,16 +4121,16 @@ impl KhrDynamicRenderingFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBeginRenderingKHR = unsafe extern "system" fn(
+pub type PFN_vkCmdBeginRendering = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_rendering_info: *const RenderingInfoKHR,
+    p_rendering_info: *const RenderingInfo,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdEndRenderingKHR = unsafe extern "system" fn(command_buffer: CommandBuffer);
+pub type PFN_vkCmdEndRendering = unsafe extern "system" fn(command_buffer: CommandBuffer);
 #[derive(Clone)]
 pub struct KhrDynamicRenderingFn {
-    pub cmd_begin_rendering_khr: PFN_vkCmdBeginRenderingKHR,
-    pub cmd_end_rendering_khr: PFN_vkCmdEndRenderingKHR,
+    pub cmd_begin_rendering_khr: PFN_vkCmdBeginRendering,
+    pub cmd_end_rendering_khr: PFN_vkCmdEndRendering,
 }
 unsafe impl Send for KhrDynamicRenderingFn {}
 unsafe impl Sync for KhrDynamicRenderingFn {}
@@ -4143,7 +4143,7 @@ impl KhrDynamicRenderingFn {
             cmd_begin_rendering_khr: unsafe {
                 unsafe extern "system" fn cmd_begin_rendering_khr(
                     _command_buffer: CommandBuffer,
-                    _p_rendering_info: *const RenderingInfoKHR,
+                    _p_rendering_info: *const RenderingInfo,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -4181,7 +4181,7 @@ impl KhrDynamicRenderingFn {
     pub unsafe fn cmd_begin_rendering_khr(
         &self,
         command_buffer: CommandBuffer,
-        p_rendering_info: *const RenderingInfoKHR,
+        p_rendering_info: *const RenderingInfo,
     ) {
         (self.cmd_begin_rendering_khr)(command_buffer, p_rendering_info)
     }
@@ -4192,7 +4192,7 @@ impl KhrDynamicRenderingFn {
 }
 #[doc = "Generated from 'VK_KHR_dynamic_rendering'"]
 impl AttachmentStoreOp {
-    pub const NONE_KHR: Self = Self(1_000_301_000);
+    pub const NONE_KHR: Self = Self::NONE;
 }
 #[doc = "Generated from 'VK_KHR_dynamic_rendering'"]
 impl PipelineCreateFlags {
@@ -4203,11 +4203,13 @@ impl PipelineCreateFlags {
 }
 #[doc = "Generated from 'VK_KHR_dynamic_rendering'"]
 impl StructureType {
-    pub const RENDERING_INFO_KHR: Self = Self(1_000_044_000);
-    pub const RENDERING_ATTACHMENT_INFO_KHR: Self = Self(1_000_044_001);
-    pub const PIPELINE_RENDERING_CREATE_INFO_KHR: Self = Self(1_000_044_002);
-    pub const PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR: Self = Self(1_000_044_003);
-    pub const COMMAND_BUFFER_INHERITANCE_RENDERING_INFO_KHR: Self = Self(1_000_044_004);
+    pub const RENDERING_INFO_KHR: Self = Self::RENDERING_INFO;
+    pub const RENDERING_ATTACHMENT_INFO_KHR: Self = Self::RENDERING_ATTACHMENT_INFO;
+    pub const PIPELINE_RENDERING_CREATE_INFO_KHR: Self = Self::PIPELINE_RENDERING_CREATE_INFO;
+    pub const PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR: Self =
+        Self::PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES;
+    pub const COMMAND_BUFFER_INHERITANCE_RENDERING_INFO_KHR: Self =
+        Self::COMMAND_BUFFER_INHERITANCE_RENDERING_INFO;
     pub const RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR: Self = Self(1_000_044_006);
     pub const RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT: Self = Self(1_000_044_007);
     pub const ATTACHMENT_SAMPLE_COUNT_INFO_AMD: Self = Self(1_000_044_008);
@@ -5476,24 +5478,25 @@ impl ExtTextureCompressionAstcHdrFn {
 }
 #[doc = "Generated from 'VK_EXT_texture_compression_astc_hdr'"]
 impl Format {
-    pub const ASTC_4X4_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_000);
-    pub const ASTC_5X4_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_001);
-    pub const ASTC_5X5_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_002);
-    pub const ASTC_6X5_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_003);
-    pub const ASTC_6X6_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_004);
-    pub const ASTC_8X5_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_005);
-    pub const ASTC_8X6_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_006);
-    pub const ASTC_8X8_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_007);
-    pub const ASTC_10X5_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_008);
-    pub const ASTC_10X6_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_009);
-    pub const ASTC_10X8_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_010);
-    pub const ASTC_10X10_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_011);
-    pub const ASTC_12X10_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_012);
-    pub const ASTC_12X12_SFLOAT_BLOCK_EXT: Self = Self(1_000_066_013);
+    pub const ASTC_4X4_SFLOAT_BLOCK_EXT: Self = Self::ASTC_4X4_SFLOAT_BLOCK;
+    pub const ASTC_5X4_SFLOAT_BLOCK_EXT: Self = Self::ASTC_5X4_SFLOAT_BLOCK;
+    pub const ASTC_5X5_SFLOAT_BLOCK_EXT: Self = Self::ASTC_5X5_SFLOAT_BLOCK;
+    pub const ASTC_6X5_SFLOAT_BLOCK_EXT: Self = Self::ASTC_6X5_SFLOAT_BLOCK;
+    pub const ASTC_6X6_SFLOAT_BLOCK_EXT: Self = Self::ASTC_6X6_SFLOAT_BLOCK;
+    pub const ASTC_8X5_SFLOAT_BLOCK_EXT: Self = Self::ASTC_8X5_SFLOAT_BLOCK;
+    pub const ASTC_8X6_SFLOAT_BLOCK_EXT: Self = Self::ASTC_8X6_SFLOAT_BLOCK;
+    pub const ASTC_8X8_SFLOAT_BLOCK_EXT: Self = Self::ASTC_8X8_SFLOAT_BLOCK;
+    pub const ASTC_10X5_SFLOAT_BLOCK_EXT: Self = Self::ASTC_10X5_SFLOAT_BLOCK;
+    pub const ASTC_10X6_SFLOAT_BLOCK_EXT: Self = Self::ASTC_10X6_SFLOAT_BLOCK;
+    pub const ASTC_10X8_SFLOAT_BLOCK_EXT: Self = Self::ASTC_10X8_SFLOAT_BLOCK;
+    pub const ASTC_10X10_SFLOAT_BLOCK_EXT: Self = Self::ASTC_10X10_SFLOAT_BLOCK;
+    pub const ASTC_12X10_SFLOAT_BLOCK_EXT: Self = Self::ASTC_12X10_SFLOAT_BLOCK;
+    pub const ASTC_12X12_SFLOAT_BLOCK_EXT: Self = Self::ASTC_12X12_SFLOAT_BLOCK;
 }
 #[doc = "Generated from 'VK_EXT_texture_compression_astc_hdr'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT: Self = Self(1_000_066_000);
+    pub const PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT: Self =
+        Self::PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES;
 }
 impl ExtAstcDecodeModeFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -9944,14 +9947,18 @@ impl ExtInlineUniformBlockFn {
 }
 #[doc = "Generated from 'VK_EXT_inline_uniform_block'"]
 impl DescriptorType {
-    pub const INLINE_UNIFORM_BLOCK_EXT: Self = Self(1_000_138_000);
+    pub const INLINE_UNIFORM_BLOCK_EXT: Self = Self::INLINE_UNIFORM_BLOCK;
 }
 #[doc = "Generated from 'VK_EXT_inline_uniform_block'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT: Self = Self(1_000_138_000);
-    pub const PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT: Self = Self(1_000_138_001);
-    pub const WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT: Self = Self(1_000_138_002);
-    pub const DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT: Self = Self(1_000_138_003);
+    pub const PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT: Self =
+        Self::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES;
+    pub const PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT: Self =
+        Self::PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES;
+    pub const WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT: Self =
+        Self::WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK;
+    pub const DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT: Self =
+        Self::DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO;
 }
 impl AmdExtension140Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -11164,8 +11171,8 @@ impl FormatFeatureFlags {
         Self(0b10_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_acceleration_structure'"]
-impl FormatFeatureFlags2KHR {
-    pub const ACCELERATION_STRUCTURE_VERTEX_BUFFER: Self =
+impl FormatFeatureFlags2 {
+    pub const ACCELERATION_STRUCTURE_VERTEX_BUFFER_KHR: Self =
         Self(0b10_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_acceleration_structure'"]
@@ -13660,11 +13667,12 @@ impl ExtGlobalPriorityFn {
 }
 #[doc = "Generated from 'VK_EXT_global_priority'"]
 impl Result {
-    pub const ERROR_NOT_PERMITTED_EXT: Self = Self(-1_000_174_001);
+    pub const ERROR_NOT_PERMITTED_EXT: Self = Self::ERROR_NOT_PERMITTED_KHR;
 }
 #[doc = "Generated from 'VK_EXT_global_priority'"]
 impl StructureType {
-    pub const DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT: Self = Self(1_000_174_000);
+    pub const DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT: Self =
+        Self::DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR;
 }
 impl KhrShaderSubgroupExtendedTypesFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -14156,23 +14164,33 @@ impl StructureType {
 impl VideoCodecOperationFlagsKHR {
     pub const DECODE_H265_EXT: Self = Self(0b10);
 }
-impl AmdExtension189Fn {
+impl KhrGlobalPriorityFn {
     pub fn name() -> &'static ::std::ffi::CStr {
-        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_189\0") }
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_global_priority\0") }
     }
-    pub const SPEC_VERSION: u32 = 0u32;
+    pub const SPEC_VERSION: u32 = 1u32;
 }
 #[derive(Clone)]
-pub struct AmdExtension189Fn {}
-unsafe impl Send for AmdExtension189Fn {}
-unsafe impl Sync for AmdExtension189Fn {}
-impl AmdExtension189Fn {
+pub struct KhrGlobalPriorityFn {}
+unsafe impl Send for KhrGlobalPriorityFn {}
+unsafe impl Sync for KhrGlobalPriorityFn {}
+impl KhrGlobalPriorityFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
     {
         Self {}
     }
+}
+#[doc = "Generated from 'VK_KHR_global_priority'"]
+impl Result {
+    pub const ERROR_NOT_PERMITTED_KHR: Self = Self(-1_000_174_001);
+}
+#[doc = "Generated from 'VK_KHR_global_priority'"]
+impl StructureType {
+    pub const DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR: Self = Self(1_000_174_000);
+    pub const PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR: Self = Self(1_000_388_000);
+    pub const QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR: Self = Self(1_000_388_001);
 }
 impl AmdMemoryOverallocationBehaviorFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -14270,7 +14288,8 @@ impl ExtPipelineCreationFeedbackFn {
 }
 #[doc = "Generated from 'VK_EXT_pipeline_creation_feedback'"]
 impl StructureType {
-    pub const PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT: Self = Self(1_000_192_000);
+    pub const PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT: Self =
+        Self::PIPELINE_CREATION_FEEDBACK_CREATE_INFO;
 }
 impl GoogleExtension194Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -15604,7 +15623,8 @@ impl KhrShaderTerminateInvocationFn {
 }
 #[doc = "Generated from 'VK_KHR_shader_terminate_invocation'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES_KHR: Self = Self(1_000_215_000);
+    pub const PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES_KHR: Self =
+        Self::PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES;
 }
 impl GoogleExtension217Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -15714,7 +15734,7 @@ impl FormatFeatureFlags {
     pub const FRAGMENT_DENSITY_MAP_EXT: Self = Self(0b1_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_EXT_fragment_density_map'"]
-impl FormatFeatureFlags2KHR {
+impl FormatFeatureFlags2 {
     pub const FRAGMENT_DENSITY_MAP_EXT: Self = Self(0b1_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_EXT_fragment_density_map'"]
@@ -15889,15 +15909,17 @@ impl ExtSubgroupSizeControlFn {
 }
 #[doc = "Generated from 'VK_EXT_subgroup_size_control'"]
 impl PipelineShaderStageCreateFlags {
-    pub const ALLOW_VARYING_SUBGROUP_SIZE_EXT: Self = Self(0b1);
-    pub const REQUIRE_FULL_SUBGROUPS_EXT: Self = Self(0b10);
+    pub const ALLOW_VARYING_SUBGROUP_SIZE_EXT: Self = Self::ALLOW_VARYING_SUBGROUP_SIZE;
+    pub const REQUIRE_FULL_SUBGROUPS_EXT: Self = Self::REQUIRE_FULL_SUBGROUPS;
 }
 #[doc = "Generated from 'VK_EXT_subgroup_size_control'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT: Self = Self(1_000_225_000);
+    pub const PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT: Self =
+        Self::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES;
     pub const PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT: Self =
-        Self(1_000_225_001);
-    pub const PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT: Self = Self(1_000_225_002);
+        Self::PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO;
+    pub const PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT: Self =
+        Self::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES;
 }
 impl KhrFragmentShadingRateFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -16015,8 +16037,8 @@ impl FormatFeatureFlags {
         Self(0b100_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_fragment_shading_rate'"]
-impl FormatFeatureFlags2KHR {
-    pub const FRAGMENT_SHADING_RATE_ATTACHMENT: Self =
+impl FormatFeatureFlags2 {
+    pub const FRAGMENT_SHADING_RATE_ATTACHMENT_KHR: Self =
         Self(0b100_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_fragment_shading_rate'"]
@@ -16497,14 +16519,14 @@ impl ExtToolingInfoFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPhysicalDeviceToolPropertiesEXT = unsafe extern "system" fn(
+pub type PFN_vkGetPhysicalDeviceToolProperties = unsafe extern "system" fn(
     physical_device: PhysicalDevice,
     p_tool_count: *mut u32,
-    p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
+    p_tool_properties: *mut PhysicalDeviceToolProperties,
 ) -> Result;
 #[derive(Clone)]
 pub struct ExtToolingInfoFn {
-    pub get_physical_device_tool_properties_ext: PFN_vkGetPhysicalDeviceToolPropertiesEXT,
+    pub get_physical_device_tool_properties_ext: PFN_vkGetPhysicalDeviceToolProperties,
 }
 unsafe impl Send for ExtToolingInfoFn {}
 unsafe impl Sync for ExtToolingInfoFn {}
@@ -16518,7 +16540,7 @@ impl ExtToolingInfoFn {
                 unsafe extern "system" fn get_physical_device_tool_properties_ext(
                     _physical_device: PhysicalDevice,
                     _p_tool_count: *mut u32,
-                    _p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
+                    _p_tool_properties: *mut PhysicalDeviceToolProperties,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -16542,7 +16564,7 @@ impl ExtToolingInfoFn {
         &self,
         physical_device: PhysicalDevice,
         p_tool_count: *mut u32,
-        p_tool_properties: *mut PhysicalDeviceToolPropertiesEXT,
+        p_tool_properties: *mut PhysicalDeviceToolProperties,
     ) -> Result {
         (self.get_physical_device_tool_properties_ext)(
             physical_device,
@@ -16553,12 +16575,12 @@ impl ExtToolingInfoFn {
 }
 #[doc = "Generated from 'VK_EXT_tooling_info'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT: Self = Self(1_000_245_000);
+    pub const PHYSICAL_DEVICE_TOOL_PROPERTIES_EXT: Self = Self::PHYSICAL_DEVICE_TOOL_PROPERTIES;
 }
 #[doc = "Generated from 'VK_EXT_tooling_info'"]
-impl ToolPurposeFlagsEXT {
-    pub const DEBUG_REPORTING: Self = Self(0b10_0000);
-    pub const DEBUG_MARKERS: Self = Self(0b100_0000);
+impl ToolPurposeFlags {
+    pub const DEBUG_REPORTING_EXT: Self = Self(0b10_0000);
+    pub const DEBUG_MARKERS_EXT: Self = Self(0b100_0000);
 }
 impl ExtSeparateStencilUsageFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -17570,28 +17592,28 @@ impl ExtExtendedDynamicStateFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetCullModeEXT =
+pub type PFN_vkCmdSetCullMode =
     unsafe extern "system" fn(command_buffer: CommandBuffer, cull_mode: CullModeFlags);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetFrontFaceEXT =
+pub type PFN_vkCmdSetFrontFace =
     unsafe extern "system" fn(command_buffer: CommandBuffer, front_face: FrontFace);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetPrimitiveTopologyEXT =
+pub type PFN_vkCmdSetPrimitiveTopology =
     unsafe extern "system" fn(command_buffer: CommandBuffer, primitive_topology: PrimitiveTopology);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetViewportWithCountEXT = unsafe extern "system" fn(
+pub type PFN_vkCmdSetViewportWithCount = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     viewport_count: u32,
     p_viewports: *const Viewport,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetScissorWithCountEXT = unsafe extern "system" fn(
+pub type PFN_vkCmdSetScissorWithCount = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     scissor_count: u32,
     p_scissors: *const Rect2D,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBindVertexBuffers2EXT = unsafe extern "system" fn(
+pub type PFN_vkCmdBindVertexBuffers2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     first_binding: u32,
     binding_count: u32,
@@ -17601,22 +17623,22 @@ pub type PFN_vkCmdBindVertexBuffers2EXT = unsafe extern "system" fn(
     p_strides: *const DeviceSize,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetDepthTestEnableEXT =
+pub type PFN_vkCmdSetDepthTestEnable =
     unsafe extern "system" fn(command_buffer: CommandBuffer, depth_test_enable: Bool32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetDepthWriteEnableEXT =
+pub type PFN_vkCmdSetDepthWriteEnable =
     unsafe extern "system" fn(command_buffer: CommandBuffer, depth_write_enable: Bool32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetDepthCompareOpEXT =
+pub type PFN_vkCmdSetDepthCompareOp =
     unsafe extern "system" fn(command_buffer: CommandBuffer, depth_compare_op: CompareOp);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetDepthBoundsTestEnableEXT =
+pub type PFN_vkCmdSetDepthBoundsTestEnable =
     unsafe extern "system" fn(command_buffer: CommandBuffer, depth_bounds_test_enable: Bool32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetStencilTestEnableEXT =
+pub type PFN_vkCmdSetStencilTestEnable =
     unsafe extern "system" fn(command_buffer: CommandBuffer, stencil_test_enable: Bool32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetStencilOpEXT = unsafe extern "system" fn(
+pub type PFN_vkCmdSetStencilOp = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     face_mask: StencilFaceFlags,
     fail_op: StencilOp,
@@ -17626,18 +17648,18 @@ pub type PFN_vkCmdSetStencilOpEXT = unsafe extern "system" fn(
 );
 #[derive(Clone)]
 pub struct ExtExtendedDynamicStateFn {
-    pub cmd_set_cull_mode_ext: PFN_vkCmdSetCullModeEXT,
-    pub cmd_set_front_face_ext: PFN_vkCmdSetFrontFaceEXT,
-    pub cmd_set_primitive_topology_ext: PFN_vkCmdSetPrimitiveTopologyEXT,
-    pub cmd_set_viewport_with_count_ext: PFN_vkCmdSetViewportWithCountEXT,
-    pub cmd_set_scissor_with_count_ext: PFN_vkCmdSetScissorWithCountEXT,
-    pub cmd_bind_vertex_buffers2_ext: PFN_vkCmdBindVertexBuffers2EXT,
-    pub cmd_set_depth_test_enable_ext: PFN_vkCmdSetDepthTestEnableEXT,
-    pub cmd_set_depth_write_enable_ext: PFN_vkCmdSetDepthWriteEnableEXT,
-    pub cmd_set_depth_compare_op_ext: PFN_vkCmdSetDepthCompareOpEXT,
-    pub cmd_set_depth_bounds_test_enable_ext: PFN_vkCmdSetDepthBoundsTestEnableEXT,
-    pub cmd_set_stencil_test_enable_ext: PFN_vkCmdSetStencilTestEnableEXT,
-    pub cmd_set_stencil_op_ext: PFN_vkCmdSetStencilOpEXT,
+    pub cmd_set_cull_mode_ext: PFN_vkCmdSetCullMode,
+    pub cmd_set_front_face_ext: PFN_vkCmdSetFrontFace,
+    pub cmd_set_primitive_topology_ext: PFN_vkCmdSetPrimitiveTopology,
+    pub cmd_set_viewport_with_count_ext: PFN_vkCmdSetViewportWithCount,
+    pub cmd_set_scissor_with_count_ext: PFN_vkCmdSetScissorWithCount,
+    pub cmd_bind_vertex_buffers2_ext: PFN_vkCmdBindVertexBuffers2,
+    pub cmd_set_depth_test_enable_ext: PFN_vkCmdSetDepthTestEnable,
+    pub cmd_set_depth_write_enable_ext: PFN_vkCmdSetDepthWriteEnable,
+    pub cmd_set_depth_compare_op_ext: PFN_vkCmdSetDepthCompareOp,
+    pub cmd_set_depth_bounds_test_enable_ext: PFN_vkCmdSetDepthBoundsTestEnable,
+    pub cmd_set_stencil_test_enable_ext: PFN_vkCmdSetStencilTestEnable,
+    pub cmd_set_stencil_op_ext: PFN_vkCmdSetStencilOp,
 }
 unsafe impl Send for ExtExtendedDynamicStateFn {}
 unsafe impl Sync for ExtExtendedDynamicStateFn {}
@@ -18021,21 +18043,22 @@ impl ExtExtendedDynamicStateFn {
 }
 #[doc = "Generated from 'VK_EXT_extended_dynamic_state'"]
 impl DynamicState {
-    pub const CULL_MODE_EXT: Self = Self(1_000_267_000);
-    pub const FRONT_FACE_EXT: Self = Self(1_000_267_001);
-    pub const PRIMITIVE_TOPOLOGY_EXT: Self = Self(1_000_267_002);
-    pub const VIEWPORT_WITH_COUNT_EXT: Self = Self(1_000_267_003);
-    pub const SCISSOR_WITH_COUNT_EXT: Self = Self(1_000_267_004);
-    pub const VERTEX_INPUT_BINDING_STRIDE_EXT: Self = Self(1_000_267_005);
-    pub const DEPTH_TEST_ENABLE_EXT: Self = Self(1_000_267_006);
-    pub const DEPTH_WRITE_ENABLE_EXT: Self = Self(1_000_267_007);
-    pub const DEPTH_COMPARE_OP_EXT: Self = Self(1_000_267_008);
-    pub const DEPTH_BOUNDS_TEST_ENABLE_EXT: Self = Self(1_000_267_009);
-    pub const STENCIL_TEST_ENABLE_EXT: Self = Self(1_000_267_010);
-    pub const STENCIL_OP_EXT: Self = Self(1_000_267_011);
+    pub const CULL_MODE_EXT: Self = Self::CULL_MODE;
+    pub const FRONT_FACE_EXT: Self = Self::FRONT_FACE;
+    pub const PRIMITIVE_TOPOLOGY_EXT: Self = Self::PRIMITIVE_TOPOLOGY;
+    pub const VIEWPORT_WITH_COUNT_EXT: Self = Self::VIEWPORT_WITH_COUNT;
+    pub const SCISSOR_WITH_COUNT_EXT: Self = Self::SCISSOR_WITH_COUNT;
+    pub const VERTEX_INPUT_BINDING_STRIDE_EXT: Self = Self::VERTEX_INPUT_BINDING_STRIDE;
+    pub const DEPTH_TEST_ENABLE_EXT: Self = Self::DEPTH_TEST_ENABLE;
+    pub const DEPTH_WRITE_ENABLE_EXT: Self = Self::DEPTH_WRITE_ENABLE;
+    pub const DEPTH_COMPARE_OP_EXT: Self = Self::DEPTH_COMPARE_OP;
+    pub const DEPTH_BOUNDS_TEST_ENABLE_EXT: Self = Self::DEPTH_BOUNDS_TEST_ENABLE;
+    pub const STENCIL_TEST_ENABLE_EXT: Self = Self::STENCIL_TEST_ENABLE;
+    pub const STENCIL_OP_EXT: Self = Self::STENCIL_OP;
 }
 #[doc = "Generated from 'VK_EXT_extended_dynamic_state'"]
 impl StructureType {
+    #[doc = "Not promoted to 1.3"]
     pub const PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT: Self = Self(1_000_267_000);
 }
 impl KhrDeferredHostOperationsFn {
@@ -18554,7 +18577,7 @@ impl ExtShaderDemoteToHelperInvocationFn {
 #[doc = "Generated from 'VK_EXT_shader_demote_to_helper_invocation'"]
 impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT: Self =
-        Self(1_000_276_000);
+        Self::PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES;
 }
 impl NvDeviceGeneratedCommandsFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -18911,8 +18934,10 @@ impl KhrShaderIntegerDotProductFn {
 }
 #[doc = "Generated from 'VK_KHR_shader_integer_dot_product'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR: Self = Self(1_000_280_000);
-    pub const PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES_KHR: Self = Self(1_000_280_001);
+    pub const PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES_KHR: Self =
+        Self::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES;
+    pub const PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES_KHR: Self =
+        Self::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES;
 }
 impl ExtTexelBufferAlignmentFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -18936,8 +18961,10 @@ impl ExtTexelBufferAlignmentFn {
 }
 #[doc = "Generated from 'VK_EXT_texel_buffer_alignment'"]
 impl StructureType {
+    #[doc = "Not promoted to 1.3"]
     pub const PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT: Self = Self(1_000_281_000);
-    pub const PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT: Self = Self(1_000_281_001);
+    pub const PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT: Self =
+        Self::PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES;
 }
 impl QcomRenderPassTransformFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -19336,40 +19363,40 @@ impl ExtPrivateDataFn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCreatePrivateDataSlotEXT = unsafe extern "system" fn(
+pub type PFN_vkCreatePrivateDataSlot = unsafe extern "system" fn(
     device: Device,
-    p_create_info: *const PrivateDataSlotCreateInfoEXT,
+    p_create_info: *const PrivateDataSlotCreateInfo,
     p_allocator: *const AllocationCallbacks,
-    p_private_data_slot: *mut PrivateDataSlotEXT,
+    p_private_data_slot: *mut PrivateDataSlot,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkDestroyPrivateDataSlotEXT = unsafe extern "system" fn(
+pub type PFN_vkDestroyPrivateDataSlot = unsafe extern "system" fn(
     device: Device,
-    private_data_slot: PrivateDataSlotEXT,
+    private_data_slot: PrivateDataSlot,
     p_allocator: *const AllocationCallbacks,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkSetPrivateDataEXT = unsafe extern "system" fn(
+pub type PFN_vkSetPrivateData = unsafe extern "system" fn(
     device: Device,
     object_type: ObjectType,
     object_handle: u64,
-    private_data_slot: PrivateDataSlotEXT,
+    private_data_slot: PrivateDataSlot,
     data: u64,
 ) -> Result;
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetPrivateDataEXT = unsafe extern "system" fn(
+pub type PFN_vkGetPrivateData = unsafe extern "system" fn(
     device: Device,
     object_type: ObjectType,
     object_handle: u64,
-    private_data_slot: PrivateDataSlotEXT,
+    private_data_slot: PrivateDataSlot,
     p_data: *mut u64,
 );
 #[derive(Clone)]
 pub struct ExtPrivateDataFn {
-    pub create_private_data_slot_ext: PFN_vkCreatePrivateDataSlotEXT,
-    pub destroy_private_data_slot_ext: PFN_vkDestroyPrivateDataSlotEXT,
-    pub set_private_data_ext: PFN_vkSetPrivateDataEXT,
-    pub get_private_data_ext: PFN_vkGetPrivateDataEXT,
+    pub create_private_data_slot_ext: PFN_vkCreatePrivateDataSlot,
+    pub destroy_private_data_slot_ext: PFN_vkDestroyPrivateDataSlot,
+    pub set_private_data_ext: PFN_vkSetPrivateData,
+    pub get_private_data_ext: PFN_vkGetPrivateData,
 }
 unsafe impl Send for ExtPrivateDataFn {}
 unsafe impl Sync for ExtPrivateDataFn {}
@@ -19382,9 +19409,9 @@ impl ExtPrivateDataFn {
             create_private_data_slot_ext: unsafe {
                 unsafe extern "system" fn create_private_data_slot_ext(
                     _device: Device,
-                    _p_create_info: *const PrivateDataSlotCreateInfoEXT,
+                    _p_create_info: *const PrivateDataSlotCreateInfo,
                     _p_allocator: *const AllocationCallbacks,
-                    _p_private_data_slot: *mut PrivateDataSlotEXT,
+                    _p_private_data_slot: *mut PrivateDataSlot,
                 ) -> Result {
                     panic!(concat!(
                         "Unable to load ",
@@ -19404,7 +19431,7 @@ impl ExtPrivateDataFn {
             destroy_private_data_slot_ext: unsafe {
                 unsafe extern "system" fn destroy_private_data_slot_ext(
                     _device: Device,
-                    _private_data_slot: PrivateDataSlotEXT,
+                    _private_data_slot: PrivateDataSlot,
                     _p_allocator: *const AllocationCallbacks,
                 ) {
                     panic!(concat!(
@@ -19427,7 +19454,7 @@ impl ExtPrivateDataFn {
                     _device: Device,
                     _object_type: ObjectType,
                     _object_handle: u64,
-                    _private_data_slot: PrivateDataSlotEXT,
+                    _private_data_slot: PrivateDataSlot,
                     _data: u64,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(set_private_data_ext)))
@@ -19446,7 +19473,7 @@ impl ExtPrivateDataFn {
                     _device: Device,
                     _object_type: ObjectType,
                     _object_handle: u64,
-                    _private_data_slot: PrivateDataSlotEXT,
+                    _private_data_slot: PrivateDataSlot,
                     _p_data: *mut u64,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(get_private_data_ext)))
@@ -19466,9 +19493,9 @@ impl ExtPrivateDataFn {
     pub unsafe fn create_private_data_slot_ext(
         &self,
         device: Device,
-        p_create_info: *const PrivateDataSlotCreateInfoEXT,
+        p_create_info: *const PrivateDataSlotCreateInfo,
         p_allocator: *const AllocationCallbacks,
-        p_private_data_slot: *mut PrivateDataSlotEXT,
+        p_private_data_slot: *mut PrivateDataSlot,
     ) -> Result {
         (self.create_private_data_slot_ext)(device, p_create_info, p_allocator, p_private_data_slot)
     }
@@ -19476,7 +19503,7 @@ impl ExtPrivateDataFn {
     pub unsafe fn destroy_private_data_slot_ext(
         &self,
         device: Device,
-        private_data_slot: PrivateDataSlotEXT,
+        private_data_slot: PrivateDataSlot,
         p_allocator: *const AllocationCallbacks,
     ) {
         (self.destroy_private_data_slot_ext)(device, private_data_slot, p_allocator)
@@ -19487,7 +19514,7 @@ impl ExtPrivateDataFn {
         device: Device,
         object_type: ObjectType,
         object_handle: u64,
-        private_data_slot: PrivateDataSlotEXT,
+        private_data_slot: PrivateDataSlot,
         data: u64,
     ) -> Result {
         (self.set_private_data_ext)(device, object_type, object_handle, private_data_slot, data)
@@ -19498,7 +19525,7 @@ impl ExtPrivateDataFn {
         device: Device,
         object_type: ObjectType,
         object_handle: u64,
-        private_data_slot: PrivateDataSlotEXT,
+        private_data_slot: PrivateDataSlot,
         p_data: *mut u64,
     ) {
         (self.get_private_data_ext)(
@@ -19512,13 +19539,14 @@ impl ExtPrivateDataFn {
 }
 #[doc = "Generated from 'VK_EXT_private_data'"]
 impl ObjectType {
-    pub const PRIVATE_DATA_SLOT_EXT: Self = Self(1_000_295_000);
+    pub const PRIVATE_DATA_SLOT_EXT: Self = Self::PRIVATE_DATA_SLOT;
 }
 #[doc = "Generated from 'VK_EXT_private_data'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT: Self = Self(1_000_295_000);
-    pub const DEVICE_PRIVATE_DATA_CREATE_INFO_EXT: Self = Self(1_000_295_001);
-    pub const PRIVATE_DATA_SLOT_CREATE_INFO_EXT: Self = Self(1_000_295_002);
+    pub const PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT: Self =
+        Self::PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES;
+    pub const DEVICE_PRIVATE_DATA_CREATE_INFO_EXT: Self = Self::DEVICE_PRIVATE_DATA_CREATE_INFO;
+    pub const PRIVATE_DATA_SLOT_CREATE_INFO_EXT: Self = Self::PRIVATE_DATA_SLOT_CREATE_INFO;
 }
 impl KhrExtension297Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -19566,22 +19594,22 @@ impl ExtPipelineCreationCacheControlFn {
 }
 #[doc = "Generated from 'VK_EXT_pipeline_creation_cache_control'"]
 impl PipelineCacheCreateFlags {
-    pub const EXTERNALLY_SYNCHRONIZED_EXT: Self = Self(0b1);
+    pub const EXTERNALLY_SYNCHRONIZED_EXT: Self = Self::EXTERNALLY_SYNCHRONIZED;
 }
 #[doc = "Generated from 'VK_EXT_pipeline_creation_cache_control'"]
 impl PipelineCreateFlags {
-    pub const FAIL_ON_PIPELINE_COMPILE_REQUIRED_EXT: Self = Self(0b1_0000_0000);
-    pub const EARLY_RETURN_ON_FAILURE_EXT: Self = Self(0b10_0000_0000);
+    pub const FAIL_ON_PIPELINE_COMPILE_REQUIRED_EXT: Self = Self::FAIL_ON_PIPELINE_COMPILE_REQUIRED;
+    pub const EARLY_RETURN_ON_FAILURE_EXT: Self = Self::EARLY_RETURN_ON_FAILURE;
 }
 #[doc = "Generated from 'VK_EXT_pipeline_creation_cache_control'"]
 impl Result {
-    pub const PIPELINE_COMPILE_REQUIRED_EXT: Self = Self(1_000_297_000);
-    pub const ERROR_PIPELINE_COMPILE_REQUIRED_EXT: Self = Self::PIPELINE_COMPILE_REQUIRED_EXT;
+    pub const PIPELINE_COMPILE_REQUIRED_EXT: Self = Self::PIPELINE_COMPILE_REQUIRED;
+    pub const ERROR_PIPELINE_COMPILE_REQUIRED_EXT: Self = Self::PIPELINE_COMPILE_REQUIRED;
 }
 #[doc = "Generated from 'VK_EXT_pipeline_creation_cache_control'"]
 impl StructureType {
     pub const PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT: Self =
-        Self(1_000_297_000);
+        Self::PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES;
 }
 impl KhrExtension299Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -19661,9 +19689,10 @@ impl KhrVideoEncodeQueueFn {
     }
 }
 #[doc = "Generated from 'VK_KHR_video_encode_queue'"]
-impl AccessFlags2KHR {
-    pub const VIDEO_ENCODE_READ: Self = Self(0b10_0000_0000_0000_0000_0000_0000_0000_0000_0000);
-    pub const VIDEO_ENCODE_WRITE: Self = Self(0b100_0000_0000_0000_0000_0000_0000_0000_0000_0000);
+impl AccessFlags2 {
+    pub const VIDEO_ENCODE_READ_KHR: Self = Self(0b10_0000_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const VIDEO_ENCODE_WRITE_KHR: Self =
+        Self(0b100_0000_0000_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_encode_queue'"]
 impl BufferUsageFlags {
@@ -19676,9 +19705,9 @@ impl FormatFeatureFlags {
     pub const VIDEO_ENCODE_DPB_KHR: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_encode_queue'"]
-impl FormatFeatureFlags2KHR {
-    pub const VIDEO_ENCODE_INPUT: Self = Self(0b1000_0000_0000_0000_0000_0000_0000);
-    pub const VIDEO_ENCODE_DPB: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000);
+impl FormatFeatureFlags2 {
+    pub const VIDEO_ENCODE_INPUT_KHR: Self = Self(0b1000_0000_0000_0000_0000_0000_0000);
+    pub const VIDEO_ENCODE_DPB_KHR: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_encode_queue'"]
 impl ImageLayout {
@@ -19693,8 +19722,8 @@ impl ImageUsageFlags {
     pub const VIDEO_ENCODE_DPB_KHR: Self = Self(0b1000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_encode_queue'"]
-impl PipelineStageFlags2KHR {
-    pub const VIDEO_ENCODE: Self = Self(0b1000_0000_0000_0000_0000_0000_0000);
+impl PipelineStageFlags2 {
+    pub const VIDEO_ENCODE_KHR: Self = Self(0b1000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_video_encode_queue'"]
 impl QueryType {
@@ -19757,7 +19786,7 @@ impl QcomRenderPassStoreOpsFn {
 }
 #[doc = "Generated from 'VK_QCOM_render_pass_store_ops'"]
 impl AttachmentStoreOp {
-    pub const NONE_QCOM: Self = Self::NONE_KHR;
+    pub const NONE_QCOM: Self = Self::NONE;
 }
 impl QcomExtension303Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -19986,47 +20015,47 @@ impl KhrSynchronization2Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetEvent2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdSetEvent2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     event: Event,
-    p_dependency_info: *const DependencyInfoKHR,
+    p_dependency_info: *const DependencyInfo,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdResetEvent2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdResetEvent2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     event: Event,
-    stage_mask: PipelineStageFlags2KHR,
+    stage_mask: PipelineStageFlags2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWaitEvents2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdWaitEvents2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
     event_count: u32,
     p_events: *const Event,
-    p_dependency_infos: *const DependencyInfoKHR,
+    p_dependency_infos: *const DependencyInfo,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdPipelineBarrier2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdPipelineBarrier2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_dependency_info: *const DependencyInfoKHR,
+    p_dependency_info: *const DependencyInfo,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdWriteTimestamp2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdWriteTimestamp2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    stage: PipelineStageFlags2KHR,
+    stage: PipelineStageFlags2,
     query_pool: QueryPool,
     query: u32,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkQueueSubmit2KHR = unsafe extern "system" fn(
+pub type PFN_vkQueueSubmit2 = unsafe extern "system" fn(
     queue: Queue,
     submit_count: u32,
-    p_submits: *const SubmitInfo2KHR,
+    p_submits: *const SubmitInfo2,
     fence: Fence,
 ) -> Result;
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdWriteBufferMarker2AMD = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    stage: PipelineStageFlags2KHR,
+    stage: PipelineStageFlags2,
     dst_buffer: Buffer,
     dst_offset: DeviceSize,
     marker: u32,
@@ -20039,12 +20068,12 @@ pub type PFN_vkGetQueueCheckpointData2NV = unsafe extern "system" fn(
 );
 #[derive(Clone)]
 pub struct KhrSynchronization2Fn {
-    pub cmd_set_event2_khr: PFN_vkCmdSetEvent2KHR,
-    pub cmd_reset_event2_khr: PFN_vkCmdResetEvent2KHR,
-    pub cmd_wait_events2_khr: PFN_vkCmdWaitEvents2KHR,
-    pub cmd_pipeline_barrier2_khr: PFN_vkCmdPipelineBarrier2KHR,
-    pub cmd_write_timestamp2_khr: PFN_vkCmdWriteTimestamp2KHR,
-    pub queue_submit2_khr: PFN_vkQueueSubmit2KHR,
+    pub cmd_set_event2_khr: PFN_vkCmdSetEvent2,
+    pub cmd_reset_event2_khr: PFN_vkCmdResetEvent2,
+    pub cmd_wait_events2_khr: PFN_vkCmdWaitEvents2,
+    pub cmd_pipeline_barrier2_khr: PFN_vkCmdPipelineBarrier2,
+    pub cmd_write_timestamp2_khr: PFN_vkCmdWriteTimestamp2,
+    pub queue_submit2_khr: PFN_vkQueueSubmit2,
     pub cmd_write_buffer_marker2_amd: PFN_vkCmdWriteBufferMarker2AMD,
     pub get_queue_checkpoint_data2_nv: PFN_vkGetQueueCheckpointData2NV,
 }
@@ -20060,7 +20089,7 @@ impl KhrSynchronization2Fn {
                 unsafe extern "system" fn cmd_set_event2_khr(
                     _command_buffer: CommandBuffer,
                     _event: Event,
-                    _p_dependency_info: *const DependencyInfoKHR,
+                    _p_dependency_info: *const DependencyInfo,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_set_event2_khr)))
                 }
@@ -20076,7 +20105,7 @@ impl KhrSynchronization2Fn {
                 unsafe extern "system" fn cmd_reset_event2_khr(
                     _command_buffer: CommandBuffer,
                     _event: Event,
-                    _stage_mask: PipelineStageFlags2KHR,
+                    _stage_mask: PipelineStageFlags2,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_reset_event2_khr)))
                 }
@@ -20094,7 +20123,7 @@ impl KhrSynchronization2Fn {
                     _command_buffer: CommandBuffer,
                     _event_count: u32,
                     _p_events: *const Event,
-                    _p_dependency_infos: *const DependencyInfoKHR,
+                    _p_dependency_infos: *const DependencyInfo,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_wait_events2_khr)))
                 }
@@ -20110,7 +20139,7 @@ impl KhrSynchronization2Fn {
             cmd_pipeline_barrier2_khr: unsafe {
                 unsafe extern "system" fn cmd_pipeline_barrier2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_dependency_info: *const DependencyInfoKHR,
+                    _p_dependency_info: *const DependencyInfo,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -20129,7 +20158,7 @@ impl KhrSynchronization2Fn {
             cmd_write_timestamp2_khr: unsafe {
                 unsafe extern "system" fn cmd_write_timestamp2_khr(
                     _command_buffer: CommandBuffer,
-                    _stage: PipelineStageFlags2KHR,
+                    _stage: PipelineStageFlags2,
                     _query_pool: QueryPool,
                     _query: u32,
                 ) {
@@ -20151,7 +20180,7 @@ impl KhrSynchronization2Fn {
                 unsafe extern "system" fn queue_submit2_khr(
                     _queue: Queue,
                     _submit_count: u32,
-                    _p_submits: *const SubmitInfo2KHR,
+                    _p_submits: *const SubmitInfo2,
                     _fence: Fence,
                 ) -> Result {
                     panic!(concat!("Unable to load ", stringify!(queue_submit2_khr)))
@@ -20167,7 +20196,7 @@ impl KhrSynchronization2Fn {
             cmd_write_buffer_marker2_amd: unsafe {
                 unsafe extern "system" fn cmd_write_buffer_marker2_amd(
                     _command_buffer: CommandBuffer,
-                    _stage: PipelineStageFlags2KHR,
+                    _stage: PipelineStageFlags2,
                     _dst_buffer: Buffer,
                     _dst_offset: DeviceSize,
                     _marker: u32,
@@ -20215,7 +20244,7 @@ impl KhrSynchronization2Fn {
         &self,
         command_buffer: CommandBuffer,
         event: Event,
-        p_dependency_info: *const DependencyInfoKHR,
+        p_dependency_info: *const DependencyInfo,
     ) {
         (self.cmd_set_event2_khr)(command_buffer, event, p_dependency_info)
     }
@@ -20224,7 +20253,7 @@ impl KhrSynchronization2Fn {
         &self,
         command_buffer: CommandBuffer,
         event: Event,
-        stage_mask: PipelineStageFlags2KHR,
+        stage_mask: PipelineStageFlags2,
     ) {
         (self.cmd_reset_event2_khr)(command_buffer, event, stage_mask)
     }
@@ -20234,7 +20263,7 @@ impl KhrSynchronization2Fn {
         command_buffer: CommandBuffer,
         event_count: u32,
         p_events: *const Event,
-        p_dependency_infos: *const DependencyInfoKHR,
+        p_dependency_infos: *const DependencyInfo,
     ) {
         (self.cmd_wait_events2_khr)(command_buffer, event_count, p_events, p_dependency_infos)
     }
@@ -20242,7 +20271,7 @@ impl KhrSynchronization2Fn {
     pub unsafe fn cmd_pipeline_barrier2_khr(
         &self,
         command_buffer: CommandBuffer,
-        p_dependency_info: *const DependencyInfoKHR,
+        p_dependency_info: *const DependencyInfo,
     ) {
         (self.cmd_pipeline_barrier2_khr)(command_buffer, p_dependency_info)
     }
@@ -20250,7 +20279,7 @@ impl KhrSynchronization2Fn {
     pub unsafe fn cmd_write_timestamp2_khr(
         &self,
         command_buffer: CommandBuffer,
-        stage: PipelineStageFlags2KHR,
+        stage: PipelineStageFlags2,
         query_pool: QueryPool,
         query: u32,
     ) {
@@ -20261,7 +20290,7 @@ impl KhrSynchronization2Fn {
         &self,
         queue: Queue,
         submit_count: u32,
-        p_submits: *const SubmitInfo2KHR,
+        p_submits: *const SubmitInfo2,
         fence: Fence,
     ) -> Result {
         (self.queue_submit2_khr)(queue, submit_count, p_submits, fence)
@@ -20270,7 +20299,7 @@ impl KhrSynchronization2Fn {
     pub unsafe fn cmd_write_buffer_marker2_amd(
         &self,
         command_buffer: CommandBuffer,
-        stage: PipelineStageFlags2KHR,
+        stage: PipelineStageFlags2,
         dst_buffer: Buffer,
         dst_offset: DeviceSize,
         marker: u32,
@@ -20289,10 +20318,10 @@ impl KhrSynchronization2Fn {
 }
 #[doc = "Generated from 'VK_KHR_synchronization2'"]
 impl AccessFlags {
-    pub const NONE_KHR: Self = Self(0);
+    pub const NONE_KHR: Self = Self::NONE;
 }
 #[doc = "Generated from 'VK_KHR_synchronization2'"]
-impl AccessFlags2KHR {
+impl AccessFlags2 {
     pub const TRANSFORM_FEEDBACK_WRITE_EXT: Self = Self(0b10_0000_0000_0000_0000_0000_0000);
     pub const TRANSFORM_FEEDBACK_COUNTER_READ_EXT: Self = Self(0b100_0000_0000_0000_0000_0000_0000);
     pub const TRANSFORM_FEEDBACK_COUNTER_WRITE_EXT: Self =
@@ -20301,54 +20330,56 @@ impl AccessFlags2KHR {
     pub const CONDITIONAL_RENDERING_READ_EXT: Self = Self(0b1_0000_0000_0000_0000_0000);
     pub const COMMAND_PREPROCESS_READ_NV: Self = Self(0b10_0000_0000_0000_0000);
     pub const COMMAND_PREPROCESS_WRITE_NV: Self = Self(0b100_0000_0000_0000_0000);
-    pub const FRAGMENT_SHADING_RATE_ATTACHMENT_READ: Self = Self(0b1000_0000_0000_0000_0000_0000);
-    pub const SHADING_RATE_IMAGE_READ_NV: Self = Self::FRAGMENT_SHADING_RATE_ATTACHMENT_READ;
-    pub const ACCELERATION_STRUCTURE_READ: Self = Self(0b10_0000_0000_0000_0000_0000);
-    pub const ACCELERATION_STRUCTURE_WRITE: Self = Self(0b100_0000_0000_0000_0000_0000);
-    pub const ACCELERATION_STRUCTURE_READ_NV: Self = Self::ACCELERATION_STRUCTURE_READ;
-    pub const ACCELERATION_STRUCTURE_WRITE_NV: Self = Self::ACCELERATION_STRUCTURE_WRITE;
+    pub const FRAGMENT_SHADING_RATE_ATTACHMENT_READ_KHR: Self =
+        Self(0b1000_0000_0000_0000_0000_0000);
+    pub const SHADING_RATE_IMAGE_READ_NV: Self = Self::FRAGMENT_SHADING_RATE_ATTACHMENT_READ_KHR;
+    pub const ACCELERATION_STRUCTURE_READ_KHR: Self = Self(0b10_0000_0000_0000_0000_0000);
+    pub const ACCELERATION_STRUCTURE_WRITE_KHR: Self = Self(0b100_0000_0000_0000_0000_0000);
+    pub const ACCELERATION_STRUCTURE_READ_NV: Self = Self::ACCELERATION_STRUCTURE_READ_KHR;
+    pub const ACCELERATION_STRUCTURE_WRITE_NV: Self = Self::ACCELERATION_STRUCTURE_WRITE_KHR;
     pub const FRAGMENT_DENSITY_MAP_READ_EXT: Self = Self(0b1_0000_0000_0000_0000_0000_0000);
     pub const COLOR_ATTACHMENT_READ_NONCOHERENT_EXT: Self = Self(0b1000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_synchronization2'"]
 impl EventCreateFlags {
-    pub const DEVICE_ONLY_KHR: Self = Self(0b1);
+    pub const DEVICE_ONLY_KHR: Self = Self::DEVICE_ONLY;
 }
 #[doc = "Generated from 'VK_KHR_synchronization2'"]
 impl ImageLayout {
-    pub const READ_ONLY_OPTIMAL_KHR: Self = Self(1_000_314_000);
-    pub const ATTACHMENT_OPTIMAL_KHR: Self = Self(1_000_314_001);
+    pub const READ_ONLY_OPTIMAL_KHR: Self = Self::READ_ONLY_OPTIMAL;
+    pub const ATTACHMENT_OPTIMAL_KHR: Self = Self::ATTACHMENT_OPTIMAL;
 }
 #[doc = "Generated from 'VK_KHR_synchronization2'"]
 impl PipelineStageFlags {
-    pub const NONE_KHR: Self = Self(0);
+    pub const NONE_KHR: Self = Self::NONE;
 }
 #[doc = "Generated from 'VK_KHR_synchronization2'"]
-impl PipelineStageFlags2KHR {
+impl PipelineStageFlags2 {
     pub const TRANSFORM_FEEDBACK_EXT: Self = Self(0b1_0000_0000_0000_0000_0000_0000);
     #[doc = "A pipeline stage for conditional rendering predicate fetch"]
     pub const CONDITIONAL_RENDERING_EXT: Self = Self(0b100_0000_0000_0000_0000);
     pub const COMMAND_PREPROCESS_NV: Self = Self(0b10_0000_0000_0000_0000);
-    pub const FRAGMENT_SHADING_RATE_ATTACHMENT: Self = Self(0b100_0000_0000_0000_0000_0000);
-    pub const SHADING_RATE_IMAGE_NV: Self = Self::FRAGMENT_SHADING_RATE_ATTACHMENT;
-    pub const ACCELERATION_STRUCTURE_BUILD: Self = Self(0b10_0000_0000_0000_0000_0000_0000);
-    pub const RAY_TRACING_SHADER: Self = Self(0b10_0000_0000_0000_0000_0000);
-    pub const RAY_TRACING_SHADER_NV: Self = Self::RAY_TRACING_SHADER;
-    pub const ACCELERATION_STRUCTURE_BUILD_NV: Self = Self::ACCELERATION_STRUCTURE_BUILD;
+    pub const FRAGMENT_SHADING_RATE_ATTACHMENT_KHR: Self = Self(0b100_0000_0000_0000_0000_0000);
+    pub const SHADING_RATE_IMAGE_NV: Self = Self::FRAGMENT_SHADING_RATE_ATTACHMENT_KHR;
+    pub const ACCELERATION_STRUCTURE_BUILD_KHR: Self = Self(0b10_0000_0000_0000_0000_0000_0000);
+    pub const RAY_TRACING_SHADER_KHR: Self = Self(0b10_0000_0000_0000_0000_0000);
+    pub const RAY_TRACING_SHADER_NV: Self = Self::RAY_TRACING_SHADER_KHR;
+    pub const ACCELERATION_STRUCTURE_BUILD_NV: Self = Self::ACCELERATION_STRUCTURE_BUILD_KHR;
     pub const FRAGMENT_DENSITY_PROCESS_EXT: Self = Self(0b1000_0000_0000_0000_0000_0000);
     pub const TASK_SHADER_NV: Self = Self(0b1000_0000_0000_0000_0000);
     pub const MESH_SHADER_NV: Self = Self(0b1_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_synchronization2'"]
 impl StructureType {
-    pub const MEMORY_BARRIER_2_KHR: Self = Self(1_000_314_000);
-    pub const BUFFER_MEMORY_BARRIER_2_KHR: Self = Self(1_000_314_001);
-    pub const IMAGE_MEMORY_BARRIER_2_KHR: Self = Self(1_000_314_002);
-    pub const DEPENDENCY_INFO_KHR: Self = Self(1_000_314_003);
-    pub const SUBMIT_INFO_2_KHR: Self = Self(1_000_314_004);
-    pub const SEMAPHORE_SUBMIT_INFO_KHR: Self = Self(1_000_314_005);
-    pub const COMMAND_BUFFER_SUBMIT_INFO_KHR: Self = Self(1_000_314_006);
-    pub const PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR: Self = Self(1_000_314_007);
+    pub const MEMORY_BARRIER_2_KHR: Self = Self::MEMORY_BARRIER_2;
+    pub const BUFFER_MEMORY_BARRIER_2_KHR: Self = Self::BUFFER_MEMORY_BARRIER_2;
+    pub const IMAGE_MEMORY_BARRIER_2_KHR: Self = Self::IMAGE_MEMORY_BARRIER_2;
+    pub const DEPENDENCY_INFO_KHR: Self = Self::DEPENDENCY_INFO;
+    pub const SUBMIT_INFO_2_KHR: Self = Self::SUBMIT_INFO_2;
+    pub const SEMAPHORE_SUBMIT_INFO_KHR: Self = Self::SEMAPHORE_SUBMIT_INFO;
+    pub const COMMAND_BUFFER_SUBMIT_INFO_KHR: Self = Self::COMMAND_BUFFER_SUBMIT_INFO;
+    pub const PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR: Self =
+        Self::PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
     pub const QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV: Self = Self(1_000_314_008);
     pub const CHECKPOINT_DATA_2_NV: Self = Self(1_000_314_009);
 }
@@ -20389,7 +20420,7 @@ impl AmdExtension317Fn {
     }
 }
 #[doc = "Generated from 'VK_AMD_extension_317'"]
-impl AccessFlags2KHR {
+impl AccessFlags2 {
     pub const RESERVED_41_AMD: Self = Self(0b10_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_AMD_extension_317'"]
@@ -20408,6 +20439,10 @@ impl DescriptorSetLayoutCreateFlags {
 #[doc = "Generated from 'VK_AMD_extension_317'"]
 impl ImageCreateFlags {
     pub const RESERVED_16_AMD: Self = Self(0b1_0000_0000_0000_0000);
+}
+#[doc = "Generated from 'VK_AMD_extension_317'"]
+impl ImageViewCreateFlags {
+    pub const RESERVED_2_AMD: Self = Self(0b100);
 }
 #[doc = "Generated from 'VK_AMD_extension_317'"]
 impl SamplerCreateFlags {
@@ -20608,7 +20643,7 @@ impl KhrZeroInitializeWorkgroupMemoryFn {
 #[doc = "Generated from 'VK_KHR_zero_initialize_workgroup_memory'"]
 impl StructureType {
     pub const PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES_KHR: Self =
-        Self(1_000_325_000);
+        Self::PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES;
 }
 impl NvFragmentShadingRateEnumsFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -20771,10 +20806,12 @@ impl ExtYcbcr2plane444FormatsFn {
 }
 #[doc = "Generated from 'VK_EXT_ycbcr_2plane_444_formats'"]
 impl Format {
-    pub const G8_B8R8_2PLANE_444_UNORM_EXT: Self = Self(1_000_330_000);
-    pub const G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT: Self = Self(1_000_330_001);
-    pub const G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT: Self = Self(1_000_330_002);
-    pub const G16_B16R16_2PLANE_444_UNORM_EXT: Self = Self(1_000_330_003);
+    pub const G8_B8R8_2PLANE_444_UNORM_EXT: Self = Self::G8_B8R8_2PLANE_444_UNORM;
+    pub const G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16_EXT: Self =
+        Self::G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16;
+    pub const G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16_EXT: Self =
+        Self::G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16;
+    pub const G16_B16R16_2PLANE_444_UNORM_EXT: Self = Self::G16_B16R16_2PLANE_444_UNORM;
 }
 #[doc = "Generated from 'VK_EXT_ycbcr_2plane_444_formats'"]
 impl StructureType {
@@ -20889,7 +20926,8 @@ impl ExtImageRobustnessFn {
 }
 #[doc = "Generated from 'VK_EXT_image_robustness'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT: Self = Self(1_000_335_000);
+    pub const PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT: Self =
+        Self::PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES;
 }
 impl KhrWorkgroupMemoryExplicitLayoutFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -20925,43 +20963,43 @@ impl KhrCopyCommands2Fn {
     pub const SPEC_VERSION: u32 = 1u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyBuffer2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdCopyBuffer2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_copy_buffer_info: *const CopyBufferInfo2KHR,
+    p_copy_buffer_info: *const CopyBufferInfo2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyImage2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdCopyImage2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_copy_image_info: *const CopyImageInfo2KHR,
+    p_copy_image_info: *const CopyImageInfo2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyBufferToImage2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdCopyBufferToImage2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2KHR,
+    p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdCopyImageToBuffer2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdCopyImageToBuffer2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2KHR,
+    p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdBlitImage2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdBlitImage2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_blit_image_info: *const BlitImageInfo2KHR,
+    p_blit_image_info: *const BlitImageInfo2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdResolveImage2KHR = unsafe extern "system" fn(
+pub type PFN_vkCmdResolveImage2 = unsafe extern "system" fn(
     command_buffer: CommandBuffer,
-    p_resolve_image_info: *const ResolveImageInfo2KHR,
+    p_resolve_image_info: *const ResolveImageInfo2,
 );
 #[derive(Clone)]
 pub struct KhrCopyCommands2Fn {
-    pub cmd_copy_buffer2_khr: PFN_vkCmdCopyBuffer2KHR,
-    pub cmd_copy_image2_khr: PFN_vkCmdCopyImage2KHR,
-    pub cmd_copy_buffer_to_image2_khr: PFN_vkCmdCopyBufferToImage2KHR,
-    pub cmd_copy_image_to_buffer2_khr: PFN_vkCmdCopyImageToBuffer2KHR,
-    pub cmd_blit_image2_khr: PFN_vkCmdBlitImage2KHR,
-    pub cmd_resolve_image2_khr: PFN_vkCmdResolveImage2KHR,
+    pub cmd_copy_buffer2_khr: PFN_vkCmdCopyBuffer2,
+    pub cmd_copy_image2_khr: PFN_vkCmdCopyImage2,
+    pub cmd_copy_buffer_to_image2_khr: PFN_vkCmdCopyBufferToImage2,
+    pub cmd_copy_image_to_buffer2_khr: PFN_vkCmdCopyImageToBuffer2,
+    pub cmd_blit_image2_khr: PFN_vkCmdBlitImage2,
+    pub cmd_resolve_image2_khr: PFN_vkCmdResolveImage2,
 }
 unsafe impl Send for KhrCopyCommands2Fn {}
 unsafe impl Sync for KhrCopyCommands2Fn {}
@@ -20974,7 +21012,7 @@ impl KhrCopyCommands2Fn {
             cmd_copy_buffer2_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_buffer2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_copy_buffer_info: *const CopyBufferInfo2KHR,
+                    _p_copy_buffer_info: *const CopyBufferInfo2,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_copy_buffer2_khr)))
                 }
@@ -20990,7 +21028,7 @@ impl KhrCopyCommands2Fn {
             cmd_copy_image2_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_image2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_copy_image_info: *const CopyImageInfo2KHR,
+                    _p_copy_image_info: *const CopyImageInfo2,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_copy_image2_khr)))
                 }
@@ -21006,7 +21044,7 @@ impl KhrCopyCommands2Fn {
             cmd_copy_buffer_to_image2_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_buffer_to_image2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2KHR,
+                    _p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -21026,7 +21064,7 @@ impl KhrCopyCommands2Fn {
             cmd_copy_image_to_buffer2_khr: unsafe {
                 unsafe extern "system" fn cmd_copy_image_to_buffer2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2KHR,
+                    _p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -21046,7 +21084,7 @@ impl KhrCopyCommands2Fn {
             cmd_blit_image2_khr: unsafe {
                 unsafe extern "system" fn cmd_blit_image2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_blit_image_info: *const BlitImageInfo2KHR,
+                    _p_blit_image_info: *const BlitImageInfo2,
                 ) {
                     panic!(concat!("Unable to load ", stringify!(cmd_blit_image2_khr)))
                 }
@@ -21062,7 +21100,7 @@ impl KhrCopyCommands2Fn {
             cmd_resolve_image2_khr: unsafe {
                 unsafe extern "system" fn cmd_resolve_image2_khr(
                     _command_buffer: CommandBuffer,
-                    _p_resolve_image_info: *const ResolveImageInfo2KHR,
+                    _p_resolve_image_info: *const ResolveImageInfo2,
                 ) {
                     panic!(concat!(
                         "Unable to load ",
@@ -21084,7 +21122,7 @@ impl KhrCopyCommands2Fn {
     pub unsafe fn cmd_copy_buffer2_khr(
         &self,
         command_buffer: CommandBuffer,
-        p_copy_buffer_info: *const CopyBufferInfo2KHR,
+        p_copy_buffer_info: *const CopyBufferInfo2,
     ) {
         (self.cmd_copy_buffer2_khr)(command_buffer, p_copy_buffer_info)
     }
@@ -21092,7 +21130,7 @@ impl KhrCopyCommands2Fn {
     pub unsafe fn cmd_copy_image2_khr(
         &self,
         command_buffer: CommandBuffer,
-        p_copy_image_info: *const CopyImageInfo2KHR,
+        p_copy_image_info: *const CopyImageInfo2,
     ) {
         (self.cmd_copy_image2_khr)(command_buffer, p_copy_image_info)
     }
@@ -21100,7 +21138,7 @@ impl KhrCopyCommands2Fn {
     pub unsafe fn cmd_copy_buffer_to_image2_khr(
         &self,
         command_buffer: CommandBuffer,
-        p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2KHR,
+        p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2,
     ) {
         (self.cmd_copy_buffer_to_image2_khr)(command_buffer, p_copy_buffer_to_image_info)
     }
@@ -21108,7 +21146,7 @@ impl KhrCopyCommands2Fn {
     pub unsafe fn cmd_copy_image_to_buffer2_khr(
         &self,
         command_buffer: CommandBuffer,
-        p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2KHR,
+        p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2,
     ) {
         (self.cmd_copy_image_to_buffer2_khr)(command_buffer, p_copy_image_to_buffer_info)
     }
@@ -21116,7 +21154,7 @@ impl KhrCopyCommands2Fn {
     pub unsafe fn cmd_blit_image2_khr(
         &self,
         command_buffer: CommandBuffer,
-        p_blit_image_info: *const BlitImageInfo2KHR,
+        p_blit_image_info: *const BlitImageInfo2,
     ) {
         (self.cmd_blit_image2_khr)(command_buffer, p_blit_image_info)
     }
@@ -21124,24 +21162,24 @@ impl KhrCopyCommands2Fn {
     pub unsafe fn cmd_resolve_image2_khr(
         &self,
         command_buffer: CommandBuffer,
-        p_resolve_image_info: *const ResolveImageInfo2KHR,
+        p_resolve_image_info: *const ResolveImageInfo2,
     ) {
         (self.cmd_resolve_image2_khr)(command_buffer, p_resolve_image_info)
     }
 }
 #[doc = "Generated from 'VK_KHR_copy_commands2'"]
 impl StructureType {
-    pub const COPY_BUFFER_INFO_2_KHR: Self = Self(1_000_337_000);
-    pub const COPY_IMAGE_INFO_2_KHR: Self = Self(1_000_337_001);
-    pub const COPY_BUFFER_TO_IMAGE_INFO_2_KHR: Self = Self(1_000_337_002);
-    pub const COPY_IMAGE_TO_BUFFER_INFO_2_KHR: Self = Self(1_000_337_003);
-    pub const BLIT_IMAGE_INFO_2_KHR: Self = Self(1_000_337_004);
-    pub const RESOLVE_IMAGE_INFO_2_KHR: Self = Self(1_000_337_005);
-    pub const BUFFER_COPY_2_KHR: Self = Self(1_000_337_006);
-    pub const IMAGE_COPY_2_KHR: Self = Self(1_000_337_007);
-    pub const IMAGE_BLIT_2_KHR: Self = Self(1_000_337_008);
-    pub const BUFFER_IMAGE_COPY_2_KHR: Self = Self(1_000_337_009);
-    pub const IMAGE_RESOLVE_2_KHR: Self = Self(1_000_337_010);
+    pub const COPY_BUFFER_INFO_2_KHR: Self = Self::COPY_BUFFER_INFO_2;
+    pub const COPY_IMAGE_INFO_2_KHR: Self = Self::COPY_IMAGE_INFO_2;
+    pub const COPY_BUFFER_TO_IMAGE_INFO_2_KHR: Self = Self::COPY_BUFFER_TO_IMAGE_INFO_2;
+    pub const COPY_IMAGE_TO_BUFFER_INFO_2_KHR: Self = Self::COPY_IMAGE_TO_BUFFER_INFO_2;
+    pub const BLIT_IMAGE_INFO_2_KHR: Self = Self::BLIT_IMAGE_INFO_2;
+    pub const RESOLVE_IMAGE_INFO_2_KHR: Self = Self::RESOLVE_IMAGE_INFO_2;
+    pub const BUFFER_COPY_2_KHR: Self = Self::BUFFER_COPY_2;
+    pub const IMAGE_COPY_2_KHR: Self = Self::IMAGE_COPY_2;
+    pub const IMAGE_BLIT_2_KHR: Self = Self::IMAGE_BLIT_2;
+    pub const BUFFER_IMAGE_COPY_2_KHR: Self = Self::BUFFER_IMAGE_COPY_2;
+    pub const IMAGE_RESOLVE_2_KHR: Self = Self::IMAGE_RESOLVE_2;
 }
 impl ArmExtension339Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -21203,8 +21241,8 @@ impl Ext4444FormatsFn {
 }
 #[doc = "Generated from 'VK_EXT_4444_formats'"]
 impl Format {
-    pub const A4R4G4B4_UNORM_PACK16_EXT: Self = Self(1_000_340_000);
-    pub const A4B4G4R4_UNORM_PACK16_EXT: Self = Self(1_000_340_001);
+    pub const A4R4G4B4_UNORM_PACK16_EXT: Self = Self::A4R4G4B4_UNORM_PACK16;
+    pub const A4B4G4R4_UNORM_PACK16_EXT: Self = Self::A4B4G4R4_UNORM_PACK16;
 }
 #[doc = "Generated from 'VK_EXT_4444_formats'"]
 impl StructureType {
@@ -21820,7 +21858,7 @@ impl KhrFormatFeatureFlags2Fn {
 }
 #[doc = "Generated from 'VK_KHR_format_feature_flags2'"]
 impl StructureType {
-    pub const FORMAT_PROPERTIES_3_KHR: Self = Self(1_000_360_000);
+    pub const FORMAT_PROPERTIES_3_KHR: Self = Self::FORMAT_PROPERTIES_3;
 }
 impl ExtExtension362Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -22468,7 +22506,7 @@ impl PipelineBindPoint {
     pub const SUBPASS_SHADING_HUAWEI: Self = Self(1_000_369_003);
 }
 #[doc = "Generated from 'VK_HUAWEI_subpass_shading'"]
-impl PipelineStageFlags2KHR {
+impl PipelineStageFlags2 {
     pub const SUBPASS_SHADING_HUAWEI: Self =
         Self(0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000);
 }
@@ -22540,7 +22578,7 @@ impl HuaweiInvocationMaskFn {
     }
 }
 #[doc = "Generated from 'VK_HUAWEI_invocation_mask'"]
-impl AccessFlags2KHR {
+impl AccessFlags2 {
     pub const INVOCATION_MASK_READ_HUAWEI: Self =
         Self(0b1000_0000_0000_0000_0000_0000_0000_0000_0000_0000);
 }
@@ -22549,7 +22587,7 @@ impl ImageUsageFlags {
     pub const INVOCATION_MASK_HUAWEI: Self = Self(0b100_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_HUAWEI_invocation_mask'"]
-impl PipelineStageFlags2KHR {
+impl PipelineStageFlags2 {
     pub const INVOCATION_MASK_HUAWEI: Self =
         Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000);
 }
@@ -22743,24 +22781,24 @@ impl ExtExtendedDynamicState2Fn {
 pub type PFN_vkCmdSetPatchControlPointsEXT =
     unsafe extern "system" fn(command_buffer: CommandBuffer, patch_control_points: u32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetRasterizerDiscardEnableEXT =
+pub type PFN_vkCmdSetRasterizerDiscardEnable =
     unsafe extern "system" fn(command_buffer: CommandBuffer, rasterizer_discard_enable: Bool32);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetDepthBiasEnableEXT =
+pub type PFN_vkCmdSetDepthBiasEnable =
     unsafe extern "system" fn(command_buffer: CommandBuffer, depth_bias_enable: Bool32);
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdSetLogicOpEXT =
     unsafe extern "system" fn(command_buffer: CommandBuffer, logic_op: LogicOp);
 #[allow(non_camel_case_types)]
-pub type PFN_vkCmdSetPrimitiveRestartEnableEXT =
+pub type PFN_vkCmdSetPrimitiveRestartEnable =
     unsafe extern "system" fn(command_buffer: CommandBuffer, primitive_restart_enable: Bool32);
 #[derive(Clone)]
 pub struct ExtExtendedDynamicState2Fn {
     pub cmd_set_patch_control_points_ext: PFN_vkCmdSetPatchControlPointsEXT,
-    pub cmd_set_rasterizer_discard_enable_ext: PFN_vkCmdSetRasterizerDiscardEnableEXT,
-    pub cmd_set_depth_bias_enable_ext: PFN_vkCmdSetDepthBiasEnableEXT,
+    pub cmd_set_rasterizer_discard_enable_ext: PFN_vkCmdSetRasterizerDiscardEnable,
+    pub cmd_set_depth_bias_enable_ext: PFN_vkCmdSetDepthBiasEnable,
     pub cmd_set_logic_op_ext: PFN_vkCmdSetLogicOpEXT,
-    pub cmd_set_primitive_restart_enable_ext: PFN_vkCmdSetPrimitiveRestartEnableEXT,
+    pub cmd_set_primitive_restart_enable_ext: PFN_vkCmdSetPrimitiveRestartEnable,
 }
 unsafe impl Send for ExtExtendedDynamicState2Fn {}
 unsafe impl Sync for ExtExtendedDynamicState2Fn {}
@@ -22907,14 +22945,17 @@ impl ExtExtendedDynamicState2Fn {
 }
 #[doc = "Generated from 'VK_EXT_extended_dynamic_state2'"]
 impl DynamicState {
+    #[doc = "Not promoted to 1.3"]
     pub const PATCH_CONTROL_POINTS_EXT: Self = Self(1_000_377_000);
-    pub const RASTERIZER_DISCARD_ENABLE_EXT: Self = Self(1_000_377_001);
-    pub const DEPTH_BIAS_ENABLE_EXT: Self = Self(1_000_377_002);
+    pub const RASTERIZER_DISCARD_ENABLE_EXT: Self = Self::RASTERIZER_DISCARD_ENABLE;
+    pub const DEPTH_BIAS_ENABLE_EXT: Self = Self::DEPTH_BIAS_ENABLE;
+    #[doc = "Not promoted to 1.3"]
     pub const LOGIC_OP_EXT: Self = Self(1_000_377_003);
-    pub const PRIMITIVE_RESTART_ENABLE_EXT: Self = Self(1_000_377_004);
+    pub const PRIMITIVE_RESTART_ENABLE_EXT: Self = Self::PRIMITIVE_RESTART_ENABLE;
 }
 #[doc = "Generated from 'VK_EXT_extended_dynamic_state2'"]
 impl StructureType {
+    #[doc = "Not promoted to 1.3"]
     pub const PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT: Self = Self(1_000_377_000);
 }
 impl QnxScreenSurfaceFn {
@@ -23219,12 +23260,12 @@ impl KhrExtension387Fn {
     }
 }
 #[doc = "Generated from 'VK_KHR_extension_387'"]
-impl AccessFlags2KHR {
-    pub const RESERVED_387: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000);
+impl AccessFlags2 {
+    pub const RESERVED_387_KHR: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000);
 }
 #[doc = "Generated from 'VK_KHR_extension_387'"]
-impl PipelineStageFlags2KHR {
-    pub const RESERVED_387: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000);
+impl PipelineStageFlags2 {
+    pub const RESERVED_387_KHR: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000);
 }
 impl ExtExtension388Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -23266,8 +23307,10 @@ impl ExtGlobalPriorityQueryFn {
 }
 #[doc = "Generated from 'VK_EXT_global_priority_query'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_EXT: Self = Self(1_000_388_000);
-    pub const QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_EXT: Self = Self(1_000_388_001);
+    pub const PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_EXT: Self =
+        Self::PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR;
+    pub const QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_EXT: Self =
+        Self::QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR;
 }
 impl ExtExtension390Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -23611,7 +23654,7 @@ impl AttachmentLoadOp {
 }
 #[doc = "Generated from 'VK_EXT_load_store_op_none'"]
 impl AttachmentStoreOp {
-    pub const NONE_EXT: Self = Self::NONE_KHR;
+    pub const NONE_EXT: Self = Self::NONE;
 }
 impl FbExtension402Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -23885,30 +23928,30 @@ impl KhrMaintenance4Fn {
     pub const SPEC_VERSION: u32 = 2u32;
 }
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceBufferMemoryRequirementsKHR = unsafe extern "system" fn(
+pub type PFN_vkGetDeviceBufferMemoryRequirements = unsafe extern "system" fn(
     device: Device,
-    p_info: *const DeviceBufferMemoryRequirementsKHR,
+    p_info: *const DeviceBufferMemoryRequirements,
     p_memory_requirements: *mut MemoryRequirements2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceImageMemoryRequirementsKHR = unsafe extern "system" fn(
+pub type PFN_vkGetDeviceImageMemoryRequirements = unsafe extern "system" fn(
     device: Device,
-    p_info: *const DeviceImageMemoryRequirementsKHR,
+    p_info: *const DeviceImageMemoryRequirements,
     p_memory_requirements: *mut MemoryRequirements2,
 );
 #[allow(non_camel_case_types)]
-pub type PFN_vkGetDeviceImageSparseMemoryRequirementsKHR = unsafe extern "system" fn(
+pub type PFN_vkGetDeviceImageSparseMemoryRequirements = unsafe extern "system" fn(
     device: Device,
-    p_info: *const DeviceImageMemoryRequirementsKHR,
+    p_info: *const DeviceImageMemoryRequirements,
     p_sparse_memory_requirement_count: *mut u32,
     p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
 );
 #[derive(Clone)]
 pub struct KhrMaintenance4Fn {
-    pub get_device_buffer_memory_requirements_khr: PFN_vkGetDeviceBufferMemoryRequirementsKHR,
-    pub get_device_image_memory_requirements_khr: PFN_vkGetDeviceImageMemoryRequirementsKHR,
+    pub get_device_buffer_memory_requirements_khr: PFN_vkGetDeviceBufferMemoryRequirements,
+    pub get_device_image_memory_requirements_khr: PFN_vkGetDeviceImageMemoryRequirements,
     pub get_device_image_sparse_memory_requirements_khr:
-        PFN_vkGetDeviceImageSparseMemoryRequirementsKHR,
+        PFN_vkGetDeviceImageSparseMemoryRequirements,
 }
 unsafe impl Send for KhrMaintenance4Fn {}
 unsafe impl Sync for KhrMaintenance4Fn {}
@@ -23921,7 +23964,7 @@ impl KhrMaintenance4Fn {
             get_device_buffer_memory_requirements_khr: unsafe {
                 unsafe extern "system" fn get_device_buffer_memory_requirements_khr(
                     _device: Device,
-                    _p_info: *const DeviceBufferMemoryRequirementsKHR,
+                    _p_info: *const DeviceBufferMemoryRequirements,
                     _p_memory_requirements: *mut MemoryRequirements2,
                 ) {
                     panic!(concat!(
@@ -23942,7 +23985,7 @@ impl KhrMaintenance4Fn {
             get_device_image_memory_requirements_khr: unsafe {
                 unsafe extern "system" fn get_device_image_memory_requirements_khr(
                     _device: Device,
-                    _p_info: *const DeviceImageMemoryRequirementsKHR,
+                    _p_info: *const DeviceImageMemoryRequirements,
                     _p_memory_requirements: *mut MemoryRequirements2,
                 ) {
                     panic!(concat!(
@@ -23963,7 +24006,7 @@ impl KhrMaintenance4Fn {
             get_device_image_sparse_memory_requirements_khr: unsafe {
                 unsafe extern "system" fn get_device_image_sparse_memory_requirements_khr(
                     _device: Device,
-                    _p_info: *const DeviceImageMemoryRequirementsKHR,
+                    _p_info: *const DeviceImageMemoryRequirements,
                     _p_sparse_memory_requirement_count: *mut u32,
                     _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
                 ) {
@@ -23988,7 +24031,7 @@ impl KhrMaintenance4Fn {
     pub unsafe fn get_device_buffer_memory_requirements_khr(
         &self,
         device: Device,
-        p_info: *const DeviceBufferMemoryRequirementsKHR,
+        p_info: *const DeviceBufferMemoryRequirements,
         p_memory_requirements: *mut MemoryRequirements2,
     ) {
         (self.get_device_buffer_memory_requirements_khr)(device, p_info, p_memory_requirements)
@@ -23997,7 +24040,7 @@ impl KhrMaintenance4Fn {
     pub unsafe fn get_device_image_memory_requirements_khr(
         &self,
         device: Device,
-        p_info: *const DeviceImageMemoryRequirementsKHR,
+        p_info: *const DeviceImageMemoryRequirements,
         p_memory_requirements: *mut MemoryRequirements2,
     ) {
         (self.get_device_image_memory_requirements_khr)(device, p_info, p_memory_requirements)
@@ -24006,7 +24049,7 @@ impl KhrMaintenance4Fn {
     pub unsafe fn get_device_image_sparse_memory_requirements_khr(
         &self,
         device: Device,
-        p_info: *const DeviceImageMemoryRequirementsKHR,
+        p_info: *const DeviceImageMemoryRequirements,
         p_sparse_memory_requirement_count: *mut u32,
         p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
     ) {
@@ -24020,14 +24063,16 @@ impl KhrMaintenance4Fn {
 }
 #[doc = "Generated from 'VK_KHR_maintenance4'"]
 impl ImageAspectFlags {
-    pub const NONE_KHR: Self = Self(0);
+    pub const NONE_KHR: Self = Self::NONE;
 }
 #[doc = "Generated from 'VK_KHR_maintenance4'"]
 impl StructureType {
-    pub const PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES_KHR: Self = Self(1_000_413_000);
-    pub const PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES_KHR: Self = Self(1_000_413_001);
-    pub const DEVICE_BUFFER_MEMORY_REQUIREMENTS_KHR: Self = Self(1_000_413_002);
-    pub const DEVICE_IMAGE_MEMORY_REQUIREMENTS_KHR: Self = Self(1_000_413_003);
+    pub const PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES_KHR: Self =
+        Self::PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES;
+    pub const PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES_KHR: Self =
+        Self::PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES;
+    pub const DEVICE_BUFFER_MEMORY_REQUIREMENTS_KHR: Self = Self::DEVICE_BUFFER_MEMORY_REQUIREMENTS;
+    pub const DEVICE_IMAGE_MEMORY_REQUIREMENTS_KHR: Self = Self::DEVICE_IMAGE_MEMORY_REQUIREMENTS;
 }
 impl HuaweiExtension415Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -24359,7 +24404,7 @@ impl NvLinearColorAttachmentFn {
     }
 }
 #[doc = "Generated from 'VK_NV_linear_color_attachment'"]
-impl FormatFeatureFlags2KHR {
+impl FormatFeatureFlags2 {
     #[doc = "Format support linear image as render target, it cannot be mixed with non linear attachment"]
     pub const LINEAR_COLOR_ATTACHMENT_NV: Self =
         Self(0b100_0000_0000_0000_0000_0000_0000_0000_0000_0000);
@@ -24557,7 +24602,7 @@ impl QcomExtension441Fn {
     }
 }
 #[doc = "Generated from 'VK_QCOM_extension_441'"]
-impl FormatFeatureFlags2KHR {
+impl FormatFeatureFlags2 {
     pub const RESERVED_34_QCOM: Self = Self(0b100_0000_0000_0000_0000_0000_0000_0000_0000);
     pub const RESERVED_35_QCOM: Self = Self(0b1000_0000_0000_0000_0000_0000_0000_0000_0000);
     pub const RESERVED_36_QCOM: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000_0000);
@@ -24749,6 +24794,24 @@ pub struct SecExtension451Fn {}
 unsafe impl Send for SecExtension451Fn {}
 unsafe impl Sync for SecExtension451Fn {}
 impl SecExtension451Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {}
+    }
+}
+impl NvExtension452Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_452\0") }
+    }
+    pub const SPEC_VERSION: u32 = 0u32;
+}
+#[derive(Clone)]
+pub struct NvExtension452Fn {}
+unsafe impl Send for NvExtension452Fn {}
+unsafe impl Sync for NvExtension452Fn {}
+impl NvExtension452Fn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -3901,7 +3901,7 @@ impl ExtVideoEncodeH264Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_encode_h264\0") }
     }
-    pub const SPEC_VERSION: u32 = 3u32;
+    pub const SPEC_VERSION: u32 = 5u32;
 }
 #[derive(Clone)]
 pub struct ExtVideoEncodeH264Fn {}
@@ -3928,6 +3928,7 @@ impl StructureType {
     pub const VIDEO_ENCODE_H264_PROFILE_EXT: Self = Self(1_000_038_008);
     pub const VIDEO_ENCODE_H264_RATE_CONTROL_INFO_EXT: Self = Self(1_000_038_009);
     pub const VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_EXT: Self = Self(1_000_038_010);
+    pub const VIDEO_ENCODE_H264_REFERENCE_LISTS_EXT: Self = Self(1_000_038_011);
 }
 #[doc = "Generated from 'VK_EXT_video_encode_h264'"]
 impl VideoCodecOperationFlagsKHR {
@@ -3937,7 +3938,7 @@ impl ExtVideoEncodeH265Fn {
     pub fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_encode_h265\0") }
     }
-    pub const SPEC_VERSION: u32 = 4u32;
+    pub const SPEC_VERSION: u32 = 5u32;
 }
 #[derive(Clone)]
 pub struct ExtVideoEncodeH265Fn {}
@@ -19642,7 +19643,7 @@ impl KhrVideoEncodeQueueFn {
     pub fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_video_encode_queue\0") }
     }
-    pub const SPEC_VERSION: u32 = 3u32;
+    pub const SPEC_VERSION: u32 = 4u32;
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdEncodeVideoKHR = unsafe extern "system" fn(
@@ -19738,6 +19739,7 @@ impl StructureType {
     pub const VIDEO_ENCODE_INFO_KHR: Self = Self(1_000_299_000);
     pub const VIDEO_ENCODE_RATE_CONTROL_INFO_KHR: Self = Self(1_000_299_001);
     pub const VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR: Self = Self(1_000_299_002);
+    pub const VIDEO_ENCODE_CAPABILITIES_KHR: Self = Self(1_000_299_003);
 }
 impl NvDeviceDiagnosticsConfigFn {
     pub fn name() -> &'static ::std::ffi::CStr {
@@ -24812,6 +24814,60 @@ pub struct NvExtension452Fn {}
 unsafe impl Send for NvExtension452Fn {}
 unsafe impl Sync for NvExtension452Fn {}
 impl NvExtension452Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {}
+    }
+}
+impl ArmExtension453Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_ARM_extension_453\0") }
+    }
+    pub const SPEC_VERSION: u32 = 0u32;
+}
+#[derive(Clone)]
+pub struct ArmExtension453Fn {}
+unsafe impl Send for ArmExtension453Fn {}
+unsafe impl Sync for ArmExtension453Fn {}
+impl ArmExtension453Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {}
+    }
+}
+impl GoogleExtension454Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_454\0") }
+    }
+    pub const SPEC_VERSION: u32 = 0u32;
+}
+#[derive(Clone)]
+pub struct GoogleExtension454Fn {}
+unsafe impl Send for GoogleExtension454Fn {}
+unsafe impl Sync for GoogleExtension454Fn {}
+impl GoogleExtension454Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {}
+    }
+}
+impl GoogleExtension455Fn {
+    pub fn name() -> &'static ::std::ffi::CStr {
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_455\0") }
+    }
+    pub const SPEC_VERSION: u32 = 0u32;
+}
+#[derive(Clone)]
+pub struct GoogleExtension455Fn {}
+unsafe impl Send for GoogleExtension455Fn {}
+unsafe impl Sync for GoogleExtension455Fn {}
+impl GoogleExtension455Fn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,

--- a/ash/src/vk/feature_extensions.rs
+++ b/ash/src/vk/feature_extensions.rs
@@ -301,3 +301,151 @@ impl StructureType {
     pub const MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO: Self = Self(1_000_257_003);
     pub const DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO: Self = Self(1_000_257_004);
 }
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl AccessFlags {
+    pub const NONE: Self = Self(0);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl AttachmentStoreOp {
+    pub const NONE: Self = Self(1_000_301_000);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl DescriptorType {
+    pub const INLINE_UNIFORM_BLOCK: Self = Self(1_000_138_000);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl DynamicState {
+    pub const CULL_MODE: Self = Self(1_000_267_000);
+    pub const FRONT_FACE: Self = Self(1_000_267_001);
+    pub const PRIMITIVE_TOPOLOGY: Self = Self(1_000_267_002);
+    pub const VIEWPORT_WITH_COUNT: Self = Self(1_000_267_003);
+    pub const SCISSOR_WITH_COUNT: Self = Self(1_000_267_004);
+    pub const VERTEX_INPUT_BINDING_STRIDE: Self = Self(1_000_267_005);
+    pub const DEPTH_TEST_ENABLE: Self = Self(1_000_267_006);
+    pub const DEPTH_WRITE_ENABLE: Self = Self(1_000_267_007);
+    pub const DEPTH_COMPARE_OP: Self = Self(1_000_267_008);
+    pub const DEPTH_BOUNDS_TEST_ENABLE: Self = Self(1_000_267_009);
+    pub const STENCIL_TEST_ENABLE: Self = Self(1_000_267_010);
+    pub const STENCIL_OP: Self = Self(1_000_267_011);
+    pub const RASTERIZER_DISCARD_ENABLE: Self = Self(1_000_377_001);
+    pub const DEPTH_BIAS_ENABLE: Self = Self(1_000_377_002);
+    pub const PRIMITIVE_RESTART_ENABLE: Self = Self(1_000_377_004);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl EventCreateFlags {
+    pub const DEVICE_ONLY: Self = Self(0b1);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl Format {
+    pub const G8_B8R8_2PLANE_444_UNORM: Self = Self(1_000_330_000);
+    pub const G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16: Self = Self(1_000_330_001);
+    pub const G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16: Self = Self(1_000_330_002);
+    pub const G16_B16R16_2PLANE_444_UNORM: Self = Self(1_000_330_003);
+    pub const A4R4G4B4_UNORM_PACK16: Self = Self(1_000_340_000);
+    pub const A4B4G4R4_UNORM_PACK16: Self = Self(1_000_340_001);
+    pub const ASTC_4X4_SFLOAT_BLOCK: Self = Self(1_000_066_000);
+    pub const ASTC_5X4_SFLOAT_BLOCK: Self = Self(1_000_066_001);
+    pub const ASTC_5X5_SFLOAT_BLOCK: Self = Self(1_000_066_002);
+    pub const ASTC_6X5_SFLOAT_BLOCK: Self = Self(1_000_066_003);
+    pub const ASTC_6X6_SFLOAT_BLOCK: Self = Self(1_000_066_004);
+    pub const ASTC_8X5_SFLOAT_BLOCK: Self = Self(1_000_066_005);
+    pub const ASTC_8X6_SFLOAT_BLOCK: Self = Self(1_000_066_006);
+    pub const ASTC_8X8_SFLOAT_BLOCK: Self = Self(1_000_066_007);
+    pub const ASTC_10X5_SFLOAT_BLOCK: Self = Self(1_000_066_008);
+    pub const ASTC_10X6_SFLOAT_BLOCK: Self = Self(1_000_066_009);
+    pub const ASTC_10X8_SFLOAT_BLOCK: Self = Self(1_000_066_010);
+    pub const ASTC_10X10_SFLOAT_BLOCK: Self = Self(1_000_066_011);
+    pub const ASTC_12X10_SFLOAT_BLOCK: Self = Self(1_000_066_012);
+    pub const ASTC_12X12_SFLOAT_BLOCK: Self = Self(1_000_066_013);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl ImageAspectFlags {
+    pub const NONE: Self = Self(0);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl ImageLayout {
+    pub const READ_ONLY_OPTIMAL: Self = Self(1_000_314_000);
+    pub const ATTACHMENT_OPTIMAL: Self = Self(1_000_314_001);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl ObjectType {
+    pub const PRIVATE_DATA_SLOT: Self = Self(1_000_295_000);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl PipelineCacheCreateFlags {
+    pub const EXTERNALLY_SYNCHRONIZED: Self = Self(0b1);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl PipelineCreateFlags {
+    pub const FAIL_ON_PIPELINE_COMPILE_REQUIRED: Self = Self(0b1_0000_0000);
+    pub const EARLY_RETURN_ON_FAILURE: Self = Self(0b10_0000_0000);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl PipelineShaderStageCreateFlags {
+    pub const ALLOW_VARYING_SUBGROUP_SIZE: Self = Self(0b1);
+    pub const REQUIRE_FULL_SUBGROUPS: Self = Self(0b10);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl PipelineStageFlags {
+    pub const NONE: Self = Self(0);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl Result {
+    pub const PIPELINE_COMPILE_REQUIRED: Self = Self(1_000_297_000);
+}
+#[doc = "Generated from 'VK_VERSION_1_3'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_VULKAN_1_3_FEATURES: Self = Self(53);
+    pub const PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES: Self = Self(54);
+    pub const PIPELINE_CREATION_FEEDBACK_CREATE_INFO: Self = Self(1_000_192_000);
+    pub const PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES: Self = Self(1_000_215_000);
+    pub const PHYSICAL_DEVICE_TOOL_PROPERTIES: Self = Self(1_000_245_000);
+    pub const PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES: Self =
+        Self(1_000_276_000);
+    pub const PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES: Self = Self(1_000_295_000);
+    pub const DEVICE_PRIVATE_DATA_CREATE_INFO: Self = Self(1_000_295_001);
+    pub const PRIVATE_DATA_SLOT_CREATE_INFO: Self = Self(1_000_295_002);
+    pub const PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES: Self = Self(1_000_297_000);
+    pub const MEMORY_BARRIER_2: Self = Self(1_000_314_000);
+    pub const BUFFER_MEMORY_BARRIER_2: Self = Self(1_000_314_001);
+    pub const IMAGE_MEMORY_BARRIER_2: Self = Self(1_000_314_002);
+    pub const DEPENDENCY_INFO: Self = Self(1_000_314_003);
+    pub const SUBMIT_INFO_2: Self = Self(1_000_314_004);
+    pub const SEMAPHORE_SUBMIT_INFO: Self = Self(1_000_314_005);
+    pub const COMMAND_BUFFER_SUBMIT_INFO: Self = Self(1_000_314_006);
+    pub const PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES: Self = Self(1_000_314_007);
+    pub const PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES: Self = Self(1_000_325_000);
+    pub const PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES: Self = Self(1_000_335_000);
+    pub const COPY_BUFFER_INFO_2: Self = Self(1_000_337_000);
+    pub const COPY_IMAGE_INFO_2: Self = Self(1_000_337_001);
+    pub const COPY_BUFFER_TO_IMAGE_INFO_2: Self = Self(1_000_337_002);
+    pub const COPY_IMAGE_TO_BUFFER_INFO_2: Self = Self(1_000_337_003);
+    pub const BLIT_IMAGE_INFO_2: Self = Self(1_000_337_004);
+    pub const RESOLVE_IMAGE_INFO_2: Self = Self(1_000_337_005);
+    pub const BUFFER_COPY_2: Self = Self(1_000_337_006);
+    pub const IMAGE_COPY_2: Self = Self(1_000_337_007);
+    pub const IMAGE_BLIT_2: Self = Self(1_000_337_008);
+    pub const BUFFER_IMAGE_COPY_2: Self = Self(1_000_337_009);
+    pub const IMAGE_RESOLVE_2: Self = Self(1_000_337_010);
+    pub const PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES: Self = Self(1_000_225_000);
+    pub const PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO: Self = Self(1_000_225_001);
+    pub const PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES: Self = Self(1_000_225_002);
+    pub const PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES: Self = Self(1_000_138_000);
+    pub const PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES: Self = Self(1_000_138_001);
+    pub const WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK: Self = Self(1_000_138_002);
+    pub const DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO: Self = Self(1_000_138_003);
+    pub const PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES: Self = Self(1_000_066_000);
+    pub const RENDERING_INFO: Self = Self(1_000_044_000);
+    pub const RENDERING_ATTACHMENT_INFO: Self = Self(1_000_044_001);
+    pub const PIPELINE_RENDERING_CREATE_INFO: Self = Self(1_000_044_002);
+    pub const PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES: Self = Self(1_000_044_003);
+    pub const COMMAND_BUFFER_INHERITANCE_RENDERING_INFO: Self = Self(1_000_044_004);
+    pub const PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES: Self = Self(1_000_280_000);
+    pub const PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES: Self = Self(1_000_280_001);
+    pub const PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES: Self = Self(1_000_281_001);
+    pub const FORMAT_PROPERTIES_3: Self = Self(1_000_360_000);
+    pub const PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES: Self = Self(1_000_413_000);
+    pub const PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES: Self = Self(1_000_413_001);
+    pub const DEVICE_BUFFER_MEMORY_REQUIREMENTS: Self = Self(1_000_413_002);
+    pub const DEVICE_IMAGE_MEMORY_REQUIREMENTS: Self = Self(1_000_413_003);
+}

--- a/ash/src/vk/features.rs
+++ b/ash/src/vk/features.rs
@@ -6550,3 +6550,1107 @@ impl DeviceFnV1_2 {
         (self.get_device_memory_opaque_capture_address)(device, p_info)
     }
 }
+#[derive(Clone)]
+pub struct EntryFnV1_3 {}
+unsafe impl Send for EntryFnV1_3 {}
+unsafe impl Sync for EntryFnV1_3 {}
+impl EntryFnV1_3 {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {}
+    }
+}
+#[derive(Clone)]
+pub struct InstanceFnV1_3 {
+    pub get_physical_device_tool_properties: crate::vk::PFN_vkGetPhysicalDeviceToolProperties,
+}
+unsafe impl Send for InstanceFnV1_3 {}
+unsafe impl Sync for InstanceFnV1_3 {}
+impl InstanceFnV1_3 {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {
+            get_physical_device_tool_properties: unsafe {
+                unsafe extern "system" fn get_physical_device_tool_properties(
+                    _physical_device: PhysicalDevice,
+                    _p_tool_count: *mut u32,
+                    _p_tool_properties: *mut PhysicalDeviceToolProperties,
+                ) -> Result {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_physical_device_tool_properties)
+                    ))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkGetPhysicalDeviceToolProperties\0",
+                );
+                let val = _f(cname);
+                if val.is_null() {
+                    get_physical_device_tool_properties
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+        }
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceToolProperties.html>"]
+    pub unsafe fn get_physical_device_tool_properties(
+        &self,
+        physical_device: PhysicalDevice,
+        p_tool_count: *mut u32,
+        p_tool_properties: *mut PhysicalDeviceToolProperties,
+    ) -> Result {
+        (self.get_physical_device_tool_properties)(physical_device, p_tool_count, p_tool_properties)
+    }
+}
+#[derive(Clone)]
+pub struct DeviceFnV1_3 {
+    pub create_private_data_slot: crate::vk::PFN_vkCreatePrivateDataSlot,
+    pub destroy_private_data_slot: crate::vk::PFN_vkDestroyPrivateDataSlot,
+    pub set_private_data: crate::vk::PFN_vkSetPrivateData,
+    pub get_private_data: crate::vk::PFN_vkGetPrivateData,
+    pub cmd_set_event2: crate::vk::PFN_vkCmdSetEvent2,
+    pub cmd_reset_event2: crate::vk::PFN_vkCmdResetEvent2,
+    pub cmd_wait_events2: crate::vk::PFN_vkCmdWaitEvents2,
+    pub cmd_pipeline_barrier2: crate::vk::PFN_vkCmdPipelineBarrier2,
+    pub cmd_write_timestamp2: crate::vk::PFN_vkCmdWriteTimestamp2,
+    pub queue_submit2: crate::vk::PFN_vkQueueSubmit2,
+    pub cmd_copy_buffer2: crate::vk::PFN_vkCmdCopyBuffer2,
+    pub cmd_copy_image2: crate::vk::PFN_vkCmdCopyImage2,
+    pub cmd_copy_buffer_to_image2: crate::vk::PFN_vkCmdCopyBufferToImage2,
+    pub cmd_copy_image_to_buffer2: crate::vk::PFN_vkCmdCopyImageToBuffer2,
+    pub cmd_blit_image2: crate::vk::PFN_vkCmdBlitImage2,
+    pub cmd_resolve_image2: crate::vk::PFN_vkCmdResolveImage2,
+    pub cmd_begin_rendering: crate::vk::PFN_vkCmdBeginRendering,
+    pub cmd_end_rendering: crate::vk::PFN_vkCmdEndRendering,
+    pub cmd_set_cull_mode: crate::vk::PFN_vkCmdSetCullMode,
+    pub cmd_set_front_face: crate::vk::PFN_vkCmdSetFrontFace,
+    pub cmd_set_primitive_topology: crate::vk::PFN_vkCmdSetPrimitiveTopology,
+    pub cmd_set_viewport_with_count: crate::vk::PFN_vkCmdSetViewportWithCount,
+    pub cmd_set_scissor_with_count: crate::vk::PFN_vkCmdSetScissorWithCount,
+    pub cmd_bind_vertex_buffers2: crate::vk::PFN_vkCmdBindVertexBuffers2,
+    pub cmd_set_depth_test_enable: crate::vk::PFN_vkCmdSetDepthTestEnable,
+    pub cmd_set_depth_write_enable: crate::vk::PFN_vkCmdSetDepthWriteEnable,
+    pub cmd_set_depth_compare_op: crate::vk::PFN_vkCmdSetDepthCompareOp,
+    pub cmd_set_depth_bounds_test_enable: crate::vk::PFN_vkCmdSetDepthBoundsTestEnable,
+    pub cmd_set_stencil_test_enable: crate::vk::PFN_vkCmdSetStencilTestEnable,
+    pub cmd_set_stencil_op: crate::vk::PFN_vkCmdSetStencilOp,
+    pub cmd_set_rasterizer_discard_enable: crate::vk::PFN_vkCmdSetRasterizerDiscardEnable,
+    pub cmd_set_depth_bias_enable: crate::vk::PFN_vkCmdSetDepthBiasEnable,
+    pub cmd_set_primitive_restart_enable: crate::vk::PFN_vkCmdSetPrimitiveRestartEnable,
+    pub get_device_buffer_memory_requirements: crate::vk::PFN_vkGetDeviceBufferMemoryRequirements,
+    pub get_device_image_memory_requirements: crate::vk::PFN_vkGetDeviceImageMemoryRequirements,
+    pub get_device_image_sparse_memory_requirements:
+        crate::vk::PFN_vkGetDeviceImageSparseMemoryRequirements,
+}
+unsafe impl Send for DeviceFnV1_3 {}
+unsafe impl Sync for DeviceFnV1_3 {}
+impl DeviceFnV1_3 {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {
+            create_private_data_slot: unsafe {
+                unsafe extern "system" fn create_private_data_slot(
+                    _device: Device,
+                    _p_create_info: *const PrivateDataSlotCreateInfo,
+                    _p_allocator: *const AllocationCallbacks,
+                    _p_private_data_slot: *mut PrivateDataSlot,
+                ) -> Result {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(create_private_data_slot)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCreatePrivateDataSlot\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    create_private_data_slot
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            destroy_private_data_slot: unsafe {
+                unsafe extern "system" fn destroy_private_data_slot(
+                    _device: Device,
+                    _private_data_slot: PrivateDataSlot,
+                    _p_allocator: *const AllocationCallbacks,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(destroy_private_data_slot)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkDestroyPrivateDataSlot\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    destroy_private_data_slot
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            set_private_data: unsafe {
+                unsafe extern "system" fn set_private_data(
+                    _device: Device,
+                    _object_type: ObjectType,
+                    _object_handle: u64,
+                    _private_data_slot: PrivateDataSlot,
+                    _data: u64,
+                ) -> Result {
+                    panic!(concat!("Unable to load ", stringify!(set_private_data)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkSetPrivateData\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    set_private_data
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_private_data: unsafe {
+                unsafe extern "system" fn get_private_data(
+                    _device: Device,
+                    _object_type: ObjectType,
+                    _object_handle: u64,
+                    _private_data_slot: PrivateDataSlot,
+                    _p_data: *mut u64,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(get_private_data)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkGetPrivateData\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    get_private_data
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_event2: unsafe {
+                unsafe extern "system" fn cmd_set_event2(
+                    _command_buffer: CommandBuffer,
+                    _event: Event,
+                    _p_dependency_info: *const DependencyInfo,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_set_event2)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetEvent2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_event2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_reset_event2: unsafe {
+                unsafe extern "system" fn cmd_reset_event2(
+                    _command_buffer: CommandBuffer,
+                    _event: Event,
+                    _stage_mask: PipelineStageFlags2,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_reset_event2)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdResetEvent2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_reset_event2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_wait_events2: unsafe {
+                unsafe extern "system" fn cmd_wait_events2(
+                    _command_buffer: CommandBuffer,
+                    _event_count: u32,
+                    _p_events: *const Event,
+                    _p_dependency_infos: *const DependencyInfo,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_wait_events2)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdWaitEvents2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_wait_events2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_pipeline_barrier2: unsafe {
+                unsafe extern "system" fn cmd_pipeline_barrier2(
+                    _command_buffer: CommandBuffer,
+                    _p_dependency_info: *const DependencyInfo,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_pipeline_barrier2)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdPipelineBarrier2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_pipeline_barrier2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_write_timestamp2: unsafe {
+                unsafe extern "system" fn cmd_write_timestamp2(
+                    _command_buffer: CommandBuffer,
+                    _stage: PipelineStageFlags2,
+                    _query_pool: QueryPool,
+                    _query: u32,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_write_timestamp2)))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdWriteTimestamp2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_write_timestamp2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            queue_submit2: unsafe {
+                unsafe extern "system" fn queue_submit2(
+                    _queue: Queue,
+                    _submit_count: u32,
+                    _p_submits: *const SubmitInfo2,
+                    _fence: Fence,
+                ) -> Result {
+                    panic!(concat!("Unable to load ", stringify!(queue_submit2)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkQueueSubmit2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    queue_submit2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_copy_buffer2: unsafe {
+                unsafe extern "system" fn cmd_copy_buffer2(
+                    _command_buffer: CommandBuffer,
+                    _p_copy_buffer_info: *const CopyBufferInfo2,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_copy_buffer2)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdCopyBuffer2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_copy_buffer2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_copy_image2: unsafe {
+                unsafe extern "system" fn cmd_copy_image2(
+                    _command_buffer: CommandBuffer,
+                    _p_copy_image_info: *const CopyImageInfo2,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_copy_image2)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdCopyImage2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_copy_image2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_copy_buffer_to_image2: unsafe {
+                unsafe extern "system" fn cmd_copy_buffer_to_image2(
+                    _command_buffer: CommandBuffer,
+                    _p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_copy_buffer_to_image2)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdCopyBufferToImage2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_copy_buffer_to_image2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_copy_image_to_buffer2: unsafe {
+                unsafe extern "system" fn cmd_copy_image_to_buffer2(
+                    _command_buffer: CommandBuffer,
+                    _p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_copy_image_to_buffer2)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdCopyImageToBuffer2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_copy_image_to_buffer2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_blit_image2: unsafe {
+                unsafe extern "system" fn cmd_blit_image2(
+                    _command_buffer: CommandBuffer,
+                    _p_blit_image_info: *const BlitImageInfo2,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_blit_image2)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdBlitImage2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_blit_image2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_resolve_image2: unsafe {
+                unsafe extern "system" fn cmd_resolve_image2(
+                    _command_buffer: CommandBuffer,
+                    _p_resolve_image_info: *const ResolveImageInfo2,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_resolve_image2)))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdResolveImage2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_resolve_image2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_begin_rendering: unsafe {
+                unsafe extern "system" fn cmd_begin_rendering(
+                    _command_buffer: CommandBuffer,
+                    _p_rendering_info: *const RenderingInfo,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_begin_rendering)))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdBeginRendering\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_begin_rendering
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_end_rendering: unsafe {
+                unsafe extern "system" fn cmd_end_rendering(_command_buffer: CommandBuffer) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_end_rendering)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdEndRendering\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_end_rendering
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_cull_mode: unsafe {
+                unsafe extern "system" fn cmd_set_cull_mode(
+                    _command_buffer: CommandBuffer,
+                    _cull_mode: CullModeFlags,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_set_cull_mode)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetCullMode\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_cull_mode
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_front_face: unsafe {
+                unsafe extern "system" fn cmd_set_front_face(
+                    _command_buffer: CommandBuffer,
+                    _front_face: FrontFace,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_set_front_face)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetFrontFace\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_front_face
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_primitive_topology: unsafe {
+                unsafe extern "system" fn cmd_set_primitive_topology(
+                    _command_buffer: CommandBuffer,
+                    _primitive_topology: PrimitiveTopology,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_primitive_topology)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetPrimitiveTopology\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_primitive_topology
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_viewport_with_count: unsafe {
+                unsafe extern "system" fn cmd_set_viewport_with_count(
+                    _command_buffer: CommandBuffer,
+                    _viewport_count: u32,
+                    _p_viewports: *const Viewport,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_viewport_with_count)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetViewportWithCount\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_viewport_with_count
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_scissor_with_count: unsafe {
+                unsafe extern "system" fn cmd_set_scissor_with_count(
+                    _command_buffer: CommandBuffer,
+                    _scissor_count: u32,
+                    _p_scissors: *const Rect2D,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_scissor_with_count)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetScissorWithCount\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_scissor_with_count
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_bind_vertex_buffers2: unsafe {
+                unsafe extern "system" fn cmd_bind_vertex_buffers2(
+                    _command_buffer: CommandBuffer,
+                    _first_binding: u32,
+                    _binding_count: u32,
+                    _p_buffers: *const Buffer,
+                    _p_offsets: *const DeviceSize,
+                    _p_sizes: *const DeviceSize,
+                    _p_strides: *const DeviceSize,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_bind_vertex_buffers2)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdBindVertexBuffers2\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_bind_vertex_buffers2
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_depth_test_enable: unsafe {
+                unsafe extern "system" fn cmd_set_depth_test_enable(
+                    _command_buffer: CommandBuffer,
+                    _depth_test_enable: Bool32,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_depth_test_enable)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetDepthTestEnable\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_depth_test_enable
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_depth_write_enable: unsafe {
+                unsafe extern "system" fn cmd_set_depth_write_enable(
+                    _command_buffer: CommandBuffer,
+                    _depth_write_enable: Bool32,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_depth_write_enable)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetDepthWriteEnable\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_depth_write_enable
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_depth_compare_op: unsafe {
+                unsafe extern "system" fn cmd_set_depth_compare_op(
+                    _command_buffer: CommandBuffer,
+                    _depth_compare_op: CompareOp,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_depth_compare_op)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetDepthCompareOp\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_depth_compare_op
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_depth_bounds_test_enable: unsafe {
+                unsafe extern "system" fn cmd_set_depth_bounds_test_enable(
+                    _command_buffer: CommandBuffer,
+                    _depth_bounds_test_enable: Bool32,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_depth_bounds_test_enable)
+                    ))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkCmdSetDepthBoundsTestEnable\0",
+                );
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_depth_bounds_test_enable
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_stencil_test_enable: unsafe {
+                unsafe extern "system" fn cmd_set_stencil_test_enable(
+                    _command_buffer: CommandBuffer,
+                    _stencil_test_enable: Bool32,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_stencil_test_enable)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetStencilTestEnable\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_stencil_test_enable
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_stencil_op: unsafe {
+                unsafe extern "system" fn cmd_set_stencil_op(
+                    _command_buffer: CommandBuffer,
+                    _face_mask: StencilFaceFlags,
+                    _fail_op: StencilOp,
+                    _pass_op: StencilOp,
+                    _depth_fail_op: StencilOp,
+                    _compare_op: CompareOp,
+                ) {
+                    panic!(concat!("Unable to load ", stringify!(cmd_set_stencil_op)))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetStencilOp\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_stencil_op
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_rasterizer_discard_enable: unsafe {
+                unsafe extern "system" fn cmd_set_rasterizer_discard_enable(
+                    _command_buffer: CommandBuffer,
+                    _rasterizer_discard_enable: Bool32,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_rasterizer_discard_enable)
+                    ))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkCmdSetRasterizerDiscardEnable\0",
+                );
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_rasterizer_discard_enable
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_depth_bias_enable: unsafe {
+                unsafe extern "system" fn cmd_set_depth_bias_enable(
+                    _command_buffer: CommandBuffer,
+                    _depth_bias_enable: Bool32,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_depth_bias_enable)
+                    ))
+                }
+                let cname =
+                    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"vkCmdSetDepthBiasEnable\0");
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_depth_bias_enable
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            cmd_set_primitive_restart_enable: unsafe {
+                unsafe extern "system" fn cmd_set_primitive_restart_enable(
+                    _command_buffer: CommandBuffer,
+                    _primitive_restart_enable: Bool32,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(cmd_set_primitive_restart_enable)
+                    ))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkCmdSetPrimitiveRestartEnable\0",
+                );
+                let val = _f(cname);
+                if val.is_null() {
+                    cmd_set_primitive_restart_enable
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_device_buffer_memory_requirements: unsafe {
+                unsafe extern "system" fn get_device_buffer_memory_requirements(
+                    _device: Device,
+                    _p_info: *const DeviceBufferMemoryRequirements,
+                    _p_memory_requirements: *mut MemoryRequirements2,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_device_buffer_memory_requirements)
+                    ))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkGetDeviceBufferMemoryRequirements\0",
+                );
+                let val = _f(cname);
+                if val.is_null() {
+                    get_device_buffer_memory_requirements
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_device_image_memory_requirements: unsafe {
+                unsafe extern "system" fn get_device_image_memory_requirements(
+                    _device: Device,
+                    _p_info: *const DeviceImageMemoryRequirements,
+                    _p_memory_requirements: *mut MemoryRequirements2,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_device_image_memory_requirements)
+                    ))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkGetDeviceImageMemoryRequirements\0",
+                );
+                let val = _f(cname);
+                if val.is_null() {
+                    get_device_image_memory_requirements
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+            get_device_image_sparse_memory_requirements: unsafe {
+                unsafe extern "system" fn get_device_image_sparse_memory_requirements(
+                    _device: Device,
+                    _p_info: *const DeviceImageMemoryRequirements,
+                    _p_sparse_memory_requirement_count: *mut u32,
+                    _p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
+                ) {
+                    panic!(concat!(
+                        "Unable to load ",
+                        stringify!(get_device_image_sparse_memory_requirements)
+                    ))
+                }
+                let cname = ::std::ffi::CStr::from_bytes_with_nul_unchecked(
+                    b"vkGetDeviceImageSparseMemoryRequirements\0",
+                );
+                let val = _f(cname);
+                if val.is_null() {
+                    get_device_image_sparse_memory_requirements
+                } else {
+                    ::std::mem::transmute(val)
+                }
+            },
+        }
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCreatePrivateDataSlot.html>"]
+    pub unsafe fn create_private_data_slot(
+        &self,
+        device: Device,
+        p_create_info: *const PrivateDataSlotCreateInfo,
+        p_allocator: *const AllocationCallbacks,
+        p_private_data_slot: *mut PrivateDataSlot,
+    ) -> Result {
+        (self.create_private_data_slot)(device, p_create_info, p_allocator, p_private_data_slot)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkDestroyPrivateDataSlot.html>"]
+    pub unsafe fn destroy_private_data_slot(
+        &self,
+        device: Device,
+        private_data_slot: PrivateDataSlot,
+        p_allocator: *const AllocationCallbacks,
+    ) {
+        (self.destroy_private_data_slot)(device, private_data_slot, p_allocator)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkSetPrivateData.html>"]
+    pub unsafe fn set_private_data(
+        &self,
+        device: Device,
+        object_type: ObjectType,
+        object_handle: u64,
+        private_data_slot: PrivateDataSlot,
+        data: u64,
+    ) -> Result {
+        (self.set_private_data)(device, object_type, object_handle, private_data_slot, data)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetPrivateData.html>"]
+    pub unsafe fn get_private_data(
+        &self,
+        device: Device,
+        object_type: ObjectType,
+        object_handle: u64,
+        private_data_slot: PrivateDataSlot,
+        p_data: *mut u64,
+    ) {
+        (self.get_private_data)(
+            device,
+            object_type,
+            object_handle,
+            private_data_slot,
+            p_data,
+        )
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetEvent2.html>"]
+    pub unsafe fn cmd_set_event2(
+        &self,
+        command_buffer: CommandBuffer,
+        event: Event,
+        p_dependency_info: *const DependencyInfo,
+    ) {
+        (self.cmd_set_event2)(command_buffer, event, p_dependency_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdResetEvent2.html>"]
+    pub unsafe fn cmd_reset_event2(
+        &self,
+        command_buffer: CommandBuffer,
+        event: Event,
+        stage_mask: PipelineStageFlags2,
+    ) {
+        (self.cmd_reset_event2)(command_buffer, event, stage_mask)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdWaitEvents2.html>"]
+    pub unsafe fn cmd_wait_events2(
+        &self,
+        command_buffer: CommandBuffer,
+        event_count: u32,
+        p_events: *const Event,
+        p_dependency_infos: *const DependencyInfo,
+    ) {
+        (self.cmd_wait_events2)(command_buffer, event_count, p_events, p_dependency_infos)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdPipelineBarrier2.html>"]
+    pub unsafe fn cmd_pipeline_barrier2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_dependency_info: *const DependencyInfo,
+    ) {
+        (self.cmd_pipeline_barrier2)(command_buffer, p_dependency_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdWriteTimestamp2.html>"]
+    pub unsafe fn cmd_write_timestamp2(
+        &self,
+        command_buffer: CommandBuffer,
+        stage: PipelineStageFlags2,
+        query_pool: QueryPool,
+        query: u32,
+    ) {
+        (self.cmd_write_timestamp2)(command_buffer, stage, query_pool, query)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkQueueSubmit2.html>"]
+    pub unsafe fn queue_submit2(
+        &self,
+        queue: Queue,
+        submit_count: u32,
+        p_submits: *const SubmitInfo2,
+        fence: Fence,
+    ) -> Result {
+        (self.queue_submit2)(queue, submit_count, p_submits, fence)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdCopyBuffer2.html>"]
+    pub unsafe fn cmd_copy_buffer2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_copy_buffer_info: *const CopyBufferInfo2,
+    ) {
+        (self.cmd_copy_buffer2)(command_buffer, p_copy_buffer_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdCopyImage2.html>"]
+    pub unsafe fn cmd_copy_image2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_copy_image_info: *const CopyImageInfo2,
+    ) {
+        (self.cmd_copy_image2)(command_buffer, p_copy_image_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdCopyBufferToImage2.html>"]
+    pub unsafe fn cmd_copy_buffer_to_image2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_copy_buffer_to_image_info: *const CopyBufferToImageInfo2,
+    ) {
+        (self.cmd_copy_buffer_to_image2)(command_buffer, p_copy_buffer_to_image_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdCopyImageToBuffer2.html>"]
+    pub unsafe fn cmd_copy_image_to_buffer2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_copy_image_to_buffer_info: *const CopyImageToBufferInfo2,
+    ) {
+        (self.cmd_copy_image_to_buffer2)(command_buffer, p_copy_image_to_buffer_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdBlitImage2.html>"]
+    pub unsafe fn cmd_blit_image2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_blit_image_info: *const BlitImageInfo2,
+    ) {
+        (self.cmd_blit_image2)(command_buffer, p_blit_image_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdResolveImage2.html>"]
+    pub unsafe fn cmd_resolve_image2(
+        &self,
+        command_buffer: CommandBuffer,
+        p_resolve_image_info: *const ResolveImageInfo2,
+    ) {
+        (self.cmd_resolve_image2)(command_buffer, p_resolve_image_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdBeginRendering.html>"]
+    pub unsafe fn cmd_begin_rendering(
+        &self,
+        command_buffer: CommandBuffer,
+        p_rendering_info: *const RenderingInfo,
+    ) {
+        (self.cmd_begin_rendering)(command_buffer, p_rendering_info)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdEndRendering.html>"]
+    pub unsafe fn cmd_end_rendering(&self, command_buffer: CommandBuffer) {
+        (self.cmd_end_rendering)(command_buffer)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetCullMode.html>"]
+    pub unsafe fn cmd_set_cull_mode(
+        &self,
+        command_buffer: CommandBuffer,
+        cull_mode: CullModeFlags,
+    ) {
+        (self.cmd_set_cull_mode)(command_buffer, cull_mode)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetFrontFace.html>"]
+    pub unsafe fn cmd_set_front_face(&self, command_buffer: CommandBuffer, front_face: FrontFace) {
+        (self.cmd_set_front_face)(command_buffer, front_face)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetPrimitiveTopology.html>"]
+    pub unsafe fn cmd_set_primitive_topology(
+        &self,
+        command_buffer: CommandBuffer,
+        primitive_topology: PrimitiveTopology,
+    ) {
+        (self.cmd_set_primitive_topology)(command_buffer, primitive_topology)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetViewportWithCount.html>"]
+    pub unsafe fn cmd_set_viewport_with_count(
+        &self,
+        command_buffer: CommandBuffer,
+        viewport_count: u32,
+        p_viewports: *const Viewport,
+    ) {
+        (self.cmd_set_viewport_with_count)(command_buffer, viewport_count, p_viewports)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetScissorWithCount.html>"]
+    pub unsafe fn cmd_set_scissor_with_count(
+        &self,
+        command_buffer: CommandBuffer,
+        scissor_count: u32,
+        p_scissors: *const Rect2D,
+    ) {
+        (self.cmd_set_scissor_with_count)(command_buffer, scissor_count, p_scissors)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdBindVertexBuffers2.html>"]
+    pub unsafe fn cmd_bind_vertex_buffers2(
+        &self,
+        command_buffer: CommandBuffer,
+        first_binding: u32,
+        binding_count: u32,
+        p_buffers: *const Buffer,
+        p_offsets: *const DeviceSize,
+        p_sizes: *const DeviceSize,
+        p_strides: *const DeviceSize,
+    ) {
+        (self.cmd_bind_vertex_buffers2)(
+            command_buffer,
+            first_binding,
+            binding_count,
+            p_buffers,
+            p_offsets,
+            p_sizes,
+            p_strides,
+        )
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetDepthTestEnable.html>"]
+    pub unsafe fn cmd_set_depth_test_enable(
+        &self,
+        command_buffer: CommandBuffer,
+        depth_test_enable: Bool32,
+    ) {
+        (self.cmd_set_depth_test_enable)(command_buffer, depth_test_enable)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetDepthWriteEnable.html>"]
+    pub unsafe fn cmd_set_depth_write_enable(
+        &self,
+        command_buffer: CommandBuffer,
+        depth_write_enable: Bool32,
+    ) {
+        (self.cmd_set_depth_write_enable)(command_buffer, depth_write_enable)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetDepthCompareOp.html>"]
+    pub unsafe fn cmd_set_depth_compare_op(
+        &self,
+        command_buffer: CommandBuffer,
+        depth_compare_op: CompareOp,
+    ) {
+        (self.cmd_set_depth_compare_op)(command_buffer, depth_compare_op)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetDepthBoundsTestEnable.html>"]
+    pub unsafe fn cmd_set_depth_bounds_test_enable(
+        &self,
+        command_buffer: CommandBuffer,
+        depth_bounds_test_enable: Bool32,
+    ) {
+        (self.cmd_set_depth_bounds_test_enable)(command_buffer, depth_bounds_test_enable)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetStencilTestEnable.html>"]
+    pub unsafe fn cmd_set_stencil_test_enable(
+        &self,
+        command_buffer: CommandBuffer,
+        stencil_test_enable: Bool32,
+    ) {
+        (self.cmd_set_stencil_test_enable)(command_buffer, stencil_test_enable)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetStencilOp.html>"]
+    pub unsafe fn cmd_set_stencil_op(
+        &self,
+        command_buffer: CommandBuffer,
+        face_mask: StencilFaceFlags,
+        fail_op: StencilOp,
+        pass_op: StencilOp,
+        depth_fail_op: StencilOp,
+        compare_op: CompareOp,
+    ) {
+        (self.cmd_set_stencil_op)(
+            command_buffer,
+            face_mask,
+            fail_op,
+            pass_op,
+            depth_fail_op,
+            compare_op,
+        )
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetRasterizerDiscardEnable.html>"]
+    pub unsafe fn cmd_set_rasterizer_discard_enable(
+        &self,
+        command_buffer: CommandBuffer,
+        rasterizer_discard_enable: Bool32,
+    ) {
+        (self.cmd_set_rasterizer_discard_enable)(command_buffer, rasterizer_discard_enable)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetDepthBiasEnable.html>"]
+    pub unsafe fn cmd_set_depth_bias_enable(
+        &self,
+        command_buffer: CommandBuffer,
+        depth_bias_enable: Bool32,
+    ) {
+        (self.cmd_set_depth_bias_enable)(command_buffer, depth_bias_enable)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdSetPrimitiveRestartEnable.html>"]
+    pub unsafe fn cmd_set_primitive_restart_enable(
+        &self,
+        command_buffer: CommandBuffer,
+        primitive_restart_enable: Bool32,
+    ) {
+        (self.cmd_set_primitive_restart_enable)(command_buffer, primitive_restart_enable)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceBufferMemoryRequirements.html>"]
+    pub unsafe fn get_device_buffer_memory_requirements(
+        &self,
+        device: Device,
+        p_info: *const DeviceBufferMemoryRequirements,
+        p_memory_requirements: *mut MemoryRequirements2,
+    ) {
+        (self.get_device_buffer_memory_requirements)(device, p_info, p_memory_requirements)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceImageMemoryRequirements.html>"]
+    pub unsafe fn get_device_image_memory_requirements(
+        &self,
+        device: Device,
+        p_info: *const DeviceImageMemoryRequirements,
+        p_memory_requirements: *mut MemoryRequirements2,
+    ) {
+        (self.get_device_image_memory_requirements)(device, p_info, p_memory_requirements)
+    }
+    #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetDeviceImageSparseMemoryRequirements.html>"]
+    pub unsafe fn get_device_image_sparse_memory_requirements(
+        &self,
+        device: Device,
+        p_info: *const DeviceImageMemoryRequirements,
+        p_sparse_memory_requirement_count: *mut u32,
+        p_sparse_memory_requirements: *mut SparseImageMemoryRequirements2,
+    ) {
+        (self.get_device_image_sparse_memory_requirements)(
+            device,
+            p_info,
+            p_sparse_memory_requirement_count,
+            p_sparse_memory_requirements,
+        )
+    }
+}

--- a/ash/src/vk/native.rs
+++ b/ash/src/vk/native.rs
@@ -6635,122 +6635,90 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeaderFlags() {
 }
 impl StdVideoEncodeH264SliceHeaderFlags {
     #[inline]
-    pub fn idr_flag(&self) -> u32 {
+    pub fn direct_spatial_mv_pred_flag(&self) -> u32 {
         unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_idr_flag(&mut self, val: u32) {
+    pub fn set_direct_spatial_mv_pred_flag(&mut self, val: u32) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
             self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn is_reference_flag(&self) -> u32 {
+    pub fn num_ref_idx_active_override_flag(&self) -> u32 {
         unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_is_reference_flag(&mut self, val: u32) {
+    pub fn set_num_ref_idx_active_override_flag(&mut self, val: u32) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
             self._bitfield_1.set(1usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn num_ref_idx_active_override_flag(&self) -> u32 {
+    pub fn no_output_of_prior_pics_flag(&self) -> u32 {
         unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_num_ref_idx_active_override_flag(&mut self, val: u32) {
+    pub fn set_no_output_of_prior_pics_flag(&mut self, val: u32) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
             self._bitfield_1.set(2usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn no_output_of_prior_pics_flag(&self) -> u32 {
+    pub fn adaptive_ref_pic_marking_mode_flag(&self) -> u32 {
         unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_no_output_of_prior_pics_flag(&mut self, val: u32) {
+    pub fn set_adaptive_ref_pic_marking_mode_flag(&mut self, val: u32) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
             self._bitfield_1.set(3usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn long_term_reference_flag(&self) -> u32 {
+    pub fn no_prior_references_available_flag(&self) -> u32 {
         unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u32) }
     }
     #[inline]
-    pub fn set_long_term_reference_flag(&mut self, val: u32) {
+    pub fn set_no_prior_references_available_flag(&mut self, val: u32) {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
             self._bitfield_1.set(4usize, 1u8, val as u64)
         }
     }
     #[inline]
-    pub fn adaptive_ref_pic_marking_mode_flag(&self) -> u32 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_adaptive_ref_pic_marking_mode_flag(&mut self, val: u32) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(5usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub fn no_prior_references_available_flag(&self) -> u32 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_no_prior_references_available_flag(&mut self, val: u32) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(6usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
     pub fn new_bitfield_1(
-        idr_flag: u32,
-        is_reference_flag: u32,
+        direct_spatial_mv_pred_flag: u32,
         num_ref_idx_active_override_flag: u32,
         no_output_of_prior_pics_flag: u32,
-        long_term_reference_flag: u32,
         adaptive_ref_pic_marking_mode_flag: u32,
         no_prior_references_available_flag: u32,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let idr_flag: u32 = unsafe { ::std::mem::transmute(idr_flag) };
-            idr_flag as u64
+            let direct_spatial_mv_pred_flag: u32 =
+                unsafe { ::std::mem::transmute(direct_spatial_mv_pred_flag) };
+            direct_spatial_mv_pred_flag as u64
         });
         __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let is_reference_flag: u32 = unsafe { ::std::mem::transmute(is_reference_flag) };
-            is_reference_flag as u64
-        });
-        __bindgen_bitfield_unit.set(2usize, 1u8, {
             let num_ref_idx_active_override_flag: u32 =
                 unsafe { ::std::mem::transmute(num_ref_idx_active_override_flag) };
             num_ref_idx_active_override_flag as u64
         });
-        __bindgen_bitfield_unit.set(3usize, 1u8, {
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
             let no_output_of_prior_pics_flag: u32 =
                 unsafe { ::std::mem::transmute(no_output_of_prior_pics_flag) };
             no_output_of_prior_pics_flag as u64
         });
-        __bindgen_bitfield_unit.set(4usize, 1u8, {
-            let long_term_reference_flag: u32 =
-                unsafe { ::std::mem::transmute(long_term_reference_flag) };
-            long_term_reference_flag as u64
-        });
-        __bindgen_bitfield_unit.set(5usize, 1u8, {
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
             let adaptive_ref_pic_marking_mode_flag: u32 =
                 unsafe { ::std::mem::transmute(adaptive_ref_pic_marking_mode_flag) };
             adaptive_ref_pic_marking_mode_flag as u64
         });
-        __bindgen_bitfield_unit.set(6usize, 1u8, {
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
             let no_prior_references_available_flag: u32 =
                 unsafe { ::std::mem::transmute(no_prior_references_available_flag) };
             no_prior_references_available_flag as u64
@@ -6835,6 +6803,55 @@ impl StdVideoEncodeH264PictureInfoFlags {
             let long_term_reference_flag: u32 =
                 unsafe { ::std::mem::transmute(long_term_reference_flag) };
             long_term_reference_flag as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Copy, Clone)]
+pub struct StdVideoEncodeH264ReferenceInfoFlags {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub __bindgen_padding_0: [u8; 3usize],
+}
+#[test]
+fn bindgen_test_layout_StdVideoEncodeH264ReferenceInfoFlags() {
+    assert_eq!(
+        ::std::mem::size_of::<StdVideoEncodeH264ReferenceInfoFlags>(),
+        4usize,
+        concat!(
+            "Size of: ",
+            stringify!(StdVideoEncodeH264ReferenceInfoFlags)
+        )
+    );
+    assert_eq!(
+        ::std::mem::align_of::<StdVideoEncodeH264ReferenceInfoFlags>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(StdVideoEncodeH264ReferenceInfoFlags)
+        )
+    );
+}
+impl StdVideoEncodeH264ReferenceInfoFlags {
+    #[inline]
+    pub fn is_long_term(&self) -> u32 {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_is_long_term(&mut self, val: u32) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(is_long_term: u32) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let is_long_term: u32 = unsafe { ::std::mem::transmute(is_long_term) };
+            is_long_term as u64
         });
         __bindgen_bitfield_unit
     }
@@ -7183,16 +7200,14 @@ fn bindgen_test_layout_StdVideoEncodeH264RefMemMgmtCtrlOperations() {
 pub struct StdVideoEncodeH264PictureInfo {
     pub flags: StdVideoEncodeH264PictureInfoFlags,
     pub pictureType: StdVideoH264PictureType,
-    pub frameNum: u32,
-    pub pictureOrderCount: u32,
-    pub long_term_pic_num: u16,
-    pub long_term_frame_idx: u16,
+    pub frame_num: u32,
+    pub PicOrderCnt: i32,
 }
 #[test]
 fn bindgen_test_layout_StdVideoEncodeH264PictureInfo() {
     assert_eq!(
         ::std::mem::size_of::<StdVideoEncodeH264PictureInfo>(),
-        20usize,
+        16usize,
         concat!("Size of: ", stringify!(StdVideoEncodeH264PictureInfo))
     );
     assert_eq!(
@@ -7227,19 +7242,19 @@ fn bindgen_test_layout_StdVideoEncodeH264PictureInfo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH264PictureInfo>())).frameNum as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH264PictureInfo>())).frame_num as *const _ as usize
         },
         8usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264PictureInfo),
             "::",
-            stringify!(frameNum)
+            stringify!(frame_num)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH264PictureInfo>())).pictureOrderCount as *const _
+            &(*(::std::ptr::null::<StdVideoEncodeH264PictureInfo>())).PicOrderCnt as *const _
                 as usize
         },
         12usize,
@@ -7247,31 +7262,91 @@ fn bindgen_test_layout_StdVideoEncodeH264PictureInfo() {
             "Offset of field: ",
             stringify!(StdVideoEncodeH264PictureInfo),
             "::",
-            stringify!(pictureOrderCount)
+            stringify!(PicOrderCnt)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct StdVideoEncodeH264ReferenceInfo {
+    pub flags: StdVideoEncodeH264ReferenceInfoFlags,
+    pub FrameNum: u32,
+    pub PicOrderCnt: i32,
+    pub long_term_pic_num: u16,
+    pub long_term_frame_idx: u16,
+}
+#[test]
+fn bindgen_test_layout_StdVideoEncodeH264ReferenceInfo() {
+    assert_eq!(
+        ::std::mem::size_of::<StdVideoEncodeH264ReferenceInfo>(),
+        16usize,
+        concat!("Size of: ", stringify!(StdVideoEncodeH264ReferenceInfo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<StdVideoEncodeH264ReferenceInfo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(StdVideoEncodeH264ReferenceInfo))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<StdVideoEncodeH264ReferenceInfo>())).flags as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StdVideoEncodeH264ReferenceInfo),
+            "::",
+            stringify!(flags)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH264PictureInfo>())).long_term_pic_num as *const _
+            &(*(::std::ptr::null::<StdVideoEncodeH264ReferenceInfo>())).FrameNum as *const _
                 as usize
         },
-        16usize,
+        4usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH264PictureInfo),
+            stringify!(StdVideoEncodeH264ReferenceInfo),
+            "::",
+            stringify!(FrameNum)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<StdVideoEncodeH264ReferenceInfo>())).PicOrderCnt as *const _
+                as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StdVideoEncodeH264ReferenceInfo),
+            "::",
+            stringify!(PicOrderCnt)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<StdVideoEncodeH264ReferenceInfo>())).long_term_pic_num
+                as *const _ as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StdVideoEncodeH264ReferenceInfo),
             "::",
             stringify!(long_term_pic_num)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH264PictureInfo>())).long_term_frame_idx
+            &(*(::std::ptr::null::<StdVideoEncodeH264ReferenceInfo>())).long_term_frame_idx
                 as *const _ as usize
         },
-        18usize,
+        14usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH264PictureInfo),
+            stringify!(StdVideoEncodeH264ReferenceInfo),
             "::",
             stringify!(long_term_frame_idx)
         )
@@ -7281,6 +7356,7 @@ fn bindgen_test_layout_StdVideoEncodeH264PictureInfo() {
 #[derive(Debug, Copy, Clone)]
 pub struct StdVideoEncodeH264SliceHeader {
     pub flags: StdVideoEncodeH264SliceHeaderFlags,
+    pub first_mb_in_slice: u32,
     pub slice_type: StdVideoH264SliceType,
     pub seq_parameter_set_id: u8,
     pub pic_parameter_set_id: u8,
@@ -7291,18 +7367,17 @@ pub struct StdVideoEncodeH264SliceHeader {
     pub disable_deblocking_filter_idc: StdVideoH264DisableDeblockingFilterIdc,
     pub slice_alpha_c0_offset_div2: i8,
     pub slice_beta_offset_div2: i8,
-    pub pMemMgmtCtrlOperations: *mut StdVideoEncodeH264RefMemMgmtCtrlOperations,
 }
 #[test]
 fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
     assert_eq!(
         ::std::mem::size_of::<StdVideoEncodeH264SliceHeader>(),
-        40usize,
+        32usize,
         concat!("Size of: ", stringify!(StdVideoEncodeH264SliceHeader))
     );
     assert_eq!(
         ::std::mem::align_of::<StdVideoEncodeH264SliceHeader>(),
-        8usize,
+        4usize,
         concat!("Alignment of ", stringify!(StdVideoEncodeH264SliceHeader))
     );
     assert_eq!(
@@ -7319,10 +7394,23 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).slice_type as *const _
+            &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).first_mb_in_slice as *const _
                 as usize
         },
         4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StdVideoEncodeH264SliceHeader),
+            "::",
+            stringify!(first_mb_in_slice)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).slice_type as *const _
+                as usize
+        },
+        8usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
@@ -7335,7 +7423,7 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).seq_parameter_set_id
                 as *const _ as usize
         },
-        8usize,
+        12usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
@@ -7348,7 +7436,7 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).pic_parameter_set_id
                 as *const _ as usize
         },
-        9usize,
+        13usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
@@ -7361,7 +7449,7 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).idr_pic_id as *const _
                 as usize
         },
-        10usize,
+        14usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
@@ -7374,7 +7462,7 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).num_ref_idx_l0_active_minus1
                 as *const _ as usize
         },
-        12usize,
+        16usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
@@ -7387,7 +7475,7 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).num_ref_idx_l1_active_minus1
                 as *const _ as usize
         },
-        13usize,
+        17usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
@@ -7400,7 +7488,7 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).cabac_init_idc as *const _
                 as usize
         },
-        16usize,
+        20usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
@@ -7413,7 +7501,7 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).disable_deblocking_filter_idc
                 as *const _ as usize
         },
-        20usize,
+        24usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
@@ -7426,7 +7514,7 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).slice_alpha_c0_offset_div2
                 as *const _ as usize
         },
-        24usize,
+        28usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
@@ -7439,25 +7527,12 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).slice_beta_offset_div2
                 as *const _ as usize
         },
-        25usize,
+        29usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH264SliceHeader),
             "::",
             stringify!(slice_beta_offset_div2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH264SliceHeader>())).pMemMgmtCtrlOperations
-                as *const _ as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(StdVideoEncodeH264SliceHeader),
-            "::",
-            stringify!(pMemMgmtCtrlOperations)
         )
     );
 }
@@ -7825,7 +7900,6 @@ pub struct StdVideoEncodeH265SliceSegmentHeader {
     pub delta_chroma_weight_l1: [[i8; 2usize]; 15usize],
     pub delta_chroma_offset_l1: [[i8; 2usize]; 15usize],
     pub MaxNumMergeCand: u8,
-    pub slice_qp_delta: i8,
     pub slice_cb_qp_offset: i8,
     pub slice_cr_qp_offset: i8,
     pub slice_beta_offset_div2: i8,
@@ -7839,7 +7913,7 @@ pub struct StdVideoEncodeH265SliceSegmentHeader {
 fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
     assert_eq!(
         ::std::mem::size_of::<StdVideoEncodeH265SliceSegmentHeader>(),
-        224usize,
+        220usize,
         concat!(
             "Size of: ",
             stringify!(StdVideoEncodeH265SliceSegmentHeader)
@@ -8128,23 +8202,10 @@ fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_qp_delta
-                as *const _ as usize
-        },
-        201usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceSegmentHeader),
-            "::",
-            stringify!(slice_qp_delta)
-        )
-    );
-    assert_eq!(
-        unsafe {
             &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_cb_qp_offset
                 as *const _ as usize
         },
-        202usize,
+        201usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH265SliceSegmentHeader),
@@ -8157,7 +8218,7 @@ fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_cr_qp_offset
                 as *const _ as usize
         },
-        203usize,
+        202usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH265SliceSegmentHeader),
@@ -8170,7 +8231,7 @@ fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_beta_offset_div2
                 as *const _ as usize
         },
-        204usize,
+        203usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH265SliceSegmentHeader),
@@ -8183,7 +8244,7 @@ fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_tc_offset_div2
                 as *const _ as usize
         },
-        205usize,
+        204usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH265SliceSegmentHeader),
@@ -8196,7 +8257,7 @@ fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_act_y_qp_offset
                 as *const _ as usize
         },
-        206usize,
+        205usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH265SliceSegmentHeader),
@@ -8209,7 +8270,7 @@ fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_act_cb_qp_offset
                 as *const _ as usize
         },
-        207usize,
+        206usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH265SliceSegmentHeader),
@@ -8222,7 +8283,7 @@ fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_act_cr_qp_offset
                 as *const _ as usize
         },
-        208usize,
+        207usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH265SliceSegmentHeader),
@@ -8235,7 +8296,7 @@ fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
             &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).flags as *const _
                 as usize
         },
-        212usize,
+        208usize,
         concat!(
             "Offset of field: ",
             stringify!(StdVideoEncodeH265SliceSegmentHeader),

--- a/ash/src/vk/native.rs
+++ b/ash/src/vk/native.rs
@@ -7464,7 +7464,7 @@ fn bindgen_test_layout_StdVideoEncodeH264SliceHeader() {
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
-pub struct StdVideoEncodeH265SliceHeaderFlags {
+pub struct StdVideoEncodeH265SliceSegmentHeaderFlags {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
     pub luma_weight_l0_flag: u16,
@@ -7473,74 +7473,77 @@ pub struct StdVideoEncodeH265SliceHeaderFlags {
     pub chroma_weight_l1_flag: u16,
 }
 #[test]
-fn bindgen_test_layout_StdVideoEncodeH265SliceHeaderFlags() {
+fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeaderFlags() {
     assert_eq!(
-        ::std::mem::size_of::<StdVideoEncodeH265SliceHeaderFlags>(),
+        ::std::mem::size_of::<StdVideoEncodeH265SliceSegmentHeaderFlags>(),
         12usize,
-        concat!("Size of: ", stringify!(StdVideoEncodeH265SliceHeaderFlags))
+        concat!(
+            "Size of: ",
+            stringify!(StdVideoEncodeH265SliceSegmentHeaderFlags)
+        )
     );
     assert_eq!(
-        ::std::mem::align_of::<StdVideoEncodeH265SliceHeaderFlags>(),
+        ::std::mem::align_of::<StdVideoEncodeH265SliceSegmentHeaderFlags>(),
         4usize,
         concat!(
             "Alignment of ",
-            stringify!(StdVideoEncodeH265SliceHeaderFlags)
+            stringify!(StdVideoEncodeH265SliceSegmentHeaderFlags)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeaderFlags>())).luma_weight_l0_flag
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeaderFlags>()))
+                .luma_weight_l0_flag as *const _ as usize
         },
         4usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeaderFlags),
+            stringify!(StdVideoEncodeH265SliceSegmentHeaderFlags),
             "::",
             stringify!(luma_weight_l0_flag)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeaderFlags>())).chroma_weight_l0_flag
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeaderFlags>()))
+                .chroma_weight_l0_flag as *const _ as usize
         },
         6usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeaderFlags),
+            stringify!(StdVideoEncodeH265SliceSegmentHeaderFlags),
             "::",
             stringify!(chroma_weight_l0_flag)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeaderFlags>())).luma_weight_l1_flag
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeaderFlags>()))
+                .luma_weight_l1_flag as *const _ as usize
         },
         8usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeaderFlags),
+            stringify!(StdVideoEncodeH265SliceSegmentHeaderFlags),
             "::",
             stringify!(luma_weight_l1_flag)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeaderFlags>())).chroma_weight_l1_flag
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeaderFlags>()))
+                .chroma_weight_l1_flag as *const _ as usize
         },
         10usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeaderFlags),
+            stringify!(StdVideoEncodeH265SliceSegmentHeaderFlags),
             "::",
             stringify!(chroma_weight_l1_flag)
         )
     );
 }
-impl StdVideoEncodeH265SliceHeaderFlags {
+impl StdVideoEncodeH265SliceSegmentHeaderFlags {
     #[inline]
     pub fn first_slice_segment_in_pic_flag(&self) -> u32 {
         unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
@@ -7800,7 +7803,7 @@ impl StdVideoEncodeH265SliceHeaderFlags {
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct StdVideoEncodeH265SliceHeader {
+pub struct StdVideoEncodeH265SliceSegmentHeader {
     pub slice_type: StdVideoH265SliceType,
     pub slice_pic_parameter_set_id: u8,
     pub num_short_term_ref_pic_sets: u8,
@@ -7830,405 +7833,412 @@ pub struct StdVideoEncodeH265SliceHeader {
     pub slice_act_y_qp_offset: i8,
     pub slice_act_cb_qp_offset: i8,
     pub slice_act_cr_qp_offset: i8,
-    pub flags: StdVideoEncodeH265SliceHeaderFlags,
+    pub flags: StdVideoEncodeH265SliceSegmentHeaderFlags,
 }
 #[test]
-fn bindgen_test_layout_StdVideoEncodeH265SliceHeader() {
+fn bindgen_test_layout_StdVideoEncodeH265SliceSegmentHeader() {
     assert_eq!(
-        ::std::mem::size_of::<StdVideoEncodeH265SliceHeader>(),
+        ::std::mem::size_of::<StdVideoEncodeH265SliceSegmentHeader>(),
         224usize,
-        concat!("Size of: ", stringify!(StdVideoEncodeH265SliceHeader))
+        concat!(
+            "Size of: ",
+            stringify!(StdVideoEncodeH265SliceSegmentHeader)
+        )
     );
     assert_eq!(
-        ::std::mem::align_of::<StdVideoEncodeH265SliceHeader>(),
+        ::std::mem::align_of::<StdVideoEncodeH265SliceSegmentHeader>(),
         4usize,
-        concat!("Alignment of ", stringify!(StdVideoEncodeH265SliceHeader))
+        concat!(
+            "Alignment of ",
+            stringify!(StdVideoEncodeH265SliceSegmentHeader)
+        )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_type as *const _
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_type as *const _
                 as usize
         },
         0usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_type)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_pic_parameter_set_id
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>()))
+                .slice_pic_parameter_set_id as *const _ as usize
         },
         4usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_pic_parameter_set_id)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).num_short_term_ref_pic_sets
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>()))
+                .num_short_term_ref_pic_sets as *const _ as usize
         },
         5usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(num_short_term_ref_pic_sets)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_segment_address
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_segment_address
                 as *const _ as usize
         },
         8usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_segment_address)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).short_term_ref_pic_set_idx
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>()))
+                .short_term_ref_pic_set_idx as *const _ as usize
         },
         12usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(short_term_ref_pic_set_idx)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).num_long_term_sps as *const _
-                as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).num_long_term_sps
+                as *const _ as usize
         },
         13usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(num_long_term_sps)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).num_long_term_pics as *const _
-                as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).num_long_term_pics
+                as *const _ as usize
         },
         14usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(num_long_term_pics)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).collocated_ref_idx as *const _
-                as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).collocated_ref_idx
+                as *const _ as usize
         },
         15usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(collocated_ref_idx)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).num_ref_idx_l0_active_minus1
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>()))
+                .num_ref_idx_l0_active_minus1 as *const _ as usize
         },
         16usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(num_ref_idx_l0_active_minus1)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).num_ref_idx_l1_active_minus1
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>()))
+                .num_ref_idx_l1_active_minus1 as *const _ as usize
         },
         17usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(num_ref_idx_l1_active_minus1)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).luma_log2_weight_denom
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).luma_log2_weight_denom
                 as *const _ as usize
         },
         18usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(luma_log2_weight_denom)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).delta_chroma_log2_weight_denom
-                as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>()))
+                .delta_chroma_log2_weight_denom as *const _ as usize
         },
         19usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(delta_chroma_log2_weight_denom)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).delta_luma_weight_l0
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).delta_luma_weight_l0
                 as *const _ as usize
         },
         20usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(delta_luma_weight_l0)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).luma_offset_l0 as *const _
-                as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).luma_offset_l0
+                as *const _ as usize
         },
         35usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(luma_offset_l0)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).delta_chroma_weight_l0
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).delta_chroma_weight_l0
                 as *const _ as usize
         },
         50usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(delta_chroma_weight_l0)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).delta_chroma_offset_l0
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).delta_chroma_offset_l0
                 as *const _ as usize
         },
         80usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(delta_chroma_offset_l0)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).delta_luma_weight_l1
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).delta_luma_weight_l1
                 as *const _ as usize
         },
         110usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(delta_luma_weight_l1)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).luma_offset_l1 as *const _
-                as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).luma_offset_l1
+                as *const _ as usize
         },
         125usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(luma_offset_l1)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).delta_chroma_weight_l1
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).delta_chroma_weight_l1
                 as *const _ as usize
         },
         140usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(delta_chroma_weight_l1)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).delta_chroma_offset_l1
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).delta_chroma_offset_l1
                 as *const _ as usize
         },
         170usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(delta_chroma_offset_l1)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).MaxNumMergeCand as *const _
-                as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).MaxNumMergeCand
+                as *const _ as usize
         },
         200usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(MaxNumMergeCand)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_qp_delta as *const _
-                as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_qp_delta
+                as *const _ as usize
         },
         201usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_qp_delta)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_cb_qp_offset as *const _
-                as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_cb_qp_offset
+                as *const _ as usize
         },
         202usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_cb_qp_offset)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_cr_qp_offset as *const _
-                as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_cr_qp_offset
+                as *const _ as usize
         },
         203usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_cr_qp_offset)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_beta_offset_div2
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_beta_offset_div2
                 as *const _ as usize
         },
         204usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_beta_offset_div2)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_tc_offset_div2
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_tc_offset_div2
                 as *const _ as usize
         },
         205usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_tc_offset_div2)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_act_y_qp_offset
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_act_y_qp_offset
                 as *const _ as usize
         },
         206usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_act_y_qp_offset)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_act_cb_qp_offset
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_act_cb_qp_offset
                 as *const _ as usize
         },
         207usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_act_cb_qp_offset)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).slice_act_cr_qp_offset
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).slice_act_cr_qp_offset
                 as *const _ as usize
         },
         208usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(slice_act_cr_qp_offset)
         )
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StdVideoEncodeH265SliceHeader>())).flags as *const _ as usize
+            &(*(::std::ptr::null::<StdVideoEncodeH265SliceSegmentHeader>())).flags as *const _
+                as usize
         },
         212usize,
         concat!(
             "Offset of field: ",
-            stringify!(StdVideoEncodeH265SliceHeader),
+            stringify!(StdVideoEncodeH265SliceSegmentHeader),
             "::",
             stringify!(flags)
         )


### PR DESCRIPTION
Vulkan 1.3 is out, with many extensions stabilized.  This'll have to remain draft until the next spec version (hopefully next week) where (again, hopefully) https://github.com/KhronosGroup/Vulkan-Docs/pull/1746 is incorporated - otherwise we'll have to work around in our generator :(
