### PR TITLE
extensions/khr: Drop `_khr` suffix from `get_memory_fd_properties_khr`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- extensions/khr: Drop `_khr` suffix from `get_memory_fd_properties_khr` in `ExternalMemoryFd` (#580)
 - Replace `1.2-extensions` documentation links with `1.3-extensions` (#569)
 - Fixed broken (intradoc) links in the prelude and `VK_KHR_get_surface_capabilities2` extension (#559)
 

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -28,7 +28,7 @@ impl ExternalMemoryFd {
     }
 
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetMemoryFdPropertiesKHR.html>
-    pub unsafe fn get_memory_fd_properties_khr(
+    pub unsafe fn get_memory_fd_properties(
         &self,
         handle_type: vk::ExternalMemoryHandleTypeFlags,
         fd: i32,


### PR DESCRIPTION
This is an erroneous suffix that's already captured in the module path of this item, and should be omitted everywhere.  This method is the only offender besides the experimental AMD extensions.

Fixes: 98def0a ("Add `VK_KHR_external_memory_fd` extension support (#270)")

---

Draft because I want to shelve this for a bit until the next breaking release... We can probably get all the current extension additions and Vulkan 1.3 API out the door with a simple patch bump.
