### PR TITLE
Set MSRV through `rust-version` in `Cargo.toml` and validate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,17 @@ jobs:
           command: check
           args: --workspace --all-targets --all-features
 
+  check_msrv:
+    name: Check MSRV (1.59.0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dtolnay/rust-toolchain@1.59.0
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --workspace --all-targets --all-features
+
   generated:
     name: Generated
     runs-on: ubuntu-latest

--- a/ash-window/Cargo.toml
+++ b/ash-window/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["window", "ash", "graphics"]
 categories = ["game-engines", "graphics"]
 exclude = [".github/*"]
 workspace = ".."
+rust-version = "1.59.0"
 
 [dependencies]
 ash = { path = "../ash", version = "0.37", default-features = false }

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 keywords = ["vulkan", "graphic"]
 documentation = "https://docs.rs/ash"
 edition = "2018"
+rust-version = "1.59.0"
 
 [dependencies]
 libloading = { version = "0.7", optional = true }


### PR DESCRIPTION
[#590] introduced an unsuspecting MSRV bump.  While we're pro-ba-bly fine having these at the benefit of better code (in this case more appropriate `const` annotations), they should at least be clear to us when merging through a CI failure (or up-front bump of this version in the CI script).  At the same time setting [`rust-version` in `Cargo.toml`] provides a more helpful "requires newer rustc" error message (since Rust 1.56.0) instead of showing potentially tons of irrelevant compile errors in this crate to the user.

[#590]: https://github.com/MaikKlein/ash/pull/590
[`rust-version` in `Cargo.toml`]: https://doc.rust-lang.org/cargo/reference/manifest.html?highlight=pack#the-rust-version-field
