### PR TITLE
Update Vulkan-Headers to 1.3.211

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Update Vulkan-Headers to 1.3.210 (#605)
+- Update Vulkan-Headers to 1.3.211 (#605, #608)
 
 ## [0.37.0] - 2022-03-23
 

--- a/ash/Cargo.toml
+++ b/ash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ash"
-version = "0.37.0+1.3.210"
+version = "0.37.0+1.3.211"
 authors = ["maik klein <maikklein@googlemail.com>"]
 description = "Vulkan bindings for Rust"
 license = "MIT"

--- a/ash/src/vk/bitflags.rs
+++ b/ash/src/vk/bitflags.rs
@@ -1054,7 +1054,7 @@ impl PipelineStageFlags2 {
     pub const ALL_TRANSFER: Self = Self(0b1_0000_0000_0000);
     pub const ALL_TRANSFER_KHR: Self = Self::ALL_TRANSFER;
     pub const TRANSFER: Self = Self::ALL_TRANSFER_KHR;
-    pub const TRANSFER_KHR: Self = Self::TRANSFER;
+    pub const TRANSFER_KHR: Self = Self::ALL_TRANSFER;
     pub const BOTTOM_OF_PIPE: Self = Self(0b10_0000_0000_0000);
     pub const BOTTOM_OF_PIPE_KHR: Self = Self::BOTTOM_OF_PIPE;
     pub const HOST: Self = Self(0b100_0000_0000_0000);
@@ -1436,20 +1436,22 @@ impl VideoEncodeH265CapabilityFlagsEXT {
     pub const LOG2_PARALLEL_MERGE_LEVEL_MINUS2: Self = Self(0b1000_0000);
     pub const SIGN_DATA_HIDING_ENABLED: Self = Self(0b1_0000_0000);
     pub const TRANSFORM_SKIP_ENABLED: Self = Self(0b10_0000_0000);
-    pub const PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT: Self = Self(0b100_0000_0000);
-    pub const WEIGHTED_PRED: Self = Self(0b1000_0000_0000);
-    pub const WEIGHTED_BIPRED: Self = Self(0b1_0000_0000_0000);
-    pub const WEIGHTED_PRED_NO_TABLE: Self = Self(0b10_0000_0000_0000);
-    pub const TRANSQUANT_BYPASS_ENABLED: Self = Self(0b100_0000_0000_0000);
-    pub const ENTROPY_CODING_SYNC_ENABLED: Self = Self(0b1000_0000_0000_0000);
-    pub const DEBLOCKING_FILTER_OVERRIDE_ENABLED: Self = Self(0b1_0000_0000_0000_0000);
-    pub const MULTIPLE_TILE_PER_FRAME: Self = Self(0b10_0000_0000_0000_0000);
-    pub const MULTIPLE_SLICE_PER_TILE: Self = Self(0b100_0000_0000_0000_0000);
-    pub const MULTIPLE_TILE_PER_SLICE: Self = Self(0b1000_0000_0000_0000_0000);
-    pub const SLICE_SEGMENT_CTB_COUNT: Self = Self(0b1_0000_0000_0000_0000_0000);
-    pub const ROW_UNALIGNED_SLICE_SEGMENT: Self = Self(0b10_0000_0000_0000_0000_0000);
-    pub const DEPENDENT_SLICE_SEGMENT: Self = Self(0b100_0000_0000_0000_0000_0000);
-    pub const DIFFERENT_SLICE_TYPE: Self = Self(0b1000_0000_0000_0000_0000_0000);
+    pub const TRANSFORM_SKIP_DISABLED: Self = Self(0b100_0000_0000);
+    pub const PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT: Self = Self(0b1000_0000_0000);
+    pub const WEIGHTED_PRED: Self = Self(0b1_0000_0000_0000);
+    pub const WEIGHTED_BIPRED: Self = Self(0b10_0000_0000_0000);
+    pub const WEIGHTED_PRED_NO_TABLE: Self = Self(0b100_0000_0000_0000);
+    pub const TRANSQUANT_BYPASS_ENABLED: Self = Self(0b1000_0000_0000_0000);
+    pub const ENTROPY_CODING_SYNC_ENABLED: Self = Self(0b1_0000_0000_0000_0000);
+    pub const DEBLOCKING_FILTER_OVERRIDE_ENABLED: Self = Self(0b10_0000_0000_0000_0000);
+    pub const MULTIPLE_TILE_PER_FRAME: Self = Self(0b100_0000_0000_0000_0000);
+    pub const MULTIPLE_SLICE_PER_TILE: Self = Self(0b1000_0000_0000_0000_0000);
+    pub const MULTIPLE_TILE_PER_SLICE: Self = Self(0b1_0000_0000_0000_0000_0000);
+    pub const SLICE_SEGMENT_CTB_COUNT: Self = Self(0b10_0000_0000_0000_0000_0000);
+    pub const ROW_UNALIGNED_SLICE_SEGMENT: Self = Self(0b100_0000_0000_0000_0000_0000);
+    pub const DEPENDENT_SLICE_SEGMENT: Self = Self(0b1000_0000_0000_0000_0000_0000);
+    pub const DIFFERENT_SLICE_TYPE: Self = Self(0b1_0000_0000_0000_0000_0000_0000);
+    pub const B_FRAME_IN_L1_LIST: Self = Self(0b10_0000_0000_0000_0000_0000_0000);
 }
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/ash/src/vk/const_debugs.rs
+++ b/ash/src/vk/const_debugs.rs
@@ -305,6 +305,8 @@ impl fmt::Debug for AccessFlags2 {
                 "INVOCATION_MASK_READ_HUAWEI",
             ),
             (AccessFlags2::RESERVED_387_KHR.0, "RESERVED_387_KHR"),
+            (AccessFlags2::RESERVED_44_NV.0, "RESERVED_44_NV"),
+            (AccessFlags2::RESERVED_45_NV.0, "RESERVED_45_NV"),
             (AccessFlags2::RESERVED_42_NV.0, "RESERVED_42_NV"),
             (AccessFlags2::RESERVED_43_NV.0, "RESERVED_43_NV"),
         ];
@@ -566,6 +568,8 @@ impl fmt::Debug for BufferUsageFlags {
             ),
             (BufferUsageFlags::RESERVED_21_AMD.0, "RESERVED_21_AMD"),
             (BufferUsageFlags::RESERVED_22_AMD.0, "RESERVED_22_AMD"),
+            (BufferUsageFlags::RESERVED_23_NV.0, "RESERVED_23_NV"),
+            (BufferUsageFlags::RESERVED_24_NV.0, "RESERVED_24_NV"),
             (
                 BufferUsageFlags::SHADER_DEVICE_ADDRESS.0,
                 "SHADER_DEVICE_ADDRESS",
@@ -604,6 +608,14 @@ impl fmt::Debug for BuildAccelerationStructureFlagsKHR {
                 "LOW_MEMORY",
             ),
             (BuildAccelerationStructureFlagsKHR::MOTION_NV.0, "MOTION_NV"),
+            (
+                BuildAccelerationStructureFlagsKHR::RESERVED_6_NV.0,
+                "RESERVED_6_NV",
+            ),
+            (
+                BuildAccelerationStructureFlagsKHR::RESERVED_7_NV.0,
+                "RESERVED_7_NV",
+            ),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -2051,6 +2063,8 @@ impl fmt::Debug for GeometryInstanceFlagsKHR {
                 GeometryInstanceFlagsKHR::FORCE_NO_OPAQUE.0,
                 "FORCE_NO_OPAQUE",
             ),
+            (GeometryInstanceFlagsKHR::RESERVED_4_NV.0, "RESERVED_4_NV"),
+            (GeometryInstanceFlagsKHR::RESERVED_5_NV.0, "RESERVED_5_NV"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -2167,7 +2181,10 @@ impl fmt::Debug for ImageCreateFlags {
             (ImageCreateFlags::SUBSAMPLED_EXT.0, "SUBSAMPLED_EXT"),
             (ImageCreateFlags::RESERVED_16_AMD.0, "RESERVED_16_AMD"),
             (ImageCreateFlags::RESERVED_18_EXT.0, "RESERVED_18_EXT"),
-            (ImageCreateFlags::RESERVED_394_EXT.0, "RESERVED_394_EXT"),
+            (
+                ImageCreateFlags::TYPE_2D_VIEW_COMPATIBLE_EXT.0,
+                "TYPE_2D_VIEW_COMPATIBLE_EXT",
+            ),
             (
                 ImageCreateFlags::FRAGMENT_DENSITY_MAP_OFFSET_QCOM.0,
                 "FRAGMENT_DENSITY_MAP_OFFSET_QCOM",
@@ -2891,6 +2908,7 @@ impl fmt::Debug for PipelineCreateFlags {
                 PipelineCreateFlags::RAY_TRACING_ALLOW_MOTION_NV.0,
                 "RAY_TRACING_ALLOW_MOTION_NV",
             ),
+            (PipelineCreateFlags::RESERVED_24_NV.0, "RESERVED_24_NV"),
             (
                 PipelineCreateFlags::VIEW_INDEX_FROM_DEVICE_INDEX.0,
                 "VIEW_INDEX_FROM_DEVICE_INDEX",
@@ -3192,6 +3210,7 @@ impl fmt::Debug for PipelineStageFlags2 {
                 "INVOCATION_MASK_HUAWEI",
             ),
             (PipelineStageFlags2::RESERVED_387_KHR.0, "RESERVED_387_KHR"),
+            (PipelineStageFlags2::RESERVED_30_NV.0, "RESERVED_30_NV"),
             (PipelineStageFlags2::RESERVED_29_NV.0, "RESERVED_29_NV"),
         ];
         debug_flags(f, KNOWN, self.0)
@@ -3526,6 +3545,7 @@ impl fmt::Debug for RenderingFlags {
             ),
             (RenderingFlags::SUSPENDING.0, "SUSPENDING"),
             (RenderingFlags::RESUMING.0, "RESUMING"),
+            (RenderingFlags::RESERVED_3_EXT.0, "RESERVED_3_EXT"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -4929,6 +4949,9 @@ impl fmt::Debug for StructureType {
             Self::PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT => {
                 Some("PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT")
             }
+            Self::PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT => {
+                Some("PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT")
+            }
             Self::PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT => {
                 Some("PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT")
             }
@@ -5372,6 +5395,7 @@ impl fmt::Debug for SubpassDescriptionFlags {
                 SubpassDescriptionFlags::RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_ARM.0,
                 "RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_ARM",
             ),
+            (SubpassDescriptionFlags::RESERVED_7_EXT.0, "RESERVED_7_EXT"),
         ];
         debug_flags(f, KNOWN, self.0)
     }
@@ -5929,6 +5953,10 @@ impl fmt::Debug for VideoEncodeH265CapabilityFlagsEXT {
                 "TRANSFORM_SKIP_ENABLED",
             ),
             (
+                VideoEncodeH265CapabilityFlagsEXT::TRANSFORM_SKIP_DISABLED.0,
+                "TRANSFORM_SKIP_DISABLED",
+            ),
+            (
                 VideoEncodeH265CapabilityFlagsEXT::PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT.0,
                 "PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT",
             ),
@@ -5983,6 +6011,10 @@ impl fmt::Debug for VideoEncodeH265CapabilityFlagsEXT {
             (
                 VideoEncodeH265CapabilityFlagsEXT::DIFFERENT_SLICE_TYPE.0,
                 "DIFFERENT_SLICE_TYPE",
+            ),
+            (
+                VideoEncodeH265CapabilityFlagsEXT::B_FRAME_IN_L1_LIST.0,
+                "B_FRAME_IN_L1_LIST",
             ),
         ];
         debug_flags(f, KNOWN, self.0)

--- a/ash/src/vk/definitions.rs
+++ b/ash/src/vk/definitions.rs
@@ -57,7 +57,7 @@ pub const API_VERSION_1_1: u32 = make_api_version(0, 1, 1, 0);
 pub const API_VERSION_1_2: u32 = make_api_version(0, 1, 2, 0);
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_API_VERSION_1_3.html>"]
 pub const API_VERSION_1_3: u32 = make_api_version(0, 1, 3, 0);
-pub const HEADER_VERSION: u32 = 210u32;
+pub const HEADER_VERSION: u32 = 211u32;
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_HEADER_VERSION_COMPLETE.html>"]
 pub const HEADER_VERSION_COMPLETE: u32 = make_api_version(0, 1, 3, HEADER_VERSION);
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSampleMask.html>"]
@@ -31333,6 +31333,43 @@ impl<'a> AccelerationStructureBuildSizesInfoKHR<'a> {
 #[repr(C)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Copy, Clone)]
+#[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceImage2DViewOf3DFeaturesEXT.html>"]
+pub struct PhysicalDeviceImage2DViewOf3DFeaturesEXT<'a> {
+    pub s_type: StructureType,
+    pub p_next: *mut c_void,
+    pub image2_d_view_of3_d: Bool32,
+    pub sampler2_d_view_of3_d: Bool32,
+    pub _marker: PhantomData<&'a ()>,
+}
+impl ::std::default::Default for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'_> {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            s_type: StructureType::PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT,
+            p_next: ::std::ptr::null_mut(),
+            image2_d_view_of3_d: Bool32::default(),
+            sampler2_d_view_of3_d: Bool32::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+unsafe impl ExtendsPhysicalDeviceFeatures2 for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'_> {}
+unsafe impl ExtendsDeviceCreateInfo for PhysicalDeviceImage2DViewOf3DFeaturesEXT<'_> {}
+impl<'a> PhysicalDeviceImage2DViewOf3DFeaturesEXT<'a> {
+    #[inline]
+    pub fn image2_d_view_of3_d(mut self, image2_d_view_of3_d: bool) -> Self {
+        self.image2_d_view_of3_d = image2_d_view_of3_d.into();
+        self
+    }
+    #[inline]
+    pub fn sampler2_d_view_of3_d(mut self, sampler2_d_view_of3_d: bool) -> Self {
+        self.sampler2_d_view_of3_d = sampler2_d_view_of3_d.into();
+        self
+    }
+}
+#[repr(C)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Copy, Clone)]
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceMutableDescriptorTypeFeaturesVALVE.html>"]
 pub struct PhysicalDeviceMutableDescriptorTypeFeaturesVALVE<'a> {
     pub s_type: StructureType,
@@ -32916,8 +32953,6 @@ pub struct VideoDecodeInfoKHR<'a> {
     pub s_type: StructureType,
     pub p_next: *const c_void,
     pub flags: VideoDecodeFlagsKHR,
-    pub coded_offset: Offset2D,
-    pub coded_extent: Extent2D,
     pub src_buffer: Buffer,
     pub src_buffer_offset: DeviceSize,
     pub src_buffer_range: DeviceSize,
@@ -32934,8 +32969,6 @@ impl ::std::default::Default for VideoDecodeInfoKHR<'_> {
             s_type: StructureType::VIDEO_DECODE_INFO_KHR,
             p_next: ::std::ptr::null(),
             flags: VideoDecodeFlagsKHR::default(),
-            coded_offset: Offset2D::default(),
-            coded_extent: Extent2D::default(),
             src_buffer: Buffer::default(),
             src_buffer_offset: DeviceSize::default(),
             src_buffer_range: DeviceSize::default(),
@@ -32952,16 +32985,6 @@ impl<'a> VideoDecodeInfoKHR<'a> {
     #[inline]
     pub fn flags(mut self, flags: VideoDecodeFlagsKHR) -> Self {
         self.flags = flags;
-        self
-    }
-    #[inline]
-    pub fn coded_offset(mut self, coded_offset: Offset2D) -> Self {
-        self.coded_offset = coded_offset;
-        self
-    }
-    #[inline]
-    pub fn coded_extent(mut self, coded_extent: Extent2D) -> Self {
-        self.coded_extent = coded_extent;
         self
     }
     #[inline]
@@ -33064,7 +33087,7 @@ impl<'a> VideoDecodeH264ProfileEXT<'a> {
 pub struct VideoDecodeH264CapabilitiesEXT<'a> {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
-    pub max_level: u32,
+    pub max_level: StdVideoH264Level,
     pub field_offset_granularity: Offset2D,
     pub _marker: PhantomData<&'a ()>,
 }
@@ -33074,7 +33097,7 @@ impl ::std::default::Default for VideoDecodeH264CapabilitiesEXT<'_> {
         Self {
             s_type: StructureType::VIDEO_DECODE_H264_CAPABILITIES_EXT,
             p_next: ::std::ptr::null_mut(),
-            max_level: u32::default(),
+            max_level: StdVideoH264Level::default(),
             field_offset_granularity: Offset2D::default(),
             _marker: PhantomData,
         }
@@ -33083,7 +33106,7 @@ impl ::std::default::Default for VideoDecodeH264CapabilitiesEXT<'_> {
 unsafe impl ExtendsVideoDecodeCapabilitiesKHR for VideoDecodeH264CapabilitiesEXT<'_> {}
 impl<'a> VideoDecodeH264CapabilitiesEXT<'a> {
     #[inline]
-    pub fn max_level(mut self, max_level: u32) -> Self {
+    pub fn max_level(mut self, max_level: StdVideoH264Level) -> Self {
         self.max_level = max_level;
         self
     }
@@ -33343,7 +33366,7 @@ impl<'a> VideoDecodeH265ProfileEXT<'a> {
 pub struct VideoDecodeH265CapabilitiesEXT<'a> {
     pub s_type: StructureType,
     pub p_next: *mut c_void,
-    pub max_level: u32,
+    pub max_level: StdVideoH265Level,
     pub _marker: PhantomData<&'a ()>,
 }
 impl ::std::default::Default for VideoDecodeH265CapabilitiesEXT<'_> {
@@ -33352,7 +33375,7 @@ impl ::std::default::Default for VideoDecodeH265CapabilitiesEXT<'_> {
         Self {
             s_type: StructureType::VIDEO_DECODE_H265_CAPABILITIES_EXT,
             p_next: ::std::ptr::null_mut(),
-            max_level: u32::default(),
+            max_level: StdVideoH265Level::default(),
             _marker: PhantomData,
         }
     }
@@ -33360,7 +33383,7 @@ impl ::std::default::Default for VideoDecodeH265CapabilitiesEXT<'_> {
 unsafe impl ExtendsVideoDecodeCapabilitiesKHR for VideoDecodeH265CapabilitiesEXT<'_> {}
 impl<'a> VideoDecodeH265CapabilitiesEXT<'a> {
     #[inline]
-    pub fn max_level(mut self, max_level: u32) -> Self {
+    pub fn max_level(mut self, max_level: StdVideoH265Level) -> Self {
         self.max_level = max_level;
         self
     }
@@ -33887,7 +33910,6 @@ pub struct VideoEncodeInfoKHR<'a> {
     pub p_next: *const c_void,
     pub flags: VideoEncodeFlagsKHR,
     pub quality_level: u32,
-    pub coded_extent: Extent2D,
     pub dst_bitstream_buffer: Buffer,
     pub dst_bitstream_buffer_offset: DeviceSize,
     pub dst_bitstream_buffer_max_range: DeviceSize,
@@ -33906,7 +33928,6 @@ impl ::std::default::Default for VideoEncodeInfoKHR<'_> {
             p_next: ::std::ptr::null(),
             flags: VideoEncodeFlagsKHR::default(),
             quality_level: u32::default(),
-            coded_extent: Extent2D::default(),
             dst_bitstream_buffer: Buffer::default(),
             dst_bitstream_buffer_offset: DeviceSize::default(),
             dst_bitstream_buffer_max_range: DeviceSize::default(),
@@ -33929,11 +33950,6 @@ impl<'a> VideoEncodeInfoKHR<'a> {
     #[inline]
     pub fn quality_level(mut self, quality_level: u32) -> Self {
         self.quality_level = quality_level;
-        self
-    }
-    #[inline]
-    pub fn coded_extent(mut self, coded_extent: Extent2D) -> Self {
-        self.coded_extent = coded_extent;
         self
     }
     #[inline]
@@ -34157,7 +34173,7 @@ impl<'a> VideoEncodeRateControlLayerInfoKHR<'a> {
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeCapabilitiesKHR.html>"]
 pub struct VideoEncodeCapabilitiesKHR<'a> {
     pub s_type: StructureType,
-    pub p_next: *const c_void,
+    pub p_next: *mut c_void,
     pub flags: VideoEncodeCapabilityFlagsKHR,
     pub rate_control_modes: VideoEncodeRateControlModeFlagsKHR,
     pub rate_control_layer_count: u8,
@@ -34170,7 +34186,7 @@ impl ::std::default::Default for VideoEncodeCapabilitiesKHR<'_> {
     fn default() -> Self {
         Self {
             s_type: StructureType::VIDEO_ENCODE_CAPABILITIES_KHR,
-            p_next: ::std::ptr::null(),
+            p_next: ::std::ptr::null_mut(),
             flags: VideoEncodeCapabilityFlagsKHR::default(),
             rate_control_modes: VideoEncodeRateControlModeFlagsKHR::default(),
             rate_control_layer_count: u8::default(),
@@ -34221,7 +34237,7 @@ impl<'a> VideoEncodeCapabilitiesKHR<'a> {
     #[doc = r" chain will look like `A -> D -> B -> C`."]
     pub fn push_next<T: ExtendsVideoEncodeCapabilitiesKHR>(mut self, next: &'a mut T) -> Self {
         unsafe {
-            let next_ptr = <*const T>::cast(next);
+            let next_ptr = <*mut T>::cast(next);
             let last_next = ptr_chain_iter(next).last().unwrap();
             (*last_next).p_next = self.p_next as _;
             self.p_next = next_ptr;
@@ -34235,7 +34251,7 @@ impl<'a> VideoEncodeCapabilitiesKHR<'a> {
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH264CapabilitiesEXT.html>"]
 pub struct VideoEncodeH264CapabilitiesEXT<'a> {
     pub s_type: StructureType,
-    pub p_next: *const c_void,
+    pub p_next: *mut c_void,
     pub flags: VideoEncodeH264CapabilityFlagsEXT,
     pub input_mode_flags: VideoEncodeH264InputModeFlagsEXT,
     pub output_mode_flags: VideoEncodeH264OutputModeFlagsEXT,
@@ -34254,7 +34270,7 @@ impl ::std::default::Default for VideoEncodeH264CapabilitiesEXT<'_> {
     fn default() -> Self {
         Self {
             s_type: StructureType::VIDEO_ENCODE_H264_CAPABILITIES_EXT,
-            p_next: ::std::ptr::null(),
+            p_next: ::std::ptr::null_mut(),
             flags: VideoEncodeH264CapabilityFlagsEXT::default(),
             input_mode_flags: VideoEncodeH264InputModeFlagsEXT::default(),
             output_mode_flags: VideoEncodeH264OutputModeFlagsEXT::default(),
@@ -34916,7 +34932,7 @@ impl<'a> VideoEncodeH264RateControlLayerInfoEXT<'a> {
 #[doc = "<https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkVideoEncodeH265CapabilitiesEXT.html>"]
 pub struct VideoEncodeH265CapabilitiesEXT<'a> {
     pub s_type: StructureType,
-    pub p_next: *const c_void,
+    pub p_next: *mut c_void,
     pub flags: VideoEncodeH265CapabilityFlagsEXT,
     pub input_mode_flags: VideoEncodeH265InputModeFlagsEXT,
     pub output_mode_flags: VideoEncodeH265OutputModeFlagsEXT,
@@ -34944,7 +34960,7 @@ impl ::std::default::Default for VideoEncodeH265CapabilitiesEXT<'_> {
     fn default() -> Self {
         Self {
             s_type: StructureType::VIDEO_ENCODE_H265_CAPABILITIES_EXT,
-            p_next: ::std::ptr::null(),
+            p_next: ::std::ptr::null_mut(),
             flags: VideoEncodeH265CapabilityFlagsEXT::default(),
             input_mode_flags: VideoEncodeH265InputModeFlagsEXT::default(),
             output_mode_flags: VideoEncodeH265OutputModeFlagsEXT::default(),

--- a/ash/src/vk/extensions.rs
+++ b/ash/src/vk/extensions.rs
@@ -2214,7 +2214,7 @@ impl KhrVideoDecodeQueueFn {
     pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_video_decode_queue\0") }
     }
-    pub const SPEC_VERSION: u32 = 3u32;
+    pub const SPEC_VERSION: u32 = 4u32;
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdDecodeVideoKHR = unsafe extern "system" fn(
@@ -3083,7 +3083,7 @@ impl ExtVideoEncodeH265Fn {
     pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_encode_h265\0") }
     }
-    pub const SPEC_VERSION: u32 = 6u32;
+    pub const SPEC_VERSION: u32 = 7u32;
 }
 #[derive(Clone)]
 pub struct ExtVideoEncodeH265Fn {}
@@ -3119,7 +3119,7 @@ impl ExtVideoDecodeH264Fn {
     pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_decode_h264\0") }
     }
-    pub const SPEC_VERSION: u32 = 4u32;
+    pub const SPEC_VERSION: u32 = 5u32;
 }
 #[derive(Clone)]
 pub struct ExtVideoDecodeH264Fn {}
@@ -11488,7 +11488,7 @@ impl ExtVideoDecodeH265Fn {
     pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_video_decode_h265\0") }
     }
-    pub const SPEC_VERSION: u32 = 2u32;
+    pub const SPEC_VERSION: u32 = 3u32;
 }
 #[derive(Clone)]
 pub struct ExtVideoDecodeH265Fn {}
@@ -16283,7 +16283,7 @@ impl KhrVideoEncodeQueueFn {
     pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_KHR_video_encode_queue\0") }
     }
-    pub const SPEC_VERSION: u32 = 4u32;
+    pub const SPEC_VERSION: u32 = 5u32;
 }
 #[allow(non_camel_case_types)]
 pub type PFN_vkCmdEncodeVideoKHR = unsafe extern "system" fn(
@@ -19720,17 +19720,17 @@ impl StructureType {
     pub const PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT: Self = Self(1_000_392_000);
     pub const PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT: Self = Self(1_000_392_001);
 }
-impl ExtExtension394Fn {
+impl ExtImage2dViewOf3dFn {
     pub const fn name() -> &'static ::std::ffi::CStr {
-        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_394\0") }
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_image_2d_view_of_3d\0") }
     }
-    pub const SPEC_VERSION: u32 = 0u32;
+    pub const SPEC_VERSION: u32 = 1u32;
 }
 #[derive(Clone)]
-pub struct ExtExtension394Fn {}
-unsafe impl Send for ExtExtension394Fn {}
-unsafe impl Sync for ExtExtension394Fn {}
-impl ExtExtension394Fn {
+pub struct ExtImage2dViewOf3dFn {}
+unsafe impl Send for ExtImage2dViewOf3dFn {}
+unsafe impl Sync for ExtImage2dViewOf3dFn {}
+impl ExtImage2dViewOf3dFn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,
@@ -19738,9 +19738,14 @@ impl ExtExtension394Fn {
         Self {}
     }
 }
-#[doc = "Generated from 'VK_EXT_extension_394'"]
+#[doc = "Generated from 'VK_EXT_image_2d_view_of_3d'"]
 impl ImageCreateFlags {
-    pub const RESERVED_394_EXT: Self = Self(0b10_0000_0000_0000_0000);
+    #[doc = "Image is created with a layout where individual slices are capable of being used as 2D images"]
+    pub const TYPE_2D_VIEW_COMPATIBLE_EXT: Self = Self(0b10_0000_0000_0000_0000);
+}
+#[doc = "Generated from 'VK_EXT_image_2d_view_of_3d'"]
+impl StructureType {
+    pub const PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT: Self = Self(1_000_393_000);
 }
 impl KhrPortabilityEnumerationFn {
     pub const fn name() -> &'static ::std::ffi::CStr {
@@ -19801,6 +19806,36 @@ impl NvExtension397Fn {
     {
         Self {}
     }
+}
+#[doc = "Generated from 'VK_NV_extension_397'"]
+impl AccessFlags2 {
+    pub const RESERVED_44_NV: Self =
+        Self(0b1_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000);
+    pub const RESERVED_45_NV: Self =
+        Self(0b10_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000);
+}
+#[doc = "Generated from 'VK_NV_extension_397'"]
+impl BufferUsageFlags {
+    pub const RESERVED_23_NV: Self = Self(0b1000_0000_0000_0000_0000_0000);
+    pub const RESERVED_24_NV: Self = Self(0b1_0000_0000_0000_0000_0000_0000);
+}
+#[doc = "Generated from 'VK_NV_extension_397'"]
+impl BuildAccelerationStructureFlagsKHR {
+    pub const RESERVED_6_NV: Self = Self(0b100_0000);
+    pub const RESERVED_7_NV: Self = Self(0b1000_0000);
+}
+#[doc = "Generated from 'VK_NV_extension_397'"]
+impl GeometryInstanceFlagsKHR {
+    pub const RESERVED_4_NV: Self = Self(0b1_0000);
+    pub const RESERVED_5_NV: Self = Self(0b10_0000);
+}
+#[doc = "Generated from 'VK_NV_extension_397'"]
+impl PipelineCreateFlags {
+    pub const RESERVED_24_NV: Self = Self(0b1_0000_0000_0000_0000_0000_0000);
+}
+#[doc = "Generated from 'VK_NV_extension_397'"]
+impl PipelineStageFlags2 {
+    pub const RESERVED_30_NV: Self = Self(0b100_0000_0000_0000_0000_0000_0000_0000);
 }
 impl NvExtension398Fn {
     pub const fn name() -> &'static ::std::ffi::CStr {
@@ -21275,6 +21310,24 @@ impl ExtExtension463Fn {
         Self {}
     }
 }
+impl ExtExtension464Fn {
+    pub const fn name() -> &'static ::std::ffi::CStr {
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_464\0") }
+    }
+    pub const SPEC_VERSION: u32 = 0u32;
+}
+#[derive(Clone)]
+pub struct ExtExtension464Fn {}
+unsafe impl Send for ExtExtension464Fn {}
+unsafe impl Sync for ExtExtension464Fn {}
+impl ExtExtension464Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {}
+    }
+}
 impl NvExtension465Fn {
     pub const fn name() -> &'static ::std::ffi::CStr {
         unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_NV_extension_465\0") }
@@ -21313,17 +21366,61 @@ impl PipelineStageFlags2 {
 impl QueueFlags {
     pub const RESERVED_8_NV: Self = Self(0b1_0000_0000);
 }
-impl ExtExtension464Fn {
+impl ExtExtension466Fn {
     pub const fn name() -> &'static ::std::ffi::CStr {
-        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_464\0") }
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_466\0") }
     }
     pub const SPEC_VERSION: u32 = 0u32;
 }
 #[derive(Clone)]
-pub struct ExtExtension464Fn {}
-unsafe impl Send for ExtExtension464Fn {}
-unsafe impl Sync for ExtExtension464Fn {}
-impl ExtExtension464Fn {
+pub struct ExtExtension466Fn {}
+unsafe impl Send for ExtExtension466Fn {}
+unsafe impl Sync for ExtExtension466Fn {}
+impl ExtExtension466Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {}
+    }
+}
+#[doc = "Generated from 'VK_EXT_extension_466'"]
+impl RenderingFlags {
+    pub const RESERVED_3_EXT: Self = Self(0b1000);
+}
+#[doc = "Generated from 'VK_EXT_extension_466'"]
+impl SubpassDescriptionFlags {
+    pub const RESERVED_7_EXT: Self = Self(0b1000_0000);
+}
+impl ExtExtension467Fn {
+    pub const fn name() -> &'static ::std::ffi::CStr {
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_467\0") }
+    }
+    pub const SPEC_VERSION: u32 = 0u32;
+}
+#[derive(Clone)]
+pub struct ExtExtension467Fn {}
+unsafe impl Send for ExtExtension467Fn {}
+unsafe impl Sync for ExtExtension467Fn {}
+impl ExtExtension467Fn {
+    pub fn load<F>(mut _f: F) -> Self
+    where
+        F: FnMut(&::std::ffi::CStr) -> *const c_void,
+    {
+        Self {}
+    }
+}
+impl ExtExtension468Fn {
+    pub const fn name() -> &'static ::std::ffi::CStr {
+        unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_EXT_extension_468\0") }
+    }
+    pub const SPEC_VERSION: u32 = 0u32;
+}
+#[derive(Clone)]
+pub struct ExtExtension468Fn {}
+unsafe impl Send for ExtExtension468Fn {}
+unsafe impl Sync for ExtExtension468Fn {}
+impl ExtExtension468Fn {
     pub fn load<F>(mut _f: F) -> Self
     where
         F: FnMut(&::std::ffi::CStr) -> *const c_void,


### PR DESCRIPTION
Note that `video.xml` is now added to `Vulkan-Headers`, which we can start using in the future when bitfield support lands in our XML parser and the generator - or bitfields are replaced with proper flags.
