### PR TITLE
Make names const

### DIFF
--- a/ash/src/extensions/ext/buffer_device_address.rs
+++ b/ash/src/extensions/ext/buffer_device_address.rs
@@ -26,7 +26,7 @@ impl BufferDeviceAddress {
         self.fp.get_buffer_device_address_ext(self.handle, info)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtBufferDeviceAddressFn::name()
     }
 

--- a/ash/src/extensions/ext/calibrated_timestamps.rs
+++ b/ash/src/extensions/ext/calibrated_timestamps.rs
@@ -51,7 +51,7 @@ impl CalibratedTimestamps {
             .result_with_success((timestamps, max_deviation))
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtCalibratedTimestampsFn::name()
     }
 

--- a/ash/src/extensions/ext/debug_marker.rs
+++ b/ash/src/extensions/ext/debug_marker.rs
@@ -54,7 +54,7 @@ impl DebugMarker {
             .cmd_debug_marker_insert_ext(command_buffer, marker_info);
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtDebugMarkerFn::name()
     }
 

--- a/ash/src/extensions/ext/debug_report.rs
+++ b/ash/src/extensions/ext/debug_report.rs
@@ -50,7 +50,7 @@ impl DebugReport {
             .result_with_success(debug_cb)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtDebugReportFn::name()
     }
 

--- a/ash/src/extensions/ext/debug_utils.rs
+++ b/ash/src/extensions/ext/debug_utils.rs
@@ -131,7 +131,7 @@ impl DebugUtils {
         );
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtDebugUtilsFn::name()
     }
 

--- a/ash/src/extensions/ext/extended_dynamic_state.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state.rs
@@ -175,7 +175,7 @@ impl ExtendedDynamicState {
         )
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtExtendedDynamicStateFn::name()
     }
 

--- a/ash/src/extensions/ext/extended_dynamic_state2.rs
+++ b/ash/src/extensions/ext/extended_dynamic_state2.rs
@@ -66,7 +66,7 @@ impl ExtendedDynamicState2 {
             .cmd_set_primitive_restart_enable_ext(command_buffer, primitive_restart_enable.into())
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtExtendedDynamicState2Fn::name()
     }
 

--- a/ash/src/extensions/ext/full_screen_exclusive.rs
+++ b/ash/src/extensions/ext/full_screen_exclusive.rs
@@ -70,7 +70,7 @@ impl FullScreenExclusive {
             .result_with_success(present_modes)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtFullScreenExclusiveFn::name()
     }
 

--- a/ash/src/extensions/ext/headless_surface.rs
+++ b/ash/src/extensions/ext/headless_surface.rs
@@ -38,7 +38,7 @@ impl HeadlessSurface {
             .result_with_success(surface)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtHeadlessSurfaceFn::name()
     }
 

--- a/ash/src/extensions/ext/metal_surface.rs
+++ b/ash/src/extensions/ext/metal_surface.rs
@@ -37,7 +37,7 @@ impl MetalSurface {
             .result_with_success(surface)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtMetalSurfaceFn::name()
     }
 

--- a/ash/src/extensions/ext/physical_device_drm.rs
+++ b/ash/src/extensions/ext/physical_device_drm.rs
@@ -18,7 +18,7 @@ impl PhysicalDeviceDrm {
         props_drm
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtPhysicalDeviceDrmFn::name()
     }
 }

--- a/ash/src/extensions/ext/private_data.rs
+++ b/ash/src/extensions/ext/private_data.rs
@@ -86,7 +86,7 @@ impl PrivateData {
         data
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtPrivateDataFn::name()
     }
 

--- a/ash/src/extensions/ext/tooling_info.rs
+++ b/ash/src/extensions/ext/tooling_info.rs
@@ -28,7 +28,7 @@ impl ToolingInfo {
         })
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::ExtToolingInfoFn::name()
     }
 

--- a/ash/src/extensions/khr/acceleration_structure.rs
+++ b/ash/src/extensions/khr/acceleration_structure.rs
@@ -299,7 +299,7 @@ impl AccelerationStructure {
         size_info
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrAccelerationStructureFn::name()
     }
 

--- a/ash/src/extensions/khr/android_surface.rs
+++ b/ash/src/extensions/khr/android_surface.rs
@@ -37,7 +37,7 @@ impl AndroidSurface {
             .result_with_success(surface)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrAndroidSurfaceFn::name()
     }
 

--- a/ash/src/extensions/khr/buffer_device_address.rs
+++ b/ash/src/extensions/khr/buffer_device_address.rs
@@ -44,7 +44,7 @@ impl BufferDeviceAddress {
             .get_device_memory_opaque_capture_address_khr(self.handle, info)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrBufferDeviceAddressFn::name()
     }
 

--- a/ash/src/extensions/khr/copy_commands2.rs
+++ b/ash/src/extensions/khr/copy_commands2.rs
@@ -70,7 +70,7 @@ impl CopyCommands2 {
             .cmd_resolve_image2_khr(command_buffer, resolve_image_info)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrCopyCommands2Fn::name()
     }
 

--- a/ash/src/extensions/khr/create_render_pass2.rs
+++ b/ash/src/extensions/khr/create_render_pass2.rs
@@ -72,7 +72,7 @@ impl CreateRenderPass2 {
             .cmd_end_render_pass2_khr(command_buffer, subpass_end_info);
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrCreateRenderpass2Fn::name()
     }
 

--- a/ash/src/extensions/khr/deferred_host_operations.rs
+++ b/ash/src/extensions/khr/deferred_host_operations.rs
@@ -77,7 +77,7 @@ impl DeferredHostOperations {
             .result()
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrDeferredHostOperationsFn::name()
     }
 

--- a/ash/src/extensions/khr/display.rs
+++ b/ash/src/extensions/khr/display.rs
@@ -125,7 +125,7 @@ impl Display {
             .result_with_success(surface.assume_init())
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrDisplayFn::name()
     }
 

--- a/ash/src/extensions/khr/display_swapchain.rs
+++ b/ash/src/extensions/khr/display_swapchain.rs
@@ -38,7 +38,7 @@ impl DisplaySwapchain {
         err_code.result_with_success(swapchains)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrDisplaySwapchainFn::name()
     }
 

--- a/ash/src/extensions/khr/draw_indirect_count.rs
+++ b/ash/src/extensions/khr/draw_indirect_count.rs
@@ -60,7 +60,7 @@ impl DrawIndirectCount {
         );
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrDrawIndirectCountFn::name()
     }
 

--- a/ash/src/extensions/khr/dynamic_rendering.rs
+++ b/ash/src/extensions/khr/dynamic_rendering.rs
@@ -31,7 +31,7 @@ impl DynamicRendering {
         self.fp.cmd_end_rendering_khr(command_buffer)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrDynamicRenderingFn::name()
     }
 

--- a/ash/src/extensions/khr/external_fence_fd.rs
+++ b/ash/src/extensions/khr/external_fence_fd.rs
@@ -34,7 +34,7 @@ impl ExternalFenceFd {
             .result_with_success(fd)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrExternalFenceFdFn::name()
     }
 

--- a/ash/src/extensions/khr/external_fence_win32.rs
+++ b/ash/src/extensions/khr/external_fence_win32.rs
@@ -42,7 +42,7 @@ impl ExternalFenceWin32 {
             .result_with_success(handle)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrExternalFenceWin32Fn::name()
     }
 

--- a/ash/src/extensions/khr/external_memory_fd.rs
+++ b/ash/src/extensions/khr/external_memory_fd.rs
@@ -39,7 +39,7 @@ impl ExternalMemoryFd {
             .result_with_success(memory_fd_properties)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrExternalMemoryFdFn::name()
     }
 

--- a/ash/src/extensions/khr/external_memory_win32.rs
+++ b/ash/src/extensions/khr/external_memory_win32.rs
@@ -49,7 +49,7 @@ impl ExternalMemoryWin32 {
             .result_with_success(memory_win32_handle_properties)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrExternalMemoryWin32Fn::name()
     }
 

--- a/ash/src/extensions/khr/external_semaphore_fd.rs
+++ b/ash/src/extensions/khr/external_semaphore_fd.rs
@@ -37,7 +37,7 @@ impl ExternalSemaphoreFd {
             .result_with_success(fd)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrExternalSemaphoreFdFn::name()
     }
 

--- a/ash/src/extensions/khr/external_semaphore_win32.rs
+++ b/ash/src/extensions/khr/external_semaphore_win32.rs
@@ -42,7 +42,7 @@ impl ExternalSemaphoreWin32 {
             .result_with_success(handle)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrExternalSemaphoreWin32Fn::name()
     }
 

--- a/ash/src/extensions/khr/get_memory_requirements2.rs
+++ b/ash/src/extensions/khr/get_memory_requirements2.rs
@@ -73,7 +73,7 @@ impl GetMemoryRequirements2 {
         assert_eq!(count as usize, out.len());
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrGetMemoryRequirements2Fn::name()
     }
 

--- a/ash/src/extensions/khr/get_physical_device_properties2.rs
+++ b/ash/src/extensions/khr/get_physical_device_properties2.rs
@@ -148,7 +148,7 @@ impl GetPhysicalDeviceProperties2 {
         assert_eq!(count as usize, out.len());
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrGetPhysicalDeviceProperties2Fn::name()
     }
 

--- a/ash/src/extensions/khr/get_surface_capabilities2.rs
+++ b/ash/src/extensions/khr/get_surface_capabilities2.rs
@@ -70,7 +70,7 @@ impl GetSurfaceCapabilities2 {
         err_code.result()
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrGetSurfaceCapabilities2Fn::name()
     }
 

--- a/ash/src/extensions/khr/maintenance1.rs
+++ b/ash/src/extensions/khr/maintenance1.rs
@@ -28,7 +28,7 @@ impl Maintenance1 {
             .trim_command_pool_khr(self.handle, command_pool, flags);
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrMaintenance1Fn::name()
     }
 

--- a/ash/src/extensions/khr/maintenance3.rs
+++ b/ash/src/extensions/khr/maintenance3.rs
@@ -28,7 +28,7 @@ impl Maintenance3 {
             .get_descriptor_set_layout_support_khr(self.handle, create_info, out);
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrMaintenance3Fn::name()
     }
 

--- a/ash/src/extensions/khr/maintenance4.rs
+++ b/ash/src/extensions/khr/maintenance4.rs
@@ -72,7 +72,7 @@ impl Maintenance4 {
         assert_eq!(count as usize, out.len());
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrMaintenance4Fn::name()
     }
 

--- a/ash/src/extensions/khr/pipeline_executable_properties.rs
+++ b/ash/src/extensions/khr/pipeline_executable_properties.rs
@@ -61,7 +61,7 @@ impl PipelineExecutableProperties {
         })
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrPipelineExecutablePropertiesFn::name()
     }
 

--- a/ash/src/extensions/khr/present_wait.rs
+++ b/ash/src/extensions/khr/present_wait.rs
@@ -31,7 +31,7 @@ impl PresentWait {
             .result()
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrPresentWaitFn::name()
     }
 

--- a/ash/src/extensions/khr/push_descriptor.rs
+++ b/ash/src/extensions/khr/push_descriptor.rs
@@ -54,7 +54,7 @@ impl PushDescriptor {
         );
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrPushDescriptorFn::name()
     }
 

--- a/ash/src/extensions/khr/ray_tracing_pipeline.rs
+++ b/ash/src/extensions/khr/ray_tracing_pipeline.rs
@@ -166,7 +166,7 @@ impl RayTracingPipeline {
             .cmd_set_ray_tracing_pipeline_stack_size_khr(command_buffer, pipeline_stack_size);
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrRayTracingPipelineFn::name()
     }
 

--- a/ash/src/extensions/khr/surface.rs
+++ b/ash/src/extensions/khr/surface.rs
@@ -92,7 +92,7 @@ impl Surface {
             .destroy_surface_khr(self.handle, surface, allocation_callbacks.as_raw_ptr());
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrSurfaceFn::name()
     }
 

--- a/ash/src/extensions/khr/swapchain.rs
+++ b/ash/src/extensions/khr/swapchain.rs
@@ -98,7 +98,7 @@ impl Swapchain {
         })
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrSwapchainFn::name()
     }
 

--- a/ash/src/extensions/khr/synchronization2.rs
+++ b/ash/src/extensions/khr/synchronization2.rs
@@ -89,7 +89,7 @@ impl Synchronization2 {
             .result()
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrSynchronization2Fn::name()
     }
 

--- a/ash/src/extensions/khr/timeline_semaphore.rs
+++ b/ash/src/extensions/khr/timeline_semaphore.rs
@@ -45,7 +45,7 @@ impl TimelineSemaphore {
             .result()
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrTimelineSemaphoreFn::name()
     }
 

--- a/ash/src/extensions/khr/wayland_surface.rs
+++ b/ash/src/extensions/khr/wayland_surface.rs
@@ -55,7 +55,7 @@ impl WaylandSurface {
         b > 0
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrWaylandSurfaceFn::name()
     }
 

--- a/ash/src/extensions/khr/win32_surface.rs
+++ b/ash/src/extensions/khr/win32_surface.rs
@@ -51,7 +51,7 @@ impl Win32Surface {
         b > 0
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrWin32SurfaceFn::name()
     }
 

--- a/ash/src/extensions/khr/xcb_surface.rs
+++ b/ash/src/extensions/khr/xcb_surface.rs
@@ -55,7 +55,7 @@ impl XcbSurface {
         b > 0
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrXcbSurfaceFn::name()
     }
 

--- a/ash/src/extensions/khr/xlib_surface.rs
+++ b/ash/src/extensions/khr/xlib_surface.rs
@@ -55,7 +55,7 @@ impl XlibSurface {
         b > 0
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::KhrXlibSurfaceFn::name()
     }
 

--- a/ash/src/extensions/mvk/ios_surface.rs
+++ b/ash/src/extensions/mvk/ios_surface.rs
@@ -37,7 +37,7 @@ impl IOSSurface {
             .result_with_success(surface)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::MvkIosSurfaceFn::name()
     }
 

--- a/ash/src/extensions/mvk/macos_surface.rs
+++ b/ash/src/extensions/mvk/macos_surface.rs
@@ -37,7 +37,7 @@ impl MacOSSurface {
             .result_with_success(surface)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::MvkMacosSurfaceFn::name()
     }
 

--- a/ash/src/extensions/nn/vi_surface.rs
+++ b/ash/src/extensions/nn/vi_surface.rs
@@ -37,7 +37,7 @@ impl ViSurface {
             .result_with_success(surface)
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::NnViSurfaceFn::name()
     }
 

--- a/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
+++ b/ash/src/extensions/nv/device_diagnostic_checkpoints.rs
@@ -45,7 +45,7 @@ impl DeviceDiagnosticCheckpoints {
         checkpoint_data
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::NvDeviceDiagnosticCheckpointsFn::name()
     }
 

--- a/ash/src/extensions/nv/mesh_shader.rs
+++ b/ash/src/extensions/nv/mesh_shader.rs
@@ -62,7 +62,7 @@ impl MeshShader {
         );
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::NvMeshShaderFn::name()
     }
 

--- a/ash/src/extensions/nv/ray_tracing.rs
+++ b/ash/src/extensions/nv/ray_tracing.rs
@@ -249,7 +249,7 @@ impl RayTracing {
             .result()
     }
 
-    pub fn name() -> &'static CStr {
+    pub const fn name() -> &'static CStr {
         vk::NvRayTracingFn::name()
     }
 

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -5,7 +5,7 @@ use crate::vk::enums::*;
 use crate::vk::platform_types::*;
 use std::os::raw::*;
 impl KhrSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 25u32;
@@ -244,7 +244,7 @@ impl Result {
     pub const ERROR_NATIVE_WINDOW_IN_USE_KHR: Self = Self(-1_000_000_001);
 }
 impl KhrSwapchainFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_swapchain\0") }
     }
     pub const SPEC_VERSION: u32 = 70u32;
@@ -638,7 +638,7 @@ impl SwapchainCreateFlagsKHR {
     pub const PROTECTED: Self = Self(0b10);
 }
 impl KhrDisplayFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_display\0") }
     }
     pub const SPEC_VERSION: u32 = 23u32;
@@ -968,7 +968,7 @@ impl StructureType {
     pub const DISPLAY_SURFACE_CREATE_INFO_KHR: Self = Self(1_000_002_001);
 }
 impl KhrDisplaySwapchainFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_display_swapchain\0") }
     }
     pub const SPEC_VERSION: u32 = 10u32;
@@ -1045,7 +1045,7 @@ impl StructureType {
     pub const DISPLAY_PRESENT_INFO_KHR: Self = Self(1_000_003_000);
 }
 impl KhrXlibSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_xlib_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 6u32;
@@ -1154,7 +1154,7 @@ impl StructureType {
     pub const XLIB_SURFACE_CREATE_INFO_KHR: Self = Self(1_000_004_000);
 }
 impl KhrXcbSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_xcb_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 6u32;
@@ -1263,7 +1263,7 @@ impl StructureType {
     pub const XCB_SURFACE_CREATE_INFO_KHR: Self = Self(1_000_005_000);
 }
 impl KhrWaylandSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_wayland_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 6u32;
@@ -1369,7 +1369,7 @@ impl StructureType {
     pub const WAYLAND_SURFACE_CREATE_INFO_KHR: Self = Self(1_000_006_000);
 }
 impl KhrMirSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_mir_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 4u32;
@@ -1387,7 +1387,7 @@ impl KhrMirSurfaceFn {
     }
 }
 impl KhrAndroidSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_android_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 6u32;
@@ -1450,7 +1450,7 @@ impl StructureType {
     pub const ANDROID_SURFACE_CREATE_INFO_KHR: Self = Self(1_000_008_000);
 }
 impl KhrWin32SurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_win32_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 6u32;
@@ -1549,7 +1549,7 @@ impl StructureType {
     pub const WIN32_SURFACE_CREATE_INFO_KHR: Self = Self(1_000_009_000);
 }
 impl AndroidNativeBufferFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_ANDROID_native_buffer\0") }
     }
     pub const SPEC_VERSION: u32 = 8u32;
@@ -1759,7 +1759,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_PRESENTATION_PROPERTIES_ANDROID: Self = Self(1_000_010_002);
 }
 impl ExtDebugReportFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_debug_report\0") }
     }
     pub const SPEC_VERSION: u32 = 10u32;
@@ -1933,7 +1933,7 @@ impl StructureType {
     pub const DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT: Self = Self(1_000_011_000);
 }
 impl NvGlslShaderFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_glsl_shader\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -1955,7 +1955,7 @@ impl Result {
     pub const ERROR_INVALID_SHADER_NV: Self = Self(-1_000_012_000);
 }
 impl ExtDepthRangeUnrestrictedFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_depth_range_unrestricted\0")
         }
@@ -1975,7 +1975,7 @@ impl ExtDepthRangeUnrestrictedFn {
     }
 }
 impl KhrSamplerMirrorClampToEdgeFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_sampler_mirror_clamp_to_edge\0",
@@ -2004,7 +2004,7 @@ impl SamplerAddressMode {
     pub const MIRROR_CLAMP_TO_EDGE_KHR: Self = Self::MIRROR_CLAMP_TO_EDGE;
 }
 impl ImgFilterCubicFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_IMG_filter_cubic\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -2031,7 +2031,7 @@ impl FormatFeatureFlags {
     pub const SAMPLED_IMAGE_FILTER_CUBIC_IMG: Self = Self(0b10_0000_0000_0000);
 }
 impl AmdExtension17Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_17\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -2049,7 +2049,7 @@ impl AmdExtension17Fn {
     }
 }
 impl AmdExtension18Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_18\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -2067,7 +2067,7 @@ impl AmdExtension18Fn {
     }
 }
 impl AmdRasterizationOrderFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_rasterization_order\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -2089,7 +2089,7 @@ impl StructureType {
     pub const PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD: Self = Self(1_000_018_000);
 }
 impl AmdExtension20Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_20\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -2107,7 +2107,7 @@ impl AmdExtension20Fn {
     }
 }
 impl AmdShaderTrinaryMinmaxFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_shader_trinary_minmax\0")
         }
@@ -2127,7 +2127,7 @@ impl AmdShaderTrinaryMinmaxFn {
     }
 }
 impl AmdShaderExplicitVertexParameterFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_AMD_shader_explicit_vertex_parameter\0",
@@ -2149,7 +2149,7 @@ impl AmdShaderExplicitVertexParameterFn {
     }
 }
 impl ExtDebugMarkerFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_debug_marker\0") }
     }
     pub const SPEC_VERSION: u32 = 4u32;
@@ -2332,7 +2332,7 @@ impl StructureType {
     pub const DEBUG_MARKER_MARKER_INFO_EXT: Self = Self(1_000_022_002);
 }
 impl KhrVideoQueueFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_video_queue\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -2858,7 +2858,7 @@ impl StructureType {
     pub const QUEUE_FAMILY_QUERY_RESULT_STATUS_PROPERTIES_2_KHR: Self = Self(1_000_023_016);
 }
 impl KhrVideoDecodeQueueFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_video_decode_queue\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -2952,7 +2952,7 @@ impl StructureType {
     pub const VIDEO_DECODE_INFO_KHR: Self = Self(1_000_024_000);
 }
 impl AmdGcnShaderFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_gcn_shader\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -2970,7 +2970,7 @@ impl AmdGcnShaderFn {
     }
 }
 impl NvDedicatedAllocationFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_dedicated_allocation\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -2994,7 +2994,7 @@ impl StructureType {
     pub const DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV: Self = Self(1_000_026_002);
 }
 impl ExtExtension28Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_28\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -3012,7 +3012,7 @@ impl ExtExtension28Fn {
     }
 }
 impl ExtTransformFeedbackFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_transform_feedback\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -3347,7 +3347,7 @@ impl StructureType {
     pub const PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT: Self = Self(1_000_028_002);
 }
 impl NvxBinaryImportFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NVX_binary_import\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -3561,7 +3561,7 @@ impl StructureType {
     pub const CU_LAUNCH_INFO_NVX: Self = Self(1_000_029_002);
 }
 impl NvxImageViewHandleFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NVX_image_view_handle\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -3653,7 +3653,7 @@ impl StructureType {
     pub const IMAGE_VIEW_ADDRESS_PROPERTIES_NVX: Self = Self(1_000_030_001);
 }
 impl AmdExtension32Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_32\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -3671,7 +3671,7 @@ impl AmdExtension32Fn {
     }
 }
 impl AmdExtension33Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_33\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -3689,7 +3689,7 @@ impl AmdExtension33Fn {
     }
 }
 impl AmdDrawIndirectCountFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_draw_indirect_count\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -3822,7 +3822,7 @@ impl AmdDrawIndirectCountFn {
     }
 }
 impl AmdExtension35Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_35\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -3840,7 +3840,7 @@ impl AmdExtension35Fn {
     }
 }
 impl AmdNegativeViewportHeightFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_negative_viewport_height\0")
         }
@@ -3860,7 +3860,7 @@ impl AmdNegativeViewportHeightFn {
     }
 }
 impl AmdGpuShaderHalfFloatFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_gpu_shader_half_float\0")
         }
@@ -3880,7 +3880,7 @@ impl AmdGpuShaderHalfFloatFn {
     }
 }
 impl AmdShaderBallotFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_shader_ballot\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -3898,7 +3898,7 @@ impl AmdShaderBallotFn {
     }
 }
 impl ExtVideoEncodeH264Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_encode_h264\0") }
     }
     pub const SPEC_VERSION: u32 = 5u32;
@@ -3935,7 +3935,7 @@ impl VideoCodecOperationFlagsKHR {
     pub const ENCODE_H264_EXT: Self = Self(0b1_0000_0000_0000_0000);
 }
 impl ExtVideoEncodeH265Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_encode_h265\0") }
     }
     pub const SPEC_VERSION: u32 = 5u32;
@@ -3972,7 +3972,7 @@ impl VideoCodecOperationFlagsKHR {
     pub const ENCODE_H265_EXT: Self = Self(0b10_0000_0000_0000_0000);
 }
 impl ExtVideoDecodeH264Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_decode_h264\0") }
     }
     pub const SPEC_VERSION: u32 = 3u32;
@@ -4005,7 +4005,7 @@ impl VideoCodecOperationFlagsKHR {
     pub const DECODE_H264_EXT: Self = Self(0b1);
 }
 impl AmdTextureGatherBiasLodFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_texture_gather_bias_lod\0")
         }
@@ -4029,7 +4029,7 @@ impl StructureType {
     pub const TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD: Self = Self(1_000_041_000);
 }
 impl AmdShaderInfoFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_shader_info\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -4098,7 +4098,7 @@ impl AmdShaderInfoFn {
     }
 }
 impl AmdExtension44Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_44\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -4116,7 +4116,7 @@ impl AmdExtension44Fn {
     }
 }
 impl KhrDynamicRenderingFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_dynamic_rendering\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -4218,7 +4218,7 @@ impl StructureType {
     pub const MULTIVIEW_PER_VIEW_ATTRIBUTES_INFO_NVX: Self = Self(1_000_044_009);
 }
 impl AmdExtension46Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_46\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -4236,7 +4236,7 @@ impl AmdExtension46Fn {
     }
 }
 impl AmdShaderImageLoadStoreLodFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_shader_image_load_store_lod\0")
         }
@@ -4256,7 +4256,7 @@ impl AmdShaderImageLoadStoreLodFn {
     }
 }
 impl NvxExtension48Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NVX_extension_48\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -4274,7 +4274,7 @@ impl NvxExtension48Fn {
     }
 }
 impl GoogleExtension49Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_49\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -4292,7 +4292,7 @@ impl GoogleExtension49Fn {
     }
 }
 impl GgpStreamDescriptorSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GGP_stream_descriptor_surface\0")
         }
@@ -4358,7 +4358,7 @@ impl StructureType {
     pub const STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP: Self = Self(1_000_049_000);
 }
 impl NvCornerSampledImageFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_corner_sampled_image\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -4384,7 +4384,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV: Self = Self(1_000_050_000);
 }
 impl NvExtension52Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_52\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -4410,7 +4410,7 @@ impl ShaderModuleCreateFlags {
     pub const RESERVED_0_NV: Self = Self(0b1);
 }
 impl NvExtension53Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_53\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -4428,7 +4428,7 @@ impl NvExtension53Fn {
     }
 }
 impl KhrMultiviewFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_multiview\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -4458,7 +4458,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES;
 }
 impl ImgFormatPvrtcFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_IMG_format_pvrtc\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -4487,7 +4487,7 @@ impl Format {
     pub const PVRTC2_4BPP_SRGB_BLOCK_IMG: Self = Self(1_000_054_007);
 }
 impl NvExternalMemoryCapabilitiesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_external_memory_capabilities\0")
         }
@@ -4572,7 +4572,7 @@ impl NvExternalMemoryCapabilitiesFn {
     }
 }
 impl NvExternalMemoryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_external_memory\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -4595,7 +4595,7 @@ impl StructureType {
     pub const EXPORT_MEMORY_ALLOCATE_INFO_NV: Self = Self(1_000_056_001);
 }
 impl NvExternalMemoryWin32Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_external_memory_win32\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -4659,7 +4659,7 @@ impl StructureType {
     pub const EXPORT_MEMORY_WIN32_HANDLE_INFO_NV: Self = Self(1_000_057_001);
 }
 impl NvWin32KeyedMutexFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_win32_keyed_mutex\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -4681,7 +4681,7 @@ impl StructureType {
     pub const WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV: Self = Self(1_000_058_000);
 }
 impl KhrGetPhysicalDeviceProperties2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_get_physical_device_properties2\0",
@@ -4993,7 +4993,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2;
 }
 impl KhrDeviceGroupFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_device_group\0") }
     }
     pub const SPEC_VERSION: u32 = 4u32;
@@ -5316,7 +5316,7 @@ impl StructureType {
         Self::BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO;
 }
 impl ExtValidationFlagsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_validation_flags\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -5338,7 +5338,7 @@ impl StructureType {
     pub const VALIDATION_FLAGS_EXT: Self = Self(1_000_061_000);
 }
 impl NnViSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NN_vi_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -5398,7 +5398,7 @@ impl StructureType {
     pub const VI_SURFACE_CREATE_INFO_NN: Self = Self(1_000_062_000);
 }
 impl KhrShaderDrawParametersFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shader_draw_parameters\0")
         }
@@ -5418,7 +5418,7 @@ impl KhrShaderDrawParametersFn {
     }
 }
 impl ExtShaderSubgroupBallotFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_subgroup_ballot\0")
         }
@@ -5438,7 +5438,7 @@ impl ExtShaderSubgroupBallotFn {
     }
 }
 impl ExtShaderSubgroupVoteFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_subgroup_vote\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -5456,7 +5456,7 @@ impl ExtShaderSubgroupVoteFn {
     }
 }
 impl ExtTextureCompressionAstcHdrFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_EXT_texture_compression_astc_hdr\0",
@@ -5500,7 +5500,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES;
 }
 impl ExtAstcDecodeModeFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_astc_decode_mode\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -5523,7 +5523,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT: Self = Self(1_000_067_001);
 }
 impl ImgExtension69Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_IMG_extension_69\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -5541,7 +5541,7 @@ impl ImgExtension69Fn {
     }
 }
 impl KhrMaintenance1Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_maintenance1\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -5610,7 +5610,7 @@ impl Result {
     pub const ERROR_OUT_OF_POOL_MEMORY_KHR: Self = Self::ERROR_OUT_OF_POOL_MEMORY;
 }
 impl KhrDeviceGroupCreationFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_device_group_creation\0")
         }
@@ -5682,7 +5682,7 @@ impl StructureType {
     pub const DEVICE_GROUP_DEVICE_CREATE_INFO_KHR: Self = Self::DEVICE_GROUP_DEVICE_CREATE_INFO;
 }
 impl KhrExternalMemoryCapabilitiesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_external_memory_capabilities\0",
@@ -5774,7 +5774,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_ID_PROPERTIES_KHR: Self = Self::PHYSICAL_DEVICE_ID_PROPERTIES;
 }
 impl KhrExternalMemoryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_memory\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -5803,7 +5803,7 @@ impl StructureType {
     pub const EXPORT_MEMORY_ALLOCATE_INFO_KHR: Self = Self::EXPORT_MEMORY_ALLOCATE_INFO;
 }
 impl KhrExternalMemoryWin32Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_memory_win32\0")
         }
@@ -5913,7 +5913,7 @@ impl StructureType {
     pub const MEMORY_GET_WIN32_HANDLE_INFO_KHR: Self = Self(1_000_073_003);
 }
 impl KhrExternalMemoryFdFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_memory_fd\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -6011,7 +6011,7 @@ impl StructureType {
     pub const MEMORY_GET_FD_INFO_KHR: Self = Self(1_000_074_002);
 }
 impl KhrWin32KeyedMutexFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_win32_keyed_mutex\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -6033,7 +6033,7 @@ impl StructureType {
     pub const WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR: Self = Self(1_000_075_000);
 }
 impl KhrExternalSemaphoreCapabilitiesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_external_semaphore_capabilities\0",
@@ -6118,7 +6118,7 @@ impl StructureType {
     pub const EXTERNAL_SEMAPHORE_PROPERTIES_KHR: Self = Self::EXTERNAL_SEMAPHORE_PROPERTIES;
 }
 impl KhrExternalSemaphoreFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_semaphore\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -6144,7 +6144,7 @@ impl StructureType {
     pub const EXPORT_SEMAPHORE_CREATE_INFO_KHR: Self = Self::EXPORT_SEMAPHORE_CREATE_INFO;
 }
 impl KhrExternalSemaphoreWin32Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_semaphore_win32\0")
         }
@@ -6244,7 +6244,7 @@ impl StructureType {
     pub const SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR: Self = Self(1_000_078_003);
 }
 impl KhrExternalSemaphoreFdFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_semaphore_fd\0")
         }
@@ -6337,7 +6337,7 @@ impl StructureType {
     pub const SEMAPHORE_GET_FD_INFO_KHR: Self = Self(1_000_079_001);
 }
 impl KhrPushDescriptorFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_push_descriptor\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -6472,7 +6472,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR: Self = Self(1_000_080_000);
 }
 impl ExtConditionalRenderingFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_conditional_rendering\0")
         }
@@ -6576,7 +6576,7 @@ impl StructureType {
     pub const CONDITIONAL_RENDERING_BEGIN_INFO_EXT: Self = Self(1_000_081_002);
 }
 impl KhrShaderFloat16Int8Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shader_float16_int8\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -6601,7 +6601,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
 }
 impl Khr16bitStorageFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_16bit_storage\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -6624,7 +6624,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES;
 }
 impl KhrIncrementalPresentFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_incremental_present\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -6646,7 +6646,7 @@ impl StructureType {
     pub const PRESENT_REGIONS_KHR: Self = Self(1_000_084_000);
 }
 impl KhrDescriptorUpdateTemplateFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_descriptor_update_template\0")
         }
@@ -6858,7 +6858,7 @@ impl StructureType {
         Self::DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO;
 }
 impl NvxDeviceGeneratedCommandsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NVX_device_generated_commands\0")
         }
@@ -6878,7 +6878,7 @@ impl NvxDeviceGeneratedCommandsFn {
     }
 }
 impl NvClipSpaceWScalingFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_clip_space_w_scaling\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -6951,7 +6951,7 @@ impl StructureType {
     pub const PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV: Self = Self(1_000_087_000);
 }
 impl ExtDirectModeDisplayFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_direct_mode_display\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -6999,7 +6999,7 @@ impl ExtDirectModeDisplayFn {
     }
 }
 impl ExtAcquireXlibDisplayFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_acquire_xlib_display\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -7095,7 +7095,7 @@ impl ExtAcquireXlibDisplayFn {
     }
 }
 impl ExtDisplaySurfaceCounterFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_display_surface_counter\0")
         }
@@ -7163,7 +7163,7 @@ impl StructureType {
     pub const SURFACE_CAPABILITIES_2_EXT: Self = Self(1_000_090_000);
 }
 impl ExtDisplayControlFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_display_control\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -7352,7 +7352,7 @@ impl StructureType {
     pub const SWAPCHAIN_COUNTER_CREATE_INFO_EXT: Self = Self(1_000_091_003);
 }
 impl GoogleDisplayTimingFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_display_timing\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -7458,7 +7458,7 @@ impl StructureType {
     pub const PRESENT_TIMES_INFO_GOOGLE: Self = Self(1_000_092_000);
 }
 impl NvSampleMaskOverrideCoverageFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_NV_sample_mask_override_coverage\0",
@@ -7480,7 +7480,7 @@ impl NvSampleMaskOverrideCoverageFn {
     }
 }
 impl NvGeometryShaderPassthroughFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_geometry_shader_passthrough\0")
         }
@@ -7500,7 +7500,7 @@ impl NvGeometryShaderPassthroughFn {
     }
 }
 impl NvViewportArray2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_viewport_array2\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -7518,7 +7518,7 @@ impl NvViewportArray2Fn {
     }
 }
 impl NvxMultiviewPerViewAttributesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_NVX_multiview_per_view_attributes\0",
@@ -7550,7 +7550,7 @@ impl SubpassDescriptionFlags {
     pub const PER_VIEW_POSITION_X_ONLY_NVX: Self = Self(0b10);
 }
 impl NvViewportSwizzleFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_viewport_swizzle\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -7572,7 +7572,7 @@ impl StructureType {
     pub const PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV: Self = Self(1_000_098_000);
 }
 impl ExtDiscardRectanglesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_discard_rectangles\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -7646,7 +7646,7 @@ impl StructureType {
     pub const PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT: Self = Self(1_000_099_001);
 }
 impl NvExtension101Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_101\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -7664,7 +7664,7 @@ impl NvExtension101Fn {
     }
 }
 impl ExtConservativeRasterizationFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_conservative_rasterization\0")
         }
@@ -7689,7 +7689,7 @@ impl StructureType {
     pub const PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT: Self = Self(1_000_101_001);
 }
 impl ExtDepthClipEnableFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_depth_clip_enable\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -7712,7 +7712,7 @@ impl StructureType {
     pub const PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT: Self = Self(1_000_102_001);
 }
 impl NvExtension104Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_104\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -7730,7 +7730,7 @@ impl NvExtension104Fn {
     }
 }
 impl ExtSwapchainColorspaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_swapchain_colorspace\0") }
     }
     pub const SPEC_VERSION: u32 = 4u32;
@@ -7765,7 +7765,7 @@ impl ColorSpaceKHR {
     pub const EXTENDED_SRGB_NONLINEAR_EXT: Self = Self(1_000_104_014);
 }
 impl ExtHdrMetadataFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_hdr_metadata\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -7825,7 +7825,7 @@ impl StructureType {
     pub const HDR_METADATA_EXT: Self = Self(1_000_105_000);
 }
 impl ImgExtension107Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_IMG_extension_107\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -7843,7 +7843,7 @@ impl ImgExtension107Fn {
     }
 }
 impl ImgExtension108Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_IMG_extension_108\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -7861,7 +7861,7 @@ impl ImgExtension108Fn {
     }
 }
 impl KhrImagelessFramebufferFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_imageless_framebuffer\0")
         }
@@ -7894,7 +7894,7 @@ impl StructureType {
     pub const RENDER_PASS_ATTACHMENT_BEGIN_INFO_KHR: Self = Self::RENDER_PASS_ATTACHMENT_BEGIN_INFO;
 }
 impl KhrCreateRenderpass2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_create_renderpass2\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -8068,7 +8068,7 @@ impl StructureType {
     pub const SUBPASS_END_INFO_KHR: Self = Self::SUBPASS_END_INFO;
 }
 impl ImgExtension111Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_IMG_extension_111\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -8086,7 +8086,7 @@ impl ImgExtension111Fn {
     }
 }
 impl KhrSharedPresentableImageFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shared_presentable_image\0")
         }
@@ -8152,7 +8152,7 @@ impl StructureType {
     pub const SHARED_PRESENT_SURFACE_CAPABILITIES_KHR: Self = Self(1_000_111_000);
 }
 impl KhrExternalFenceCapabilitiesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_fence_capabilities\0")
         }
@@ -8234,7 +8234,7 @@ impl StructureType {
     pub const EXTERNAL_FENCE_PROPERTIES_KHR: Self = Self::EXTERNAL_FENCE_PROPERTIES;
 }
 impl KhrExternalFenceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_fence\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -8260,7 +8260,7 @@ impl StructureType {
     pub const EXPORT_FENCE_CREATE_INFO_KHR: Self = Self::EXPORT_FENCE_CREATE_INFO;
 }
 impl KhrExternalFenceWin32Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_fence_win32\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -8356,7 +8356,7 @@ impl StructureType {
     pub const FENCE_GET_WIN32_HANDLE_INFO_KHR: Self = Self(1_000_114_002);
 }
 impl KhrExternalFenceFdFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_external_fence_fd\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -8443,7 +8443,7 @@ impl StructureType {
     pub const FENCE_GET_FD_INFO_KHR: Self = Self(1_000_115_001);
 }
 impl KhrPerformanceQueryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_performance_query\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -8627,7 +8627,7 @@ impl StructureType {
     pub const PERFORMANCE_COUNTER_DESCRIPTION_KHR: Self = Self(1_000_116_006);
 }
 impl KhrMaintenance2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_maintenance2\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -8677,7 +8677,7 @@ impl TessellationDomainOrigin {
     pub const LOWER_LEFT_KHR: Self = Self::LOWER_LEFT;
 }
 impl KhrExtension119Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_119\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -8695,7 +8695,7 @@ impl KhrExtension119Fn {
     }
 }
 impl KhrGetSurfaceCapabilities2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_get_surface_capabilities2\0")
         }
@@ -8810,7 +8810,7 @@ impl StructureType {
     pub const SURFACE_FORMAT_2_KHR: Self = Self(1_000_119_002);
 }
 impl KhrVariablePointersFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_variable_pointers\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -8835,7 +8835,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES_KHR;
 }
 impl KhrGetDisplayProperties2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_get_display_properties2\0")
         }
@@ -9034,7 +9034,7 @@ impl StructureType {
     pub const DISPLAY_PLANE_CAPABILITIES_2_KHR: Self = Self(1_000_121_004);
 }
 impl MvkIosSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_MVK_ios_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 3u32;
@@ -9097,7 +9097,7 @@ impl StructureType {
     pub const IOS_SURFACE_CREATE_INFO_MVK: Self = Self(1_000_122_000);
 }
 impl MvkMacosSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_MVK_macos_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 3u32;
@@ -9160,7 +9160,7 @@ impl StructureType {
     pub const MACOS_SURFACE_CREATE_INFO_MVK: Self = Self(1_000_123_000);
 }
 impl MvkMoltenvkFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_MVK_moltenvk\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -9178,7 +9178,7 @@ impl MvkMoltenvkFn {
     }
 }
 impl ExtExternalMemoryDmaBufFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_external_memory_dma_buf\0")
         }
@@ -9202,7 +9202,7 @@ impl ExternalMemoryHandleTypeFlags {
     pub const DMA_BUF_EXT: Self = Self(0b10_0000_0000);
 }
 impl ExtQueueFamilyForeignFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_queue_family_foreign\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -9220,7 +9220,7 @@ impl ExtQueueFamilyForeignFn {
     }
 }
 impl KhrDedicatedAllocationFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_dedicated_allocation\0") }
     }
     pub const SPEC_VERSION: u32 = 3u32;
@@ -9243,7 +9243,7 @@ impl StructureType {
     pub const MEMORY_DEDICATED_ALLOCATE_INFO_KHR: Self = Self::MEMORY_DEDICATED_ALLOCATE_INFO;
 }
 impl ExtDebugUtilsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_debug_utils\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -9647,7 +9647,7 @@ impl StructureType {
     pub const DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT: Self = Self(1_000_128_004);
 }
 impl AndroidExternalMemoryAndroidHardwareBufferFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_ANDROID_external_memory_android_hardware_buffer\0",
@@ -9760,7 +9760,7 @@ impl StructureType {
     pub const ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID: Self = Self(1_000_129_006);
 }
 impl ExtSamplerFilterMinmaxFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_sampler_filter_minmax\0")
         }
@@ -9797,7 +9797,7 @@ impl StructureType {
         Self::SAMPLER_REDUCTION_MODE_CREATE_INFO;
 }
 impl KhrStorageBufferStorageClassFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_storage_buffer_storage_class\0",
@@ -9819,7 +9819,7 @@ impl KhrStorageBufferStorageClassFn {
     }
 }
 impl AmdGpuShaderInt16Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_gpu_shader_int16\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -9837,7 +9837,7 @@ impl AmdGpuShaderInt16Fn {
     }
 }
 impl AmdExtension134Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_134\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -9855,7 +9855,7 @@ impl AmdExtension134Fn {
     }
 }
 impl AmdExtension135Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_135\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -9873,7 +9873,7 @@ impl AmdExtension135Fn {
     }
 }
 impl AmdExtension136Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_136\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -9891,7 +9891,7 @@ impl AmdExtension136Fn {
     }
 }
 impl AmdMixedAttachmentSamplesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_mixed_attachment_samples\0")
         }
@@ -9911,7 +9911,7 @@ impl AmdMixedAttachmentSamplesFn {
     }
 }
 impl AmdShaderFragmentMaskFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_shader_fragment_mask\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -9929,7 +9929,7 @@ impl AmdShaderFragmentMaskFn {
     }
 }
 impl ExtInlineUniformBlockFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_inline_uniform_block\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -9962,7 +9962,7 @@ impl StructureType {
         Self::DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO;
 }
 impl AmdExtension140Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_140\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -9980,7 +9980,7 @@ impl AmdExtension140Fn {
     }
 }
 impl ExtShaderStencilExportFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_stencil_export\0")
         }
@@ -10000,7 +10000,7 @@ impl ExtShaderStencilExportFn {
     }
 }
 impl AmdExtension142Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_142\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -10018,7 +10018,7 @@ impl AmdExtension142Fn {
     }
 }
 impl AmdExtension143Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_143\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -10036,7 +10036,7 @@ impl AmdExtension143Fn {
     }
 }
 impl ExtSampleLocationsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_sample_locations\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -10148,7 +10148,7 @@ impl StructureType {
     pub const MULTISAMPLE_PROPERTIES_EXT: Self = Self(1_000_143_004);
 }
 impl KhrRelaxedBlockLayoutFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_relaxed_block_layout\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -10166,7 +10166,7 @@ impl KhrRelaxedBlockLayoutFn {
     }
 }
 impl KhrGetMemoryRequirements2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_get_memory_requirements2\0")
         }
@@ -10317,7 +10317,7 @@ impl StructureType {
         Self::SPARSE_IMAGE_MEMORY_REQUIREMENTS_2;
 }
 impl KhrImageFormatListFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_image_format_list\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -10339,7 +10339,7 @@ impl StructureType {
     pub const IMAGE_FORMAT_LIST_CREATE_INFO_KHR: Self = Self::IMAGE_FORMAT_LIST_CREATE_INFO;
 }
 impl ExtBlendOperationAdvancedFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_blend_operation_advanced\0")
         }
@@ -10418,7 +10418,7 @@ impl StructureType {
     pub const PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT: Self = Self(1_000_148_002);
 }
 impl NvFragmentCoverageToColorFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_fragment_coverage_to_color\0")
         }
@@ -10442,7 +10442,7 @@ impl StructureType {
     pub const PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV: Self = Self(1_000_149_000);
 }
 impl KhrAccelerationStructureFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_acceleration_structure\0")
         }
@@ -11212,7 +11212,7 @@ impl StructureType {
     pub const ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR: Self = Self(1_000_150_020);
 }
 impl KhrRayTracingPipelineFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_ray_tracing_pipeline\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -11621,7 +11621,7 @@ impl StructureType {
     pub const RAY_TRACING_PIPELINE_INTERFACE_CREATE_INFO_KHR: Self = Self(1_000_150_018);
 }
 impl KhrRayQueryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_ray_query\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -11643,7 +11643,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR: Self = Self(1_000_348_013);
 }
 impl NvExtension152Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_152\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -11661,7 +11661,7 @@ impl NvExtension152Fn {
     }
 }
 impl NvFramebufferMixedSamplesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_framebuffer_mixed_samples\0")
         }
@@ -11685,7 +11685,7 @@ impl StructureType {
     pub const PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV: Self = Self(1_000_152_000);
 }
 impl NvFillRectangleFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_fill_rectangle\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -11707,7 +11707,7 @@ impl PolygonMode {
     pub const FILL_RECTANGLE_NV: Self = Self(1_000_153_000);
 }
 impl NvShaderSmBuiltinsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_shader_sm_builtins\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -11730,7 +11730,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV: Self = Self(1_000_154_001);
 }
 impl ExtPostDepthCoverageFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_post_depth_coverage\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -11748,7 +11748,7 @@ impl ExtPostDepthCoverageFn {
     }
 }
 impl KhrSamplerYcbcrConversionFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_sampler_ycbcr_conversion\0")
         }
@@ -11968,7 +11968,7 @@ impl StructureType {
         Self::SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES;
 }
 impl KhrBindMemory2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_bind_memory2\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -12069,7 +12069,7 @@ impl StructureType {
     pub const BIND_IMAGE_MEMORY_INFO_KHR: Self = Self::BIND_IMAGE_MEMORY_INFO;
 }
 impl ExtImageDrmFormatModifierFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_image_drm_format_modifier\0")
         }
@@ -12152,7 +12152,7 @@ impl StructureType {
     pub const DRM_FORMAT_MODIFIER_PROPERTIES_LIST_2_EXT: Self = Self(1_000_158_006);
 }
 impl ExtExtension160Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_160\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -12170,7 +12170,7 @@ impl ExtExtension160Fn {
     }
 }
 impl ExtValidationCacheFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_validation_cache\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -12356,7 +12356,7 @@ impl StructureType {
     pub const SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT: Self = Self(1_000_160_001);
 }
 impl ExtDescriptorIndexingFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_descriptor_indexing\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -12406,7 +12406,7 @@ impl StructureType {
         Self::DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT;
 }
 impl ExtShaderViewportIndexLayerFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_viewport_index_layer\0")
         }
@@ -12426,7 +12426,7 @@ impl ExtShaderViewportIndexLayerFn {
     }
 }
 impl KhrPortabilitySubsetFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_portability_subset\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -12449,7 +12449,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR: Self = Self(1_000_163_001);
 }
 impl NvShadingRateImageFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_shading_rate_image\0") }
     }
     pub const SPEC_VERSION: u32 = 3u32;
@@ -12625,7 +12625,7 @@ impl StructureType {
         Self(1_000_164_005);
 }
 impl NvRayTracingFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_ray_tracing\0") }
     }
     pub const SPEC_VERSION: u32 = 3u32;
@@ -13328,7 +13328,7 @@ impl StructureType {
     pub const ACCELERATION_STRUCTURE_INFO_NV: Self = Self(1_000_165_012);
 }
 impl NvRepresentativeFragmentTestFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_representative_fragment_test\0")
         }
@@ -13354,7 +13354,7 @@ impl StructureType {
         Self(1_000_166_001);
 }
 impl NvExtension168Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_168\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -13372,7 +13372,7 @@ impl NvExtension168Fn {
     }
 }
 impl KhrMaintenance3Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_maintenance3\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -13435,7 +13435,7 @@ impl StructureType {
     pub const DESCRIPTOR_SET_LAYOUT_SUPPORT_KHR: Self = Self::DESCRIPTOR_SET_LAYOUT_SUPPORT;
 }
 impl KhrDrawIndirectCountFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_draw_indirect_count\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -13548,7 +13548,7 @@ impl KhrDrawIndirectCountFn {
     }
 }
 impl ExtFilterCubicFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_filter_cubic\0") }
     }
     pub const SPEC_VERSION: u32 = 3u32;
@@ -13579,7 +13579,7 @@ impl StructureType {
     pub const FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT: Self = Self(1_000_170_001);
 }
 impl QcomRenderPassShaderResolveFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_render_pass_shader_resolve\0")
         }
@@ -13604,7 +13604,7 @@ impl SubpassDescriptionFlags {
     pub const SHADER_RESOLVE_QCOM: Self = Self(0b1000);
 }
 impl QcomExtension173Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_173\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -13631,7 +13631,7 @@ impl ImageUsageFlags {
     pub const RESERVED_17_QCOM: Self = Self(0b10_0000_0000_0000_0000);
 }
 impl QcomExtension174Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_174\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -13649,7 +13649,7 @@ impl QcomExtension174Fn {
     }
 }
 impl ExtGlobalPriorityFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_global_priority\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -13676,7 +13676,7 @@ impl StructureType {
         Self::DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR;
 }
 impl KhrShaderSubgroupExtendedTypesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_shader_subgroup_extended_types\0",
@@ -13703,7 +13703,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES;
 }
 impl ExtExtension177Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_177\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -13721,7 +13721,7 @@ impl ExtExtension177Fn {
     }
 }
 impl Khr8bitStorageFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_8bit_storage\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -13744,7 +13744,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES;
 }
 impl ExtExternalMemoryHostFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_external_memory_host\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -13820,7 +13820,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT: Self = Self(1_000_178_002);
 }
 impl AmdBufferMarkerFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_buffer_marker\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -13888,7 +13888,7 @@ impl AmdBufferMarkerFn {
     }
 }
 impl KhrShaderAtomicInt64Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shader_atomic_int64\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -13911,7 +13911,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES;
 }
 impl KhrShaderClockFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shader_clock\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -13933,7 +13933,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR: Self = Self(1_000_181_000);
 }
 impl AmdExtension183Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_183\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -13951,7 +13951,7 @@ impl AmdExtension183Fn {
     }
 }
 impl AmdPipelineCompilerControlFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_pipeline_compiler_control\0")
         }
@@ -13975,7 +13975,7 @@ impl StructureType {
     pub const PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD: Self = Self(1_000_183_000);
 }
 impl ExtCalibratedTimestampsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_calibrated_timestamps\0")
         }
@@ -14092,7 +14092,7 @@ impl StructureType {
     pub const CALIBRATED_TIMESTAMP_INFO_EXT: Self = Self(1_000_184_000);
 }
 impl AmdShaderCorePropertiesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_shader_core_properties\0")
         }
@@ -14116,7 +14116,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD: Self = Self(1_000_185_000);
 }
 impl AmdExtension187Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_187\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -14134,7 +14134,7 @@ impl AmdExtension187Fn {
     }
 }
 impl ExtVideoDecodeH265Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_decode_h265\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -14166,7 +14166,7 @@ impl VideoCodecOperationFlagsKHR {
     pub const DECODE_H265_EXT: Self = Self(0b10);
 }
 impl KhrGlobalPriorityFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_global_priority\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -14194,7 +14194,7 @@ impl StructureType {
     pub const QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR: Self = Self(1_000_388_001);
 }
 impl AmdMemoryOverallocationBehaviorFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_AMD_memory_overallocation_behavior\0",
@@ -14220,7 +14220,7 @@ impl StructureType {
     pub const DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD: Self = Self(1_000_189_000);
 }
 impl ExtVertexAttributeDivisorFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_vertex_attribute_divisor\0")
         }
@@ -14246,7 +14246,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT: Self = Self(1_000_190_002);
 }
 impl GgpFrameTokenFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GGP_frame_token\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -14268,7 +14268,7 @@ impl StructureType {
     pub const PRESENT_FRAME_TOKEN_GGP: Self = Self(1_000_191_000);
 }
 impl ExtPipelineCreationFeedbackFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_pipeline_creation_feedback\0")
         }
@@ -14293,7 +14293,7 @@ impl StructureType {
         Self::PIPELINE_CREATION_FEEDBACK_CREATE_INFO;
 }
 impl GoogleExtension194Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_194\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -14311,7 +14311,7 @@ impl GoogleExtension194Fn {
     }
 }
 impl GoogleExtension195Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_195\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -14329,7 +14329,7 @@ impl GoogleExtension195Fn {
     }
 }
 impl GoogleExtension196Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_196\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -14351,7 +14351,7 @@ impl PipelineCacheCreateFlags {
     pub const RESERVED_1_EXT: Self = Self(0b10);
 }
 impl KhrDriverPropertiesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_driver_properties\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -14388,7 +14388,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR: Self = Self::PHYSICAL_DEVICE_DRIVER_PROPERTIES;
 }
 impl KhrShaderFloatControlsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shader_float_controls\0")
         }
@@ -14419,7 +14419,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES;
 }
 impl NvShaderSubgroupPartitionedFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_shader_subgroup_partitioned\0")
         }
@@ -14443,7 +14443,7 @@ impl SubgroupFeatureFlags {
     pub const PARTITIONED_NV: Self = Self(0b1_0000_0000);
 }
 impl KhrDepthStencilResolveFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_depth_stencil_resolve\0")
         }
@@ -14478,7 +14478,7 @@ impl StructureType {
         Self::SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE;
 }
 impl KhrSwapchainMutableFormatFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_swapchain_mutable_format\0")
         }
@@ -14502,7 +14502,7 @@ impl SwapchainCreateFlagsKHR {
     pub const MUTABLE_FORMAT: Self = Self(0b100);
 }
 impl NvComputeShaderDerivativesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_compute_shader_derivatives\0")
         }
@@ -14526,7 +14526,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV: Self = Self(1_000_201_000);
 }
 impl NvMeshShaderFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_mesh_shader\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -14694,7 +14694,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV: Self = Self(1_000_202_001);
 }
 impl NvFragmentShaderBarycentricFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_fragment_shader_barycentric\0")
         }
@@ -14718,7 +14718,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_NV: Self = Self(1_000_203_000);
 }
 impl NvShaderImageFootprintFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_shader_image_footprint\0")
         }
@@ -14742,7 +14742,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV: Self = Self(1_000_204_000);
 }
 impl NvScissorExclusiveFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_scissor_exclusive\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -14816,7 +14816,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV: Self = Self(1_000_205_002);
 }
 impl NvDeviceDiagnosticCheckpointsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_NV_device_diagnostic_checkpoints\0",
@@ -14913,7 +14913,7 @@ impl StructureType {
     pub const QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV: Self = Self(1_000_206_001);
 }
 impl KhrTimelineSemaphoreFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_timeline_semaphore\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -15048,7 +15048,7 @@ impl StructureType {
     pub const SEMAPHORE_SIGNAL_INFO_KHR: Self = Self::SEMAPHORE_SIGNAL_INFO;
 }
 impl KhrExtension209Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_209\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -15066,7 +15066,7 @@ impl KhrExtension209Fn {
     }
 }
 impl IntelShaderIntegerFunctions2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_INTEL_shader_integer_functions2\0")
         }
@@ -15090,7 +15090,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL: Self = Self(1_000_209_000);
 }
 impl IntelPerformanceQueryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_INTEL_performance_query\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -15427,7 +15427,7 @@ impl StructureType {
     pub const PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL: Self = Self(1_000_210_005);
 }
 impl KhrVulkanMemoryModelFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_vulkan_memory_model\0") }
     }
     pub const SPEC_VERSION: u32 = 3u32;
@@ -15450,7 +15450,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES;
 }
 impl ExtPciBusInfoFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_pci_bus_info\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -15472,7 +15472,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT: Self = Self(1_000_212_000);
 }
 impl AmdDisplayNativeHdrFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_display_native_hdr\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -15537,7 +15537,7 @@ impl StructureType {
     pub const SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD: Self = Self(1_000_213_001);
 }
 impl FuchsiaImagepipeSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_FUCHSIA_imagepipe_surface\0")
         }
@@ -15603,7 +15603,7 @@ impl StructureType {
     pub const IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA: Self = Self(1_000_214_000);
 }
 impl KhrShaderTerminateInvocationFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shader_terminate_invocation\0")
         }
@@ -15628,7 +15628,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES;
 }
 impl GoogleExtension217Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_217\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -15646,7 +15646,7 @@ impl GoogleExtension217Fn {
     }
 }
 impl ExtMetalSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_metal_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -15709,7 +15709,7 @@ impl StructureType {
     pub const METAL_SURFACE_CREATE_INFO_EXT: Self = Self(1_000_217_000);
 }
 impl ExtFragmentDensityMapFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_fragment_density_map\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -15770,7 +15770,7 @@ impl StructureType {
     pub const RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT: Self = Self(1_000_218_002);
 }
 impl ExtExtension220Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_220\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -15788,7 +15788,7 @@ impl ExtExtension220Fn {
     }
 }
 impl KhrExtension221Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_221\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -15810,7 +15810,7 @@ impl RenderPassCreateFlags {
     pub const RESERVED_0_KHR: Self = Self(0b1);
 }
 impl ExtScalarBlockLayoutFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_scalar_block_layout\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -15833,7 +15833,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES;
 }
 impl ExtExtension223Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_223\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -15851,7 +15851,7 @@ impl ExtExtension223Fn {
     }
 }
 impl GoogleHlslFunctionality1Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_hlsl_functionality1\0")
         }
@@ -15871,7 +15871,7 @@ impl GoogleHlslFunctionality1Fn {
     }
 }
 impl GoogleDecorateStringFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_decorate_string\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -15889,7 +15889,7 @@ impl GoogleDecorateStringFn {
     }
 }
 impl ExtSubgroupSizeControlFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_subgroup_size_control\0")
         }
@@ -15923,7 +15923,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES;
 }
 impl KhrFragmentShadingRateFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_fragment_shading_rate\0")
         }
@@ -16063,7 +16063,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR: Self = Self(1_000_226_004);
 }
 impl AmdShaderCoreProperties2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_shader_core_properties2\0")
         }
@@ -16087,7 +16087,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD: Self = Self(1_000_227_000);
 }
 impl AmdExtension229Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_229\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -16105,7 +16105,7 @@ impl AmdExtension229Fn {
     }
 }
 impl AmdDeviceCoherentMemoryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_device_coherent_memory\0")
         }
@@ -16134,7 +16134,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD: Self = Self(1_000_229_000);
 }
 impl AmdExtension231Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_231\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -16152,7 +16152,7 @@ impl AmdExtension231Fn {
     }
 }
 impl AmdExtension232Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_232\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -16170,7 +16170,7 @@ impl AmdExtension232Fn {
     }
 }
 impl AmdExtension233Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_233\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -16188,7 +16188,7 @@ impl AmdExtension233Fn {
     }
 }
 impl AmdExtension234Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_234\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -16206,7 +16206,7 @@ impl AmdExtension234Fn {
     }
 }
 impl ExtShaderImageAtomicInt64Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_image_atomic_int64\0")
         }
@@ -16230,7 +16230,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT: Self = Self(1_000_234_000);
 }
 impl AmdExtension236Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_236\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -16248,7 +16248,7 @@ impl AmdExtension236Fn {
     }
 }
 impl KhrSpirv14Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_spirv_1_4\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -16266,7 +16266,7 @@ impl KhrSpirv14Fn {
     }
 }
 impl ExtMemoryBudgetFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_memory_budget\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -16288,7 +16288,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT: Self = Self(1_000_237_000);
 }
 impl ExtMemoryPriorityFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_memory_priority\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -16311,7 +16311,7 @@ impl StructureType {
     pub const MEMORY_PRIORITY_ALLOCATE_INFO_EXT: Self = Self(1_000_238_001);
 }
 impl KhrSurfaceProtectedCapabilitiesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_surface_protected_capabilities\0",
@@ -16337,7 +16337,7 @@ impl StructureType {
     pub const SURFACE_PROTECTED_CAPABILITIES_KHR: Self = Self(1_000_239_000);
 }
 impl NvDedicatedAllocationImageAliasingFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_NV_dedicated_allocation_image_aliasing\0",
@@ -16364,7 +16364,7 @@ impl StructureType {
         Self(1_000_240_000);
 }
 impl KhrSeparateDepthStencilLayoutsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_separate_depth_stencil_layouts\0",
@@ -16402,7 +16402,7 @@ impl StructureType {
         Self::ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT;
 }
 impl IntelExtension243Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_INTEL_extension_243\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -16420,7 +16420,7 @@ impl IntelExtension243Fn {
     }
 }
 impl MesaExtension244Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_MESA_extension_244\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -16438,7 +16438,7 @@ impl MesaExtension244Fn {
     }
 }
 impl ExtBufferDeviceAddressFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_buffer_device_address\0")
         }
@@ -16514,7 +16514,7 @@ impl StructureType {
     pub const BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT: Self = Self(1_000_244_002);
 }
 impl ExtToolingInfoFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_tooling_info\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -16584,7 +16584,7 @@ impl ToolPurposeFlags {
     pub const DEBUG_MARKERS_EXT: Self = Self(0b100_0000);
 }
 impl ExtSeparateStencilUsageFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_separate_stencil_usage\0")
         }
@@ -16608,7 +16608,7 @@ impl StructureType {
     pub const IMAGE_STENCIL_USAGE_CREATE_INFO_EXT: Self = Self::IMAGE_STENCIL_USAGE_CREATE_INFO;
 }
 impl ExtValidationFeaturesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_validation_features\0") }
     }
     pub const SPEC_VERSION: u32 = 5u32;
@@ -16630,7 +16630,7 @@ impl StructureType {
     pub const VALIDATION_FEATURES_EXT: Self = Self(1_000_247_000);
 }
 impl KhrPresentWaitFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_present_wait\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -16690,7 +16690,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR: Self = Self(1_000_248_000);
 }
 impl NvCooperativeMatrixFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_cooperative_matrix\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -16759,7 +16759,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV: Self = Self(1_000_249_002);
 }
 impl NvCoverageReductionModeFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_coverage_reduction_mode\0")
         }
@@ -16832,7 +16832,7 @@ impl StructureType {
     pub const FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV: Self = Self(1_000_250_002);
 }
 impl ExtFragmentShaderInterlockFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_fragment_shader_interlock\0")
         }
@@ -16856,7 +16856,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT: Self = Self(1_000_251_000);
 }
 impl ExtYcbcrImageArraysFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_ycbcr_image_arrays\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -16878,7 +16878,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT: Self = Self(1_000_252_000);
 }
 impl KhrUniformBufferStandardLayoutFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_uniform_buffer_standard_layout\0",
@@ -16905,7 +16905,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES;
 }
 impl ExtProvokingVertexFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_provoking_vertex\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -16930,7 +16930,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_PROVOKING_VERTEX_PROPERTIES_EXT: Self = Self(1_000_254_002);
 }
 impl ExtFullScreenExclusiveFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_full_screen_exclusive\0")
         }
@@ -17109,7 +17109,7 @@ impl StructureType {
     pub const SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT: Self = Self(1_000_255_001);
 }
 impl ExtHeadlessSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_headless_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -17173,7 +17173,7 @@ impl StructureType {
     pub const HEADLESS_SURFACE_CREATE_INFO_EXT: Self = Self(1_000_256_000);
 }
 impl KhrBufferDeviceAddressFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_buffer_device_address\0")
         }
@@ -17320,7 +17320,7 @@ impl StructureType {
         Self::DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO;
 }
 impl ExtExtension259Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_259\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -17338,7 +17338,7 @@ impl ExtExtension259Fn {
     }
 }
 impl ExtLineRasterizationFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_line_rasterization\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -17404,7 +17404,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT: Self = Self(1_000_259_002);
 }
 impl ExtShaderAtomicFloatFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_atomic_float\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -17426,7 +17426,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT: Self = Self(1_000_260_000);
 }
 impl ExtHostQueryResetFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_host_query_reset\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -17487,7 +17487,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES;
 }
 impl GgpExtension263Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GGP_extension_263\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -17505,7 +17505,7 @@ impl GgpExtension263Fn {
     }
 }
 impl BrcmExtension264Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_BRCM_extension_264\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -17523,7 +17523,7 @@ impl BrcmExtension264Fn {
     }
 }
 impl BrcmExtension265Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_BRCM_extension_265\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -17541,7 +17541,7 @@ impl BrcmExtension265Fn {
     }
 }
 impl ExtIndexTypeUint8Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_index_type_uint8\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -17567,7 +17567,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT: Self = Self(1_000_265_000);
 }
 impl ExtExtension267Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_267\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -17585,7 +17585,7 @@ impl ExtExtension267Fn {
     }
 }
 impl ExtExtendedDynamicStateFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extended_dynamic_state\0")
         }
@@ -18063,7 +18063,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT: Self = Self(1_000_267_000);
 }
 impl KhrDeferredHostOperationsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_deferred_host_operations\0")
         }
@@ -18266,7 +18266,7 @@ impl Result {
     pub const OPERATION_NOT_DEFERRED_KHR: Self = Self(1_000_268_003);
 }
 impl KhrPipelineExecutablePropertiesFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_pipeline_executable_properties\0",
@@ -18442,7 +18442,7 @@ impl StructureType {
     pub const PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR: Self = Self(1_000_269_005);
 }
 impl IntelExtension271Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_INTEL_extension_271\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -18460,7 +18460,7 @@ impl IntelExtension271Fn {
     }
 }
 impl IntelExtension272Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_INTEL_extension_272\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -18478,7 +18478,7 @@ impl IntelExtension272Fn {
     }
 }
 impl IntelExtension273Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_INTEL_extension_273\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -18496,7 +18496,7 @@ impl IntelExtension273Fn {
     }
 }
 impl ExtShaderAtomicFloat2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_shader_atomic_float2\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -18518,7 +18518,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT: Self = Self(1_000_273_000);
 }
 impl KhrExtension275Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_275\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -18536,7 +18536,7 @@ impl KhrExtension275Fn {
     }
 }
 impl KhrExtension276Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_276\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -18554,7 +18554,7 @@ impl KhrExtension276Fn {
     }
 }
 impl ExtShaderDemoteToHelperInvocationFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_EXT_shader_demote_to_helper_invocation\0",
@@ -18581,7 +18581,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES;
 }
 impl NvDeviceGeneratedCommandsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_device_generated_commands\0")
         }
@@ -18871,7 +18871,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV: Self = Self(1_000_277_007);
 }
 impl NvInheritedViewportScissorFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_inherited_viewport_scissor\0")
         }
@@ -18896,7 +18896,7 @@ impl StructureType {
     pub const COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV: Self = Self(1_000_278_001);
 }
 impl KhrExtension280Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_280\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -18914,7 +18914,7 @@ impl KhrExtension280Fn {
     }
 }
 impl KhrShaderIntegerDotProductFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shader_integer_dot_product\0")
         }
@@ -18941,7 +18941,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES;
 }
 impl ExtTexelBufferAlignmentFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_texel_buffer_alignment\0")
         }
@@ -18968,7 +18968,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES;
 }
 impl QcomRenderPassTransformFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_render_pass_transform\0")
         }
@@ -18998,7 +18998,7 @@ impl StructureType {
     pub const RENDER_PASS_TRANSFORM_BEGIN_INFO_QCOM: Self = Self(1_000_282_001);
 }
 impl ExtExtension284Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_284\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19016,7 +19016,7 @@ impl ExtExtension284Fn {
     }
 }
 impl ExtDeviceMemoryReportFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_device_memory_report\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -19040,7 +19040,7 @@ impl StructureType {
     pub const DEVICE_MEMORY_REPORT_CALLBACK_DATA_EXT: Self = Self(1_000_284_002);
 }
 impl ExtAcquireDrmDisplayFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_acquire_drm_display\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -19132,7 +19132,7 @@ impl ExtAcquireDrmDisplayFn {
     }
 }
 impl ExtRobustness2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_robustness2\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -19155,7 +19155,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT: Self = Self(1_000_286_001);
 }
 impl ExtCustomBorderColorFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_custom_border_color\0") }
     }
     pub const SPEC_VERSION: u32 = 12u32;
@@ -19184,7 +19184,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT: Self = Self(1_000_287_002);
 }
 impl ExtExtension289Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_289\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19235,7 +19235,7 @@ impl Format {
     pub const ASTC_6X6X6_SFLOAT_BLOCK_EXT: Self = Self(1_000_288_029);
 }
 impl GoogleUserTypeFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_user_type\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -19253,7 +19253,7 @@ impl GoogleUserTypeFn {
     }
 }
 impl KhrPipelineLibraryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_pipeline_library\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -19279,7 +19279,7 @@ impl StructureType {
     pub const PIPELINE_LIBRARY_CREATE_INFO_KHR: Self = Self(1_000_290_000);
 }
 impl NvExtension292Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_292\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19297,7 +19297,7 @@ impl NvExtension292Fn {
     }
 }
 impl NvExtension293Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_293\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19315,7 +19315,7 @@ impl NvExtension293Fn {
     }
 }
 impl KhrShaderNonSemanticInfoFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_shader_non_semantic_info\0")
         }
@@ -19335,7 +19335,7 @@ impl KhrShaderNonSemanticInfoFn {
     }
 }
 impl KhrPresentIdFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_present_id\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -19358,7 +19358,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR: Self = Self(1_000_294_001);
 }
 impl ExtPrivateDataFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_private_data\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -19550,7 +19550,7 @@ impl StructureType {
     pub const PRIVATE_DATA_SLOT_CREATE_INFO_EXT: Self = Self::PRIVATE_DATA_SLOT_CREATE_INFO;
 }
 impl KhrExtension297Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_297\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19572,7 +19572,7 @@ impl PipelineShaderStageCreateFlags {
     pub const RESERVED_3_KHR: Self = Self(0b1000);
 }
 impl ExtPipelineCreationCacheControlFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_EXT_pipeline_creation_cache_control\0",
@@ -19613,7 +19613,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES;
 }
 impl KhrExtension299Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_299\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19640,7 +19640,7 @@ impl PipelineCacheCreateFlags {
     pub const RESERVED_2_KHR: Self = Self(0b100);
 }
 impl KhrVideoEncodeQueueFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_video_encode_queue\0") }
     }
     pub const SPEC_VERSION: u32 = 4u32;
@@ -19742,7 +19742,7 @@ impl StructureType {
     pub const VIDEO_ENCODE_CAPABILITIES_KHR: Self = Self(1_000_299_003);
 }
 impl NvDeviceDiagnosticsConfigFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_device_diagnostics_config\0")
         }
@@ -19767,7 +19767,7 @@ impl StructureType {
     pub const DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV: Self = Self(1_000_300_001);
 }
 impl QcomRenderPassStoreOpsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_render_pass_store_ops\0")
         }
@@ -19791,7 +19791,7 @@ impl AttachmentStoreOp {
     pub const NONE_QCOM: Self = Self::NONE;
 }
 impl QcomExtension303Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_303\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19809,7 +19809,7 @@ impl QcomExtension303Fn {
     }
 }
 impl QcomExtension304Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_304\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19827,7 +19827,7 @@ impl QcomExtension304Fn {
     }
 }
 impl QcomExtension305Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_305\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19845,7 +19845,7 @@ impl QcomExtension305Fn {
     }
 }
 impl QcomExtension306Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_306\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19863,7 +19863,7 @@ impl QcomExtension306Fn {
     }
 }
 impl QcomExtension307Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_307\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19881,7 +19881,7 @@ impl QcomExtension307Fn {
     }
 }
 impl NvExtension308Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_308\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19899,7 +19899,7 @@ impl NvExtension308Fn {
     }
 }
 impl KhrExtension309Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_309\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19917,7 +19917,7 @@ impl KhrExtension309Fn {
     }
 }
 impl QcomExtension310Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_310\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19939,7 +19939,7 @@ impl StructureType {
     pub const RESERVED_QCOM: Self = Self(1_000_309_000);
 }
 impl NvExtension311Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_311\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19957,7 +19957,7 @@ impl NvExtension311Fn {
     }
 }
 impl ExtExtension312Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_312\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19975,7 +19975,7 @@ impl ExtExtension312Fn {
     }
 }
 impl ExtExtension313Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_313\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -19993,7 +19993,7 @@ impl ExtExtension313Fn {
     }
 }
 impl AmdExtension314Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_314\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20011,7 +20011,7 @@ impl AmdExtension314Fn {
     }
 }
 impl KhrSynchronization2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_synchronization2\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -20386,7 +20386,7 @@ impl StructureType {
     pub const CHECKPOINT_DATA_2_NV: Self = Self(1_000_314_009);
 }
 impl AmdExtension316Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_316\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20404,7 +20404,7 @@ impl AmdExtension316Fn {
     }
 }
 impl AmdExtension317Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_317\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20451,7 +20451,7 @@ impl SamplerCreateFlags {
     pub const RESERVED_3_AMD: Self = Self(0b1000);
 }
 impl AmdExtension318Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_318\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20469,7 +20469,7 @@ impl AmdExtension318Fn {
     }
 }
 impl AmdExtension319Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_319\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20495,7 +20495,7 @@ impl PipelineLayoutCreateFlags {
     pub const RESERVED_0_AMD: Self = Self(0b1);
 }
 impl AmdExtension320Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_320\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20513,7 +20513,7 @@ impl AmdExtension320Fn {
     }
 }
 impl AmdExtension321Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_321\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20540,7 +20540,7 @@ impl PipelineLayoutCreateFlags {
     pub const RESERVED_1_AMD: Self = Self(0b10);
 }
 impl AmdExtension322Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_322\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20558,7 +20558,7 @@ impl AmdExtension322Fn {
     }
 }
 impl AmdExtension323Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_AMD_extension_323\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20576,7 +20576,7 @@ impl AmdExtension323Fn {
     }
 }
 impl KhrShaderSubgroupUniformControlFlowFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_shader_subgroup_uniform_control_flow\0",
@@ -20603,7 +20603,7 @@ impl StructureType {
         Self(1_000_323_000);
 }
 impl KhrExtension325Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_325\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20621,7 +20621,7 @@ impl KhrExtension325Fn {
     }
 }
 impl KhrZeroInitializeWorkgroupMemoryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_zero_initialize_workgroup_memory\0",
@@ -20648,7 +20648,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES;
 }
 impl NvFragmentShadingRateEnumsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_fragment_shading_rate_enums\0")
         }
@@ -20713,7 +20713,7 @@ impl StructureType {
     pub const PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV: Self = Self(1_000_326_002);
 }
 impl NvRayTracingMotionBlurFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_ray_tracing_motion_blur\0")
         }
@@ -20751,7 +20751,7 @@ impl StructureType {
     pub const ACCELERATION_STRUCTURE_MOTION_INFO_NV: Self = Self(1_000_327_002);
 }
 impl NvExtension329Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_329\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20769,7 +20769,7 @@ impl NvExtension329Fn {
     }
 }
 impl NvExtension330Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_330\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20787,7 +20787,7 @@ impl NvExtension330Fn {
     }
 }
 impl ExtYcbcr2plane444FormatsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_ycbcr_2plane_444_formats\0")
         }
@@ -20820,7 +20820,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT: Self = Self(1_000_330_000);
 }
 impl NvExtension332Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_332\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20838,7 +20838,7 @@ impl NvExtension332Fn {
     }
 }
 impl ExtFragmentDensityMap2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_fragment_density_map2\0")
         }
@@ -20867,7 +20867,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT: Self = Self(1_000_332_001);
 }
 impl QcomRotatedCopyCommandsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_rotated_copy_commands\0")
         }
@@ -20891,7 +20891,7 @@ impl StructureType {
     pub const COPY_COMMAND_TRANSFORM_INFO_QCOM: Self = Self(1_000_333_000);
 }
 impl KhrExtension335Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_335\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -20909,7 +20909,7 @@ impl KhrExtension335Fn {
     }
 }
 impl ExtImageRobustnessFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_image_robustness\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -20932,7 +20932,7 @@ impl StructureType {
         Self::PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES;
 }
 impl KhrWorkgroupMemoryExplicitLayoutFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_KHR_workgroup_memory_explicit_layout\0",
@@ -20959,7 +20959,7 @@ impl StructureType {
         Self(1_000_336_000);
 }
 impl KhrCopyCommands2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_copy_commands2\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -21184,7 +21184,7 @@ impl StructureType {
     pub const IMAGE_RESOLVE_2_KHR: Self = Self::IMAGE_RESOLVE_2;
 }
 impl ArmExtension339Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_ARM_extension_339\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21202,7 +21202,7 @@ impl ArmExtension339Fn {
     }
 }
 impl ExtExtension340Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_340\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21224,7 +21224,7 @@ impl ImageUsageFlags {
     pub const RESERVED_19_EXT: Self = Self(0b1000_0000_0000_0000_0000);
 }
 impl Ext4444FormatsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_4444_formats\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -21251,7 +21251,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT: Self = Self(1_000_340_000);
 }
 impl ExtExtension342Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_342\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21269,7 +21269,7 @@ impl ExtExtension342Fn {
     }
 }
 impl ArmRasterizationOrderAttachmentAccessFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_ARM_rasterization_order_attachment_access\0",
@@ -21311,7 +21311,7 @@ impl SubpassDescriptionFlags {
     pub const RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_ARM: Self = Self(0b100_0000);
 }
 impl ArmExtension344Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_ARM_extension_344\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21329,7 +21329,7 @@ impl ArmExtension344Fn {
     }
 }
 impl ExtRgba10x6FormatsFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_rgba10x6_formats\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -21351,7 +21351,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT: Self = Self(1_000_344_000);
 }
 impl NvAcquireWinrtDisplayFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_acquire_winrt_display\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -21435,7 +21435,7 @@ impl NvAcquireWinrtDisplayFn {
     }
 }
 impl ExtDirectfbSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_directfb_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -21542,7 +21542,7 @@ impl StructureType {
     pub const DIRECTFB_SURFACE_CREATE_INFO_EXT: Self = Self(1_000_346_000);
 }
 impl KhrExtension350Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_350\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21560,7 +21560,7 @@ impl KhrExtension350Fn {
     }
 }
 impl NvExtension351Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_351\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21578,7 +21578,7 @@ impl NvExtension351Fn {
     }
 }
 impl ValveMutableDescriptorTypeFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_VALVE_mutable_descriptor_type\0")
         }
@@ -21615,7 +21615,7 @@ impl StructureType {
     pub const MUTABLE_DESCRIPTOR_TYPE_CREATE_INFO_VALVE: Self = Self(1_000_351_002);
 }
 impl ExtVertexInputDynamicStateFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_vertex_input_dynamic_state\0")
         }
@@ -21695,7 +21695,7 @@ impl StructureType {
     pub const VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT: Self = Self(1_000_352_002);
 }
 impl ExtPhysicalDeviceDrmFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_physical_device_drm\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -21717,7 +21717,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_DRM_PROPERTIES_EXT: Self = Self(1_000_353_000);
 }
 impl ExtExtension355Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_355\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21735,7 +21735,7 @@ impl ExtExtension355Fn {
     }
 }
 impl ExtDepthClipControlFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_depth_clip_control\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -21758,7 +21758,7 @@ impl StructureType {
     pub const PIPELINE_VIEWPORT_DEPTH_CLIP_CONTROL_CREATE_INFO_EXT: Self = Self(1_000_355_001);
 }
 impl ExtPrimitiveTopologyListRestartFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_EXT_primitive_topology_list_restart\0",
@@ -21785,7 +21785,7 @@ impl StructureType {
         Self(1_000_356_000);
 }
 impl KhrExtension358Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_358\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21803,7 +21803,7 @@ impl KhrExtension358Fn {
     }
 }
 impl ExtExtension359Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_359\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21821,7 +21821,7 @@ impl ExtExtension359Fn {
     }
 }
 impl ExtExtension360Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_360\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21839,7 +21839,7 @@ impl ExtExtension360Fn {
     }
 }
 impl KhrFormatFeatureFlags2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_format_feature_flags2\0")
         }
@@ -21863,7 +21863,7 @@ impl StructureType {
     pub const FORMAT_PROPERTIES_3_KHR: Self = Self::FORMAT_PROPERTIES_3;
 }
 impl ExtExtension362Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_362\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21881,7 +21881,7 @@ impl ExtExtension362Fn {
     }
 }
 impl ExtExtension363Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_363\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21899,7 +21899,7 @@ impl ExtExtension363Fn {
     }
 }
 impl FuchsiaExtension364Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_FUCHSIA_extension_364\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -21917,7 +21917,7 @@ impl FuchsiaExtension364Fn {
     }
 }
 impl FuchsiaExternalMemoryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_FUCHSIA_external_memory\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -22029,7 +22029,7 @@ impl StructureType {
     pub const MEMORY_GET_ZIRCON_HANDLE_INFO_FUCHSIA: Self = Self(1_000_364_002);
 }
 impl FuchsiaExternalSemaphoreFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_FUCHSIA_external_semaphore\0")
         }
@@ -22135,7 +22135,7 @@ impl StructureType {
     pub const SEMAPHORE_GET_ZIRCON_HANDLE_INFO_FUCHSIA: Self = Self(1_000_365_001);
 }
 impl FuchsiaBufferCollectionFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_FUCHSIA_buffer_collection\0")
         }
@@ -22377,7 +22377,7 @@ impl StructureType {
     pub const BUFFER_COLLECTION_CONSTRAINTS_INFO_FUCHSIA: Self = Self(1_000_366_009);
 }
 impl FuchsiaExtension368Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_FUCHSIA_extension_368\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -22395,7 +22395,7 @@ impl FuchsiaExtension368Fn {
     }
 }
 impl QcomExtension369Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_369\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -22417,7 +22417,7 @@ impl DescriptorBindingFlags {
     pub const RESERVED_4_QCOM: Self = Self(0b1_0000);
 }
 impl HuaweiSubpassShadingFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_HUAWEI_subpass_shading\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -22523,7 +22523,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI: Self = Self(1_000_369_002);
 }
 impl HuaweiInvocationMaskFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_HUAWEI_invocation_mask\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -22598,7 +22598,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_INVOCATION_MASK_FEATURES_HUAWEI: Self = Self(1_000_370_000);
 }
 impl NvExternalMemoryRdmaFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_external_memory_rdma\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -22668,7 +22668,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV: Self = Self(1_000_371_001);
 }
 impl NvExtension373Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_373\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -22686,7 +22686,7 @@ impl NvExtension373Fn {
     }
 }
 impl NvExtension374Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_374\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -22714,7 +22714,7 @@ impl ExternalSemaphoreHandleTypeFlags {
     pub const RESERVED_6_NV: Self = Self(0b100_0000);
 }
 impl NvExtension375Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_375\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -22736,7 +22736,7 @@ impl ExternalMemoryHandleTypeFlags {
     pub const RESERVED_13_NV: Self = Self(0b10_0000_0000_0000);
 }
 impl ExtExtension376Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_376\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -22754,7 +22754,7 @@ impl ExtExtension376Fn {
     }
 }
 impl ExtExtension377Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_377\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -22772,7 +22772,7 @@ impl ExtExtension377Fn {
     }
 }
 impl ExtExtendedDynamicState2Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extended_dynamic_state2\0")
         }
@@ -22961,7 +22961,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT: Self = Self(1_000_377_000);
 }
 impl QnxScreenSurfaceFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QNX_screen_surface\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -23066,7 +23066,7 @@ impl StructureType {
     pub const SCREEN_SURFACE_CREATE_INFO_QNX: Self = Self(1_000_378_000);
 }
 impl KhrExtension380Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_380\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23084,7 +23084,7 @@ impl KhrExtension380Fn {
     }
 }
 impl KhrExtension381Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_381\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23102,7 +23102,7 @@ impl KhrExtension381Fn {
     }
 }
 impl ExtColorWriteEnableFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_color_write_enable\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -23172,7 +23172,7 @@ impl StructureType {
     pub const PIPELINE_COLOR_WRITE_CREATE_INFO_EXT: Self = Self(1_000_381_001);
 }
 impl ExtExtension383Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_383\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23190,7 +23190,7 @@ impl ExtExtension383Fn {
     }
 }
 impl ExtExtension384Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_384\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23208,7 +23208,7 @@ impl ExtExtension384Fn {
     }
 }
 impl MesaExtension385Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_MESA_extension_385\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23226,7 +23226,7 @@ impl MesaExtension385Fn {
     }
 }
 impl GoogleExtension386Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_386\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23244,7 +23244,7 @@ impl GoogleExtension386Fn {
     }
 }
 impl KhrExtension387Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_387\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23270,7 +23270,7 @@ impl PipelineStageFlags2 {
     pub const RESERVED_387_KHR: Self = Self(0b1_0000_0000_0000_0000_0000_0000_0000);
 }
 impl ExtExtension388Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_388\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23288,7 +23288,7 @@ impl ExtExtension388Fn {
     }
 }
 impl ExtGlobalPriorityQueryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_global_priority_query\0")
         }
@@ -23315,7 +23315,7 @@ impl StructureType {
         Self::QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR;
 }
 impl ExtExtension390Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_390\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23333,7 +23333,7 @@ impl ExtExtension390Fn {
     }
 }
 impl ExtExtension391Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_391\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23351,7 +23351,7 @@ impl ExtExtension391Fn {
     }
 }
 impl ExtImageViewMinLodFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_image_view_min_lod\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -23374,7 +23374,7 @@ impl StructureType {
     pub const IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT: Self = Self(1_000_391_001);
 }
 impl ExtMultiDrawFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_multi_draw\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -23503,7 +23503,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT: Self = Self(1_000_392_001);
 }
 impl ExtExtension394Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_394\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23525,7 +23525,7 @@ impl ImageCreateFlags {
     pub const RESERVED_394_EXT: Self = Self(0b10_0000_0000_0000_0000);
 }
 impl KhrExtension395Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_395\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23543,7 +23543,7 @@ impl KhrExtension395Fn {
     }
 }
 impl KhrExtension396Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_396\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23561,7 +23561,7 @@ impl KhrExtension396Fn {
     }
 }
 impl NvExtension397Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_397\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23579,7 +23579,7 @@ impl NvExtension397Fn {
     }
 }
 impl NvExtension398Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_398\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23597,7 +23597,7 @@ impl NvExtension398Fn {
     }
 }
 impl JuiceExtension399Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_JUICE_extension_399\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23615,7 +23615,7 @@ impl JuiceExtension399Fn {
     }
 }
 impl JuiceExtension400Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_JUICE_extension_400\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23633,7 +23633,7 @@ impl JuiceExtension400Fn {
     }
 }
 impl ExtLoadStoreOpNoneFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_load_store_op_none\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -23659,7 +23659,7 @@ impl AttachmentStoreOp {
     pub const NONE_EXT: Self = Self::NONE;
 }
 impl FbExtension402Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_FB_extension_402\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23677,7 +23677,7 @@ impl FbExtension402Fn {
     }
 }
 impl FbExtension403Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_FB_extension_403\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23695,7 +23695,7 @@ impl FbExtension403Fn {
     }
 }
 impl FbExtension404Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_FB_extension_404\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23713,7 +23713,7 @@ impl FbExtension404Fn {
     }
 }
 impl HuaweiExtension405Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_HUAWEI_extension_405\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23731,7 +23731,7 @@ impl HuaweiExtension405Fn {
     }
 }
 impl HuaweiExtension406Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_HUAWEI_extension_406\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23749,7 +23749,7 @@ impl HuaweiExtension406Fn {
     }
 }
 impl GgpExtension407Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GGP_extension_407\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23767,7 +23767,7 @@ impl GgpExtension407Fn {
     }
 }
 impl GgpExtension408Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GGP_extension_408\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23785,7 +23785,7 @@ impl GgpExtension408Fn {
     }
 }
 impl GgpExtension409Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GGP_extension_409\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23803,7 +23803,7 @@ impl GgpExtension409Fn {
     }
 }
 impl GgpExtension410Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GGP_extension_410\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23821,7 +23821,7 @@ impl GgpExtension410Fn {
     }
 }
 impl GgpExtension411Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GGP_extension_411\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -23839,7 +23839,7 @@ impl GgpExtension411Fn {
     }
 }
 impl ExtBorderColorSwizzleFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_border_color_swizzle\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -23862,7 +23862,7 @@ impl StructureType {
     pub const SAMPLER_BORDER_COLOR_COMPONENT_MAPPING_CREATE_INFO_EXT: Self = Self(1_000_411_001);
 }
 impl ExtPageableDeviceLocalMemoryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_EXT_pageable_device_local_memory\0",
@@ -23924,7 +23924,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT: Self = Self(1_000_412_000);
 }
 impl KhrMaintenance4Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_maintenance4\0") }
     }
     pub const SPEC_VERSION: u32 = 2u32;
@@ -24077,7 +24077,7 @@ impl StructureType {
     pub const DEVICE_IMAGE_MEMORY_REQUIREMENTS_KHR: Self = Self::DEVICE_IMAGE_MEMORY_REQUIREMENTS;
 }
 impl HuaweiExtension415Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_HUAWEI_extension_415\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24095,7 +24095,7 @@ impl HuaweiExtension415Fn {
     }
 }
 impl ArmExtension416Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_ARM_extension_416\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24113,7 +24113,7 @@ impl ArmExtension416Fn {
     }
 }
 impl KhrExtension417Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_417\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24131,7 +24131,7 @@ impl KhrExtension417Fn {
     }
 }
 impl ArmExtension418Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_ARM_extension_418\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24149,7 +24149,7 @@ impl ArmExtension418Fn {
     }
 }
 impl ExtExtension419Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_419\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24167,7 +24167,7 @@ impl ExtExtension419Fn {
     }
 }
 impl ExtExtension420Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_420\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24185,7 +24185,7 @@ impl ExtExtension420Fn {
     }
 }
 impl KhrExtension421Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_421\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24203,7 +24203,7 @@ impl KhrExtension421Fn {
     }
 }
 impl ExtExtension422Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_422\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24221,7 +24221,7 @@ impl ExtExtension422Fn {
     }
 }
 impl ExtDisableCubeMapWrapFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_disable_cube_map_wrap\0")
         }
@@ -24245,7 +24245,7 @@ impl SamplerCreateFlags {
     pub const RESERVED_2_EXT: Self = Self(0b100);
 }
 impl ArmExtension424Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_ARM_extension_424\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24263,7 +24263,7 @@ impl ArmExtension424Fn {
     }
 }
 impl ArmExtension425Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_ARM_extension_425\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24281,7 +24281,7 @@ impl ArmExtension425Fn {
     }
 }
 impl QcomFragmentDensityMapOffsetFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(
                 b"VK_QCOM_fragment_density_map_offset\0",
@@ -24314,7 +24314,7 @@ impl StructureType {
     pub const SUBPASS_FRAGMENT_DENSITY_MAP_OFFSET_END_INFO_QCOM: Self = Self(1_000_425_002);
 }
 impl NvExtension427Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_427\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24332,7 +24332,7 @@ impl NvExtension427Fn {
     }
 }
 impl NvExtension428Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_428\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24350,7 +24350,7 @@ impl NvExtension428Fn {
     }
 }
 impl NvExtension429Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_429\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24368,7 +24368,7 @@ impl NvExtension429Fn {
     }
 }
 impl NvExtension430Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_430\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24386,7 +24386,7 @@ impl NvExtension430Fn {
     }
 }
 impl NvLinearColorAttachmentFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe {
             ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_linear_color_attachment\0")
         }
@@ -24416,7 +24416,7 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV: Self = Self(1_000_430_000);
 }
 impl NvExtension432Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_432\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24434,7 +24434,7 @@ impl NvExtension432Fn {
     }
 }
 impl NvExtension433Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_433\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24452,7 +24452,7 @@ impl NvExtension433Fn {
     }
 }
 impl GoogleSurfacelessQueryFn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_surfaceless_query\0") }
     }
     pub const SPEC_VERSION: u32 = 1u32;
@@ -24470,7 +24470,7 @@ impl GoogleSurfacelessQueryFn {
     }
 }
 impl KhrExtension435Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_extension_435\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24488,7 +24488,7 @@ impl KhrExtension435Fn {
     }
 }
 impl NvExtension436Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_436\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24506,7 +24506,7 @@ impl NvExtension436Fn {
     }
 }
 impl ExtExtension437Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_437\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24524,7 +24524,7 @@ impl ExtExtension437Fn {
     }
 }
 impl ExtExtension438Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_438\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24542,7 +24542,7 @@ impl ExtExtension438Fn {
     }
 }
 impl SecExtension439Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_SEC_extension_439\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24560,7 +24560,7 @@ impl SecExtension439Fn {
     }
 }
 impl QcomExtension440Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_440\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24586,7 +24586,7 @@ impl QueueFlags {
     pub const RESERVED_7_QCOM: Self = Self(0b1000_0000);
 }
 impl QcomExtension441Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_QCOM_extension_441\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24620,7 +24620,7 @@ impl SamplerCreateFlags {
     pub const IMAGE_PROCESSING_QCOM: Self = Self(0b1_0000);
 }
 impl CoreaviExtension442Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_COREAVI_extension_442\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24638,7 +24638,7 @@ impl CoreaviExtension442Fn {
     }
 }
 impl CoreaviExtension443Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_COREAVI_extension_443\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24656,7 +24656,7 @@ impl CoreaviExtension443Fn {
     }
 }
 impl CoreaviExtension444Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_COREAVI_extension_444\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24678,7 +24678,7 @@ impl CommandPoolResetFlags {
     pub const RESERVED_1_COREAVI: Self = Self(0b10);
 }
 impl CoreaviExtension445Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_COREAVI_extension_445\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24696,7 +24696,7 @@ impl CoreaviExtension445Fn {
     }
 }
 impl CoreaviExtension446Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_COREAVI_extension_446\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24714,7 +24714,7 @@ impl CoreaviExtension446Fn {
     }
 }
 impl CoreaviExtension447Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_COREAVI_extension_447\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24732,7 +24732,7 @@ impl CoreaviExtension447Fn {
     }
 }
 impl SecExtension448Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_SEC_extension_448\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24750,7 +24750,7 @@ impl SecExtension448Fn {
     }
 }
 impl SecExtension449Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_SEC_extension_449\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24768,7 +24768,7 @@ impl SecExtension449Fn {
     }
 }
 impl SecExtension450Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_SEC_extension_450\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24786,7 +24786,7 @@ impl SecExtension450Fn {
     }
 }
 impl SecExtension451Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_SEC_extension_451\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24804,7 +24804,7 @@ impl SecExtension451Fn {
     }
 }
 impl NvExtension452Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_452\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24822,7 +24822,7 @@ impl NvExtension452Fn {
     }
 }
 impl ArmExtension453Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_ARM_extension_453\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24840,7 +24840,7 @@ impl ArmExtension453Fn {
     }
 }
 impl GoogleExtension454Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_454\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
@@ -24858,7 +24858,7 @@ impl GoogleExtension454Fn {
     }
 }
 impl GoogleExtension455Fn {
-    pub fn name() -> &'static ::std::ffi::CStr {
+    pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_extension_455\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1037,7 +1037,7 @@ pub fn generate_extension_commands<'a>(
     let byte_name_ident = Literal::byte_string(format!("{}\0", extension_name).as_bytes());
     let extension_cstr = quote! {
         impl #ident {
-            pub fn name() -> &'static ::std::ffi::CStr {
+            pub const fn name() -> &'static ::std::ffi::CStr {
                 unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(#byte_name_ident) }
             }
             #spec_version


### PR DESCRIPTION
`std::ffi::CStr::from_bytes_with_nul_unchecked` was const stabilized in [Rust 1.59](https://github.com/rust-lang/rust/blob/21b0325c68421b00c6c91055ac330bd5ffe1ea6b/RELEASES.md?plain=1#L74), meaning that the `name()` functions in extensions can now be `const` as well.

Alternatively we can do away with `name()` functions and use associated consts instead. However this would be a breaking change.

```rs
const NAME: &'static CStr = xxxxxx;
```
