### PR TITLE
`VK_NV_device_diagnostic_checkpoints`: Enable passing `pNext`-initialized structs to `get_queue_checkpoint_data`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
 - Dropped auto-generated wrapper methods from function pointer structs
   in favor of direct invocation of function pointers (#599)
+- `VK_NV_device_diagnostic_checkpoints`: Enable passing `pNext`-initialized structs to `get_queue_checkpoint_data` (#588)
 
 ### Added
 

--- a/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
+++ b/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
@@ -4,6 +4,7 @@ use std::ffi::CStr;
 use std::mem;
 use std::os::raw::c_void;
 
+/// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_NV_device_diagnostic_checkpoints.html>
 #[derive(Clone)]
 pub struct DeviceDiagnosticCheckpoints {
     fp: vk::NvDeviceDiagnosticCheckpointsFn,
@@ -26,22 +27,25 @@ impl DeviceDiagnosticCheckpoints {
         (self.fp.cmd_set_checkpoint_nv)(command_buffer, p_checkpoint_marker);
     }
 
+    /// Retrieve the number of elements to pass to [`get_queue_checkpoint_data()`][Self::get_queue_checkpoint_data()]
+    pub unsafe fn get_queue_checkpoint_data_len(&self, queue: vk::Queue) -> usize {
+        let mut count = 0;
+        (self.fp.get_queue_checkpoint_data_nv)(queue, &mut count, std::ptr::null_mut());
+        count as usize
+    }
+
     /// <https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkGetQueueCheckpointDataNV.html>
-    pub unsafe fn get_queue_checkpoint_data(&self, queue: vk::Queue) -> Vec<vk::CheckpointDataNV> {
-        let mut checkpoint_data_count: u32 = 0;
-        (self.fp.get_queue_checkpoint_data_nv)(
-            queue,
-            &mut checkpoint_data_count,
-            std::ptr::null_mut(),
-        );
-        let mut checkpoint_data: Vec<vk::CheckpointDataNV> =
-            vec![vk::CheckpointDataNV::default(); checkpoint_data_count as _];
-        (self.fp.get_queue_checkpoint_data_nv)(
-            queue,
-            &mut checkpoint_data_count,
-            checkpoint_data.as_mut_ptr(),
-        );
-        checkpoint_data
+    ///
+    /// Call [`get_queue_checkpoint_data_len()`][Self::get_queue_checkpoint_data_len()] to query the number of elements to pass to `out`.
+    /// Be sure to [`Default::default()`]-initialize these elements and optionally set their `p_next` pointer.
+    pub unsafe fn get_queue_checkpoint_data(
+        &self,
+        queue: vk::Queue,
+        out: &mut [vk::CheckpointDataNV],
+    ) {
+        let mut count = out.len() as u32;
+        (self.fp.get_queue_checkpoint_data_nv)(queue, &mut count, out.as_mut_ptr());
+        assert_eq!(count as usize, out.len());
     }
 
     pub const fn name() -> &'static CStr {


### PR DESCRIPTION
To match all other functions which accept an array of to-be-initialized structs with a `pNext` pointer that is possibly initialized by the caller.
